### PR TITLE
Golden-bench tuned lanes: A100 tuned goldens, lane records and RESULTS

### DIFF
--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -780,7 +780,12 @@ def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, a
             abs_sum += float(absolute.sum())
             count += int(absolute.size)
             if failure is None and not np.all(absolute <= tolerance):
-                failure = f"output {name!r} exceeds rtol={rtol:g}, atol={atol:g}"
+                worst = int(np.argmax(absolute - tolerance))
+                failure = (
+                    f"output {name!r} exceeds rtol={rtol:g}, atol={atol:g}: "
+                    f"{int((absolute > tolerance).sum())}/{absolute.size} elements, "
+                    f"worst at flat index {worst}: emmy={actual.flat[worst]:.6g} eager={expected.flat[worst]:.6g}"
+                )
 
     proof = {
         "status": "fail" if failure else "pass",
@@ -792,7 +797,7 @@ def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, a
         "max_rel_error": max_rel,
     }
     if failure:
-        proof["error"] = failure
+        proof["error"] = f"{failure} (max_abs={max_abs:.3g}, mean_abs={proof['mean_abs_error']:.3g}, max_rel={max_rel:.3g})"
     return proof
 
 

--- a/emmy/compiler/backend/cuda/render_target.py
+++ b/emmy/compiler/backend/cuda/render_target.py
@@ -121,7 +121,9 @@ _NATIVE_FP16_OPS: frozenset[str] = frozenset(
         "copy",
         "reciprocal",
         "relu",
-        "sigmoid",
+        # Not ``sigmoid``: its half spelling ``1/(1+hexp(-x))`` rounds three times, which lands up
+        # to two half-ulps from torch's compute-in-f32-round-once value and fails the strict
+        # ``rtol=1e-3`` gate; the non-native path below computes it in f32 and converts once.
     }
 )
 

--- a/emmy/compiler/ir/expr.py
+++ b/emmy/compiler/ir/expr.py
@@ -884,12 +884,23 @@ def _div_mod_decompose(expr: Expr, n: int, ctx: SimplifyCtx) -> tuple[Expr, Expr
         for k_side, other_side in ((expr.right, expr.left), (expr.left, expr.right)):
             if not (isinstance(k_side, Literal) and k_side.dtype == "int" and isinstance(k_side.value, int)):
                 continue
-            if k_side.value <= 0 or k_side.value % n != 0:
+            if k_side.value <= 0:
                 continue
             rng = other_side.range(ctx)
-            if rng is not None and rng.lo >= 0:
-                q_expr = BinaryExpr("*", other_side, _make_int_literal(k_side.value // n)).simplify(ctx)
+            if rng is None or rng.lo < 0:
+                continue
+            k = k_side.value
+            if k % n == 0:
+                q_expr = BinaryExpr("*", other_side, _make_int_literal(k // n)).simplify(ctx)
                 return (q_expr, _make_int_literal(0))
+            if n % k == 0:
+                # ``x*k = n*(x / d) + k*(x % d)`` for ``d = n/k``: the collapsed-reshape index
+                # ``(head*128 + col) / 1024`` (a GQA group fold over the head-dim sweep) reads as
+                # ``head / 8`` once the remainder ``(head % 8)*128 + col`` proves below ``n``.
+                d = _make_int_literal(n // k)
+                q_expr = BinaryExpr("/", other_side, d).simplify(ctx)
+                r_expr = BinaryExpr("*", BinaryExpr("%", other_side, d), _make_int_literal(k)).simplify(ctx)
+                return (q_expr, r_expr)
     if isinstance(expr, BinaryExpr) and expr.op == "+":
         L = _div_mod_decompose(expr.left, n, ctx)
         R = _div_mod_decompose(expr.right, n, ctx)

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -282,7 +282,9 @@ refusals are semantic (region ownership, a real splicer rejection, the fence aro
 and the two readable-seam refusals judged on the MERGED form — no reduce loop nested in a reduce loop, and no
 entangling a multi-statistic compound beyond its readable tails: the flat same-extent normalize sweep, or a free
 sweep of flat same-extent additive folds — the value folds of a fused softmax·V region, which read as one
-contraction over the pair; other shapes fall to the raw-loop
+contraction over the pair; and no per-step statistic chained into a fold inside a free sweep — a reduce whose
+result another reduce in the same sweep reads, the shape attention's k-norm → RoPE → `Q·Kᵀ` region takes when
+fused greedily, replaying the key statistic once per query row; other shapes fall to the raw-loop
 escape with no schedule tier and no `PLACE` seam, so evidence could never price the split back) plus one
 boundedness cap on aggregate work growth: without it a whole transformer layer splices into a single loop
 nest that no schedule can run and recognition cannot certify.

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/010_sdpa.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/010_sdpa.py
@@ -65,22 +65,25 @@ def rewrite(match: Match, root: Node, inp_q: Node, inp_k: Node, inp_v: Node, inp
 
     head_dim = q_shape[-1] if len(q_shape) >= 2 else 64
     seq_len = q_shape[-2] if len(q_shape) >= 3 else q_shape[-1]
+    # The key length is K's own, not the query's: a decode step (one query over a populated
+    # cache) scores every key, and a kt/scores shape read off the query would score only key 0.
+    kv_len = k_shape[-2] if len(k_shape) >= 3 else k_shape[-1]
     q_batch = q_shape[:-2] if len(q_shape) > 2 else ()
     k_batch = k_shape[:-2] if len(k_shape) > 2 else ()
     v_batch = v_shape[:-2] if len(v_shape) > 2 else ()
-    scores_shape = q_batch + (seq_len, seq_len)
+    scores_shape = q_batch + (seq_len, kv_len)
 
     exts = [inp_q, inp_k, inp_v] + ([inp_mask] if inp_mask is not None else [])
     frag = open_fragment(graph, exts)
 
     # K^T then GQA broadcast.
-    kt_shape = k_batch + (head_dim, seq_len) if head_dim.is_static else k_shape
+    kt_shape = k_batch + (head_dim, kv_len) if head_dim.is_static else k_shape
     kt_id = frag.add_node(
         op=TransposeOp(axes=(-2, -1)),
         inputs=[inp_k],
         output=Tensor(f"{name}_kt", kt_shape, inp_k.output.dtype),
     )
-    kt = _maybe_gqa(frag, kt_id, q_batch, k_batch, (head_dim, seq_len), name=f"{name}_kt_gqa")
+    kt = _maybe_gqa(frag, kt_id, q_batch, k_batch, (head_dim, kv_len), name=f"{name}_kt_gqa")
 
     # QK^T matmul.
     qk = matmul_decompose(frag, inp_q, kt, name=f"{name}_qk")

--- a/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
@@ -18,7 +18,9 @@ form: a merge must not nest a reduce ``Loop`` inside another reduce ``Loop``, an
 entangle a multi-statistic compound (the online-softmax pair) beyond its readable tails — the
 flat same-extent normalize sweep, or a free sweep of flat same-extent additive folds (the
 expectation channels of a fused softmax·V region, which the online-softmax pairing joins into
-one streaming loop) — other shapes fall to the raw-loop escape downstream (no schedule tier, no
+one streaming loop) — and must not chain a per-step statistic into a fold inside a free sweep (a
+reduce another reduce in the same sweep reads: attention's k-norm replayed per query row ahead
+of ``Q·Kᵀ``) — other shapes fall to the raw-loop escape downstream (no schedule tier, no
 ``PLACE`` seam), so evidence could never price the split back — plus one boundedness bound:
 ``_total_work`` sums the
 enclosing free×reduce iteration count of every compute leaf, and a merge that grows it by more

--- a/emmy/compiler/pipeline/passes/loop/fusion/030_fold_output_reshape.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/030_fold_output_reshape.py
@@ -1,4 +1,4 @@
-"""Fold a graph-output memcpy-identity reshape into its producer's ``Write``.
+"""Fold a memcpy-identity reshape into its producer's ``Write``.
 
 A traced flatten that survives to a GRAPH OUTPUT cannot fuse the normal way: ``010_merge_loop_ops``
 inlines a producer's compute at the consumer's load sites, which would re-run a reduce-bearing
@@ -16,7 +16,7 @@ the output strides, each dim's slot range-checked against its extent). The produ
 loops and its body verbatim; the copy kernel disappears and the producer's node takes the
 consumer's place as the graph output.
 
-Bails conservatively (``RuleSkipped``) on: a non-output consumer (ordinary fusion territory), a
+Bails conservatively (``RuleSkipped``) on: a
 producer with other consumers or that is itself a graph output, dtype / numel mismatch, a
 non-identity map, symbolic extents, a domain too large to verify exactly, or a write offset whose
 affine terms don't partition cleanly onto the output strides."""
@@ -143,8 +143,6 @@ def rewrite(match: Match, producer: Node, consumer: Node) -> Graph | None:
         raise RuleSkipped("producer or consumer is no longer a LoopOp")
     if producer.id not in consumer.inputs:
         raise RuleSkipped("producer is not an input of consumer")
-    if consumer.id not in graph.outputs:
-        raise RuleSkipped("consumer is not a graph output — ordinary fusion territory")
     if producer.id in graph.outputs:
         raise RuleSkipped("producer is itself a graph output — it must stay materialized")
     others = [n for n in graph.nodes.values() if n.id != consumer.id and producer.id in n.inputs]

--- a/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
@@ -9,11 +9,13 @@ offers, so the merge semantics have exactly one home.
 from __future__ import annotations
 
 from emmy.compiler.graph import Graph, Node
+from emmy.compiler.ir.expr import BinaryExpr, Literal, Var, _ExprOps
 from emmy.compiler.ir.loop import Accum, Assign, Loop, LoopOp
 from emmy.compiler.ir.pure.fold import deep_defines, deep_reads
 from emmy.compiler.ir.stmt import Body
 from emmy.compiler.pipeline import Match, RuleSkipped
 from emmy.compiler.pipeline.passes.loop.fusion._helpers import build_merged_region as _build_merged_region
+from emmy.compiler.pipeline.passes.loop.fusion._helpers import is_pure_indexmap as _is_pure_indexmap
 from emmy.compiler.pipeline.passes.loop.fusion._helpers import wrap_merge_fragment as _wrap_merge_fragment
 
 _BLOWUP_FACTOR = 8
@@ -153,6 +155,85 @@ def _chains_statistic_in_sweep(loop_op: LoopOp) -> bool:
     return walk(loop_op.body, False)
 
 
+def _mentions_plain(expr, axis: str) -> bool:
+    """Whether ``axis`` occurs in ``expr`` outside every floor-division-by-literal subtree. A
+    ``%``-by-literal counts as plain: ``n % 16`` varies within the class ``n / 16`` names, so a
+    read carrying both (the packed-word decode of a coded weight) covers ``n`` fully."""
+    import dataclasses  # noqa: PLC0415
+
+    if isinstance(expr, Var):
+        return expr.name == axis
+    if isinstance(expr, BinaryExpr) and expr.op in ("/", "//") and isinstance(expr.right, Literal):
+        return False
+    if not dataclasses.is_dataclass(expr):
+        return False
+    for f in dataclasses.fields(expr):
+        v = getattr(expr, f.name)
+        for child in v if isinstance(v, (tuple, list)) else (v,):
+            if isinstance(child, _ExprOps) and _mentions_plain(child, axis):
+                return True
+    return False
+
+
+def _replays_reduce_under_composite_axis(loop_op: LoopOp) -> bool:
+    """Whether a reduce ``Loop`` sits under a free axis its reads depend on ONLY through a
+    floor-division quotient (``flat / 256``): the reduce's value is constant across each class of that
+    axis, so it is replayed — 256× for the flattened ``(head, d)`` output of softmax·V, whose
+    per-head statistic then recomputes for every ``d`` — and no loop exists to hoist it out of
+    (the lift hoists a loop-INVARIANT statistic ahead of a sweep; a composite-indexed one is
+    neither invariant nor addressable by a ``PLACE`` seam). A reduce that does not read the axis
+    at all is the hoistable norm→linear shape and stays."""
+    reduce_names = loop_op.reduce_axis_names
+
+    def walk(stmts: Body, free: list[str]) -> bool:
+        for stmt in stmts:
+            if not isinstance(stmt, Loop):
+                continue
+            if stmt.axis.name in reduce_names:
+                exprs = [e for s in _deep_stmts(stmt.body) for e in s.exprs()]
+                for axis in free:
+                    mentioned = [e for e in exprs if axis in e.free_vars()]
+                    if mentioned and not any(_mentions_plain(e, axis) for e in mentioned):
+                        return True
+                continue  # nested reduces read as the step's composed producers
+            if walk(stmt.body, [*free, stmt.axis.name]):
+                return True
+        return False
+
+    return walk(loop_op.body, [])
+
+
+def _deep_stmts(body: Body):
+    for s in body:
+        yield s
+        for b in s.nested():
+            yield from _deep_stmts(b)
+
+
+def _collapsing_indexmap(loop_op: LoopOp) -> bool:
+    """A pure indexmap whose loads address the producer through a div/mod-by-literal of its own
+    axes — a reshape that collapses (or splits) loop axes, as opposed to a permutation or slice."""
+    from emmy.compiler.ir.stmt import Load  # noqa: PLC0415
+
+    if not _is_pure_indexmap(loop_op):
+        return False
+
+    def composite(expr) -> bool:
+        import dataclasses  # noqa: PLC0415
+
+        if isinstance(expr, BinaryExpr) and expr.op in ("/", "//", "%") and isinstance(expr.right, Literal) and expr.left.free_vars():
+            return True
+        if not dataclasses.is_dataclass(expr):
+            return False
+        for f in dataclasses.fields(expr):
+            v = getattr(expr, f.name)
+            if any(isinstance(c, _ExprOps) and composite(c) for c in (v if isinstance(v, (tuple, list)) else (v,))):
+                return True
+        return False
+
+    return any(composite(e) for s in _deep_stmts(loop_op.body) if isinstance(s, Load) for e in s.index or ())
+
+
 def _total_work(loop_op: LoopOp) -> int:
     """Sum enclosing-loop iterations over arithmetic leaves.
 
@@ -171,6 +252,13 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
     if any("__cut_" in node_id for node_id in region - {sink.id}):
         raise RuleSkipped("region crosses a decided placement cut")
 
+    if _collapsing_indexmap(sink.op) and any(graph.nodes[node_id].op.reduce_axis_names for node_id in region - {sink.id}):
+        # Splicing a reduce-bearing producer at a collapsing reshape's load sites re-runs its
+        # reduces per output element, indexed by the flat axis's quotient — the per-head softmax
+        # statistic replayed for every ``d`` of the ``(head, d)`` flatten, with no loop to hoist it
+        # out of and no seam to cut. ``030_fold_output_reshape`` retargets the producer's writes
+        # onto the flat buffer instead, keeping its loop nest; a non-identity copy stays a kernel.
+        raise RuleSkipped("sink collapses axes of a reduce-bearing producer — the reshape folds into its writes instead")
     merged = _build_merged_region(graph, region, sink)
     if merged is None:
         raise RuleSkipped("N-way Loop splicer rejected the region")
@@ -185,6 +273,10 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
         raise RuleSkipped("merge entangles a multi-statistic compound — an unreadable seam")
     if _chains_statistic_in_sweep(merged) and not any(_chains_statistic_in_sweep(graph.nodes[node_id].op) for node_id in region):
         raise RuleSkipped("merge chains a per-step statistic into a fold inside a free sweep — an unreadable seam")
+    if _replays_reduce_under_composite_axis(merged) and not any(
+        _replays_reduce_under_composite_axis(graph.nodes[node_id].op) for node_id in region
+    ):
+        raise RuleSkipped("merge replays a reduce under a free axis it reads only through a floor-division quotient — an unreadable seam")
     pre_work = sum(_total_work(graph.nodes[node_id].op) for node_id in region)
     post_work = _total_work(merged)
     if post_work > _BLOWUP_FACTOR * pre_work:

--- a/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.loop import Accum, Assign, Loop, LoopOp
+from emmy.compiler.ir.pure.fold import deep_defines, deep_reads
 from emmy.compiler.ir.stmt import Body
 from emmy.compiler.pipeline import Match, RuleSkipped
 from emmy.compiler.pipeline.passes.loop.fusion._helpers import build_merged_region as _build_merged_region
@@ -114,6 +115,44 @@ def _entangled_multi_stat(loop_op: LoopOp) -> bool:
     return walk(loop_op.body)
 
 
+def _chains_statistic_in_sweep(loop_op: LoopOp) -> bool:
+    """Whether a free sweep replays a reduce ``Loop`` whose accumulators feed a LATER reduce
+    ``Loop`` in the same sweep — a per-step statistic chained into a contraction.
+
+    One fold per sweep step is readable: the fused norm→linear sweep (the row statistic is the
+    sweep's outer sibling, each step is one dot) and softmax·V's expectation channels (one
+    additive fold per channel). A statistic recomputed INSIDE the sweep and consumed by a second
+    fold there is not — recognition cannot hoist it to an operand (its reads are sweep-local) and
+    keeps the whole step as the raw-loop escape, with no schedule tier and no ``PLACE`` seam, so
+    evidence could never price the split back. Attention's k-norm → RoPE → ``Q·Kᵀ`` region is the
+    case: fused greedily, the key statistic replays once per query row and the contraction runs
+    scalar."""
+    reduce_names = loop_op.reduce_axis_names
+
+    def walk(stmts: Body, in_sweep: bool) -> bool:
+        # Names carrying a statistic computed at THIS level: a reduce loop's accumulators and the
+        # pure stmts derived from them. Names from enclosing levels are the readable outer state.
+        tainted: set[str] = set()
+        seen_reduce = False
+        for stmt in stmts:
+            if not isinstance(stmt, Loop):
+                if set(stmt.deps()) & tainted:
+                    tainted |= set(stmt.defines())
+                continue
+            is_reduce = stmt.axis.name in reduce_names
+            if is_reduce:
+                if in_sweep and tainted & deep_reads(list(stmt.body)):
+                    return True
+                tainted |= deep_defines(stmt)
+            # A free loop is a sweep once a sibling reduce precedes it (or it sits inside one).
+            if walk(stmt.body, in_sweep or (not is_reduce and seen_reduce)):
+                return True
+            seen_reduce = seen_reduce or is_reduce
+        return False
+
+    return walk(loop_op.body, False)
+
+
 def _total_work(loop_op: LoopOp) -> int:
     """Sum enclosing-loop iterations over arithmetic leaves.
 
@@ -144,6 +183,8 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
         # expectation channels the pairing joins). A merge that entangles the pair with any
         # other tail produces a cell recognition keeps as the raw-loop escape.
         raise RuleSkipped("merge entangles a multi-statistic compound — an unreadable seam")
+    if _chains_statistic_in_sweep(merged) and not any(_chains_statistic_in_sweep(graph.nodes[node_id].op) for node_id in region):
+        raise RuleSkipped("merge chains a per-step statistic into a fold inside a free sweep — an unreadable seam")
     pre_work = sum(_total_work(graph.nodes[node_id].op) for node_id in region)
     post_work = _total_work(merged)
     if post_work > _BLOWUP_FACTOR * pre_work:

--- a/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
@@ -15,7 +15,6 @@ from emmy.compiler.ir.pure.fold import deep_defines, deep_reads
 from emmy.compiler.ir.stmt import Body
 from emmy.compiler.pipeline import Match, RuleSkipped
 from emmy.compiler.pipeline.passes.loop.fusion._helpers import build_merged_region as _build_merged_region
-from emmy.compiler.pipeline.passes.loop.fusion._helpers import is_pure_indexmap as _is_pure_indexmap
 from emmy.compiler.pipeline.passes.loop.fusion._helpers import wrap_merge_fragment as _wrap_merge_fragment
 
 _BLOWUP_FACTOR = 8
@@ -210,13 +209,11 @@ def _deep_stmts(body: Body):
             yield from _deep_stmts(b)
 
 
-def _collapsing_indexmap(loop_op: LoopOp) -> bool:
-    """A pure indexmap whose loads address the producer through a div/mod-by-literal of its own
-    axes — a reshape that collapses (or splits) loop axes, as opposed to a permutation or slice."""
+def _collapsing_loads(loop_op: LoopOp, producers: set[str]) -> bool:
+    """Whether ``loop_op`` loads one of ``producers`` through a div/mod-by-literal of its own
+    axes — a reshape that collapses (or splits) loop axes, whether the sink is the bare reshape
+    or a compute that already absorbed it (the output-gate multiply over the flattened heads)."""
     from emmy.compiler.ir.stmt import Load  # noqa: PLC0415
-
-    if not _is_pure_indexmap(loop_op):
-        return False
 
     def composite(expr) -> bool:
         import dataclasses  # noqa: PLC0415
@@ -231,7 +228,7 @@ def _collapsing_indexmap(loop_op: LoopOp) -> bool:
                 return True
         return False
 
-    return any(composite(e) for s in _deep_stmts(loop_op.body) if isinstance(s, Load) for e in s.index or ())
+    return any(composite(e) for s in _deep_stmts(loop_op.body) if isinstance(s, Load) and s.input in producers for e in s.index or ())
 
 
 def _total_work(loop_op: LoopOp) -> int:
@@ -252,13 +249,15 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
     if any("__cut_" in node_id for node_id in region - {sink.id}):
         raise RuleSkipped("region crosses a decided placement cut")
 
-    if _collapsing_indexmap(sink.op) and any(graph.nodes[node_id].op.reduce_axis_names for node_id in region - {sink.id}):
+    producers = region - {sink.id}
+    if _collapsing_loads(sink.op, producers) and any(graph.nodes[node_id].op.reduce_axis_names for node_id in producers):
         # Splicing a reduce-bearing producer at a collapsing reshape's load sites re-runs its
         # reduces per output element, indexed by the flat axis's quotient — the per-head softmax
-        # statistic replayed for every ``d`` of the ``(head, d)`` flatten, with no loop to hoist it
-        # out of and no seam to cut. ``030_fold_output_reshape`` retargets the producer's writes
-        # onto the flat buffer instead, keeping its loop nest; a non-identity copy stays a kernel.
-        raise RuleSkipped("sink collapses axes of a reduce-bearing producer — the reshape folds into its writes instead")
+        # statistic replayed for every ``d`` of the ``(head, d)`` flatten, or P·V spelled per flat
+        # cell with composite operand indices no slab loader can address — with no loop to hoist
+        # it out of and no seam to cut. ``030_fold_output_reshape`` retargets a pure reshape onto
+        # the producer's writes instead, keeping its loop nest; a computing sink stays a kernel.
+        raise RuleSkipped("sink reads a reduce-bearing producer through a collapsing reshape — an unreadable seam")
     merged = _build_merged_region(graph, region, sink)
     if merged is None:
         raise RuleSkipped("N-way Loop splicer rejected the region")

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -135,7 +135,7 @@ def _exp_weight(defs: dict, name: str, mx: str) -> str | None:
     return None
 
 
-def _components(t: Fold, mx: str, canon: str) -> list[tuple[str, tuple, list, tuple]] | None:
+def _components(t: Fold, mx: str, canon: str, states: tuple[str, ...] = ()) -> list[tuple[str, tuple, list, tuple]] | None:
     """Read EVERY additive component of sibling fold ``t`` as a carrier component joining a pair:
     each lifted value factors (``split_invariant_factors``) into loop-invariant factors × the
     pair's own per-element weight (``exp(score′ − mx)``, score′ α-equal to ``canon``) × a residual
@@ -179,8 +179,11 @@ def _components(t: Fold, mx: str, canon: str) -> list[tuple[str, tuple, list, tu
         stmts = list(vcone.members)
         if any(not isinstance(s, (Load, Assign, Select)) for s in stmts):
             return None
-        if ({mx} | set(t.combine.results) | edge_results) & {a for s in stmts for a in s.deps()}:
-            return None  # the value cone must be free of the pair's carried states / dropped edges
+        if ({mx, *states} | set(t.combine.results) | edge_results) & {a for s in stmts for a in s.deps()}:
+            # The value cone must be free of the pair's carried states (its own, the max's, and
+            # every sibling already joined — a ``1/den`` sunk into the channel's λ would stream
+            # against the RUNNING denominator once merged) and of the dropped edges.
+            return None
         covered |= {id(s) for s in Body(tuple(body)).backward_cone([value]).members}
         out.append((state, inv, stmts, tuple(values)))
     if any(id(s) not in covered for s in body):
@@ -221,7 +224,7 @@ def _pair(fmax, rest: list) -> tuple[Fold, int, list] | None:
     for t in rest:
         comps = None
         if isinstance(t, Fold) and t.axis is not None and t.axis.extent == fmax.axis.extent:
-            comps = _components(t, mx, canon)
+            comps = _components(t, mx, canon, tuple(states))
         if comps is None:
             break
         ren = {t.axis.name: fmax.axis.name} if t.axis.name != fmax.axis.name else {}
@@ -364,7 +367,9 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
         return None
     stat_defs = set(_operand_result_names(stat)) | {nm for s in stat_epi for nm in s.defines()}
     edge_names = frozenset(nm for e in edges for nm in _operand_result_names(e))
-    bound = _bind_stat_channels(fcol, n_ax.name, stat_defs, frozenset(a.name for a in free) | {n_ax.name}, edge_names)
+    bound = _bind_stat_channels(
+        fcol, n_ax.name, stat_defs, frozenset(a.name for a in free) | {n_ax.name}, edge_names, m_name=free[-1].name if free else None
+    )
     if bound is None:
         return None
     cone, channels = bound
@@ -459,7 +464,7 @@ def _channel_product(f: Fold) -> object:
 
 
 def _bind_stat_channels(
-    f: Fold, n_name: str, stat_defs: set, axes: frozenset, edge_names: frozenset = frozenset()
+    f: Fold, n_name: str, stat_defs: set, axes: frozenset, edge_names: frozenset = frozenset(), m_name: str | None = None
 ) -> tuple[list, tuple] | None:
     """The computed-A channel read for the fused view: per additive component, a two-arg ⊗
     (distributing over the carrier's one commutative-monoid ⊕) whose directly-named B load is
@@ -491,6 +496,12 @@ def _bind_stat_channels(
             return None
         reads.append((lift, loads[b_arg], a_arg))
     if len({lift.op for lift, _, _ in reads}) != 1:
+        return None
+    if m_name is not None and any(m_name in _idx_vars(b) for _, b, _ in reads):
+        # B must be (n, k)-indexed and never read the row axis — the mirror of the A-cone check
+        # below. A row-dependent B is a batched matvec, not a bilinear form: the mma emitter
+        # addresses ONE B slab per tile, so binding it reads the first row's slab for all 16
+        # (decode attention with the heads as rows, V read per head).
         return None
     # ONE shared A value across channels, by VALUE-TREE equality: fusion duplicates the cone SSA
     # per channel (fresh names, interleaved order, per-copy operand order), so name equality is

--- a/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
@@ -39,7 +39,7 @@ def _peel(body: Body) -> tuple[list, list[Stmt]]:
     """Split a body into ``(free_axes, per_cell_stmts)``.
 
     The outer chain of **free** loops becomes the parallel axes. At every level of the
-    chain a leading run of pure stmts (``Load`` / ``Assign`` / ``Init`` — loop-invariant
+    chain a leading run of pure stmts (``Load`` / ``Assign`` / ``Init`` / ``Select`` — loop-invariant
     loads hoisted above or between the free loops, e.g. a broadcast row scale ``rs[m]``
     read once per ``m``) is sunk into the per-cell body, re-evaluated per cell. The chain
     stops at the first reduce loop, branch, or non-pure stmt — everything from there down
@@ -49,7 +49,7 @@ def _peel(body: Body) -> tuple[list, list[Stmt]]:
     cur = list(body)
     while True:
         i = 0
-        while i < len(cur) and isinstance(cur[i], (Load, Assign, Init)):
+        while i < len(cur) and isinstance(cur[i], (Load, Assign, Init, Select)):
             i += 1
         head, rest = cur[:i], cur[i:]
         if len(rest) != 1 or not isinstance(rest[0], Loop) or rest[0].is_reduce:
@@ -76,18 +76,22 @@ def _route_prologue(pending: list, loop: Loop, suffix_reads: set[str]) -> tuple[
     need = set(deep_reads(list(loop.body)))
     take: set[int] = set()
     dup: dict[int, dict[str, str]] = {}
+    # Reads by stmts that stay AHEAD of the loop: the suffix, plus — walking backwards — every
+    # pending stmt that does not sink (a raw loop, a fold, a kept stmt). A value one of those
+    # reads cannot move past it into the λ, or it would read an undefined name.
+    outside = set(suffix_reads)
     for i in range(len(pending) - 1, -1, -1):
         s = pending[i]
-        if not isinstance(s, (Load, Assign, Select)):
-            continue  # a fold / raw loop / Init never sinks; its results read as free names
-        defs = set(s.defines())
+        defs = set(s.defines()) if isinstance(s, (Load, Assign, Select)) else set()
         if not defs & need:
+            outside |= set(deep_reads([s]))  # a fold / raw loop / Init never sinks
             continue
-        if defs & suffix_reads:
+        if defs & outside:
             if isinstance(s, Load) and not s.deps() and not any(e.free_vars() for e in s.index or ()):
                 dup[i] = {nm: f"{nm}__stat" for nm in defs}
                 take.add(i)
                 continue
+            outside |= set(s.deps())
             continue  # feeds both sides and cannot be duplicated — the λ read stays free
         take.add(i)
         need |= set(s.deps())

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -664,6 +664,19 @@ def _resolve_inputs(fx_node: Any, node_map: dict[str, NodeRef], g: Graph | None 
     return result
 
 
+# Fill-value tensor constructors and their static fill; ``None`` reads the fill from the call.
+_FILL_CONSTRUCTORS = {
+    "new_zeros": 0.0,
+    "zeros": 0.0,
+    "zeros_like": 0.0,
+    "ones": 1.0,
+    "ones_like": 1.0,
+    "new_full": None,
+    "full": None,
+    "full_like": None,
+}
+
+
 def _handle_placeholder(
     g: Graph,
     fx_node: Any,
@@ -1220,17 +1233,19 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
     # dtype/device template; receiver values do not participate in the result. Represent the
     # constructed tensor as a scalar plus an explicit broadcast so its FX metadata shape is
     # preserved even when the receiver has an unrelated shape.
-    if op_name in ("new_zeros", "new_full"):
+    # The ``_like`` forms and the receiver-less factories (``zeros``/``ones``/``full``, exported as
+    # leaves with no tensor input at all) construct the same way.
+    if op_name in _FILL_CONSTRUCTORS:
         from emmy.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to
 
-        if op_name == "new_full":
-            fill = fx_node.args[2] if len(fx_node.args) > 2 else (fx_node.kwargs or {}).get("fill_value")
+        fill = _FILL_CONSTRUCTORS[op_name]
+        scalar_id = None
+        if fill is None:
+            fill_position = 2 if op_name == "new_full" else 1
+            fill = fx_node.args[fill_position] if len(fx_node.args) > fill_position else (fx_node.kwargs or {}).get("fill_value")
             if not isinstance(fill, (int, float, bool)):
-                raise NotImplementedError(f"aten.new_full requires a static scalar fill value, got {fill!r}")
+                raise NotImplementedError(f"aten.{op_name} requires a static scalar fill value, got {fill!r}")
             scalar_id = input_ids[-1] if input_ids and isinstance(g.nodes[input_ids[-1]].op, ConstantOp) else None
-        else:
-            fill = 0.0
-            scalar_id = None
         if scalar_id is None:
             scalar_name = f"{name}_scalar"
             scalar_id = g.add_node(

--- a/emmy/serving/twins.py
+++ b/emmy/serving/twins.py
@@ -342,7 +342,13 @@ def _layer_signatures(trunk, config) -> list[tuple[str, str, int]]:
     for i, block in enumerate(trunk.layers):
         attn = at(types, i, "homogeneous")
         mlp = at(mlp_types, i, "sparse" if moe_block_parts(block.mlp) is not None else "dense")
-        inferred_heads, _width = _attention_query_layout(block.self_attn)
+        attention = getattr(block, "self_attn", None)
+        if attention is None:
+            raise NotImplementedError(
+                f"serving twins: layer {i} ({type(block).__name__}, {attn}) has no self_attn; "
+                "blocks whose token mixer is not attention (e.g. a gated delta net) have no serving program yet"
+            )
+        inferred_heads, _width = _attention_query_layout(attention)
         nheads = at(heads, i, inferred_heads)
         out.append((str(mlp), str(attn), int(nheads)))
     return out

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/RESULTS.md
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/RESULTS.md
@@ -114,6 +114,106 @@ SoftCap decode is the remaining performance-reproduction outlier. This replay re
 paper's A100 compiler table reports 1.86x over its best compiler baseline. The modern PyTorch lane does not implement
 SoftCap, so this result should not be treated as reproduced until that difference is explained.
 
+## Tuned Emmy on the same A100 (2026-08-21)
+
+### Question
+
+The 2026-08-16 run measured UNTUNED Emmy. This run replays a committed tuned golden per setup, so the schedules
+Emmy deploys are the ones a full hybrid search selected on this exact card.
+
+### Protocol
+
+Each setup's program was traced from `operators.sh`, hybrid-tuned (agent proposals drawn from this card's own
+measured schedules, then MCTS at 48 candidates / patience 12 / seed 0 under a per-setup wall budget), and its
+deployable `-O3` finalists re-measured against a cold greedy pick; the winner is committed under
+`golden/<operator>-b1-s<sequence_length>.golden.yaml`. The lane then runs two arms per setup: the golden replay
+times Emmy alone, and an `emmy run -c` reference arm re-traces the same snippet for eager, torch.compile, and the
+strict Emmy-vs-eager correctness proof. Both arms use one warmup and 15 measured iterations and take the minimum,
+matching the earlier run and the Neptune convention. Compiler revision `0f9c3026`+ (goldens) / `080bde08` (lane).
+
+### Result (µs, minimum of 15; Neptune from the archived 2026-08-16 profiles)
+
+`emmy tuned` sums each setup's post-fusion targets, taking the committed pin where one exists and the greedy pick
+otherwise. Ratios above 1.00x favour Emmy.
+
+| setup | eager | torch.compile | emmy untuned | emmy tuned | Neptune | tc/emmy | Neptune/emmy |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| decode_causal 256 | 12.24 | 12.18 | 25.77 | 23.46 | 10.91 | 0.52x | 0.47x |
+| decode_causal 512 | 16.01 | 15.96 | 44.48 | 40.96 | 14.59 | 0.39x | 0.36x |
+| decode_causal 1024 | 21.02 | 20.84 | 84.57 | 78.92 | 21.38 | 0.26x | 0.27x |
+| decode_causal 2048 | 29.37 | 28.89 | 299.52 | 158.16 | 35.26 | 0.18x | 0.22x |
+| decode_causal 4096 | 52.99 | 54.39 | 593.92 | 585.73 | 57.85 | 0.09x | 0.10x |
+| decode_causal 8192 | 91.96 | 92.77 | 1184.77 | 1174.53 | 94.53 | 0.08x | 0.08x |
+| decode_causal 16384 | 167.94 | 167.42 | 2361.34 | 2336.77 | 165.69 | 0.07x | 0.07x |
+| decode_causal 32768 | 318.46 | 318.46 | 4713.47 | 4668.42 | 320.74 | 0.07x | 0.07x |
+| decode_gqa 256 | 68.85 | 12.59 | 21.14 | 47.53 | 10.34 | 0.26x | 0.22x |
+| decode_gqa 512 | 100.17 | 21.40 | 27.44 | 61.64 | 10.75 | 0.35x | 0.17x |
+| decode_gqa 1024 | 186.71 | 25.84 | 36.65 | 85.04 | 12.58 | 0.30x | 0.15x |
+| decode_gqa 2048 | 348.62 | 33.12 | 62.52 | 147.49 | 15.78 | 0.22x | 0.11x |
+| decode_gqa 4096 | 670.23 | 71.90 | 138.68 | 334.97 | 22.98 | 0.21x | 0.07x |
+| decode_gqa 8192 | 1308.21 | 115.76 | 320.51 | 816.98 | 40.10 | 0.14x | 0.05x |
+| decode_gqa 16384 | 2663.38 | 236.81 | 629.25 | 1662.98 | 67.61 | 0.14x | 0.04x |
+| decode_gqa 32768 | 5869.13 | 448.22 | 1403.90 | 3979.26 | 111.07 | 0.11x | 0.03x |
+| prefill_global 256 | 16.13 | 15.91 | 93.37 | 32.21 | 19.01 | 0.49x | 0.59x |
+| prefill_global 512 | 43.26 | 42.89 | 165.89 | 89.97 | 50.37 | 0.48x | 0.56x |
+| prefill_global 1024 | 122.37 | 120.32 | 3254.27 | 597.45 | 153.82 | 0.20x | 0.26x |
+| prefill_global 2048 | 342.02 | 330.75 | 12595.20 | 1990.66 | 479.81 | 0.17x | 0.24x |
+| prefill_global 4096 | 1269.76 | 1256.45 | 49434.62 | 7092.22 | 1586.33 | 0.18x | 0.22x |
+| prefill_global 8192 | 4728.83 | 4728.83 | 197223.42 | 197455.88 | 5988.16 | 0.02x | 0.03x |
+| prefill_global 16384 | 18829.31 | 18853.89 | 783868.96 | 711223.27 | 23607.12 | 0.03x | 0.03x |
+| prefill_causal 256 | 19.35 | 19.07 | 95.88 | 37.17 | 20.89 | 0.51x | 0.56x |
+| prefill_causal 512 | 49.15 | 49.15 | — | 103.95 | 43.17 | 0.47x | 0.42x |
+| prefill_causal 1024 | 100.86 | 96.77 | 3297.28 | 627.66 | 102.11 | 0.15x | 0.16x |
+| prefill_causal 2048 | 272.38 | 272.38 | — | 2021.38 | 297.98 | 0.13x | 0.15x |
+| prefill_causal 4096 | 772.10 | 766.98 | 49837.06 | 7477.25 | 887.29 | 0.10x | 0.12x |
+| prefill_causal 8192 | 2959.36 | 2984.96 | — | 198784.00 | 3499.08 | 0.02x | 0.02x |
+| prefill_causal 16384 | 10240.00 | 10198.02 | — | 711098.39 | 13229.56 | 0.01x | 0.02x |
+| prefill_gqa 256 | 31.74 | 31.74 | — | 65.26 | 28.61 | 0.49x | 0.44x |
+| prefill_gqa 512 | 58.37 | 57.09 | 546.82 | 328.19 | 64.10 | 0.17x | 0.20x |
+| prefill_gqa 1024 | 152.58 | 150.53 | — | 1043.46 | 173.06 | 0.14x | 0.17x |
+| prefill_gqa 2048 | 424.96 | 411.65 | 5637.12 | 3658.75 | 488.70 | 0.11x | 0.13x |
+| prefill_gqa 4096 | 1531.90 | 1531.90 | — | 10569.73 | 1667.73 | 0.14x | 0.16x |
+| prefill_gqa 8192 | 5177.34 | 5180.42 | — | 354388.98 | 6796.48 | 0.01x | 0.02x |
+| prefill_gqa 16384 | 20008.96 | 19987.46 | 1574933.47 | — | 26118.12 | — | — |
+
+The three sequence-32768 prefill setups and `prefill_gqa 16384` produced no Emmy replay: the lane's ten-minute
+per-setup budget expires while the kernel is still running. Their goldens exist and their targets are pinned, so
+they are unmeasured rather than untuned.
+
+### Conclusion
+
+Two things changed against the 2026-08-16 run. All sixteen decode setups now pass strict Emmy-vs-eager
+correctness — the earlier failure was an SDPA decomposition that read the key length off the query, so decode
+scored only the first key — and tuning is worth 1.2x to 6.6x on the prefill families it reaches
+(`prefill_global 2048` 12595 → 1991 µs, `prefill_causal 4096` 49837 → 7477 µs).
+
+Emmy is nevertheless behind on every one of the 36 measured setups: 0.03x–0.59x of Neptune and 0.01x–0.52x of
+current torch.compile. The gap is smallest at sequence 256–512 (roughly 0.5x) and widens with context, because
+Emmy's attention still materializes the full score matrix — its two post-fusion targets are a scores/statistics
+kernel and a softmax·V kernel — while Neptune, FlashInfer, and the SDPA library backends all run a fused streaming
+attention that never writes it. That is an algorithm the compiler does not yet express, not a schedule the tuner
+can find: correcting the decode key length made decode correct and 3–10x slower than the incorrect version, which
+is the same wall from the other side.
+
+### Limitations
+
+- One card, one batch size, one head dimension; minimum-of-15 with a single warmup, matching the artifact.
+- The Neptune column is replayed from the 2026-08-16 archive rather than re-measured, so it carries that run's
+  software stack (PyTorch 2.6.0 inside the pinned image) while this arm is PyTorch 2.13.0.
+- The `emmy untuned` column comes from the reference arm's greedy deploy in the same process; it is blank where
+  that arm failed strict and the PyTorch-only fallback supplied eager and Inductor.
+- Four setups are unmeasured on the Emmy side (above); their rows are not evidence of a result either way.
+
+### Run and system
+
+- Status: succeeded (5/5 rows)
+- Result timestamp: 2026-08-21T16:20:56Z; run ID: `20260821T162056Z`
+- Rows: decode_causal `9f8816b4a4fb`, decode_gqa `a5484cfcec5d`, prefill_causal `606182d43644`,
+  prefill_global `c40c2a24baf1`, prefill_gqa `2df1673a2808`
+- Git revision: `080bde08`; dirty: false
+- GPU: NVIDIA A100-SXM4-80GB, UUID `GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`; PyTorch 2.13.0+cu130
+- Raw-results archive: `results_emmy_a100x1.tar.gz`; archived root `2026-08-21_16-20-56/`
+
 ## Protocol and limitations
 
 - Neptune ran revision `3aa55c12ac822337e630b809b0d9eabb11eee5d3` in the pinned image

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s1024.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s1024.golden.yaml
@@ -1,0 +1,301 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_5d9078.86f7ec81a812
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop/r2
+      STAGE: ''
+      TILE: ''
+      WORK: t128
+    measurements:
+      emmy_us: 24.3512
+      reference_us: 130.048
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_13dc30.f55ec127ee29
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t1024
+    measurements:
+      emmy_us: 54.2151
+      reference_us: 173.056
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_5d9078
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 1024]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 1024]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_13dc30
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s16384.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s16384.golden.yaml
@@ -1,0 +1,290 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_4c376a.ac322438d3ca
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t64
+    measurements:
+      emmy_us: 402.432
+      reference_us: 390.144
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_97792a.4f52299530a5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_4c376a
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 16384]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 16384]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_97792a
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s2048.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s2048.golden.yaml
@@ -1,0 +1,301 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_3e4bb5.423404062ef4
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop/r2
+      STAGE: ''
+      TILE: ''
+      WORK: t128
+    measurements:
+      emmy_us: 46.8114
+      reference_us: 118.784
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_ee531f.dcf10a113e39
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t1024
+    measurements:
+      emmy_us: 106.1547
+      reference_us: 210.944
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_3e4bb5
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 2048]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 2048]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_ee531f
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s256.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s256.golden.yaml
@@ -1,0 +1,279 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_b00b13.57395ef905b5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_2ec466.dce8bd94803f
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_b00b13
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 256]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 256]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_2ec466
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s32768.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s32768.golden.yaml
@@ -1,0 +1,290 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_21d43c.69391f1fc66a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t64
+    measurements:
+      emmy_us: 801.792
+      reference_us: 769.024
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_9d6ebb.22edd8493192
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_21d43c
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 32768]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 32768]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_9d6ebb
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s4096.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s4096.golden.yaml
@@ -1,0 +1,290 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_0c5081.7cfb46545da9
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop/r2
+      STAGE: ''
+      TILE: ''
+      WORK: t128
+    measurements:
+      emmy_us: 94.7665
+      reference_us: 161.792
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_03f0c3.3b8c94cac09d
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_0c5081
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 4096]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 4096]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_03f0c3
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s512.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s512.golden.yaml
@@ -1,0 +1,290 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_52c54c.d2ea078f08b4
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop/r2
+      STAGE: ''
+      TILE: ''
+      WORK: t128
+    measurements:
+      emmy_us: 13.0829
+      reference_us: 134.144
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_abd303.6df36c98373e
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_52c54c
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 512]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 512]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_abd303
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s8192.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_causal-b1-s8192.golden.yaml
@@ -1,0 +1,290 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_b30180.75f6e2e9788e
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop/r2
+      STAGE: ''
+      TILE: ''
+      WORK: t128
+    measurements:
+      emmy_us: 187.5968
+      reference_us: 221.184
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_73d500.fa5193c2857c
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: k
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: q
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        values: {tuple: [v1]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_b30180
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 8192]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1, 8192]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in0]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: in0
+                        op: {elementwise: maximum}
+                        dtype: null
+                        axes: {tuple: [a1]}
+                        base: null
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names: {tuple: [in1]}
+                        input: scaled_dot_product_attention_scaled
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a1}}
+                        dtype: null
+                    - class: Assign
+                      fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                    - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                    - class: Accum
+                      fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a1]}, base: null}
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+              - class: Assign
+                fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a2, extent: {dim: 128}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a3}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                          - class: Assign
+                            fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: v
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a3}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                          - class: Accum
+                            fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: scaled_dot_product_attention
+                        index:
+                          tuple:
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a0}}
+                          - {expr: {literal: {value: 0, dtype: int}}}
+                          - {expr: {var: a2}}
+                        values: {tuple: [acc2]}
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_73d500
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s1024.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s1024.golden.yaml
@@ -1,0 +1,76 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 1024, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 1024, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 1024, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 1024, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_145281.c89c866da112
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      WORK: w2x1
+    measurements:
+      emmy_us: 37.0759
+      reference_us: 197.4918
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_033a3e.d74afc99d28d
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s16384.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s16384.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 16384, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 16384, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 16384, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 16384, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_1dc7b9.e21bb16e0179
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_8e261c.d852dd1ff622
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s2048.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s2048.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 2048, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 2048, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 2048, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 2048, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_121651.b460607ef546
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_9a6457.0f307d57b54b
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s256.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s256.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 256, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 256, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 256, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 256, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_e7adee.aeced1dcf48b
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_10e9fb.3b6c5386359e
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s32768.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s32768.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 32768, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 32768, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 32768, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 32768, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_2df32e.0b00fb4f7cf6
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_5e8ce2.853df611f190
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s4096.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s4096.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 4096, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 4096, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 4096, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 4096, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_76e265.ea6aab5411f1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_93ce6e.692b0d01e13a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s512.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s512.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 512, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 512, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 512, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 512, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_282a00.9857b11a4684
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_447e3c.cb7e25298a75
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s8192.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/decode_gqa-b1-s8192.golden.yaml
@@ -1,0 +1,65 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [reshape_3]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 8, 1, 128]}}
+    inputs: [q]
+    outputs: [[reshape, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 8192, 128]}}
+    inputs: [k]
+    outputs: [[reshape_1, f16, [1, 8, 1, 8192, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 8192, 128]]]
+  - id: reshape_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 8, 1, 8192, 128]}}
+    inputs: [v]
+    outputs: [[reshape_2, f16, [1, 8, 1, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [reshape, reshape_1, reshape_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 8, 1, 128]]]
+  - id: reshape_3
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 64, 1, 128]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[reshape_3, f16, [1, 64, 1, 128]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - reshape
+    - reshape_1
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_30ceb8.4f87b05ec9ab
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - reshape_2
+    - reshape_3
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_reduce_43ccca.885fbb668e92
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s1024.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s1024.golden.yaml
@@ -1,0 +1,390 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1024, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_fa8c5d.55dd8237906a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 112.1849
+      reference_us: 3643.3921
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_9d6982.b707348b36ce
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_fa8c5d
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1024, 1024]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1024, 1024]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 1024}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_9d6982
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1024, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s16384.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s16384.golden.yaml
@@ -1,0 +1,379 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 16384, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_bb44f0.256eea723cbb
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_7ae42f.1d1a09787c6d
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_bb44f0
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 16384, 16384]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 16384, 16384]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 16384}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_7ae42f
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 16384, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s2048.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s2048.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 2048, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_0e2b1e.d4fc7531d63c
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 401.408
+      reference_us: 11945.9839
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_96a0e4.5681f203dc3f
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 1666.048
+      reference_us: 1741.824
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_0e2b1e
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 2048, 2048]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 2048, 2048]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 2048}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_96a0e4
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 2048, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s256.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s256.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 256, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_dd8461.8022c1e36c9a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 12.3386
+      reference_us: 158.72
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_0e288e.5847f1a513e7
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w8x2
+    measurements:
+      emmy_us: 23.552
+      reference_us: 157.696
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_dd8461
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 256, 256]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 256, 256]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 256}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_0e288e
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 256, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s32768.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s32768.golden.yaml
@@ -1,0 +1,379 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 32768, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_862a54.c4e17ba35fef
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_fa474a.fbddfa61ff32
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_862a54
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 32768, 32768]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 32768, 32768]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 32768}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_fa474a
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 32768, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s4096.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s4096.golden.yaml
@@ -1,0 +1,390 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 4096, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_64d6cb.c6053f464198
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 1564.672
+      reference_us: 46171.1349
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_e59314.f7255a951512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_64d6cb
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 4096, 4096]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 4096, 4096]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 4096}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_e59314
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 4096, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s512.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s512.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 512, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_743d90.6aefd5da2652
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 35.4377
+      reference_us: 191.488
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_43c290.6791ada8b4d6
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w16x2
+    measurements:
+      emmy_us: 61.184
+      reference_us: 160.768
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_743d90
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 512, 512]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 512, 512]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 512}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_43c290
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 512, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s8192.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_causal-b1-s8192.golden.yaml
@@ -1,0 +1,379 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 8192, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_3529d5.eaa4e4e57f38
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_9c0346.c905db1737bf
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_3529d5
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 8192, 8192]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 8192, 8192]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 8192}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_9c0346
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 8192, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s1024.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s1024.golden.yaml
@@ -1,0 +1,317 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1024, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1024, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_fa8c5d.55dd8237906a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 112.1849
+      reference_us: 3752.96
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_8d64a2.99a082e1aaaf
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 483.328
+      reference_us: 786.432
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_fa8c5d
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1024, 1024]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 1024, 1024]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 1024}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_8d64a2
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 1024, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s16384.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s16384.golden.yaml
@@ -1,0 +1,295 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 16384, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 16384, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_bb44f0.256eea723cbb
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_90015d.55dcd90288cd
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_bb44f0
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 16384, 16384]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 16384, 16384]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 16384}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_90015d
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 16384, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s2048.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s2048.golden.yaml
@@ -1,0 +1,317 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 2048, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 2048, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_0e2b1e.d4fc7531d63c
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 401.408
+      reference_us: 12199.9359
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_521df8.de5b8233d89d
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 1576.96
+      reference_us: 2037.76
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_0e2b1e
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 2048, 2048]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 2048, 2048]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 2048}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_521df8
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 2048, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s256.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s256.golden.yaml
@@ -1,0 +1,317 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 256, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 256, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_dd8461.8022c1e36c9a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 12.3133
+      reference_us: 194.56
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_819e18.344b5f299240
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w8x2
+    measurements:
+      emmy_us: 19.8451
+      reference_us: 568.32
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_dd8461
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 256, 256]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 256, 256]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 256}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_819e18
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 256, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s32768.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s32768.golden.yaml
@@ -1,0 +1,295 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 32768, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 32768, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_862a54.c4e17ba35fef
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_02b2f2.876504422c97
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_862a54
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 32768, 32768]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 32768, 32768]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 32768}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_02b2f2
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 32768, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s4096.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s4096.golden.yaml
@@ -1,0 +1,306 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 4096, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 4096, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_64d6cb.c6053f464198
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 1563.648
+      reference_us: 46228.4813
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_4721e6.6861d9f1b18d
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_64d6cb
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 4096, 4096]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 4096, 4096]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 4096}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_4721e6
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 4096, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s512.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s512.golden.yaml
@@ -1,0 +1,317 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 512, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 512, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_743d90.6aefd5da2652
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 35.4743
+      reference_us: 209.92
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_b1f986.f9e76ccc6332
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w16x2
+    measurements:
+      emmy_us: 54.0444
+      reference_us: 467.968
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_743d90
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 512, 512]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 512, 512]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 512}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_b1f986
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 512, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s8192.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_global-b1-s8192.golden.yaml
@@ -1,0 +1,295 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 8192, 128]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 8192, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_3529d5.eaa4e4e57f38
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_2dae2a.c20441129182
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 32, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_3529d5
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 8192, 8192]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 32, 8192, 8192]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 32, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 32}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in0]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: in0
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names: {tuple: [in1]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v0, op: {elementwise: subtract}, args: {tuple: [in1, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v1, op: {elementwise: exp}, args: {tuple: [v0]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v1, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v2, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 8192}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v3, op: {elementwise: subtract}, args: {tuple: [in2, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v4, op: {elementwise: exp}, args: {tuple: [v3]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v5, op: {elementwise: multiply}, args: {tuple: [v2, v4]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v6, op: {elementwise: multiply}, args: {tuple: [in3, v5]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v6, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_2dae2a
+    inputs: [scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 32, 8192, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s1024.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s1024.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1024, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 1024, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_aff2b4.bc0e9935ff51
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 213.1968
+      reference_us: 1327.104
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_324620.411b975d8c64
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 827.392
+      reference_us: 892.928
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 1024, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 1024, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_aff2b4
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 1024, 1024]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 1024, 1024]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 1024, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 1024}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 1024}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 1024}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_324620
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 1024, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s16384.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s16384.golden.yaml
@@ -1,0 +1,379 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 16384, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 16384, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_40a2fc.680d71dc7c75
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_b05372.44dc9e754c36
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 16384, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 16384, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_40a2fc
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 16384, 16384]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 16384, 16384]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 16384, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 16384}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 16384}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 16384}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_b05372
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 16384, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s2048.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s2048.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 2048, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 2048, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_da0d85.1a9bc8bd6ae5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      WORK: w1x8
+    measurements:
+      emmy_us: 786.432
+      reference_us: 3520.5121
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_ea07bf.dc0cba60d104
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 2874.368
+      reference_us: 3024.8959
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 2048, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 2048, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_da0d85
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 2048, 2048]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 2048, 2048]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 2048, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 2048}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_ea07bf
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 2048, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s256.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s256.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 256, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 256, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_6d8b07.8c771b7ddcc4
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 21.7489
+      reference_us: 202.752
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_6f5cf3.cc862d0949fa
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w16x2
+    measurements:
+      emmy_us: 43.3197
+      reference_us: 214.016
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 256, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 256, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_6d8b07
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 256, 256]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 256, 256]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 256, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 256}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 256}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 256}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_6f5cf3
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 256, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s32768.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s32768.golden.yaml
@@ -1,0 +1,379 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 32768, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 32768, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_309141.4851da733fc4
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_e9fa78.f5c1a117e972
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 32768, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 32768, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_309141
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 32768, 32768]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 32768, 32768]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 32768, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 32768}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 32768}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 32768}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_e9fa78
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 32768, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s4096.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s4096.golden.yaml
@@ -1,0 +1,390 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 4096, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 4096, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_74e2da.8478ad47cfd3
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_faa606.d225d23d7c51
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w4x2
+    measurements:
+      emmy_us: 10946.5599
+      reference_us: 10946.5599
+      reference_backend: emmy-greedy
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 4096, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 4096, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_74e2da
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 4096, 4096]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 4096, 4096]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 4096, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 4096}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_faa606
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 4096, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s512.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s512.golden.yaml
@@ -1,0 +1,401 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 512, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 512, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_2d50f2.2782123f9381
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d2/smem-async
+      TILE: mma_m16n8k16_f16_f32/f8x4/k8
+      WORK: w1x2
+    measurements:
+      emmy_us: 62.656
+      reference_us: 1483.776
+      reference_backend: emmy-reference
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_b50418.333141ff0705
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 266.24
+      reference_us: 359.424
+      reference_backend: emmy-reference
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 512, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 512, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_2d50f2
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 512, 512]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 512, 512]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 512}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_b50418
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 512, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s8192.golden.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/golden/prefill_gqa-b1-s8192.golden.yaml
@@ -1,0 +1,379 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 8192, 128]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [q, k, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 8192, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_reduce_1631d3.a2295dc30408
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    loop: 1
+  realizations:
+  - name: k_sdpa_reduce_5c3732.1b572d67ea86
+    bindings: {}
+    pins:
+      FAST_MATH: false
+loops:
+- inputs: [k, q]
+  outputs: [scaled_dot_product_attention_scaled]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 8, 8192, 128]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 64, 8192, 128]]]
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: k
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: q
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              values: {tuple: [v1]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_1631d3
+    inputs: [scaled_dot_product_attention_scale, k, q]
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 8192, 8192]]]
+- inputs: [scaled_dot_product_attention_scaled, v]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_mask_fill_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_fill_c
+      value: -1000000000.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
+  - id: scaled_dot_product_attention_mask_zero_c
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_mask_zero_c
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
+  - id: scaled_dot_product_attention_scaled
+    op: input
+    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 64, 8192, 8192]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 8, 8192, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_mask_fill_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Load
+          fields:
+            names: {tuple: [in1]}
+            input: scaled_dot_product_attention_mask_zero_c
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 64}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 8192}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v0
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in2]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2]}
+                              base: null
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 8192}, window: null}}
+                        body:
+                          body:
+                          - class: Select
+                            fields:
+                              name: v2
+                              branches:
+                                tuple:
+                                - class: SelectBranch
+                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
+                                - class: SelectBranch
+                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
+                          - class: Load
+                            fields:
+                              names: {tuple: [in3]}
+                              input: scaled_dot_product_attention_scaled
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a2}}
+                              dtype: null
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 8192}, window: null}}
+                              body:
+                                body:
+                                - class: Select
+                                  fields:
+                                    name: v7
+                                    branches:
+                                      tuple:
+                                      - class: SelectBranch
+                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
+                                      - class: SelectBranch
+                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: scaled_dot_product_attention_scaled
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in5]}
+                                    input: v
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {binary: {op: /, left: {var: a0}, right: {literal: {value: 8, dtype: int}}}}}
+                                      - {expr: {var: a4}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
+                              unroll: false
+                              role: {axis_role: free}
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a3}}
+                              values: {tuple: [acc2]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        role: {axis_role: free}
+                        seed: true
+                  unroll: false
+                  role: {axis_role: free}
+                  seed: true
+            unroll: false
+            role: {axis_role: free}
+            seed: true
+      name: k_sdpa_reduce_5c3732
+    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, v]
+    outputs: [[scaled_dot_product_attention, f16, [1, 64, 8192, 128]]]
+gpu_name: NVIDIA A100 80GB

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
@@ -15,6 +15,12 @@
 #   neptune  the pinned artifact's own tune + Nsight profile for one operator (10 operators)
 #   emmy     bench eager / torch.compile / Emmy, with Emmy replaying a pre-tuned golden (5 operators)
 #
+# The emmy lane runs two arms per setup: the golden replay times the committed tuned schedules, and
+# a `emmy run -c` reference arm supplies eager, torch.compile, and the strict Emmy-vs-eager
+# correctness proof. They are separate because `emmy trace --code` stores a single-op program's
+# post-fusion targets as Loop IR — every kernel of an SDPA snippet shares one provenance selector —
+# and a Loop IR target carries no torch twin to compare against.
+#
 # Tuning happens outside this recipe, through the tune-kernels skill: trace each setup from
 # operators.sh (`./operators.sh OPERATOR SEQUENCE_LENGTH` prints the exact module source this
 # experiment benches), tune the working golden on an A100, and commit the validated result under

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/results_emmy_a100x1.tar.gz
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/results_emmy_a100x1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccdffd8c5a5837b27489cc394d6f49022ccac8dd8b73ce678bc6e376575c6a1a
+size 4691381

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 # Comparison lane: bench one common attention operator's sequence sweep as
-# eager PyTorch / torch.compile / Emmy. Emmy replays the setup's committed golden, so this lane only
-# measures — the search happens outside the recipe, through the tune-kernels skill. The greedy row in
-# each record remains untuned Emmy; the golden's pinned rows carry the searched schedules, re-measured
-# here at -O3.
+# eager PyTorch / torch.compile / Emmy. Two arms per setup:
+#
+#   replay     `emmy run --golden` re-measures the setup's committed tuned schedules at -O3.
+#              `emmy trace --code` stores a single-op program's post-fusion targets as Loop IR
+#              (every kernel shares one provenance selector), and a Loop IR target has no torch
+#              twin, so this arm times Emmy only — the reference and the correctness gate are the
+#              second arm's job.
+#   reference  `emmy run -c` re-traces the same snippet and benches eager, torch.compile, and the
+#              UNTUNED Emmy deploy under --strict, so every setup carries an eager reference, an
+#              Inductor reference, and a direct Emmy-vs-eager correctness proof. When that arm
+#              fails, run_pytorch.py still preserves the two PyTorch references on their own.
+#
+# The search happens outside the recipe, through the tune-kernels skill.
 set -euo pipefail
 
 if [ "$#" -ne 4 ]; then
@@ -22,7 +31,7 @@ source "$here/operators.sh"
 
 mkdir -p "$results/json" "$results/dumps" "$results/logs"
 status_file=$results/setup-status.tsv
-printf "operator\tsequence_length\tstatus\n" > "$status_file"
+printf "operator\tsequence_length\treplay\treference\n" > "$status_file"
 successful_setups=0
 missing_goldens=0
 
@@ -30,33 +39,42 @@ for sequence_length in "${SEQUENCE_LENGTHS[@]}"; do
   setup="${operator}-b1-s${sequence_length}"
   golden=$golden_dir/$setup.golden.yaml
   if [ ! -f "$golden" ]; then
-    printf "%s\t%s\t%s\n" "$operator" "$sequence_length" "missing-golden" >> "$status_file"
+    printf "%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" "missing-golden" "skipped" >> "$status_file"
     missing_goldens=$((missing_goldens + 1))
     continue
   fi
+  source_code=$(operator_code "$operator" "$sequence_length")
 
   # --json takes a path per target: a file for a single-target golden, a directory when the
   # traced program lowered to several post-fusion kernels.
   if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
-    "$emmy" run --golden "$golden" --bench --strict \
-    --bench-backends eager,tcompile,emmy --warmup 1 --iters 15 --no-record-nodes \
+    "$emmy" run --golden "$golden" --bench --bench-backends emmy \
+    --warmup 1 --iters 15 --no-record-nodes \
     --json "$results/json/$setup" --dump-dir "$results/dumps/$setup" \
     2>&1 | tee "$results/logs/$setup.log"; then
-    status=ok
+    replay=ok
     successful_setups=$((successful_setups + 1))
   else
-    emmy_status=$?
+    replay="failed:$?"
+  fi
+
+  if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
+    "$emmy" run -c "$source_code" --bench --strict --bench-backends eager,tcompile,emmy \
+    --warmup 1 --iters 15 --no-record-nodes --json "$results/json/$setup.reference.json" \
+    2>&1 | tee "$results/logs/$setup.reference.log"; then
+    reference=ok
+  else
+    reference_status=$?
     if timeout --signal=TERM --kill-after=30s 600s \
       "$python" "$pytorch_runner" "$operator" "$sequence_length" \
       --warmup 1 --iters 15 --json "$results/json/$setup.pytorch.json" \
       2>&1 | tee "$results/logs/$setup.pytorch.log"; then
-      status="pytorch-only:emmy-failed:$emmy_status"
-      successful_setups=$((successful_setups + 1))
+      reference="pytorch-only:emmy-failed:$reference_status"
     else
-      status="failed:emmy=$emmy_status,pytorch=$?"
+      reference="failed:emmy=$reference_status,pytorch=$?"
     fi
   fi
-  printf "%s\t%s\t%s\n" "$operator" "$sequence_length" "$status" >> "$status_file"
+  printf "%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" "$replay" "$reference" >> "$status_file"
 done
 
 # A missing golden is a broken lane input, not a measurement: fail rather than silently

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -55,6 +55,107 @@ concrete per kernel, per card.
 5. Host provisioning traps (recorded for reuse): fresh CloudRift boxes need `apt-get update` before
    `python3.12-venv`; V100 needs torch cu126 + `cupy-cuda12x==13.6.0` + `fastrlock` (nvrtc 13 dropped Volta).
 
+## Platform a100x1 — replayed tuned golden (2026-08-21)
+
+### Question
+
+Does a fully tuned committed golden change the A100 picture for the common corpus, and which kernels does the
+tuner still fail to reach? This is the first `common` row that replays a committed golden instead of searching
+inside the recipe, so the searched schedules and the measured schedules are the same by construction.
+
+### Protocol
+
+Both rows replay `golden/qwen3-06b-s{1,512}_a100.golden.yaml` and run five fresh `emmy run --golden ... --bench
+--strict --bench-backends eager,tcompile,emmy --warmup 10 --iters 100` processes with an empty per-task tuning DB,
+online checkpoint, and cubin cache. The goldens came from a hybrid search on the same A100: `emmy trace` inventory,
+agent-proposed warp/staged and cooperative rows from the card's own knob vocabulary, `emmy tune --max-candidates 48
+--patience 12 --seed 0` per target, then a deployable `-O3` A/B of the searched winner and every measured proposal
+against a cold greedy pick. A realization is committed only when it replays a knob map that every one of the
+target's CUDA kernels realized, and only when it beat that cold greedy pick; the other targets keep an inventory
+realization and deploy the greedy schedule.
+
+### Per-kernel result (median of five processes, µs)
+
+`untuned` is the cold greedy pick re-benched in the same process; `tuned` is the committed realization where one
+exists and the greedy pick otherwise.
+
+| seq | target | role | eager | torch.compile | untuned | tuned | vs eager | vs tcompile |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 512 | k_mean_20f978 | input RMSNorm | 191.89 | 9.12 | 3.83 | 3.17 | 60.54x | 2.88x |
+| 512 | k_linear_reduce_06a42b | v_proj | 11.78 | 12.37 | 74.67 | 17.50 | 0.67x | 0.71x |
+| 512 | k_linear_1fd3d5 | q_proj + reshape to heads | 100.79 | 21.65 | 133.41 | 22.32 | 4.52x | 0.97x |
+| 512 | k_linear_a09c5a | k_proj + reshape to heads | 59.86 | 14.73 | 69.92 | 17.28 | 3.46x | 0.85x |
+| 512 | k_sdpa_linear_reduce_c0a378 | softmax·V, computed V | 45.74 | 46.12 | 160.26 | 160.26 | 0.29x | 0.29x |
+| 512 | k_linear_sdpa_reduce_e24efe | o_proj + residual | 60.25 | 61.23 | 315.39 | 315.39 | 0.19x | 0.19x |
+| 512 | k_linear_mean_reduce_dc067d | post-attn norm + gate/up + SiLU | 246.94 | 50.25 | 67.17 | 67.24 | 3.67x | 0.75x |
+| 512 | k_linear_6b4b5f | down_proj + residual | 32.09 | 37.21 | 243.46 | 46.67 | 0.69x | 0.80x |
+| 512 | k_sdpa_mean_reduce_29d3df | q/k norm + RoPE + scores + softmax stats | 745.56 | failed | 21094.40 | 21094.40 | 0.04x | — |
+| 1 | k_mean_b8e46d | input RMSNorm | 121.83 | 2.92 | 3.06 | 2.38 | 51.24x | 1.23x |
+| 1 | k_linear_reduce_7ef15d | v_proj | 7.38 | 7.25 | 11.21 | 4.74 | 1.56x | 1.53x |
+| 1 | k_linear_49a16b | q_proj + reshape to heads | 35.02 | 6.79 | 21.57 | 4.84 | 7.23x | 1.40x |
+| 1 | k_linear_dfb21f | k_proj + reshape to heads | 33.65 | 5.26 | 11.17 | 4.74 | 7.10x | 1.11x |
+| 1 | k_sdpa_linear_reduce_d0f5c0 | softmax·V, computed V | 11.92 | 10.63 | 104.68 | 104.68 | 0.11x | 0.10x |
+| 1 | k_linear_sdpa_reduce_14c8c7 | o_proj + residual | 14.04 | 12.16 | 111.62 | 111.62 | 0.13x | 0.11x |
+| 1 | k_linear_mean_reduce_549927 | post-attn norm + gate/up + SiLU | 154.62 | 16.38 | 3614.72 | 393.22 | 0.39x | 0.04x |
+| 1 | k_linear_2dcd0c | down_proj + residual | 9.49 | 7.72 | 34.00 | 9.46 | 1.00x | 0.82x |
+| 1 | k_sdpa_mean_reduce_0a2624 | q/k norm + RoPE + scores + softmax stats | 334.78 | failed | 115.71 | 115.71 | 2.89x | — |
+
+Layer totals as the sum of those medians: sequence 512 is 1494.89 eager, 252.68 Inductor, 21744.23 Emmy; sequence 1
+is 722.74 eager, 69.12 Inductor, 751.38 Emmy. Tuning moved the sequence-1 layer from 4027.74 to 751.38 µs (5.4x) and
+the sequence-512 layer from 22162.51 to 21744.23 µs — 1.6x once the one unreachable attention kernel is set aside
+(1068.11 to 649.83 µs over the other eight targets).
+
+### Repeat variation
+
+Every measured target's five paired latencies agree to within 0.4% of their median, and the pinned realizations
+reproduce their tuning-time -O3 measurement to within 0.5%. The dominant sequence-512 attention kernel varies by
+0.2% across repeats, so the layer total is not noise-limited anywhere.
+
+### Conclusion
+
+Tuning is decisive on the projections and the norms and is completely blocked on the fused attention kernels.
+Emmy now beats eager on 11 of 18 targets and matches or beats current-PyTorch Inductor on 6 (both norms, all three
+sequence-1 projections, and sequence-512 q_proj within 3%). Every remaining loss is one of three structural cases:
+
+1. The sequence-512 online-softmax statistics kernel runs a scalar `t128`/`coop` fold at 21.1 ms against 745 µs
+   eager. No proposal or searched candidate reaches a warp tier: the target lowers to two CUDA kernels whose
+   schedule knobs disagree, so no single pinned map replays it, and every partial pin comes back `pin_unmatched`
+   or `ambiguous_multi_kernel`.
+2. `softmax·V` and `o_proj + residual` lower to three CUDA kernels each with disagreeing knobs, so the golden format
+   (one knob map per realization) cannot carry any searched schedule for them. They deploy the greedy pick.
+3. The remaining projection losses (v_proj and down_proj at 512, down_proj at 1) are code-generation quality: the
+   correct staged warp tier is reached and still trails cuBLAS by 1.2–1.5x.
+
+### Limitations
+
+- Layer-0 evidence only, one model, one card; never a whole-model claim.
+- Both rows report `failed`. `torch.compile` cannot compile the reference for `k_sdpa_mean_reduce` on PyTorch
+  2.13.0 (`InductorError: ValueError: The argument '((0)) + 64' is not comparable` from `sizevars._stride_vars`),
+  so `--strict` rejects that target in every repeat. That target is ordered last in both goldens, so the other
+  eight still measure in all five processes; without that ordering `emmy run` exits at the failing target and drops
+  every later one.
+- The Inductor column is missing for that one target on both sequence lengths, so a geometric mean over the full
+  corpus is not available for this platform; the eight-target denominator is stated explicitly above.
+- The five repeats share one deployed host and run back to back, so they capture process-level and not day-level
+  variation.
+
+### Run and system
+
+- Status: failed (2/2 rows, `torch.compile` reference unavailable on one target; all other targets measured)
+- Result timestamp: 2026-08-21T00:31:35Z; run ID: `20260821T003135Z`
+- Rows: `...sl1_scommon` (row ID `551082cef77b`, 459.03 s) and `...sl512_scommon` (row ID `3a4d139974b8`, 2005.02 s)
+- Git revision: `20569845` (working tree clean at staging)
+- Host: `riftvm`; Ubuntu 24.04.1 LTS; kernel `6.8.0-51-generic`; AMD EPYC 7742 64-Core Processor
+- GPU: NVIDIA A100-SXM4-80GB, UUID `GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`
+- Host NVCC `12.9.86`; cuBLAS `12.9.1.4`; PyTorch 2.13.0+cu130
+
+### Durable files
+
+- Raw-results archive: `results_a100x1.tar.gz`; archived root `2026-08-21_00-31-35/`
+- Members: both `*.experiment.yaml` records, both `*_artifacts.tar.gz` task archives (traces, per-repeat
+  verification JSON per target, per-repeat logs and exit statuses, package freeze), and the two runner logs
+- Committed goldens: `golden/qwen3-06b-s1_a100.golden.yaml`, `golden/qwen3-06b-s512_a100.golden.yaml`
+
 ## Platform sections
 
 ### rtx5090x1

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -69,10 +69,15 @@ Both rows replay `golden/qwen3-06b-s{1,512}_a100.golden.yaml` and run five fresh
 --strict --bench-backends eager,tcompile,emmy --warmup 10 --iters 100` processes with an empty per-task tuning DB,
 online checkpoint, and cubin cache. The goldens came from a hybrid search on the same A100: `emmy trace` inventory,
 agent-proposed warp/staged and cooperative rows from the card's own knob vocabulary, `emmy tune --max-candidates 48
---patience 12 --seed 0` per target, then a deployable `-O3` A/B of the searched winner and every measured proposal
-against a cold greedy pick. A realization is committed only when it replays a knob map that every one of the
-target's CUDA kernels realized, and only when it beat that cold greedy pick; the other targets keep an inventory
-realization and deploy the greedy schedule.
+--patience 12 --seed 0` per target with a 900-second per-target wall budget, then a deployable `-O3` A/B of the
+searched winner and every measured proposal against a cold greedy pick. A realization is committed only when it
+replays a knob map that every one of the target's CUDA kernels realized, and only when it beat that cold greedy
+pick; the other targets keep an inventory realization and deploy the greedy schedule.
+
+The sequence-512 attention statistics target re-keyed when fusion learned to refuse a per-step statistic chained
+into a fold inside a free sweep: it now splits into two gather kernels, a k-norm/RoPE kernel, and an mma score
+kernel. Those four targets were tuned fresh; every other realization carried its earlier committed schedule over
+verbatim and was re-measured beside the fresh ones.
 
 ### Per-kernel result (median of five processes, µs)
 
@@ -81,79 +86,85 @@ exists and the greedy pick otherwise.
 
 | seq | target | role | eager | torch.compile | untuned | tuned | vs eager | vs tcompile |
 | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 512 | k_mean_20f978 | input RMSNorm | 191.89 | 9.12 | 3.83 | 3.17 | 60.54x | 2.88x |
-| 512 | k_linear_reduce_06a42b | v_proj | 11.78 | 12.37 | 74.67 | 17.50 | 0.67x | 0.71x |
-| 512 | k_linear_1fd3d5 | q_proj + reshape to heads | 100.79 | 21.65 | 133.41 | 22.32 | 4.52x | 0.97x |
-| 512 | k_linear_a09c5a | k_proj + reshape to heads | 59.86 | 14.73 | 69.92 | 17.28 | 3.46x | 0.85x |
-| 512 | k_sdpa_linear_reduce_c0a378 | softmax·V, computed V | 45.74 | 46.12 | 160.26 | 160.26 | 0.29x | 0.29x |
-| 512 | k_linear_sdpa_reduce_e24efe | o_proj + residual | 60.25 | 61.23 | 315.39 | 315.39 | 0.19x | 0.19x |
-| 512 | k_linear_mean_reduce_dc067d | post-attn norm + gate/up + SiLU | 246.94 | 50.25 | 67.17 | 67.24 | 3.67x | 0.75x |
-| 512 | k_linear_6b4b5f | down_proj + residual | 32.09 | 37.21 | 243.46 | 46.67 | 0.69x | 0.80x |
-| 512 | k_sdpa_mean_reduce_29d3df | q/k norm + RoPE + scores + softmax stats | 745.56 | failed | 21094.40 | 21094.40 | 0.04x | — |
-| 1 | k_mean_b8e46d | input RMSNorm | 121.83 | 2.92 | 3.06 | 2.38 | 51.24x | 1.23x |
-| 1 | k_linear_reduce_7ef15d | v_proj | 7.38 | 7.25 | 11.21 | 4.74 | 1.56x | 1.53x |
-| 1 | k_linear_49a16b | q_proj + reshape to heads | 35.02 | 6.79 | 21.57 | 4.84 | 7.23x | 1.40x |
-| 1 | k_linear_dfb21f | k_proj + reshape to heads | 33.65 | 5.26 | 11.17 | 4.74 | 7.10x | 1.11x |
-| 1 | k_sdpa_linear_reduce_d0f5c0 | softmax·V, computed V | 11.92 | 10.63 | 104.68 | 104.68 | 0.11x | 0.10x |
-| 1 | k_linear_sdpa_reduce_14c8c7 | o_proj + residual | 14.04 | 12.16 | 111.62 | 111.62 | 0.13x | 0.11x |
-| 1 | k_linear_mean_reduce_549927 | post-attn norm + gate/up + SiLU | 154.62 | 16.38 | 3614.72 | 393.22 | 0.39x | 0.04x |
-| 1 | k_linear_2dcd0c | down_proj + residual | 9.49 | 7.72 | 34.00 | 9.46 | 1.00x | 0.82x |
-| 1 | k_sdpa_mean_reduce_0a2624 | q/k norm + RoPE + scores + softmax stats | 334.78 | failed | 115.71 | 115.71 | 2.89x | — |
+| 512 | k_mean_20f978 | input RMSNorm | 191.88 | 8.89 | 3.83 | 3.17 | 60.59x | 2.81x |
+| 512 | k_linear_reduce_06a42b | v_proj | 12.12 | 12.54 | 74.67 | 17.50 | 0.69x | 0.72x |
+| 512 | k_linear_1fd3d5 | q_proj + reshape to heads | 100.50 | 21.65 | 133.41 | 22.35 | 4.50x | 0.97x |
+| 512 | k_linear_a09c5a | k_proj + reshape to heads | 59.79 | 14.73 | 70.00 | 17.23 | 3.47x | 0.85x |
+| 512 | k_unsqueeze_636992 | RoPE cos gather | 1.50 | 1.48 | 1.41 | 1.32 | 1.13x | 1.12x |
+| 512 | k_unsqueeze_636992.unsqueeze_1 | RoPE sin gather | 1.48 | 1.48 | 1.43 | 1.32 | 1.12x | 1.12x |
+| 512 | k_sdpa_linear_reduce_c0a378 | softmax·V, computed V | 45.74 | 46.04 | 159.57 | 159.57 | 0.29x | 0.29x |
+| 512 | k_linear_sdpa_reduce_e24efe | o_proj + residual | 60.16 | 61.27 | 315.05 | 315.05 | 0.19x | 0.19x |
+| 512 | k_linear_mean_reduce_dc067d | post-attn norm + gate/up + SiLU | 246.47 | 49.62 | 67.17 | 67.24 | 3.67x | 0.74x |
+| 512 | k_linear_6b4b5f | down_proj + residual | 30.72 | 35.84 | 243.46 | 46.57 | 0.66x | 0.77x |
+| 512 | k_mean_6cb2c7 | q/k norm + RoPE + scores + softmax stats | 271.56 | failed | 6.34 | 5.43 | 50.03x | — |
+| 1 | k_mean_b8e46d | input RMSNorm | 121.86 | 2.99 | 3.06 | 2.38 | 51.26x | 1.26x |
+| 1 | k_linear_reduce_7ef15d | v_proj | 7.49 | 7.17 | 11.19 | 4.74 | 1.58x | 1.51x |
+| 1 | k_linear_49a16b | q_proj + reshape to heads | 35.04 | 6.79 | 21.57 | 4.84 | 7.24x | 1.40x |
+| 1 | k_linear_dfb21f | k_proj + reshape to heads | 33.74 | 5.25 | 11.16 | 4.74 | 7.11x | 1.11x |
+| 1 | k_sdpa_linear_reduce_d0f5c0 | softmax·V, computed V | 11.92 | 10.63 | 25.28 | 25.28 | 0.47x | 0.42x |
+| 1 | k_linear_sdpa_reduce_14c8c7 | o_proj + residual | 14.04 | 12.17 | 36.99 | 36.99 | 0.38x | 0.33x |
+| 1 | k_linear_mean_reduce_549927 | post-attn norm + gate/up + SiLU | 154.62 | 16.38 | 3614.72 | 393.56 | 0.39x | 0.04x |
+| 1 | k_linear_2dcd0c | down_proj + residual | 9.52 | 7.59 | 33.97 | 9.45 | 1.01x | 0.80x |
+| 1 | k_sdpa_mean_reduce_0a2624 | q/k norm + RoPE + scores + softmax stats | 334.54 | failed | 39.78 | 39.78 | 8.41x | — |
 
-Layer totals as the sum of those medians: sequence 512 is 1494.89 eager, 252.68 Inductor, 21744.23 Emmy; sequence 1
-is 722.74 eager, 69.12 Inductor, 751.38 Emmy. Tuning moved the sequence-1 layer from 4027.74 to 751.38 µs (5.4x) and
-the sequence-512 layer from 22162.51 to 21744.23 µs — 1.6x once the one unreachable attention kernel is set aside
-(1068.11 to 649.83 µs over the other eight targets).
+The sequence-512 `k_sdpa_mean_reduce_7968d0` mma score kernel is the twelfth target: `emmy run` exits at the first
+strict failure, and `k_mean_6cb2c7` already fails on its missing Inductor reference, so the score kernel measured in
+none of the five repeats. Its cold greedy deploy timed 114.05 µs in the tuning A/B against 745 µs eager for the
+whole pre-split attention statistics target.
+
+Layer totals as the sum of those medians: sequence 512 is 1021.90 eager, 253.54 Inductor (two targets missing), and
+656.74 Emmy over the eleven measured targets; sequence 1 is 722.78 eager, 68.97 Inductor (one target missing), and
+521.76 Emmy. Emmy's sequence-512 layer was 21744 µs before the attention fusion fix and the re-tune, so the corpus
+moved 33x; sequence 1 moved from 4027.74 untuned to 521.76.
 
 ### Repeat variation
 
 Every measured target's five paired latencies agree to within 0.4% of their median, and the pinned realizations
-reproduce their tuning-time -O3 measurement to within 0.5%. The dominant sequence-512 attention kernel varies by
-0.2% across repeats, so the layer total is not noise-limited anywhere.
+reproduce their tuning-time -O3 measurement to within 0.5%.
 
 ### Conclusion
 
-Tuning is decisive on the projections and the norms and is completely blocked on the fused attention kernels.
-Emmy now beats eager on 11 of 18 targets and matches or beats current-PyTorch Inductor on 6 (both norms, all three
-sequence-1 projections, and sequence-512 q_proj within 3%). Every remaining loss is one of three structural cases:
+Emmy now beats eager on both layer totals (1.56x at sequence 512, 1.39x at sequence 1) and beats or matches Inductor
+on eight of the twenty measured targets. Every remaining loss is one of three structural cases:
 
-1. The sequence-512 online-softmax statistics kernel runs a scalar `t128`/`coop` fold at 21.1 ms against 745 µs
-   eager. No proposal or searched candidate reaches a warp tier: the target lowers to two CUDA kernels whose
-   schedule knobs disagree, so no single pinned map replays it, and every partial pin comes back `pin_unmatched`
-   or `ambiguous_multi_kernel`.
-2. `softmax·V` and `o_proj + residual` lower to three CUDA kernels each with disagreeing knobs, so the golden format
-   (one knob map per realization) cannot carry any searched schedule for them. They deploy the greedy pick.
+1. `softmax·V` and `o_proj + residual` lower to three CUDA kernels each whose schedule knobs disagree, so the golden
+   format — one knob map per realization — cannot carry any searched schedule and they deploy the greedy pick.
+   `emmy eval variants` shows the softmax·V kernel offered only the scalar tier (seven configs, all
+   `REDUCE@a2=coop` with `WORK` from `t4` to `t128`; no warp/mma row exists), while the o_proj kernel's searched
+   pick is rank 3 of 10 at 1.72x the best measured config.
+2. The sequence-1 fused post-attention norm + gate/up + SiLU still runs a 393 µs cooperative fold against 155 µs
+   eager and 16 µs Inductor, even though tuning already took it from 3615 µs.
 3. The remaining projection losses (v_proj and down_proj at 512, down_proj at 1) are code-generation quality: the
    correct staged warp tier is reached and still trails cuBLAS by 1.2–1.5x.
 
 ### Limitations
 
 - Layer-0 evidence only, one model, one card; never a whole-model claim.
-- Both rows report `failed`. `torch.compile` cannot compile the reference for `k_sdpa_mean_reduce` on PyTorch
-  2.13.0 (`InductorError: ValueError: The argument '((0)) + 64' is not comparable` from `sizevars._stride_vars`),
-  so `--strict` rejects that target in every repeat. That target is ordered last in both goldens, so the other
-  eight still measure in all five processes; without that ordering `emmy run` exits at the failing target and drops
-  every later one.
-- The Inductor column is missing for that one target on both sequence lengths, so a geometric mean over the full
-  corpus is not available for this platform; the eight-target denominator is stated explicitly above.
-- The five repeats share one deployed host and run back to back, so they capture process-level and not day-level
-  variation.
+- Both rows report `failed`. `torch.compile` cannot compile the reference for the RoPE-bearing attention targets on
+  PyTorch 2.13.0 (`InductorError: ValueError: The argument '((0)) + 64' is not comparable` from
+  `sizevars._stride_vars`), so `--strict` rejects them in every repeat. Those targets are ordered last in both
+  goldens so the rest still measure; at sequence 512 the second such target is therefore never reached.
+- The Inductor column is missing for those targets, so a geometric mean over the full corpus is not available; the
+  measured denominators are stated above.
+- The five repeats share one deployed host and run back to back, so they capture process-level, not day-level,
+  variation. The experiment record reports `git_dirty: true` because unrelated experiment files were still
+  uncommitted when the run staged; the staged paths themselves were clean.
 
 ### Run and system
 
-- Status: failed (2/2 rows, `torch.compile` reference unavailable on one target; all other targets measured)
-- Result timestamp: 2026-08-21T00:31:35Z; run ID: `20260821T003135Z`
-- Rows: `...sl1_scommon` (row ID `551082cef77b`, 459.03 s) and `...sl512_scommon` (row ID `3a4d139974b8`, 2005.02 s)
-- Git revision: `20569845` (working tree clean at staging)
+- Status: failed (2/2 rows, `torch.compile` reference unavailable on the RoPE targets; all other targets measured)
+- Result timestamp: 2026-08-21T04:25:20Z; run ID: `20260821T042520Z`
+- Rows: `...sl1_scommon` (row ID `551082cef77b`, 442.77 s) and `...sl512_scommon` (row ID `3a4d139974b8`, 1861.3 s)
+- Git revision: `651d6cfd`
 - Host: `riftvm`; Ubuntu 24.04.1 LTS; kernel `6.8.0-51-generic`; AMD EPYC 7742 64-Core Processor
 - GPU: NVIDIA A100-SXM4-80GB, UUID `GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`
 - Host NVCC `12.9.86`; cuBLAS `12.9.1.4`; PyTorch 2.13.0+cu130
 
 ### Durable files
 
-- Raw-results archive: `results_a100x1.tar.gz`; archived root `2026-08-21_00-31-35/`
-- Members: both `*.experiment.yaml` records, both `*_artifacts.tar.gz` task archives (traces, per-repeat
-  verification JSON per target, per-repeat logs and exit statuses, package freeze), and the two runner logs
+- Raw-results archive: `results_a100x1.tar.gz`; archived root `2026-08-21_04-25-20/`
+- Members: both `*.experiment.yaml` records, both `*_artifacts.tar.gz` task archives (per-repeat verification JSON
+  per target, per-repeat logs and exit statuses, package freeze), and the two runner logs
 - Committed goldens: `golden/qwen3-06b-s1_a100.golden.yaml`, `golden/qwen3-06b-s512_a100.golden.yaml`
 
 ## Platform sections

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -74,10 +74,11 @@ searched winner and every measured proposal against a cold greedy pick. A realiz
 replays a knob map that every one of the target's CUDA kernels realized, and only when it beat that cold greedy
 pick; the other targets keep an inventory realization and deploy the greedy schedule.
 
-The sequence-512 attention statistics target re-keyed when fusion learned to refuse a per-step statistic chained
-into a fold inside a free sweep: it now splits into two gather kernels, a k-norm/RoPE kernel, and an mma score
-kernel. Those four targets were tuned fresh; every other realization carried its earlier committed schedule over
-verbatim and was re-measured beside the fresh ones.
+The attention statistics targets re-keyed twice while fusion learned to refuse a per-step statistic chained into a
+fold inside a free sweep, and again when a computing sink stopped absorbing the same splice. At sequence 512 the
+target now splits into two RoPE gather kernels, a k-norm/RoPE kernel, and an mma score kernel; at sequence 1 into a
+q/k-norm reduce and a score kernel. Each re-keyed target was tuned fresh; every other realization carried its
+earlier committed schedule over verbatim and was re-measured beside the fresh ones.
 
 ### Per-kernel result (median of five processes, µs)
 
@@ -86,36 +87,36 @@ exists and the greedy pick otherwise.
 
 | seq | target | role | eager | torch.compile | untuned | tuned | vs eager | vs tcompile |
 | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 512 | k_mean_20f978 | input RMSNorm | 191.88 | 8.89 | 3.83 | 3.17 | 60.59x | 2.81x |
-| 512 | k_linear_reduce_06a42b | v_proj | 12.12 | 12.54 | 74.67 | 17.50 | 0.69x | 0.72x |
-| 512 | k_linear_1fd3d5 | q_proj + reshape to heads | 100.50 | 21.65 | 133.41 | 22.35 | 4.50x | 0.97x |
-| 512 | k_linear_a09c5a | k_proj + reshape to heads | 59.79 | 14.73 | 70.00 | 17.23 | 3.47x | 0.85x |
-| 512 | k_unsqueeze_636992 | RoPE cos gather | 1.50 | 1.48 | 1.41 | 1.32 | 1.13x | 1.12x |
-| 512 | k_unsqueeze_636992.unsqueeze_1 | RoPE sin gather | 1.48 | 1.48 | 1.43 | 1.32 | 1.12x | 1.12x |
-| 512 | k_sdpa_linear_reduce_c0a378 | softmax·V, computed V | 45.74 | 46.04 | 159.57 | 159.57 | 0.29x | 0.29x |
-| 512 | k_linear_sdpa_reduce_e24efe | o_proj + residual | 60.16 | 61.27 | 315.05 | 315.05 | 0.19x | 0.19x |
-| 512 | k_linear_mean_reduce_dc067d | post-attn norm + gate/up + SiLU | 246.47 | 49.62 | 67.17 | 67.24 | 3.67x | 0.74x |
-| 512 | k_linear_6b4b5f | down_proj + residual | 30.72 | 35.84 | 243.46 | 46.57 | 0.66x | 0.77x |
-| 512 | k_mean_6cb2c7 | q/k norm + RoPE + scores + softmax stats | 271.56 | failed | 6.34 | 5.43 | 50.03x | — |
-| 1 | k_mean_b8e46d | input RMSNorm | 121.86 | 2.99 | 3.06 | 2.38 | 51.26x | 1.26x |
-| 1 | k_linear_reduce_7ef15d | v_proj | 7.49 | 7.17 | 11.19 | 4.74 | 1.58x | 1.51x |
-| 1 | k_linear_49a16b | q_proj + reshape to heads | 35.04 | 6.79 | 21.57 | 4.84 | 7.24x | 1.40x |
-| 1 | k_linear_dfb21f | k_proj + reshape to heads | 33.74 | 5.25 | 11.16 | 4.74 | 7.11x | 1.11x |
-| 1 | k_sdpa_linear_reduce_d0f5c0 | softmax·V, computed V | 11.92 | 10.63 | 25.28 | 25.28 | 0.47x | 0.42x |
-| 1 | k_linear_sdpa_reduce_14c8c7 | o_proj + residual | 14.04 | 12.17 | 36.99 | 36.99 | 0.38x | 0.33x |
-| 1 | k_linear_mean_reduce_549927 | post-attn norm + gate/up + SiLU | 154.62 | 16.38 | 3614.72 | 393.56 | 0.39x | 0.04x |
-| 1 | k_linear_2dcd0c | down_proj + residual | 9.52 | 7.59 | 33.97 | 9.45 | 1.01x | 0.80x |
-| 1 | k_sdpa_mean_reduce_0a2624 | q/k norm + RoPE + scores + softmax stats | 334.54 | failed | 39.78 | 39.78 | 8.41x | — |
+| 512 | k_mean_20f978 | input RMSNorm | 191.66 | 8.76 | 3.83 | 3.17 | 60.53x | 2.77x |
+| 512 | k_linear_reduce_06a42b | v_proj | 12.89 | 13.40 | 74.59 | 17.44 | 0.74x | 0.77x |
+| 512 | k_linear_1fd3d5 | q_proj + reshape to heads | 100.50 | 21.50 | 132.68 | 22.32 | 4.50x | 0.96x |
+| 512 | k_linear_a09c5a | k_proj + reshape to heads | 59.86 | 14.73 | 69.85 | 17.27 | 3.47x | 0.85x |
+| 512 | k_unsqueeze_636992 | RoPE cos gather | 1.49 | 1.48 | 1.47 | 1.32 | 1.13x | 1.12x |
+| 512 | k_unsqueeze_636992.unsqueeze_1 | RoPE sin gather | 1.48 | 1.54 | 1.46 | 1.32 | 1.12x | 1.17x |
+| 512 | k_sdpa_linear_reduce_c0a378 | softmax·V, computed V | 45.70 | 46.08 | 159.57 | 159.57 | 0.29x | 0.29x |
+| 512 | k_linear_sdpa_reduce_e24efe | o_proj + residual | 60.19 | 61.27 | 315.73 | 315.73 | 0.19x | 0.19x |
+| 512 | k_linear_mean_reduce_dc067d | post-attn norm + gate/up + SiLU | 246.47 | 49.94 | 67.17 | 67.24 | 3.67x | 0.74x |
+| 512 | k_linear_6b4b5f | down_proj + residual | 30.38 | 35.50 | 243.46 | 46.52 | 0.65x | 0.76x |
+| 512 | k_mean_6cb2c7 | k-norm + RoPE | 271.52 | failed | 6.34 | 5.43 | 50.04x | — |
+| 1 | k_mean_b8e46d | input RMSNorm | 121.81 | 2.87 | 3.07 | 2.38 | 51.22x | 1.20x |
+| 1 | k_linear_reduce_7ef15d | v_proj | 7.56 | 7.52 | 11.15 | 4.74 | 1.59x | 1.59x |
+| 1 | k_linear_49a16b | q_proj + reshape to heads | 35.11 | 6.77 | 21.57 | 4.84 | 7.26x | 1.40x |
+| 1 | k_linear_dfb21f | k_proj + reshape to heads | 33.63 | 5.25 | 11.13 | 4.74 | 7.09x | 1.11x |
+| 1 | k_mean_37b56e | q/k norm + RoPE | 34.57 | 4.28 | 1.61 | 1.52 | 22.71x | 2.81x |
+| 1 | k_sdpa_linear_reduce_d0f5c0 | softmax·V, computed V | 11.91 | 10.61 | 25.22 | 25.22 | 0.47x | 0.42x |
+| 1 | k_linear_sdpa_reduce_14c8c7 | o_proj + residual | 14.05 | 12.16 | 36.86 | 36.86 | 0.38x | 0.33x |
+| 1 | k_linear_mean_reduce_549927 | post-attn norm + gate/up + SiLU | 154.62 | 16.38 | 3615.74 | 393.22 | 0.39x | 0.04x |
+| 1 | k_linear_2dcd0c | down_proj + residual | 9.92 | 7.70 | 33.97 | 9.45 | 1.05x | 0.81x |
+| 1 | k_sdpa_mean_reduce_5dfb29 | scores + softmax stats | 300.65 | failed | 39.40 | 39.40 | 7.63x | — |
 
-The sequence-512 `k_sdpa_mean_reduce_7968d0` mma score kernel is the twelfth target: `emmy run` exits at the first
-strict failure, and `k_mean_6cb2c7` already fails on its missing Inductor reference, so the score kernel measured in
-none of the five repeats. Its cold greedy deploy timed 114.05 µs in the tuning A/B against 745 µs eager for the
-whole pre-split attention statistics target.
+The sequence-512 `k_sdpa_mean_reduce_7968d0` mma score kernel is the twelfth target and measured in none of the five
+repeats: `emmy run` exits at the first strict failure and `k_mean_6cb2c7` already fails on its missing Inductor
+reference. Its cold greedy deploy timed 114.05 µs in the tuning A/B.
 
-Layer totals as the sum of those medians: sequence 512 is 1021.90 eager, 253.54 Inductor (two targets missing), and
-656.74 Emmy over the eleven measured targets; sequence 1 is 722.78 eager, 68.97 Inductor (one target missing), and
-521.76 Emmy. Emmy's sequence-512 layer was 21744 µs before the attention fusion fix and the re-tune, so the corpus
-moved 33x; sequence 1 moved from 4027.74 untuned to 521.76.
+Layer totals as the sum of those medians: sequence 512 is 1022.13 eager, 254.19 Inductor (two targets missing), and
+657.33 Emmy over the eleven measured targets; sequence 1 is 723.83 eager, 73.53 Inductor (one target missing), and
+522.37 Emmy. Emmy's sequence-512 layer was 21744 µs before the attention fusion fixes and the re-tune, so the corpus
+moved 33x; sequence 1 moved from 4028 untuned to 522.
 
 ### Repeat variation
 
@@ -124,16 +125,17 @@ reproduce their tuning-time -O3 measurement to within 0.5%.
 
 ### Conclusion
 
-Emmy now beats eager on both layer totals (1.56x at sequence 512, 1.39x at sequence 1) and beats or matches Inductor
-on eight of the twenty measured targets. Every remaining loss is one of three structural cases:
+Emmy beats eager on both layer totals (1.56x at sequence 512, 1.39x at sequence 1) and beats or matches Inductor on
+nine of the twenty-one measured targets. Every remaining loss is one of three structural cases:
 
 1. `softmax·V` and `o_proj + residual` lower to three CUDA kernels each whose schedule knobs disagree, so the golden
    format — one knob map per realization — cannot carry any searched schedule and they deploy the greedy pick.
    `emmy eval variants` shows the softmax·V kernel offered only the scalar tier (seven configs, all
    `REDUCE@a2=coop` with `WORK` from `t4` to `t128`; no warp/mma row exists), while the o_proj kernel's searched
-   pick is rank 3 of 10 at 1.72x the best measured config.
+   pick is rank 3 of 10 at 1.72x the best measured config. A uniform pin does make the map conflict-free but only
+   until the schedule splits a fourth, knob-free epilogue kernel out.
 2. The sequence-1 fused post-attention norm + gate/up + SiLU still runs a 393 µs cooperative fold against 155 µs
-   eager and 16 µs Inductor, even though tuning already took it from 3615 µs.
+   eager and 16 µs Inductor, even though tuning already took it from 3616 µs.
 3. The remaining projection losses (v_proj and down_proj at 512, down_proj at 1) are code-generation quality: the
    correct staged warp tier is reached and still trails cuBLAS by 1.2–1.5x.
 
@@ -147,22 +149,21 @@ on eight of the twenty measured targets. Every remaining loss is one of three st
 - The Inductor column is missing for those targets, so a geometric mean over the full corpus is not available; the
   measured denominators are stated above.
 - The five repeats share one deployed host and run back to back, so they capture process-level, not day-level,
-  variation. The experiment record reports `git_dirty: true` because unrelated experiment files were still
-  uncommitted when the run staged; the staged paths themselves were clean.
+  variation.
 
 ### Run and system
 
 - Status: failed (2/2 rows, `torch.compile` reference unavailable on the RoPE targets; all other targets measured)
-- Result timestamp: 2026-08-21T04:25:20Z; run ID: `20260821T042520Z`
-- Rows: `...sl1_scommon` (row ID `551082cef77b`, 442.77 s) and `...sl512_scommon` (row ID `3a4d139974b8`, 1861.3 s)
-- Git revision: `651d6cfd`
+- Result timestamp: 2026-08-21T10:01:28Z; run ID: `20260821T100128Z`
+- Rows: `...sl1_scommon` (row ID `551082cef77b`, 493.44 s) and `...sl512_scommon` (row ID `3a4d139974b8`, 1891.78 s)
+- Git revision: `e2f61e2e`; dirty: false
 - Host: `riftvm`; Ubuntu 24.04.1 LTS; kernel `6.8.0-51-generic`; AMD EPYC 7742 64-Core Processor
 - GPU: NVIDIA A100-SXM4-80GB, UUID `GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`
 - Host NVCC `12.9.86`; cuBLAS `12.9.1.4`; PyTorch 2.13.0+cu130
 
 ### Durable files
 
-- Raw-results archive: `results_a100x1.tar.gz`; archived root `2026-08-21_04-25-20/`
+- Raw-results archive: `results_a100x1.tar.gz`; archived root `2026-08-21_10-01-28/`
 - Members: both `*.experiment.yaml` records, both `*_artifacts.tar.gz` task archives (per-repeat verification JSON
   per target, per-repeat logs and exit statuses, package freeze), and the two runner logs
 - Committed goldens: `golden/qwen3-06b-s1_a100.golden.yaml`, `golden/qwen3-06b-s512_a100.golden.yaml`

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
@@ -1220,8 +1220,8 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 2.3771
-      reference_us: 121.8309
+      emmy_us: 2.3779
+      reference_us: 121.8654
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1240,8 +1240,8 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 4.7445
-      reference_us: 7.8507
+      emmy_us: 4.7191
+      reference_us: 5.5936
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1263,7 +1263,7 @@ configs:
       WORK: t512
     measurements:
       emmy_us: 4.8416
-      reference_us: 35.0158
+      reference_us: 35.1407
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1285,7 +1285,31 @@ configs:
       WORK: t512
     measurements:
       emmy_us: 4.7397
-      reference_us: 33.7541
+      reference_us: 33.6403
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_2
+    - add_2_c1_bc
+    - mean_2
+    - pow_3
+    - rsqrt_2
+  realizations:
+  - name: k_mean_37b56e.969dd81bf016
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t32
+    measurements:
+      emmy_us: 1.5219
+      reference_us: 34.455
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1344,7 +1368,7 @@ configs:
       WORK: t1024
     measurements:
       emmy_us: 393.216
-      reference_us: 155.648
+      reference_us: 154.624
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1364,22 +1388,19 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 9.4575
-      reference_us: 9.3342
+      emmy_us: 9.4382
+      reference_us: 9.3298
       reference_backend: torch-eager
 - program: 0
   target:
     origins:
     - add_1
     - add_1_c1_bc
-    - add_2
-    - add_2_c1_bc
     - add_3
     - add_4
     - cat
     - cat_1
     - mean_1
-    - mean_2
     - mul_2
     - mul_3
     - mul_4
@@ -1395,10 +1416,8 @@ configs:
     - p_attn_k_norm_weight_bc
     - p_attn_q_norm_weight_bc
     - pow_2
-    - pow_3
     - rsqrt_1
     - rsqrt_1_bc
-    - rsqrt_2
     - rsqrt_2_bc
     - scaled_dot_product_attention
     - slice_1
@@ -1414,7 +1433,7 @@ configs:
     - unsqueeze_1_bc
     - unsqueeze_bc
   realizations:
-  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8
+  - name: k_sdpa_mean_reduce_5dfb29.be43ff7940ea
     bindings: {}
     pins:
       FAST_MATH: false

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
@@ -1,0 +1,1422 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [hidden_states, position_embeddings_0, position_embeddings_1, attention_mask]
+  outputs: [add_7]
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_1_c1, f32, [1]]]
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_1_c1]
+    outputs: [[add_1_c1_bc, f32, [1, 1, 16, 1]]]
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_2_c1, f32, [1]]]
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_2_c1]
+    outputs: [[add_2_c1_bc, f32, [1, 1, 8, 1]]]
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_6_c1, f32, [1]]]
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_6_c1]
+    outputs: [[add_6_c1_bc, f32, [1, 1, 1]]]
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_c1, f32, [1]]]
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_c1]
+    outputs: [[add_c1_bc, f32, [1, 1, 1]]]
+  - id: attention_mask
+    op: input
+    outputs: [[attention_mask, f32, []]]
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_1_c2, f16, [1]]]
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_c2, f16, [1]]]
+  - id: hidden_states
+    op: input
+    outputs: [[hidden_states, f16, [1, 1, 1024]]]
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_norm_weight, f16, [128]]]
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_k_norm_weight]
+    outputs: [[p_attn_k_norm_weight_bc, f16, [1, 1, 8, 128]]]
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_proj_weight, f16, [1024, 1024]]]
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.o_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 2048]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_o_proj_weight, f16, [1024, 2048]]]
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_norm_weight, f16, [128]]]
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_q_norm_weight]
+    outputs: [[p_attn_q_norm_weight_bc, f16, [1, 1, 16, 128]]]
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [2048, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_proj_weight, f16, [2048, 1024]]]
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.v_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_v_proj_weight, f16, [1024, 1024]]]
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: input_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_input_layernorm_weight, f16, [1024]]]
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_input_layernorm_weight]
+    outputs: [[p_input_layernorm_weight_bc, f16, [1, 1, 1024]]]
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.down_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 3072]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_down_proj_weight, f16, [1024, 3072]]]
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.gate_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_gate_proj_weight, f16, [3072, 1024]]]
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.up_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_up_proj_weight, f16, [3072, 1024]]]
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: post_attention_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_post_attention_layernorm_weight, f16, [1024]]]
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_post_attention_layernorm_weight]
+    outputs: [[p_post_attention_layernorm_weight_bc, f16, [1, 1, 1024]]]
+  - id: position_embeddings_0
+    op: input
+    outputs: [[position_embeddings_0, f16, [1, 1, 128]]]
+  - id: position_embeddings_1
+    op: input
+    outputs: [[position_embeddings_1, f16, [1, 1, 128]]]
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_1_c1, f32, [1]]]
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_1_c1]
+    outputs: [[pow_1_c1_bc, f32, [1, 1, 1024]]]
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_2_c1, f32, [1]]]
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_2_c1]
+    outputs: [[pow_2_c1_bc, f32, [1, 1, 16, 128]]]
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_3_c1, f32, [1]]]
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_3_c1]
+    outputs: [[pow_3_c1_bc, f32, [1, 1, 8, 128]]]
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_4_c1, f32, [1]]]
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_4_c1]
+    outputs: [[pow_4_c1_bc, f32, [1, 1, 1024]]]
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c1, f16, [1]]]
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c2, f16, [1]]]
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c3, f16, [1]]]
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c1, f16, [1]]]
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c2, f16, [1]]]
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c3, f16, [1]]]
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c1, f16, [1]]]
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c2, f16, [1]]]
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c3, f16, [1]]]
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c1, f16, [1]]]
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c2, f16, [1]]]
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c3, f16, [1]]]
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [hidden_states]
+    outputs: [[to, f32, [1, 1, 1024]]]
+  - id: pow_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to, pow_1_c1_bc]
+    outputs: [[pow_1, f32, [1, 1, 1024]]]
+  - id: mean
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_1]
+    outputs: [[mean, f32, [1, 1, 1]]]
+  - id: add
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean, add_c1_bc]
+    outputs: [[add, f32, [1, 1, 1]]]
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add]
+    outputs: [[rsqrt, f32, [1, 1, 1]]]
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt]
+    outputs: [[rsqrt_bc, f32, [1, 1, 1024]]]
+  - id: mul
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to, rsqrt_bc]
+    outputs: [[mul, f32, [1, 1, 1024]]]
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul]
+    outputs: [[to_1, f16, [1, 1, 1024]]]
+  - id: mul_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_input_layernorm_weight_bc, to_1]
+    outputs: [[mul_1, f16, [1, 1, 1024]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_q_proj_weight]
+    outputs: [[linear, f16, [1, 1, 2048]]]
+  - id: linear_1
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_k_proj_weight]
+    outputs: [[linear_1, f16, [1, 1, 1024]]]
+  - id: linear_2
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_v_proj_weight]
+    outputs: [[linear_2, f16, [1, 1, 1024]]]
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c1, f16, [1]]]
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c2, f16, [1]]]
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c1, f16, [1]]]
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c2, f16, [1]]]
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c1, f16, [1]]]
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c2, f16, [1]]]
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c1, f16, [1]]]
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c2, f16, [1]]]
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_0]
+    outputs: [[unsqueeze, f16, [1, 1, 1, 128]]]
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 8, 1, 128]]]
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_1]
+    outputs: [[unsqueeze_1, f16, [1, 1, 1, 128]]]
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 8, 1, 128]]]
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 16, 1, 128]]]
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_1_c1, f16, [1]]]
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 16, 1, 128]]]
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_c1, f16, [1]]]
+  - id: view
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1, 128]}}
+    inputs: [linear]
+    outputs: [[view, f16, [1, 1, 16, 128]]]
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view]
+    outputs: [[to_2, f32, [1, 1, 16, 128]]]
+  - id: pow_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_2, pow_2_c1_bc]
+    outputs: [[pow_2, f32, [1, 1, 16, 128]]]
+  - id: mean_1
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_2]
+    outputs: [[mean_1, f32, [1, 1, 16, 1]]]
+  - id: add_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_1, add_1_c1_bc]
+    outputs: [[add_1, f32, [1, 1, 16, 1]]]
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_1]
+    outputs: [[rsqrt_1, f32, [1, 1, 16, 1]]]
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_1]
+    outputs: [[rsqrt_1_bc, f32, [1, 1, 16, 128]]]
+  - id: mul_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_2, rsqrt_1_bc]
+    outputs: [[mul_2, f32, [1, 1, 16, 128]]]
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_2]
+    outputs: [[to_3, f16, [1, 1, 16, 128]]]
+  - id: mul_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_q_norm_weight_bc, to_3]
+    outputs: [[mul_3, f16, [1, 1, 16, 128]]]
+  - id: transpose
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_3]
+    outputs: [[transpose, f16, [1, 16, 1, 128]]]
+  - id: mul_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose, unsqueeze_bc]
+    outputs: [[mul_6, f16, [1, 16, 1, 128]]]
+  - id: slice_1
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 1, 64]}, dim: 3, start: 0}
+    inputs: [transpose, slice_1_c1, slice_1_c2, slice_1_c3]
+    outputs: [[slice_1, f16, [1, 16, 1, 64]]]
+  - id: slice_2
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 1, 64]}, dim: 3, start: 64}
+    inputs: [transpose, slice_2_c1, slice_2_c2, slice_2_c3]
+    outputs: [[slice_2, f16, [1, 16, 1, 64]]]
+  - id: neg
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_2]
+    outputs: [[neg, f16, [1, 16, 1, 64]]]
+  - id: cat
+    op: torch.cat
+    inputs: [neg, slice_1, cat_c2]
+    outputs: [[cat, f16, [1, 16, 1, 128]]]
+  - id: mul_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat, unsqueeze_1_bc]
+    outputs: [[mul_7, f16, [1, 16, 1, 128]]]
+  - id: add_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_6, mul_7]
+    outputs: [[add_3, f16, [1, 16, 1, 128]]]
+  - id: view_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1, 128]}}
+    inputs: [linear_1]
+    outputs: [[view_1, f16, [1, 1, 8, 128]]]
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view_1]
+    outputs: [[to_4, f32, [1, 1, 8, 128]]]
+  - id: pow_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_4, pow_3_c1_bc]
+    outputs: [[pow_3, f32, [1, 1, 8, 128]]]
+  - id: mean_2
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_3]
+    outputs: [[mean_2, f32, [1, 1, 8, 1]]]
+  - id: add_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_2, add_2_c1_bc]
+    outputs: [[add_2, f32, [1, 1, 8, 1]]]
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_2]
+    outputs: [[rsqrt_2, f32, [1, 1, 8, 1]]]
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_2]
+    outputs: [[rsqrt_2_bc, f32, [1, 1, 8, 128]]]
+  - id: mul_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_4, rsqrt_2_bc]
+    outputs: [[mul_4, f32, [1, 1, 8, 128]]]
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_4]
+    outputs: [[to_5, f16, [1, 1, 8, 128]]]
+  - id: mul_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_k_norm_weight_bc, to_5]
+    outputs: [[mul_5, f16, [1, 1, 8, 128]]]
+  - id: transpose_1
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_5]
+    outputs: [[transpose_1, f16, [1, 8, 1, 128]]]
+  - id: mul_8
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose_1, n0]
+    outputs: [[mul_8, f16, [1, 8, 1, 128]]]
+  - id: slice_3
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 1, 64]}, dim: 3, start: 0}
+    inputs: [transpose_1, slice_3_c1, slice_3_c2, slice_3_c3]
+    outputs: [[slice_3, f16, [1, 8, 1, 64]]]
+  - id: slice_4
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 1, 64]}, dim: 3, start: 64}
+    inputs: [transpose_1, slice_4_c1, slice_4_c2, slice_4_c3]
+    outputs: [[slice_4, f16, [1, 8, 1, 64]]]
+  - id: neg_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_4]
+    outputs: [[neg_1, f16, [1, 8, 1, 64]]]
+  - id: cat_1
+    op: torch.cat
+    inputs: [neg_1, slice_3, cat_1_c2]
+    outputs: [[cat_1, f16, [1, 8, 1, 128]]]
+  - id: mul_9
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat_1, n1]
+    outputs: [[mul_9, f16, [1, 8, 1, 128]]]
+  - id: add_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_8, mul_9]
+    outputs: [[add_4, f16, [1, 8, 1, 128]]]
+  - id: view_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1, 128]}}
+    inputs: [linear_2]
+    outputs: [[view_2, f16, [1, 1, 8, 128]]]
+  - id: transpose_2
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [view_2]
+    outputs: [[transpose_2, f16, [1, 8, 1, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: 0.08838834764831845}
+    inputs: [add_3, add_4, transpose_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 16, 1, 128]]]
+  - id: transpose_3
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[transpose_3, f16, [1, 1, 16, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1]}}
+    inputs: [transpose_3]
+    outputs: [[reshape, f16, [1, 1, 2048]]]
+  - id: linear_3
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [reshape, p_attn_o_proj_weight]
+    outputs: [[linear_3, f16, [1, 1, 1024]]]
+  - id: add_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [hidden_states, linear_3]
+    outputs: [[add_5, f16, [1, 1, 1024]]]
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [add_5]
+    outputs: [[to_6, f32, [1, 1, 1024]]]
+  - id: pow_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_6, pow_4_c1_bc]
+    outputs: [[pow_4, f32, [1, 1, 1024]]]
+  - id: mean_3
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_4]
+    outputs: [[mean_3, f32, [1, 1, 1]]]
+  - id: add_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_3, add_6_c1_bc]
+    outputs: [[add_6, f32, [1, 1, 1]]]
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_6]
+    outputs: [[rsqrt_3, f32, [1, 1, 1]]]
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_3]
+    outputs: [[rsqrt_3_bc, f32, [1, 1, 1024]]]
+  - id: mul_10
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_6, rsqrt_3_bc]
+    outputs: [[mul_10, f32, [1, 1, 1024]]]
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul_10]
+    outputs: [[to_7, f16, [1, 1, 1024]]]
+  - id: mul_11
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_post_attention_layernorm_weight_bc, to_7]
+    outputs: [[mul_11, f16, [1, 1, 1024]]]
+  - id: linear_4
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_gate_proj_weight]
+    outputs: [[linear_4, f16, [1, 1, 3072]]]
+  - id: linear_5
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_up_proj_weight]
+    outputs: [[linear_5, f16, [1, 1, 3072]]]
+  - id: silu
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: silu}}
+    inputs: [linear_4]
+    outputs: [[silu, f16, [1, 1, 3072]]]
+  - id: mul_12
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [silu, linear_5]
+    outputs: [[mul_12, f16, [1, 1, 3072]]]
+  - id: linear_6
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_12, p_mlp_down_proj_weight]
+    outputs: [[linear_6, f16, [1, 1, 1024]]]
+  - id: add_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [add_5, linear_6]
+    outputs: [[add_7, f16, [1, 1, 1024]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t512
+    measurements:
+      emmy_us: 2.3779
+      reference_us: 121.9125
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_7ef15d.37e7fb9e7dd5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop-t
+      STAGE: ''
+      TILE: ''
+      WORK: t512
+    measurements:
+      emmy_us: 4.7415
+      reference_us: 4.992
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_49a16b.119bca97a211
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop-t
+      STAGE: ''
+      TILE: ''
+      WORK: t512
+    measurements:
+      emmy_us: 4.8367
+      reference_us: 35.0658
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_dfb21f.68dcd44586ec
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop-t
+      STAGE: ''
+      TILE: ''
+      WORK: t512
+    measurements:
+      emmy_us: 5.288
+      reference_us: 33.6277
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_d0f5c0.128c6f715151
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_14c8c7.b69c5cc0ab9b
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_549927.f3a20e07e940
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE@a0: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t1024
+    measurements:
+      emmy_us: 393.5573
+      reference_us: 153.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_2dcd0c.28b342e368a5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop-t
+      STAGE: ''
+      TILE: ''
+      WORK: t512
+    measurements:
+      emmy_us: 9.4575
+      reference_us: 9.3735
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
@@ -1220,8 +1220,8 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 2.3779
-      reference_us: 121.9125
+      emmy_us: 2.3771
+      reference_us: 121.8309
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1240,8 +1240,8 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 4.7415
-      reference_us: 4.992
+      emmy_us: 4.7445
+      reference_us: 7.8507
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1262,8 +1262,8 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 4.8367
-      reference_us: 35.0658
+      emmy_us: 4.8416
+      reference_us: 35.0158
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1284,8 +1284,8 @@ configs:
       TILE: ''
       WORK: t512
     measurements:
-      emmy_us: 5.288
-      reference_us: 33.6277
+      emmy_us: 4.7397
+      reference_us: 33.7541
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1343,8 +1343,8 @@ configs:
       TILE: ''
       WORK: t1024
     measurements:
-      emmy_us: 393.5573
-      reference_us: 153.6
+      emmy_us: 393.216
+      reference_us: 155.648
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1365,7 +1365,7 @@ configs:
       WORK: t512
     measurements:
       emmy_us: 9.4575
-      reference_us: 9.3735
+      reference_us: 9.3342
       reference_backend: torch-eager
 - program: 0
   target:

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
@@ -1,0 +1,1435 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [hidden_states, position_embeddings_0, position_embeddings_1, attention_mask]
+  outputs: [add_7]
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_1_c1, f32, [1]]]
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_1_c1]
+    outputs: [[add_1_c1_bc, f32, [1, 512, 16, 1]]]
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_2_c1, f32, [1]]]
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_2_c1]
+    outputs: [[add_2_c1_bc, f32, [1, 512, 8, 1]]]
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_6_c1, f32, [1]]]
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_6_c1]
+    outputs: [[add_6_c1_bc, f32, [1, 512, 1]]]
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_c1, f32, [1]]]
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_c1]
+    outputs: [[add_c1_bc, f32, [1, 512, 1]]]
+  - id: attention_mask
+    op: input
+    outputs: [[attention_mask, f32, []]]
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_1_c2, f16, [1]]]
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_c2, f16, [1]]]
+  - id: hidden_states
+    op: input
+    outputs: [[hidden_states, f16, [1, 512, 1024]]]
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_norm_weight, f16, [128]]]
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_k_norm_weight]
+    outputs: [[p_attn_k_norm_weight_bc, f16, [1, 512, 8, 128]]]
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_proj_weight, f16, [1024, 1024]]]
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.o_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 2048]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_o_proj_weight, f16, [1024, 2048]]]
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_norm_weight, f16, [128]]]
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_q_norm_weight]
+    outputs: [[p_attn_q_norm_weight_bc, f16, [1, 512, 16, 128]]]
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [2048, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_proj_weight, f16, [2048, 1024]]]
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.v_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_v_proj_weight, f16, [1024, 1024]]]
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: input_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_input_layernorm_weight, f16, [1024]]]
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_input_layernorm_weight]
+    outputs: [[p_input_layernorm_weight_bc, f16, [1, 512, 1024]]]
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.down_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 3072]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_down_proj_weight, f16, [1024, 3072]]]
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.gate_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_gate_proj_weight, f16, [3072, 1024]]]
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.up_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_up_proj_weight, f16, [3072, 1024]]]
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: post_attention_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_post_attention_layernorm_weight, f16, [1024]]]
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_post_attention_layernorm_weight]
+    outputs: [[p_post_attention_layernorm_weight_bc, f16, [1, 512, 1024]]]
+  - id: position_embeddings_0
+    op: input
+    outputs: [[position_embeddings_0, f16, [1, 512, 128]]]
+  - id: position_embeddings_1
+    op: input
+    outputs: [[position_embeddings_1, f16, [1, 512, 128]]]
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_1_c1, f32, [1]]]
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_1_c1]
+    outputs: [[pow_1_c1_bc, f32, [1, 512, 1024]]]
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_2_c1, f32, [1]]]
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_2_c1]
+    outputs: [[pow_2_c1_bc, f32, [1, 512, 16, 128]]]
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_3_c1, f32, [1]]]
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_3_c1]
+    outputs: [[pow_3_c1_bc, f32, [1, 512, 8, 128]]]
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_4_c1, f32, [1]]]
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_4_c1]
+    outputs: [[pow_4_c1_bc, f32, [1, 512, 1024]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c1, f16, [1]]]
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c2, f16, [1]]]
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c3, f16, [1]]]
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c1, f16, [1]]]
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c2, f16, [1]]]
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c3, f16, [1]]]
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c1, f16, [1]]]
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c2, f16, [1]]]
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c3, f16, [1]]]
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c1, f16, [1]]]
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c2, f16, [1]]]
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c3, f16, [1]]]
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [hidden_states]
+    outputs: [[to, f32, [1, 512, 1024]]]
+  - id: pow_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to, pow_1_c1_bc]
+    outputs: [[pow_1, f32, [1, 512, 1024]]]
+  - id: mean
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_1]
+    outputs: [[mean, f32, [1, 512, 1]]]
+  - id: add
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean, add_c1_bc]
+    outputs: [[add, f32, [1, 512, 1]]]
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add]
+    outputs: [[rsqrt, f32, [1, 512, 1]]]
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt]
+    outputs: [[rsqrt_bc, f32, [1, 512, 1024]]]
+  - id: mul
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to, rsqrt_bc]
+    outputs: [[mul, f32, [1, 512, 1024]]]
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul]
+    outputs: [[to_1, f16, [1, 512, 1024]]]
+  - id: mul_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_input_layernorm_weight_bc, to_1]
+    outputs: [[mul_1, f16, [1, 512, 1024]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_q_proj_weight]
+    outputs: [[linear, f16, [1, 512, 2048]]]
+  - id: linear_1
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_k_proj_weight]
+    outputs: [[linear_1, f16, [1, 512, 1024]]]
+  - id: linear_2
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_v_proj_weight]
+    outputs: [[linear_2, f16, [1, 512, 1024]]]
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c1, f16, [1]]]
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c2, f16, [1]]]
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c1, f16, [1]]]
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c2, f16, [1]]]
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c1, f16, [1]]]
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c2, f16, [1]]]
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c1, f16, [1]]]
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c2, f16, [1]]]
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_0]
+    outputs: [[unsqueeze, f16, [1, 1, 512, 128]]]
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 8, 512, 128]]]
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_1]
+    outputs: [[unsqueeze_1, f16, [1, 1, 512, 128]]]
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 8, 512, 128]]]
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 16, 512, 128]]]
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_1_c1, f16, [1]]]
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 16, 512, 128]]]
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_c1, f16, [1]]]
+  - id: view
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1, 128]}}
+    inputs: [linear]
+    outputs: [[view, f16, [1, 512, 16, 128]]]
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view]
+    outputs: [[to_2, f32, [1, 512, 16, 128]]]
+  - id: pow_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_2, pow_2_c1_bc]
+    outputs: [[pow_2, f32, [1, 512, 16, 128]]]
+  - id: mean_1
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_2]
+    outputs: [[mean_1, f32, [1, 512, 16, 1]]]
+  - id: add_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_1, add_1_c1_bc]
+    outputs: [[add_1, f32, [1, 512, 16, 1]]]
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_1]
+    outputs: [[rsqrt_1, f32, [1, 512, 16, 1]]]
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_1]
+    outputs: [[rsqrt_1_bc, f32, [1, 512, 16, 128]]]
+  - id: mul_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_2, rsqrt_1_bc]
+    outputs: [[mul_2, f32, [1, 512, 16, 128]]]
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_2]
+    outputs: [[to_3, f16, [1, 512, 16, 128]]]
+  - id: mul_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_q_norm_weight_bc, to_3]
+    outputs: [[mul_3, f16, [1, 512, 16, 128]]]
+  - id: transpose
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_3]
+    outputs: [[transpose, f16, [1, 16, 512, 128]]]
+  - id: mul_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose, unsqueeze_bc]
+    outputs: [[mul_6, f16, [1, 16, 512, 128]]]
+  - id: slice_1
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 512, 64]}, dim: 3, start: 0}
+    inputs: [transpose, slice_1_c1, slice_1_c2, slice_1_c3]
+    outputs: [[slice_1, f16, [1, 16, 512, 64]]]
+  - id: slice_2
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 512, 64]}, dim: 3, start: 64}
+    inputs: [transpose, slice_2_c1, slice_2_c2, slice_2_c3]
+    outputs: [[slice_2, f16, [1, 16, 512, 64]]]
+  - id: neg
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_2]
+    outputs: [[neg, f16, [1, 16, 512, 64]]]
+  - id: cat
+    op: torch.cat
+    inputs: [neg, slice_1, cat_c2]
+    outputs: [[cat, f16, [1, 16, 512, 128]]]
+  - id: mul_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat, unsqueeze_1_bc]
+    outputs: [[mul_7, f16, [1, 16, 512, 128]]]
+  - id: add_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_6, mul_7]
+    outputs: [[add_3, f16, [1, 16, 512, 128]]]
+  - id: view_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1, 128]}}
+    inputs: [linear_1]
+    outputs: [[view_1, f16, [1, 512, 8, 128]]]
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view_1]
+    outputs: [[to_4, f32, [1, 512, 8, 128]]]
+  - id: pow_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_4, pow_3_c1_bc]
+    outputs: [[pow_3, f32, [1, 512, 8, 128]]]
+  - id: mean_2
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_3]
+    outputs: [[mean_2, f32, [1, 512, 8, 1]]]
+  - id: add_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_2, add_2_c1_bc]
+    outputs: [[add_2, f32, [1, 512, 8, 1]]]
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_2]
+    outputs: [[rsqrt_2, f32, [1, 512, 8, 1]]]
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_2]
+    outputs: [[rsqrt_2_bc, f32, [1, 512, 8, 128]]]
+  - id: mul_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_4, rsqrt_2_bc]
+    outputs: [[mul_4, f32, [1, 512, 8, 128]]]
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_4]
+    outputs: [[to_5, f16, [1, 512, 8, 128]]]
+  - id: mul_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_k_norm_weight_bc, to_5]
+    outputs: [[mul_5, f16, [1, 512, 8, 128]]]
+  - id: transpose_1
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_5]
+    outputs: [[transpose_1, f16, [1, 8, 512, 128]]]
+  - id: mul_8
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose_1, n0]
+    outputs: [[mul_8, f16, [1, 8, 512, 128]]]
+  - id: slice_3
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 512, 64]}, dim: 3, start: 0}
+    inputs: [transpose_1, slice_3_c1, slice_3_c2, slice_3_c3]
+    outputs: [[slice_3, f16, [1, 8, 512, 64]]]
+  - id: slice_4
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 512, 64]}, dim: 3, start: 64}
+    inputs: [transpose_1, slice_4_c1, slice_4_c2, slice_4_c3]
+    outputs: [[slice_4, f16, [1, 8, 512, 64]]]
+  - id: neg_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_4]
+    outputs: [[neg_1, f16, [1, 8, 512, 64]]]
+  - id: cat_1
+    op: torch.cat
+    inputs: [neg_1, slice_3, cat_1_c2]
+    outputs: [[cat_1, f16, [1, 8, 512, 128]]]
+  - id: mul_9
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat_1, n1]
+    outputs: [[mul_9, f16, [1, 8, 512, 128]]]
+  - id: add_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_8, mul_9]
+    outputs: [[add_4, f16, [1, 8, 512, 128]]]
+  - id: view_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1, 128]}}
+    inputs: [linear_2]
+    outputs: [[view_2, f16, [1, 512, 8, 128]]]
+  - id: transpose_2
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [view_2]
+    outputs: [[transpose_2, f16, [1, 8, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: 0.08838834764831845}
+    inputs: [add_3, add_4, transpose_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 16, 512, 128]]]
+  - id: transpose_3
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[transpose_3, f16, [1, 512, 16, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1]}}
+    inputs: [transpose_3]
+    outputs: [[reshape, f16, [1, 512, 2048]]]
+  - id: linear_3
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [reshape, p_attn_o_proj_weight]
+    outputs: [[linear_3, f16, [1, 512, 1024]]]
+  - id: add_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [hidden_states, linear_3]
+    outputs: [[add_5, f16, [1, 512, 1024]]]
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [add_5]
+    outputs: [[to_6, f32, [1, 512, 1024]]]
+  - id: pow_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_6, pow_4_c1_bc]
+    outputs: [[pow_4, f32, [1, 512, 1024]]]
+  - id: mean_3
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_4]
+    outputs: [[mean_3, f32, [1, 512, 1]]]
+  - id: add_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_3, add_6_c1_bc]
+    outputs: [[add_6, f32, [1, 512, 1]]]
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_6]
+    outputs: [[rsqrt_3, f32, [1, 512, 1]]]
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_3]
+    outputs: [[rsqrt_3_bc, f32, [1, 512, 1024]]]
+  - id: mul_10
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_6, rsqrt_3_bc]
+    outputs: [[mul_10, f32, [1, 512, 1024]]]
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul_10]
+    outputs: [[to_7, f16, [1, 512, 1024]]]
+  - id: mul_11
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_post_attention_layernorm_weight_bc, to_7]
+    outputs: [[mul_11, f16, [1, 512, 1024]]]
+  - id: linear_4
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_gate_proj_weight]
+    outputs: [[linear_4, f16, [1, 512, 3072]]]
+  - id: linear_5
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_up_proj_weight]
+    outputs: [[linear_5, f16, [1, 512, 3072]]]
+  - id: silu
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: silu}}
+    inputs: [linear_4]
+    outputs: [[silu, f16, [1, 512, 3072]]]
+  - id: mul_12
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [silu, linear_5]
+    outputs: [[mul_12, f16, [1, 512, 3072]]]
+  - id: linear_6
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_12, p_mlp_down_proj_weight]
+    outputs: [[linear_6, f16, [1, 512, 1024]]]
+  - id: add_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [add_5, linear_6]
+    outputs: [[add_7, f16, [1, 512, 1024]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t256
+    measurements:
+      emmy_us: 3.1598
+      reference_us: 191.5469
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_06a42b.975d5314f1c7
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 17.4446
+      reference_us: 11.6907
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_1fd3d5.d0f217697284
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      WORK: w4x1
+    measurements:
+      emmy_us: 22.2777
+      reference_us: 100.4983
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_a09c5a.f753cb04390b
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 17.2844
+      reference_us: 59.7858
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_c0a378.ace3043c96cf
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_e24efe.109440eff691
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_dc067d.a2e77bf96bb2
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w8x2
+    measurements:
+      emmy_us: 67.0379
+      reference_us: 246.4689
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_6b4b5f.a59ee74a4345
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 46.5189
+      reference_us: 32.768
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2
+    bindings: {}
+    pins:
+      FAST_MATH: false
+gpu_name: NVIDIA A100 80GB
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
@@ -1233,8 +1233,8 @@ configs:
       TILE: ''
       WORK: t256
     measurements:
-      emmy_us: 3.1598
-      reference_us: 191.5469
+      emmy_us: 3.1663
+      reference_us: 191.9
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1253,8 +1253,8 @@ configs:
       TILE: mma_m16n8k16_f16_f32/f4x4/k8
       WORK: w2x2
     measurements:
-      emmy_us: 17.4446
-      reference_us: 11.6907
+      emmy_us: 17.5158
+      reference_us: 12.9707
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1275,8 +1275,8 @@ configs:
       TILE: mma_m16n8k16_f16_f32/f1x4/k8
       WORK: w4x1
     measurements:
-      emmy_us: 22.2777
-      reference_us: 100.4983
+      emmy_us: 22.3651
+      reference_us: 100.6446
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1298,7 +1298,47 @@ configs:
       WORK: w2x2
     measurements:
       emmy_us: 17.2844
-      reference_us: 59.7858
+      reference_us: 59.8646
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - unsqueeze
+  realizations:
+  - name: k_unsqueeze_636992.e0770b339983
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: ''
+      TILE: f4
+      WORK: ''
+    measurements:
+      emmy_us: 1.321
+      reference_us: 1.4967
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - unsqueeze_1
+  realizations:
+  - name: k_unsqueeze_636992.e0770b339983.unsqueeze_1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: ''
+      STAGE: ''
+      TILE: f4
+      WORK: ''
+    measurements:
+      emmy_us: 1.3205
+      reference_us: 1.4689
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1356,8 +1396,8 @@ configs:
       TILE: mma_m16n8k16_f16_f32/f1x8/k8
       WORK: w8x2
     measurements:
-      emmy_us: 67.0379
-      reference_us: 246.4689
+      emmy_us: 67.3792
+      reference_us: 246.5477
       reference_backend: torch-eager
 - program: 0
   target:
@@ -1378,56 +1418,73 @@ configs:
       WORK: w2x2
     measurements:
       emmy_us: 46.5189
-      reference_us: 32.768
+      reference_us: 30.0373
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_2
+    - add_2_c1_bc
+    - add_4
+    - cat_1
+    - mean_2
+    - mul_4
+    - mul_5
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - pow_3
+    - rsqrt_2
+    - rsqrt_2_bc
+    - slice_3
+    - slice_4
+    - to_5
+    - transpose_1
+  realizations:
+  - name: k_mean_6cb2c7.159833359fae
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      RASTER: ''
+      REDUCE: coop
+      STAGE: ''
+      TILE: ''
+      WORK: t64
+    measurements:
+      emmy_us: 5.4038
+      reference_us: 271.5479
       reference_backend: torch-eager
 - program: 0
   target:
     origins:
     - add_1
     - add_1_c1_bc
-    - add_2
-    - add_2_c1_bc
     - add_3
-    - add_4
     - cat
-    - cat_1
     - mean_1
-    - mean_2
     - mul_2
     - mul_3
-    - mul_4
-    - mul_5
     - mul_6
     - mul_7
-    - mul_8
-    - mul_9
-    - n0
-    - n1
     - neg
-    - neg_1
-    - p_attn_k_norm_weight_bc
     - p_attn_q_norm_weight_bc
     - pow_2
-    - pow_3
     - rsqrt_1
     - rsqrt_1_bc
-    - rsqrt_2
-    - rsqrt_2_bc
     - scaled_dot_product_attention
     - slice_1
     - slice_2
-    - slice_3
-    - slice_4
     - to_3
-    - to_5
     - transpose
-    - transpose_1
-    - unsqueeze
-    - unsqueeze_1
     - unsqueeze_1_bc
     - unsqueeze_bc
   realizations:
-  - name: k_sdpa_mean_reduce_29d3df.171afed452e2
+  - name: k_sdpa_mean_reduce_7968d0.c530162a5c99
     bindings: {}
     pins:
       FAST_MATH: false

--- a/experiments/golden-bench-2026/kernels/recipe.yaml
+++ b/experiments/golden-bench-2026/kernels/recipe.yaml
@@ -1,5 +1,10 @@
 # One bounded model-derived corpus and its diagnostics. Every row is an ordinary matrix task on a shared per-GPU VM;
 # the study field keeps the headline common corpus, large-shape supplement, convergence check, and ablation separate.
+#
+# A row that names a `golden` replays `golden/<golden>.golden.yaml` instead of tracing and searching: those
+# schedules were tuned by the tune-kernels skill and committed beside this recipe, and the row only re-measures them
+# at deployable -O3. Rows with `golden: ""` keep the original trace + in-recipe search. Both paths end in the same
+# five fresh-process `emmy run --golden ... --bench --strict` repeats, so the two lanes produce the same evidence.
 command:
   stage:
     - emmy
@@ -7,6 +12,7 @@ command:
     - requirements.txt
     - Makefile
     - experiments/golden-bench-2026/kernels/recipe.yaml
+    - experiments/golden-bench-2026/kernels/golden
   strict: true
   run: |
     set -euo pipefail
@@ -23,7 +29,7 @@ command:
         final_status=1
       fi
       printf 'study=%s\nstatus=%s\n' "$study" "$$final_status" > $task_dir/status.txt
-      archive_tmp=$${task_dir}.artifacts.tar.gz
+      archive_tmp=$task_dir.artifacts.tar.gz
       tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
       mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
       exit "$$final_status"
@@ -40,26 +46,43 @@ command:
     devices="$gpu_device_ids"
     first_device=$${devices%%,*}
 
-    trace_args=(
-      ./venv/bin/emmy trace "$model_ref" --layer "$layer" --seq-len "$seq_len"
-      --model-provenance "$model_ref" --output $task_dir/working.yaml
-    )
-    "$${trace_args[@]}" 2>&1 | tee $task_dir/trace.log
-
-    if [ "$budget" = "0" ]; then
-      echo "tuning intentionally skipped for the cold greedy case" | tee $task_dir/tune.log
+    if [ -n "$golden" ]; then
+      cp $repo_dir/experiments/golden-bench-2026/kernels/golden/$golden.golden.yaml $task_dir/working.yaml
+      echo "replaying committed golden $golden" | tee $task_dir/trace.log
+      echo "search owned by the tune-kernels skill; this row only re-measures" | tee $task_dir/tune.log
     else
-      ./venv/bin/emmy tune --golden-file $task_dir/working.yaml --clean \
-        --devices "$$devices" --max-candidates "$budget" --patience "$patience" --seed "$seed" \
-        --dump-dir $task_dir/dump 2>&1 | tee $task_dir/tune.log
+      trace_args=(
+        ./venv/bin/emmy trace "$model_ref" --layer "$layer" --seq-len "$seq_len"
+        --model-provenance "$model_ref" --output $task_dir/working.yaml
+      )
+      "$${trace_args[@]}" 2>&1 | tee $task_dir/trace.log
+
+      if [ "$budget" = "0" ]; then
+        echo "tuning intentionally skipped for the cold greedy case" | tee $task_dir/tune.log
+      else
+        ./venv/bin/emmy tune --golden-file $task_dir/working.yaml --clean \
+          --devices "$$devices" --max-candidates "$budget" --patience "$patience" --seed "$seed" \
+          --dump-dir $task_dir/dump 2>&1 | tee $task_dir/tune.log
+      fi
     fi
 
+    # Every repeat runs even when one target fails its correctness/backend gate, so a single hard
+    # target cannot discard the other four fresh-process replays. The per-repeat exit status is
+    # preserved and the task still fails, so the failure is reported rather than hidden.
+    verification_status=0
     for repeat in 0 1 2 3 4; do
-      EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
+      if EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
         --golden $task_dir/working.yaml --bench --strict \
         --json $task_dir/verification/repeat-$$repeat --warmup 10 --iters 100 \
-        --bench-backends eager,tcompile,emmy 2>&1 | tee $task_dir/verification-$$repeat.log
+        --bench-backends eager,tcompile,emmy 2>&1 | tee $task_dir/verification-$$repeat.log; then
+        repeat_status=0
+      else
+        repeat_status=$$?
+        verification_status=$$repeat_status
+      fi
+      printf '%s\n' "$$repeat_status" > $task_dir/verification/repeat-$$repeat.status
     done
+    exit "$$verification_status"
   result_files:
     - artifacts.tar.gz
   timeout: 86400
@@ -75,15 +98,30 @@ matrices:
       patience: 4
       seed: 0
       fp8_mma: 0
+      golden: ""
       zip:
         deploy.gpu:
           - "NVIDIA Tesla V100 SXM3 32GB"
-          - "NVIDIA A100 80GB"
           - "NVIDIA GeForce RTX 4090"
           - "NVIDIA GeForce RTX 5090"
           - "NVIDIA H200 141GB"
           - "NVIDIA B200"
         deploy.gpu_count: 1
+
+  # The same common corpus on the A100, replaying the committed fully tuned goldens instead of searching.
+  - cross:
+      study: common
+      model_ref: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
+      layer: 0
+      budget: 0
+      patience: 0
+      seed: 0
+      fp8_mma: 0
+      deploy.gpu: "NVIDIA A100 80GB"
+      deploy.gpu_count: 1
+      zip:
+        seq_len: [1, 512]
+        golden: [qwen3-06b-s1_a100, qwen3-06b-s512_a100]
 
   # Dynamic-FP8 checkpoint layers on FP8-capable GPUs. A future golden filter will define the W8A8-only corpus.
   - cross:
@@ -95,6 +133,7 @@ matrices:
       patience: 4
       seed: 0
       fp8_mma: 1
+      golden: ""
       zip:
         deploy.gpu:
           - "NVIDIA GeForce RTX 4090"
@@ -113,6 +152,7 @@ matrices:
       patience: 3
       seed: 0
       fp8_mma: 1
+      golden: ""
       zip:
         deploy.gpu: ["NVIDIA H200 141GB", "NVIDIA B200"]
         deploy.gpu_count: 1
@@ -127,6 +167,7 @@ matrices:
       patience: 3
       seed: 0
       fp8_mma: 0
+      golden: ""
       zip:
         deploy.gpu: ["NVIDIA H200 141GB", "NVIDIA B200"]
         deploy.gpu_count: 1
@@ -141,6 +182,7 @@ matrices:
       patience: 4
       seed: [0, 1, 2]
       fp8_mma: 0
+      golden: ""
       deploy.gpu: "NVIDIA H200 141GB"
       deploy.gpu_count: 1
 
@@ -154,6 +196,7 @@ matrices:
       patience: 4
       seed: [0, 1, 2]
       fp8_mma: 1
+      golden: ""
       deploy.gpu: "NVIDIA H200 141GB"
       deploy.gpu_count: 1
 
@@ -164,6 +207,7 @@ matrices:
     seq_len: 512
     seed: 0
     fp8_mma: 0
+    golden: ""
     deploy.gpu: "NVIDIA H200 141GB"
     deploy.gpu_count: 1
     zip:

--- a/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c47d15b092d35f008909c9fb67ffcaaf7e75e046359c1764a263791d0ac03157
+size 227427

--- a/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c47d15b092d35f008909c9fb67ffcaaf7e75e046359c1764a263791d0ac03157
-size 227427
+oid sha256:a3545bd8ce69bd784dfc34a9ea181ecdac2a1431fe90d528dac013afb2d609f3
+size 229219

--- a/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3545bd8ce69bd784dfc34a9ea181ecdac2a1431fe90d528dac013afb2d609f3
-size 229219
+oid sha256:623c7b6a7cdffb4b95402c881d1b4d503002d51bf80d8ccedf30b7168258581c
+size 232103

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -985,3 +985,39 @@ def test_full_self_attn_tinyllama_seq512(_chain_tile_pins):
     (default on sm_90+) reorders FMAs vs cp.async. Catches order-of-magnitude regressions, not
     bit-equivalence."""
     _run_self_attn_tinyllama(seq_len=512, threshold=2.0)
+
+
+class _GqaDecodeBatch(torch.nn.Module):
+    """The Neptune ``decode_gqa`` spelling: the query heads of one KV group as a broadcast batch dim."""
+
+    def forward(self, q, k, v):
+        return F.scaled_dot_product_attention(
+            q.reshape(1, 2, 4, 1, 16), k.reshape(1, 2, 1, 64, 16), v.reshape(1, 2, 1, 64, 16), is_causal=False
+        ).reshape(1, 8, 1, 16)
+
+
+@requires_cuda
+@pytest.mark.parametrize("variant", ["plain", "gqa_batch"])
+def test_decode_sdpa_matches_torch(variant):
+    """One query over a populated key set — the shape every decode step takes. Three defects hid
+    behind it: the SDPA decomposition read the KEY length off the query (scores ``(1, 1)``, so the
+    output was ``ΣV``), the fused softmax·V view took the heads as the mma rows while V varied
+    per head (B must never read the row axis), and the GQA batch spelling sank ``1/den`` into the
+    joined expectation channel, streaming it against the running denominator (NaN)."""
+    torch.manual_seed(0)
+    if variant == "plain":
+        module, q = _Sdpa(), torch.randn(1, 8, 1, 16)
+        ref_shape = (1, 8, 64, 16)
+    else:
+        module, q = _GqaDecodeBatch(), torch.randn(1, 8, 1, 16)
+        ref_shape = (1, 2, 64, 16)
+    k, v = (torch.randn(*ref_shape) for _ in range(2))
+    backend, compiled, _graph, kernels = _trace(module, (q, k, v))
+    assert kernels
+    cq, ck, cv = q.cuda(), k.cuda(), v.cuda()
+
+    def rc():
+        with torch.no_grad():
+            return module(cq, ck, cv).cpu().flatten().numpy()
+
+    assert _max_diff(backend, compiled, {"q": q.numpy(), "k": k.numpy(), "v": v.numpy()}, rc) < 1e-4

--- a/tests/compiler/ir/test_expr_simplify_symbolic.py
+++ b/tests/compiler/ir/test_expr_simplify_symbolic.py
@@ -126,3 +126,14 @@ def test_static_axis_unchanged_behavior():
     assert ctx.ranges["a"] == Interval(0, 31)
     # i % 32 with i in [0,32) folds to i (literal path).
     assert BinaryExpr("%", Var("a"), Literal(32, "int")).simplify(ctx) == Var("a")
+
+
+def test_scaled_term_div_folds_through_a_larger_divisor():
+    """``(h*128 + c) / 1024`` with ``c < 128`` is ``h / 8``: the collapsed GQA-group index of a
+    decode sweep. Unfolded, every statistic indexed by it looked column-dependent and was replayed
+    per head-dim column by fusion."""
+    ctx = extend_simplify_ctx(extend_simplify_ctx(SimplifyCtx.empty(), Axis("h", 64)), Axis("c", 128))
+    idx = BinaryExpr("+", BinaryExpr("*", Var("h"), Literal(128, "int")), Var("c"))
+    assert BinaryExpr("/", idx, Literal(1024, "int")).simplify(ctx) == BinaryExpr("/", Var("h"), Literal(8, "int"))
+    rem = BinaryExpr("%", idx, Literal(1024, "int")).simplify(ctx)
+    assert rem == BinaryExpr("+", BinaryExpr("*", BinaryExpr("%", Var("h"), Literal(8, "int")), Literal(128, "int")), Var("c"))

--- a/tests/compiler/passes/test_decompose_rules.py
+++ b/tests/compiler/passes/test_decompose_rules.py
@@ -836,3 +836,19 @@ def test_transpose_fold_is_capability_and_shape_unconditional():
             target_mod.set_target(None)
         assert folded_m1, f"M=1 matvec weight must fold at {cap}"
         assert folded_m64, f"M>1 weight must fold at {cap} — the sub-sm_90 no-fold gate is deleted"
+
+
+def test_sdpa_scores_take_the_key_length_from_k():
+    """A decode step scores one query against every key: the scores and K^T shapes read the key
+    length off K, not the query (the query-length reading scored key 0 alone)."""
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("Q", (2, 1, 8)), node_id="Q")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("K", (2, 16, 8)), node_id="K")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("V", (2, 16, 8)), node_id="V")
+    g.add_node(op=SdpaOp(is_causal=False, scale=None), inputs=["Q", "K", "V"], output=Tensor("out", (2, 1, 8)), node_id="sdpa_out")
+    g.inputs, g.outputs = ["Q", "K", "V"], ["sdpa_out"]
+    result = _apply(g, "010_sdpa.py")
+    shapes = {n.output.name: tuple(d.as_static() for d in n.output.shape) for n in result.nodes.values()}
+    assert shapes["out_kt"] == (2, 8, 16)
+    assert shapes["out_scaled"] == (2, 1, 16)
+    assert shapes["out_softmax"] == (2, 1, 16)

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -389,3 +389,50 @@ def test_multi_stat_entangled_with_expanding_tail_still_refuses() -> None:
 
 def _wrap_rows(body: Body) -> Body:
     return Body.coerce((Loop(axis=Axis(name="a0", extent=Dim(8)), body=body),))
+
+
+def test_fusion_refuses_a_per_step_statistic_chained_inside_a_sweep() -> None:
+    """The attention ``k-norm → Q·Kᵀ`` shape: fused greedily, the key statistic is recomputed once
+    per query row INSIDE the key sweep and feeds the dot there — a step recognition can only keep
+    as the raw-loop escape (21 ms scalar against a 360 µs eager on Qwen3-0.6B layer 0). The merge
+    is refused; the single-fold-per-step sweeps (norm→linear, expectation channels) are not."""
+    from emmy.compiler.pipeline.passes.loop.fusion._merge import _chains_statistic_in_sweep
+
+    m, n, k, k2 = Axis("m", Dim(8)), Axis("n", Dim(8)), Axis("k", Dim(16)), Axis("k2", Dim(16))
+    dot = Loop(
+        axis=k,
+        body=Body(
+            (
+                Load(name="xv", input="x", index=(Var("m"), Var("k"))),
+                Load(name="wv", input="w", index=(Var("n"), Var("k"))),
+                Assign(name="ws", op=ElementwiseImpl("multiply"), args=("wv", "rs")),
+                Assign(name="prod", op=ElementwiseImpl("multiply"), args=("xv", "ws")),
+                Accum(name="acc", value="prod", op=ElementwiseImpl("add"), axes=("k",)),
+            )
+        ),
+    )
+    row_stat = Loop(
+        axis=k2,
+        body=Body(
+            (
+                Load(name="wq", input="w", index=(Var("n"), Var("k2"))),
+                Assign(name="sq", op=ElementwiseImpl("multiply"), args=("wq", "wq")),
+                Accum(name="ss", value="sq", op=ElementwiseImpl("add"), axes=("k2",)),
+            )
+        ),
+    )
+    rs = Assign(name="rs", op=ElementwiseImpl("rsqrt"), args=("ss",))
+    store = Write(output="out", index=(Var("m"), Var("n")), value="acc")
+    outer_stat = Loop(
+        axis=Axis("k3", Dim(16)),
+        body=Body(
+            (Load(name="xq", input="x", index=(Var("m"), Var("k3"))), Accum(name="qs", value="xq", op=ElementwiseImpl("add"), axes=("k3",)))
+        ),
+    )
+
+    # Statistic replayed per sweep step and chained into the dot: refused.
+    chained = LoopOp(body=Body((Loop(axis=m, body=Body((outer_stat, Loop(axis=n, body=Body((row_stat, rs, dot, store)))))),)))
+    assert _chains_statistic_in_sweep(chained)
+    # The same statistic hoisted above the sweep (norm→linear's readable form): one fold per step.
+    hoisted = LoopOp(body=Body((Loop(axis=n, body=Body((row_stat, rs, Loop(axis=m, body=Body((dot, store)))))),)))
+    assert not _chains_statistic_in_sweep(hoisted)

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -527,10 +527,9 @@ def test_fusion_folds_a_collapsing_reshape_instead_of_splicing_a_reduce_into_it(
         inputs={"s": g.nodes["s"].output},
     )
     g.add_node(op=flat, inputs=["s"], output=Tensor("r", (32,), F16), node_id="r")
-    g.add_node(op=ElementwiseOp(op="exp"), inputs=["r"], output=Tensor("y", (32,), F16), node_id="y")
-    g.inputs, g.outputs = ["x"], ["y"]
+    g.inputs, g.outputs = ["x"], ["r"]
 
-    out = Pipeline.build(LOOP_PASSES).run(g)
+    out = Pipeline.build(LOOP_PASSES).run(g.copy())
     loops = [n for n in out.nodes.values() if isinstance(n.op, LoopOp)]
     reducing = [n for n in loops if n.op.reduce_axis_names]
     assert len(reducing) == 1, "one reduce-bearing loop — the reshape did not splice the reduce"
@@ -541,3 +540,13 @@ def test_fusion_folds_a_collapsing_reshape_instead_of_splicing_a_reduce_into_it(
     assert not any(isinstance(s, Load) and s.input == "s" for n in loops for s in n.op.body.iter()), (
         "the copy folded into the producer's writes"
     )
+
+    # A COMPUTING sink that absorbed the reshape (the output-gate multiply over the flattened
+    # heads) refuses the splice the same way; it has no identity to fold, so it stays a kernel
+    # reading the producer's materialized tensor.
+    g.add_node(op=ElementwiseOp(op="exp"), inputs=["r"], output=Tensor("y", (32,), F16), node_id="y")
+    g.outputs = ["y"]
+    out = Pipeline.build(LOOP_PASSES).run(g)
+    loops = [n for n in out.nodes.values() if isinstance(n.op, LoopOp)]
+    assert len([n for n in loops if n.op.reduce_axis_names]) == 1, "the reduce was not spliced into the gate kernel"
+    assert any(isinstance(s, Load) and s.input == "s" for n in loops for s in n.op.body.iter()), "the gate kernel reads s"

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -436,3 +436,108 @@ def test_fusion_refuses_a_per_step_statistic_chained_inside_a_sweep() -> None:
     # The same statistic hoisted above the sweep (norm→linear's readable form): one fold per step.
     hoisted = LoopOp(body=Body((Loop(axis=n, body=Body((row_stat, rs, Loop(axis=m, body=Body((dot, store)))))),)))
     assert not _chains_statistic_in_sweep(hoisted)
+
+
+def test_fusion_refuses_a_reduce_replayed_under_a_composite_axis() -> None:
+    """softmax·V spliced into its ``(head, d)`` flatten: the kernel's free axis is the flat
+    ``head*256 + d`` and the per-head statistic reads it only as ``flat / 256`` — recomputed for
+    every ``d`` with no loop to hoist it out of. Refused; a reduce that does not read the axis
+    (the hoistable norm→linear statistic) is not."""
+    from emmy.compiler.ir.expr import BinaryExpr, Literal
+    from emmy.compiler.pipeline.passes.loop.fusion._merge import _replays_reduce_under_composite_axis
+
+    q, flat, k = Axis("q", Dim(8)), Axis("f", Dim(512)), Axis("k", Dim(16))
+    head = BinaryExpr("/", Var("f"), Literal(256, "int"))
+    stat = Loop(
+        axis=k,
+        body=Body(
+            (
+                Load(name="s", input="scores", index=(head, Var("q"), Var("k"))),
+                Accum(name="mx", value="s", op=ElementwiseImpl("maximum"), axes=("k",)),
+            )
+        ),
+    )
+    store = Write(output="out", index=(Var("q"), Var("f")), value="mx")
+    replayed = LoopOp(body=Body((Loop(axis=q, body=Body((Loop(axis=flat, body=Body((stat, store))),))),)))
+    assert _replays_reduce_under_composite_axis(replayed)
+    invariant = Loop(
+        axis=k,
+        body=Body(
+            (
+                Load(name="x", input="x", index=(Var("q"), Var("k"))),
+                Accum(name="ss", value="x", op=ElementwiseImpl("add"), axes=("k",)),
+            )
+        ),
+    )
+    store_ss = Write(output="out", index=(Var("q"), Var("f")), value="ss")
+    hoistable = LoopOp(body=Body((Loop(axis=q, body=Body((Loop(axis=flat, body=Body((invariant, store_ss))),))),)))
+    assert not _replays_reduce_under_composite_axis(hoistable)
+
+
+def test_fusion_folds_a_collapsing_reshape_instead_of_splicing_a_reduce_into_it() -> None:
+    """softmax·V followed by its ``(head, d) → flat`` reshape: splicing the reduce-bearing
+    producer at the reshape's load sites replays its statistic per flat element (the head is
+    ``flat / 256``); the merge is refused and ``030_fold_output_reshape`` retargets the
+    producer's writes onto the flat buffer instead, whether or not the reshape is the graph
+    output. The fused graph keeps one reduce-bearing loop whose free axes are still ``(h, d)``."""
+    import math
+
+    from emmy.compiler.ir.expr import BinaryExpr, Literal
+    from emmy.compiler.ir.tensor.ir import ElementwiseOp
+    from emmy.compiler.pipeline import LOOP_PASSES
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (4, 8, 16), F16), node_id="x")
+    h, d, k = Axis("h", Dim(4)), Axis("d", Dim(8)), Axis("k", Dim(16))
+    red = Loop(
+        axis=k,
+        body=Body(
+            (
+                Load(name="xv", input="x", index=(Var("h"), Var("d"), Var("k"))),
+                Accum(name="acc", value="xv", op=ElementwiseImpl("add"), axes=("k",)),
+            )
+        ),
+    )
+    prod = LoopOp(
+        body=Body(
+            (Loop(axis=h, body=Body((Loop(axis=d, body=Body((red, Write(output="s", index=(Var("h"), Var("d")), value="acc")))),))),)
+        ),
+        inputs={"x": g.nodes["x"].output},
+    )
+    g.add_node(op=prod, inputs=["x"], output=Tensor("s", (4, 8), F16), node_id="s")
+    f = Axis("f", Dim(32))
+    flat = LoopOp(
+        body=Body(
+            (
+                Loop(
+                    axis=f,
+                    body=Body(
+                        (
+                            Load(
+                                name="sv",
+                                input="s",
+                                index=(BinaryExpr("/", Var("f"), Literal(8, "int")), BinaryExpr("%", Var("f"), Literal(8, "int"))),
+                            ),
+                            Write(output="r", index=(Var("f"),), value="sv"),
+                        )
+                    ),
+                ),
+            )
+        ),
+        inputs={"s": g.nodes["s"].output},
+    )
+    g.add_node(op=flat, inputs=["s"], output=Tensor("r", (32,), F16), node_id="r")
+    g.add_node(op=ElementwiseOp(op="exp"), inputs=["r"], output=Tensor("y", (32,), F16), node_id="y")
+    g.inputs, g.outputs = ["x"], ["y"]
+
+    out = Pipeline.build(LOOP_PASSES).run(g)
+    loops = [n for n in out.nodes.values() if isinstance(n.op, LoopOp)]
+    reducing = [n for n in loops if n.op.reduce_axis_names]
+    assert len(reducing) == 1, "one reduce-bearing loop — the reshape did not splice the reduce"
+    free = [lp for lp in reducing[0].op.body.iter() if isinstance(lp, Loop) and lp.axis.name not in reducing[0].op.reduce_axis_names]
+    # The free extents still cover one output element per reduce (``loop/canonicalize`` may
+    # re-fuse the clean ``(h, d)`` pair into the flat axis — a layout choice, not a replay).
+    assert math.prod(lp.axis.extent.as_static() for lp in free) == 32
+    assert not any(isinstance(s, Load) and s.input == "s" for n in loops for s in n.op.body.iter()), (
+        "the copy folded into the producer's writes"
+    )

--- a/tests/compiler/passes/test_total_lift.py
+++ b/tests/compiler/passes/test_total_lift.py
@@ -329,3 +329,46 @@ def test_recognize_fires_through_the_pipeline():
 
     tiles = [n.op for n in lowered.nodes.values() if isinstance(n.op, TileOp)]
     assert tiles, "the lift fired and nothing downstream traffics in LoopOp"
+
+
+def test_prologue_read_by_an_earlier_raw_loop_is_not_sunk_past_it():
+    """A pure prologue value read by a reduce loop that DECLINED the lift (so it stands raw, ahead
+    of a later reduce) must stay ahead of that raw loop. Sinking it into the later loop's λ leaves
+    the raw loop reading an undefined name — the decode-attention ``v1`` / ``v3`` miscompile."""
+    m = Axis("m", Dim(8))
+    k1, k2, k3 = (Axis(nm, Dim(1)) for nm in ("k", "k2", "k3"))
+    # ``sc`` feeds pass1 AND the epilogue-side chain, so pass1 cannot take it and stays raw.
+    prologue = (
+        Load(name="s", input="x", index=(Var("m"),)),
+        Assign(name="sc", op=ElementwiseImpl("add"), args=("s", "s")),
+    )
+    pass1 = Loop(axis=k1, body=Body((Accum(name="mx", value="sc", op=ElementwiseImpl("maximum"), axes=("k",)),)))
+    mid = (
+        Assign(name="sh", op=ElementwiseImpl("subtract"), args=("sc", "mx")),
+        Assign(name="ex", op=ElementwiseImpl("exp"), args=("sh",)),
+    )
+    pass2 = Loop(axis=k2, body=Body((Accum(name="den", value="ex", op=ElementwiseImpl("add"), axes=("k2",)),)))
+    tail = (
+        Assign(name="pr", op=ElementwiseImpl("divide"), args=("ex", "den")),
+        Load(name="vv", input="v", index=(Var("m"),)),
+        Assign(name="pv", op=ElementwiseImpl("multiply"), args=("vv", "pr")),
+    )
+    pass3 = Loop(axis=k3, body=Body((Accum(name="acc", value="pv", op=ElementwiseImpl("add"), axes=("k3",)),)))
+    cell = (*prologue, pass1, *mid, pass2, *tail, pass3, Write(output="out", index=(Var("m"),), value="acc"))
+    tile = _tile(Body((Loop(axis=m, body=Body(cell)),)))
+
+    # Every name a stmt reads is defined by an earlier stmt at the same or an enclosing level.
+    def check(body, defined):
+        for s in body:
+            if isinstance(s, Loop):
+                check(list(s.body), set(defined) | {s.axis.name})
+                defined |= set(deep_defines(s))
+                continue
+            reads = set(s.deps()) if not isinstance(s, Fold) else set()
+            assert reads <= defined, f"{s} reads {sorted(reads - defined)} before definition"
+            defined |= set(s.defines()) if not isinstance(s, Fold) else set(deep_defines(s))
+
+    from emmy.compiler.ir.pure.fold import deep_defines
+
+    root = tile.op
+    check(list(root.lower()), {a.name for a in tile.place.free})

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -1457,3 +1457,31 @@ def test_trace_clamp_matches_torch_eager():
     with torch.no_grad():
         want = m(gate, up).numpy()
     np.testing.assert_allclose(next(iter(outs.values())), want, rtol=1e-5, atol=1e-6)
+
+
+def test_trace_factory_constructors_and_like_forms_match_eager():
+    """``torch.ones``/``zeros``/``full`` export as input-less leaves; ``ones_like`` carries a template.
+
+    Before, a zero-input factory produced no graph node at all, so its consumer lost an operand
+    and failed later with an unrelated error (the ``triu``/``masked_fill`` chunk-mask idiom).
+    """
+    import numpy as np
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.backend.numpy import NumpyBackend
+    from emmy.compiler.trace.torch import trace_module
+
+    class Factories(nn.Module):
+        def forward(self, x):
+            ones = torch.ones(x.shape[-1], x.shape[-1], dtype=x.dtype)
+            full = torch.full((x.shape[-1],), 2.5, dtype=x.dtype)
+            like = torch.ones_like(x) - torch.zeros_like(x)
+            return x * ones.sum(dim=0) + full + like
+
+    x = torch.randn(2, 3, 4)
+    graph = trace_module(Factories(), (x,))
+    backend = NumpyBackend()
+    result, _ = backend.run(backend.compile(graph), input_data={graph.inputs[0]: x.numpy()})
+    got = next(iter(result.outputs.values()))
+    np.testing.assert_allclose(got, Factories()(x).numpy(), rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary

The experiment side of the golden-bench-2026 tuned-lane campaign, on top of the compiler fixes in #584 (rebase onto it once that merges; the six compiler commits are currently duplicated here).

- **Kernel corpus (A100 common rows)**: the recipe replays a committed hybrid-tuned golden instead of searching in-recipe (`golden/qwen3-06b-s{1,512}_a100.golden.yaml`); five fresh-process -O3 replays archived. Emmy beats eager on both layer totals (1.56× at s512, 1.39× at s1; s512 moved 21.7 ms → 657 µs over the campaign). Remaining losses: softmax·V, o_proj+residual, v_proj, down_proj, M=1 norm+gate/up. Both rows still report `failed` because Inductor 2.13 cannot compile the RoPE reference for two targets.
- **Neptune comparison lane**: split into a golden replay arm and a reference arm; all 40 setups (5 operators × 8 lengths) hybrid-tuned and committed; 5/5 rows succeeded. All 16 decode setups pass strict for the first time. Emmy loses every measured setup to Neptune and torch.compile (0.59× → 0.02×, widening with context) — attention still materializes the score matrix; four 32K/16K prefill setups hit the lane's 600 s budget.
- **Qwen3.8-27B (RTX 4090)** stays stock-only: the delta-rule `copy_` recurrence, the compressed-tensors W4A16 loader and the runner's missing recurrent-state carry block an Emmy arm. The tuned layer-3 kernel inventory lives under `_tune/` (untracked), not in a recipe golden (partial coverage).

Draft until rebased onto #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)