### PR TITLE
Attention recognition: chain root formation, decode-attention and lift fixes

### DIFF
--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -780,7 +780,12 @@ def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, a
             abs_sum += float(absolute.sum())
             count += int(absolute.size)
             if failure is None and not np.all(absolute <= tolerance):
-                failure = f"output {name!r} exceeds rtol={rtol:g}, atol={atol:g}"
+                worst = int(np.argmax(absolute - tolerance))
+                failure = (
+                    f"output {name!r} exceeds rtol={rtol:g}, atol={atol:g}: "
+                    f"{int((absolute > tolerance).sum())}/{absolute.size} elements, "
+                    f"worst at flat index {worst}: emmy={actual.flat[worst]:.6g} eager={expected.flat[worst]:.6g}"
+                )
 
     proof = {
         "status": "fail" if failure else "pass",
@@ -792,7 +797,7 @@ def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, a
         "max_rel_error": max_rel,
     }
     if failure:
-        proof["error"] = failure
+        proof["error"] = f"{failure} (max_abs={max_abs:.3g}, mean_abs={proof['mean_abs_error']:.3g}, max_rel={max_rel:.3g})"
     return proof
 
 

--- a/emmy/compiler/backend/cuda/render_target.py
+++ b/emmy/compiler/backend/cuda/render_target.py
@@ -121,7 +121,9 @@ _NATIVE_FP16_OPS: frozenset[str] = frozenset(
         "copy",
         "reciprocal",
         "relu",
-        "sigmoid",
+        # Not ``sigmoid``: its half spelling ``1/(1+hexp(-x))`` rounds three times, which lands up
+        # to two half-ulps from torch's compute-in-f32-round-once value and fails the strict
+        # ``rtol=1e-3`` gate; the non-native path below computes it in f32 and converts once.
     }
 )
 

--- a/emmy/compiler/ir/expr.py
+++ b/emmy/compiler/ir/expr.py
@@ -884,12 +884,23 @@ def _div_mod_decompose(expr: Expr, n: int, ctx: SimplifyCtx) -> tuple[Expr, Expr
         for k_side, other_side in ((expr.right, expr.left), (expr.left, expr.right)):
             if not (isinstance(k_side, Literal) and k_side.dtype == "int" and isinstance(k_side.value, int)):
                 continue
-            if k_side.value <= 0 or k_side.value % n != 0:
+            if k_side.value <= 0:
                 continue
             rng = other_side.range(ctx)
-            if rng is not None and rng.lo >= 0:
-                q_expr = BinaryExpr("*", other_side, _make_int_literal(k_side.value // n)).simplify(ctx)
+            if rng is None or rng.lo < 0:
+                continue
+            k = k_side.value
+            if k % n == 0:
+                q_expr = BinaryExpr("*", other_side, _make_int_literal(k // n)).simplify(ctx)
                 return (q_expr, _make_int_literal(0))
+            if n % k == 0:
+                # ``x*k = n*(x / d) + k*(x % d)`` for ``d = n/k``: the collapsed-reshape index
+                # ``(head*128 + col) / 1024`` (a GQA group fold over the head-dim sweep) reads as
+                # ``head / 8`` once the remainder ``(head % 8)*128 + col`` proves below ``n``.
+                d = _make_int_literal(n // k)
+                q_expr = BinaryExpr("/", other_side, d).simplify(ctx)
+                r_expr = BinaryExpr("*", BinaryExpr("%", other_side, d), _make_int_literal(k)).simplify(ctx)
+                return (q_expr, r_expr)
     if isinstance(expr, BinaryExpr) and expr.op == "+":
         L = _div_mod_decompose(expr.left, n, ctx)
         R = _div_mod_decompose(expr.right, n, ctx)

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -602,15 +602,28 @@ class Fold:
         bound param (:func:`splice_operands` — positional binding names the edges, ties in
         operand order), so a fold with hoisted inputs lowers byte-identically to the flat form
         that carried them in its body."""
-        stmts = splice_operands(self._splice_edges(), _flatten_nodes(self.step_stmts()))
+        stmts = splice_operands(self._step_edges(), _flatten_nodes(self.step_stmts()))
         return Loop(axis=self.axis, body=Body(stmts), unroll=self.unroll, role=self.role)
+
+    def _hoisted_edges(self) -> tuple:
+        """The operand edges the loop does NOT re-evaluate per step: a computed edge whose subtree
+        never reads the fold's iteration var (a chained producer — the normalized row's
+        statistic, a sibling fold's projected result) is loop-invariant and lowers ONCE, ahead of
+        the loop. A gmem ``Load`` edge always rides the step (its index is the operand slab)."""
+        if self.axis is None:
+            return ()
+        return tuple(e for e in self._splice_edges() if isinstance(e, Fold) and self.axis.name not in deep_reads(list(e.lower())))
+
+    def _step_edges(self) -> tuple:
+        hoisted = {id(e) for e in self._hoisted_edges()}
+        return tuple(e for e in self._splice_edges() if id(e) not in hoisted)
 
     def spliced_step(self) -> tuple[Stmt, ...]:
         """The (derived) step with every operand edge's body spliced before its first use — the
         stmt sequence the emit-side node walk consumes (nested structural nodes NOT flattened;
         :attr:`loop` additionally flattens them). Edges the derived blocked evaluation already
         consumed (a twisted fold's head node / expectation Load) never splice twice."""
-        return splice_operands(self._splice_edges(), self.step_stmts())
+        return splice_operands(self._step_edges(), self.step_stmts())
 
     @property
     def out(self) -> str:
@@ -633,8 +646,8 @@ class Fold:
         import back into :mod:`~emmy.compiler.ir.tile.ops`."""
         if self.axis is None:
             prefix = [s for e in self.operands for s in operand_body(e)]
-            return [*prefix, *self.body]
-        return [self.loop]
+            return [*prefix, *_flatten_nodes(tuple(self.body))]
+        return [*(s for e in self._hoisted_edges() for s in operand_body(e)), self.loop]
 
     # ---- the STRUCTURAL protocol — children, defs, reads, bound axes. Spelled with the stmt
     # vocabulary's names on purpose: one canonicalizer and one deep walk then serve a term and its

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -398,7 +398,15 @@ def head(op):
     node-level fact the scheduler dispatches on — the :class:`~emmy.compiler.ir.axis.AxisRole`, the
     reduce ``Axis``, the operand edges — is a STORED param on what this returns, so a scheduling
     read never needs :func:`reduce_loop` (which synthesizes a whole nest) to reach it."""
-    node = op.operands[0] if isinstance(op, Fold) and op.axis is None and op.operands else op
+    node = op
+    if isinstance(op, Fold) and op.axis is None:
+        if op.operands:
+            node = op.operands[0]
+        else:
+            # The chain form's sweep case: the column fold reads the boundary store's sweep axis,
+            # so root formation keeps it as the projection's one fold BODY member.
+            members = [s for s in op.body if isinstance(s, Fold)]
+            node = members[0] if len(members) == 1 else op
     return node if isinstance(node, Fold) and node.axis is not None else None
 
 

--- a/emmy/compiler/ir/tile/path.py
+++ b/emmy/compiler/ir/tile/path.py
@@ -379,6 +379,11 @@ def resolve(root, key: str, *, all_sites: tuple[Site, ...] | None = None) -> Sit
         cands = " or ".join(sorted(_spellings(parsed.family, s, fam_sites) for s in fam_sites))
         raise ValueError(f"{parsed.family} is ambiguous: use {cands}")
     matches = _match(parsed, fam_sites)
+    if not matches and parsed.axis is None and parsed.ordinal is not None and parsed.segments and parsed.segments[-1] in ("a", "b"):
+        # The strict parse read ``a2`` as the second ``a`` edge; an axis the loop stamp named
+        # ``a2`` is the other reading, and the literal axis name comes first.
+        as_axis = _Key(family=parsed.family, segments=parsed.segments[:-1], axis=f"{parsed.segments[-1]}{parsed.ordinal}", ordinal=None)
+        matches = _match(as_axis, fam_sites)
     if not matches and parsed.axis is not None and parsed.ordinal is None:
         m = _AXIS_ORDINAL_RE.match(parsed.axis)
         if m and m.group(1):

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -189,6 +189,22 @@ a term has at most TWO views (`_schedule._views`):
 (The old mixed-A promotion "reading" is gone: a materialized edge whose dtype the atom cannot bind directly takes the
 CONVERTING smem compute fill on the one tree — a stage resolution, not a derivation.)
 
+**The stored tree is a CHAIN, never a demoted loop.** Root formation (`_lift._form_root` / `_chain`) closes every
+fold over the values it reads from the cell: a fold whose λ reads a name a pure cell stmt defines (a normalized row's
+scale, a sibling statistic's projected result) takes that value through a zero-axis PROJECTION EDGE — the producing
+pure stmts as the edge's body, the folds they read as its operands, any fold state the consumer also reads passed
+through as a result — bound positionally to a new lift param. λ stays closed; the edge is the `make_cone` prologue
+generalized. A fold reading a boundary store's sweep axis runs once per swept element, so it stays the projection's
+fold BODY member — a stored node in place — rather than an operand (operands lower ahead of the sweep). Every node
+keeps its `PLACE` seam: the k-norm → RoPE → `Q·Kᵀ` region used to lose its statistic and dot to the raw-loop escape
+the moment one read the other's projected value, which no pin could then name. Edges that do not read the fold's
+axis lower ONCE ahead of the loop (`Fold.lower`, the reduce tier's `_emit`), so the captured loop stays byte-exact.
+The two readings above derive from the chain: `fused_view` reads a chained column (its edge's statistic and epilogue,
+the column minus the edge regenerating the raw column loop), and the per-cell reading is the chain UNDONE
+(`_classify.demoted_chain` — the statistic back at the root, the column as its captured loop), which is what the
+reduce tiers schedule and materialize. Cuts under a sweep are legal: the sweep axis is an iteration axis of the cut
+piece, not a captured value.
+
 A row carries NO view ownership: the derived contraction view offers only warp tiles (a computed operand's scalar
 list is empty) and the per-cell view only scalar / per-cell ones, so the row's `WORK` tier decodes its view by
 construction — replay is a function of `(stored op, row)` and nothing else. The union carries two obligations:

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/010_sdpa.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/010_sdpa.py
@@ -65,22 +65,25 @@ def rewrite(match: Match, root: Node, inp_q: Node, inp_k: Node, inp_v: Node, inp
 
     head_dim = q_shape[-1] if len(q_shape) >= 2 else 64
     seq_len = q_shape[-2] if len(q_shape) >= 3 else q_shape[-1]
+    # The key length is K's own, not the query's: a decode step (one query over a populated
+    # cache) scores every key, and a kt/scores shape read off the query would score only key 0.
+    kv_len = k_shape[-2] if len(k_shape) >= 3 else k_shape[-1]
     q_batch = q_shape[:-2] if len(q_shape) > 2 else ()
     k_batch = k_shape[:-2] if len(k_shape) > 2 else ()
     v_batch = v_shape[:-2] if len(v_shape) > 2 else ()
-    scores_shape = q_batch + (seq_len, seq_len)
+    scores_shape = q_batch + (seq_len, kv_len)
 
     exts = [inp_q, inp_k, inp_v] + ([inp_mask] if inp_mask is not None else [])
     frag = open_fragment(graph, exts)
 
     # K^T then GQA broadcast.
-    kt_shape = k_batch + (head_dim, seq_len) if head_dim.is_static else k_shape
+    kt_shape = k_batch + (head_dim, kv_len) if head_dim.is_static else k_shape
     kt_id = frag.add_node(
         op=TransposeOp(axes=(-2, -1)),
         inputs=[inp_k],
         output=Tensor(f"{name}_kt", kt_shape, inp_k.output.dtype),
     )
-    kt = _maybe_gqa(frag, kt_id, q_batch, k_batch, (head_dim, seq_len), name=f"{name}_kt_gqa")
+    kt = _maybe_gqa(frag, kt_id, q_batch, k_batch, (head_dim, kv_len), name=f"{name}_kt_gqa")
 
     # QK^T matmul.
     qk = matmul_decompose(frag, inp_q, kt, name=f"{name}_qk")

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -133,14 +133,19 @@ def _emit(op, ctx: Ctx) -> Frag:
         # edge per computed input: the row statistic, plus (attention) the per-cell score
         # contraction its ``exp(s − m)`` reads.
         prefix = [s for e in op.operands for s in _emit(e, ctx).body]
-        return Frag(body=[*prefix, *_emit_body(op.body, ctx)], out=_map_wire(op))
+        # A body member that is itself a node (a fold reading the store's sweep axis, chained
+        # over its statistic) emits in place, per cell.
+        body = [s for m in op.body for s in (_emit(m, ctx).body if isinstance(m, Fold) else [m])]
+        return Frag(body=[*prefix, *_emit_body(Body(tuple(body)), ctx)], out=_map_wire(op))
     if isinstance(op, Fold):
         # Every fold WITH an axis, at any role — the per-cell scalar contraction (no TILE slice)
-        # included, since a contraction is this same node under the bilinear reading. Operand
-        # edges splice ahead of first use.
+        # included, since a contraction is this same node under the bilinear reading. Loop-
+        # invariant edges (a chained statistic) emit once ahead of the loop; the rest splice into
+        # the step ahead of first use.
+        hoisted = [s for e in op._hoisted_edges() for s in _emit(e, ctx).body]
         stmts = _emit_body(Body(op.spliced_step()), ctx)
         loop = Loop(axis=op.axis, body=Body(tuple(stmts)), unroll=op.unroll, role=op.role)
-        return Frag(body=[loop], out=Handle(op.out))
+        return Frag(body=[*hoisted, loop], out=Handle(op.out))
     raise TypeError(f"_emit: expected a Fold node, got {type(op).__name__}")
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -21,7 +21,16 @@ from dataclasses import replace
 from emmy.compiler.ir.axis import AxisRole
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure import Lambda, component_ops
-from emmy.compiler.ir.pure.fold import Channel, Fold, _operand_result_names, refs_axis, stmt_axis_names
+from emmy.compiler.ir.pure.fold import (
+    Channel,
+    Fold,
+    _operand_binding,
+    _operand_result_names,
+    deep_defines,
+    deep_reads,
+    refs_axis,
+    stmt_axis_names,
+)
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body, Load, Loop, Select, Write
 from emmy.compiler.ir.tile.ops import _cone_canon, make_cone, split_invariant_factors
@@ -166,6 +175,16 @@ def _components(t: Fold, mx: str, canon: str, states: tuple[str, ...] = ()) -> l
         if split is None:
             return None
         inv, local = split
+        # An invariant factor bound through an operand EDGE (the chain form's ``1/den``) is
+        # invariant only if that edge is free of the pair's carried states: a projection over
+        # the denominator streams the RUNNING denominator once merged, the same defect the
+        # sunk-factor case below declines.
+        binding = _operand_binding(t)
+        banned = {mx, *states}
+        for c in inv:
+            e = binding.get(c)
+            if isinstance(e, Fold) and banned & (set(deep_reads(e.lower())) | deep_defines(e)):
+                return None
         weights, values = [], []
         for n in local:
             score = _exp_weight(defs, n, mx)
@@ -280,6 +299,91 @@ def _pair(fmax, rest: list) -> tuple[Fold, int, list] | None:
     return merged, consumed, epilogue
 
 
+def _chained_column(col: Fold) -> tuple[Fold, list, Loop] | None:
+    """Read a CHAINED column fold — one whose operands carry exactly one zero-axis projection
+    edge over one statistic fold — as ``(statistic, epilogue stmts, raw column loop)``: the
+    pieces the demoted-loop form of the same cell used to hold apart. ``None`` when ``col`` is
+    not that shape."""
+    if not isinstance(col, Fold) or col.axis is None:
+        return None
+    edges = [e for e in col.operands if isinstance(e, Fold) and e.axis is None]
+    if len(edges) != 1:
+        return None
+    (edge,) = edges
+    if len(edge.operands) != 1 or not isinstance(edge.operands[0], Fold) or edge.operands[0].axis is None:
+        return None
+    stat = edge.operands[0]
+    if stat.role not in (AxisRole.PLANAR, AxisRole.TWISTED) or stat.composed is not None:
+        return None
+    bare, _edge = _unchain(col)
+    return stat, list(edge.body), bare.loop
+
+
+def demoted_chain(op):
+    """The per-cell READING of a chained root — the chain undone: each chained column fold's
+    statistic becomes a root operand, its epilogue and the column's captured loop body members
+    (the raw column loop the pre-chain spelling carried), byte-identical at lowering. The reduce
+    tiers schedule this view (the statistic's cooperative partition is a ROOT site there); the
+    stored chain keeps the nodes — and the seams — the tiers cannot address."""
+    if not (isinstance(op, Fold) and op.axis is None):
+        return op
+    operands: list = []
+    body: list = []
+    changed = False
+
+    def undo(col: Fold) -> bool:
+        """Append ``col``'s pre-chain spelling: its edge's fold operands as root operands (the
+        first stays hoisted; the materializer recurses into ``operands[0]`` only, so the rest
+        restore to their loops at the body head), the edge body as the epilogue, the column as
+        its captured loop."""
+        bare, edge = _unchain(col)
+        if edge is None:
+            return False
+        folds = [e for e in edge.operands if isinstance(e, Fold)]
+        if folds:
+            if not operands:
+                operands.append(folds[0])
+                rest = folds[1:]
+            else:
+                rest = folds
+            body.extend(s for f in rest for s in f.lower())
+        body.extend([*edge.body, bare.loop])
+        return True
+
+    for e in op.operands:
+        if isinstance(e, Fold) and e.axis is not None and undo(e):
+            changed = True
+            continue
+        operands.append(e)
+    for m in op.body:
+        if isinstance(m, Fold) and m.axis is not None and undo(m):
+            changed = True
+        elif isinstance(m, Fold):
+            body.extend(m.lower())
+            changed = True
+        else:
+            body.append(m)
+    if not changed:
+        return op
+    return Fold.projection(operands=tuple(operands), body=Body(tuple(body)))
+
+
+def _unchain(col: Fold) -> tuple[Fold, Fold | None]:
+    """``col`` with its one zero-axis projection edge detached — the column fold as it read before
+    root formation closed it (its λ reading the edge's results as free names) — and that edge."""
+    edges = [e for e in col.operands if isinstance(e, Fold) and e.axis is None]
+    if len(edges) != 1:
+        return col, None
+    (edge,) = edges
+    bound = set(edge.lift.results)
+    bare = replace(
+        col,
+        operands=tuple(e for e in col.operands if e is not edge),
+        lift=Lambda(params=tuple(p for p in col.lift.params if p not in bound), body=col.lift.body, results=col.lift.results),
+    )
+    return bare, edge
+
+
 def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     """B3 — the MONOID-PRODUCER composition, read off the lifted tree: a root projection whose one
     operand is a per-row statistic fold (PLANAR Σx² — RMSNorm; TWISTED ``(m, l)`` — softmax·V) and
@@ -301,15 +405,41 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     row; its columns are the statistic's own axis — so the schedule sees a contraction in both
     places or the statistic stays a scalar sweep while the weight reaches the tensor core."""
     node, free, stores = tile.op, tuple(tile.place.free), tuple(tile.stores)
-    if not (isinstance(node, Fold) and node.axis is None and len(node.operands) == 1):
+    if not (isinstance(node, Fold) and node.axis is None):
         return None
-    stat = node.operands[0]
-    if not isinstance(stat, Fold) or stat.axis is None or stat.composed is not None:
-        return None
-    if stat.role not in (AxisRole.PLANAR, AxisRole.TWISTED):
-        return None  # the statistic is a projected reduce; a contraction there is another shape
     body = list(node.body)
-    if len(stores) == 1 and stores[0].sweep is not None:
+    # The CHAIN form: root formation closed the column fold over the statistic's projected
+    # epilogue through a projection edge. It is the root's one operand, or — when it reads the
+    # boundary store's sweep axis — the root's one fold body member. The edge's operand is the
+    # statistic, its body the epilogue, and the column fold minus that edge regenerates the raw
+    # column loop the demoted form carried — byte-identical, so the reading below is unchanged.
+    chain = None
+    if len(node.operands) == 1:
+        chain = _chained_column(node.operands[0])
+    elif not node.operands:
+        folds = [s for s in body if isinstance(s, Fold)]
+        if len(folds) == 1:
+            chain = _chained_column(folds[0])
+            if chain is not None:
+                # Body stmts ahead of the column fold are its prologue (they join the statistic
+                # epilogue the cone reads); the rest is the combine tail.
+                at = body.index(folds[0])
+                chain = (chain[0], [*body[:at], *chain[1]], chain[2])
+                body = body[at + 1 :]
+    if chain is None:
+        if len(node.operands) != 1:
+            return None
+        stat = node.operands[0]
+        if not isinstance(stat, Fold) or stat.axis is None or stat.composed is not None:
+            return None
+        if stat.role not in (AxisRole.PLANAR, AxisRole.TWISTED):
+            return None  # the statistic is a projected reduce; a contraction there is another shape
+    if chain is not None and len(stores) == 1 and stores[0].sweep is not None:
+        stat, stat_epi, kloop = chain
+        n_ax, writes, tail = stores[0].sweep, [stores[0].write], body
+    elif chain is not None:
+        return None
+    elif len(stores) == 1 and stores[0].sweep is not None:
         n_ax, writes = stores[0].sweep, [stores[0].write]
         loops = [i for i, s in enumerate(body) if isinstance(s, Loop) and s.is_reduce]
         if len(loops) != 1:
@@ -557,7 +687,7 @@ def _legalize(node):
     FREE sweeps only), so the restored sibling stays correct on every tier."""
     if isinstance(node, Fold) and node.axis is None and len(node.operands) > 1:
         keep, rest = node.operands[0], node.operands[1:]
-        node = Fold.projection(body=Body((*(f.loop for f in rest), *node.body)), operands=(keep,))
+        node = Fold.projection(body=Body((*(s for f in rest for s in f.lower()), *node.body)), operands=(keep,))
     if isinstance(node, Fold) and node.axis is None and any(isinstance(s, Loop) for s in node.body):
         lowered = tuple(_lower_nested_folds(s) if isinstance(s, Loop) else s for s in node.body)
         if any(a is not b for a, b in zip(lowered, node.body, strict=True)):
@@ -567,8 +697,19 @@ def _legalize(node):
 
 def _lower_nested_folds(s: Loop) -> Loop:
     """``s`` with every ``Fold`` member below it lowered to its verbatim loop, deep."""
-    members = tuple(m.loop if isinstance(m, Fold) else (_lower_nested_folds(m) if isinstance(m, Loop) else m) for m in s.body)
-    return s if all(a is b for a, b in zip(members, s.body, strict=True)) else replace(s, body=Body(members))
+    members: list = []
+    changed = False
+    for m in s.body:
+        if isinstance(m, Fold):
+            members.extend(m.lower())
+            changed = True
+        elif isinstance(m, Loop):
+            lowered = _lower_nested_folds(m)
+            changed = changed or lowered is not m
+            members.append(lowered)
+        else:
+            members.append(m)
+    return s if not changed else replace(s, body=Body(tuple(members)))
 
 
 def _replace_body(lift: Lambda, body: Body) -> Lambda:
@@ -606,7 +747,7 @@ def _deep_idx_vars(stmts) -> set[str]:
     return out
 
 
-def _cone(body: list, arg: str, avoid_name: str, k_name: str, axes: frozenset) -> list | None:
+def _cone(body: list, arg: str, avoid_name: str, k_name: str, axes: frozenset, bound: frozenset = frozenset()) -> list | None:
     """The backward cone of ``arg`` within a λ body, when it reads as a pure MAP producer for one
     contraction side: every member a ``Load`` / ``Assign`` / ``Select``, self-contained (no free
     SSA reads — a cross-operand read is another stage's shape; an AXIS var is an iteration
@@ -617,7 +758,7 @@ def _cone(body: list, arg: str, avoid_name: str, k_name: str, axes: frozenset) -
     stmts = list(cone.members)
     if not stmts or any(not isinstance(s, (Load, Assign, Select)) for s in stmts):
         return None
-    if set(cone.external_reads) - axes - {k_name}:
+    if set(cone.external_reads) - axes - {k_name} - bound:
         return None
     loads = [s for s in stmts if isinstance(s, Load)]
     if any(avoid_name in _idx_vars(ld) for ld in loads) or not any(k_name in _idx_vars(ld) for ld in loads):
@@ -652,8 +793,21 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
     hoist (the fp8 / W8A8 mul-hoist arm — the ``Σ a⊗(s⊗w) = s⊗Σ a⊗w`` reassociation, licensed
     by the same distributivity/commutativity traits) — registered casualties until ported to
     the λ body."""
-    if f.axis is None or f.combine is None or f.operands:
-        return None  # a fold with operand edges already composes producers — another stage's shape
+    if f.axis is None or f.combine is None:
+        return None
+    stat = sweep = None
+    bound_values: frozenset = frozenset()
+    if f.operands:
+        # The CHAIN form: root formation closed this fold over a statistic's projected epilogue
+        # through one projection edge. Bind the bare fold and hang the statistic + epilogue on
+        # the computed-A cone as its source (``make_cone(stat=…)``) — the one reading the
+        # demoted-loop form reached only through ``fused_view``.
+        chain = _chained_column(f)
+        if chain is None:
+            return None  # a fold composing other producers — another stage's shape
+        stat, sweep, _ = chain
+        f, edge = _unchain(f)
+        bound_values = frozenset(edge.lift.results)  # the edge's results — row-invariant values the cone may read
     ops = component_ops(f.combine)
     if ops is None or len(set(ops)) != 1:
         return None  # the carrier is not a product of ONE ⊕ monoid
@@ -724,6 +878,8 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
     if all(b is not None for _, b, _ in reads):
         consumed.update(id(b) for _, b, _ in reads)
         a_edge = role_load(a_arg, m_name, n_name)
+        if a_edge is not None and stat is not None:
+            return None  # a materialized A beside a chained statistic is not the computed-A shape
         if a_edge is not None:
             if len(reads) > 1:
                 # A multi-channel node over a MATERIALIZED shared A (the merged QKV cell) has no
@@ -736,13 +892,13 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
             h = hoisted()
             if h is not None:
                 return h
-            cone = _cone([s for s in body if id(s) not in consumed], a_arg, n_name, k_name, axes)
+            cone = _cone([s for s in body if id(s) not in consumed], a_arg, n_name, k_name, axes, bound_values)
             if cone is None:
                 return None  # a computed A that does not read cleanly — the fold stays PLANAR
             consumed.update(id(s) for s in cone)
-            a_edge = make_cone(cone, k_name)
+            a_edge = make_cone(cone, k_name, stat=stat, sweep=tuple(sweep)) if stat is not None else make_cone(cone, k_name)
         b_edges: list = [b for _, b, _ in reads]
-    elif len(reads) == 1 and (a_edge := role_load(a_arg, m_name, n_name)) is not None:
+    elif stat is None and len(reads) == 1 and (a_edge := role_load(a_arg, m_name, n_name)) is not None:
         # B rides a computed value (A is the direct load). A storage decode × k-invariant factors
         # binds through the mul-hoist first; any other pure MAP cone is a closed zero-axis
         # operand node — no row-statistic seam to split; its whole MAP tree is evaluated at each

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -135,7 +135,7 @@ def _exp_weight(defs: dict, name: str, mx: str) -> str | None:
     return None
 
 
-def _components(t: Fold, mx: str, canon: str) -> list[tuple[str, tuple, list, tuple]] | None:
+def _components(t: Fold, mx: str, canon: str, states: tuple[str, ...] = ()) -> list[tuple[str, tuple, list, tuple]] | None:
     """Read EVERY additive component of sibling fold ``t`` as a carrier component joining a pair:
     each lifted value factors (``split_invariant_factors``) into loop-invariant factors × the
     pair's own per-element weight (``exp(score′ − mx)``, score′ α-equal to ``canon``) × a residual
@@ -179,8 +179,11 @@ def _components(t: Fold, mx: str, canon: str) -> list[tuple[str, tuple, list, tu
         stmts = list(vcone.members)
         if any(not isinstance(s, (Load, Assign, Select)) for s in stmts):
             return None
-        if ({mx} | set(t.combine.results) | edge_results) & {a for s in stmts for a in s.deps()}:
-            return None  # the value cone must be free of the pair's carried states / dropped edges
+        if ({mx, *states} | set(t.combine.results) | edge_results) & {a for s in stmts for a in s.deps()}:
+            # The value cone must be free of the pair's carried states (its own, the max's, and
+            # every sibling already joined — a ``1/den`` sunk into the channel's λ would stream
+            # against the RUNNING denominator once merged) and of the dropped edges.
+            return None
         covered |= {id(s) for s in Body(tuple(body)).backward_cone([value]).members}
         out.append((state, inv, stmts, tuple(values)))
     if any(id(s) not in covered for s in body):
@@ -221,7 +224,7 @@ def _pair(fmax, rest: list) -> tuple[Fold, int, list] | None:
     for t in rest:
         comps = None
         if isinstance(t, Fold) and t.axis is not None and t.axis.extent == fmax.axis.extent:
-            comps = _components(t, mx, canon)
+            comps = _components(t, mx, canon, tuple(states))
         if comps is None:
             break
         ren = {t.axis.name: fmax.axis.name} if t.axis.name != fmax.axis.name else {}
@@ -364,7 +367,9 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
         return None
     stat_defs = set(_operand_result_names(stat)) | {nm for s in stat_epi for nm in s.defines()}
     edge_names = frozenset(nm for e in edges for nm in _operand_result_names(e))
-    bound = _bind_stat_channels(fcol, n_ax.name, stat_defs, frozenset(a.name for a in free) | {n_ax.name}, edge_names)
+    bound = _bind_stat_channels(
+        fcol, n_ax.name, stat_defs, frozenset(a.name for a in free) | {n_ax.name}, edge_names, m_name=free[-1].name if free else None
+    )
     if bound is None:
         return None
     cone, channels = bound
@@ -459,7 +464,7 @@ def _channel_product(f: Fold) -> object:
 
 
 def _bind_stat_channels(
-    f: Fold, n_name: str, stat_defs: set, axes: frozenset, edge_names: frozenset = frozenset()
+    f: Fold, n_name: str, stat_defs: set, axes: frozenset, edge_names: frozenset = frozenset(), m_name: str | None = None
 ) -> tuple[list, tuple] | None:
     """The computed-A channel read for the fused view: per additive component, a two-arg ⊗
     (distributing over the carrier's one commutative-monoid ⊕) whose directly-named B load is
@@ -491,6 +496,12 @@ def _bind_stat_channels(
             return None
         reads.append((lift, loads[b_arg], a_arg))
     if len({lift.op for lift, _, _ in reads}) != 1:
+        return None
+    if m_name is not None and any(m_name in _idx_vars(b) for _, b, _ in reads):
+        # B must be (n, k)-indexed and never read the row axis — the mirror of the A-cone check
+        # below. A row-dependent B is a batched matvec, not a bilinear form: the mma emitter
+        # addresses ONE B slab per tile, so binding it reads the first row's slab for all 16
+        # (decode attention with the heads as rows, V read per head).
         return None
     # ONE shared A value across channels, by VALUE-TREE equality: fusion duplicates the cone SSA
     # per channel (fresh names, interleaved order, per-copy operand order), so name equality is

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -92,7 +92,11 @@ def _cuttable(root, site: Site, stores: tuple, free: tuple) -> bool:
     child = site.node
     if len(_operand_result_names(child)) != 1:
         return False
-    if _captured_values(child, axis_names(root) | {a.name for a in free}):
+    # A boundary store's SWEEP axis is an iteration axis of the kernel (it lives off-term on the
+    # ``Store``): a child under the sweep reads it as a coordinate, never as a captured value —
+    # the cut piece iterates it as one of its own free axes (:func:`realize_cut`).
+    sweep_axes = {st.sweep.name for st in stores if st.sweep is not None}
+    if _captured_values(child, axis_names(root) | {a.name for a in free} | sweep_axes):
         return False
     trivial_body = (isinstance(root, Fold) and root.axis is None) and not len(root.body) and all(st.sweep is None for st in stores)
     if trivial_body and any(s is child for s in root.operands):
@@ -105,7 +109,6 @@ def _cuttable(root, site: Site, stores: tuple, free: tuple) -> bool:
     # subtree (found live: ``Assign v9: arg 'acc1' not defined`` on the m4096 geglu cut).
     probe = Load(name=operand_name(child), input="__seam_probe", index=())
     parent_tree = _replace_edge(root, child, probe)
-    sweep_axes = {st.sweep.name for st in stores if st.sweep is not None}  # boundary-store sweeps live off-term (1q)
     if _captured_values(parent_tree, axis_names(parent_tree) | sweep_axes | {a.name for a in free}):
         return False
     return True
@@ -163,10 +166,14 @@ def _ancestor_axes(root, child) -> tuple[Axis, ...]:
     def walk(node, acc: tuple[Axis, ...]) -> tuple[Axis, ...] | None:
         if node is child:
             return acc
-        edges = node.operands if isinstance(node, Fold) else ()
-        # A ZERO-AXIS node contributes no fold axis to the path (it does not iterate).
-        below = (*acc, node.axis) if isinstance(node, Fold) and node.axis is not None else acc
-        for e in edges:
+        if not isinstance(node, Fold):
+            return None
+        # A ZERO-AXIS node contributes no fold axis to the path (it does not iterate). Its body
+        # members that are nodes (a chained column fold reading the store's sweep) are children
+        # like its operand edges.
+        below = (*acc, node.axis) if node.axis is not None else acc
+        members = (*node.operands, *(m for m in node.body if isinstance(m, Fold))) if node.axis is None else node.operands
+        for e in members:
             if isinstance(e, Fold):
                 got = walk(e, below)
                 if got is not None:
@@ -259,7 +266,13 @@ def _replace_edge(node, child, load: Load):
     # seam is the same rewrite whether the node reads as a map, a reduce or a contraction.
     if any(e is child for e in node.operands):
         return _dc_replace(node, operands=tuple(load if e is child else e for e in node.operands))
-    return _dc_replace(node, operands=tuple(_replace_edge(e, child, load) if isinstance(e, Fold) else e for e in node.operands))
+    out = _dc_replace(node, operands=tuple(_replace_edge(e, child, load) if isinstance(e, Fold) else e for e in node.operands))
+    if node.axis is None and any(isinstance(m, Fold) for m in node.body):
+        # A zero-axis node's body members that are nodes (the chained column fold in a sweep)
+        # carry seams too; the seam child itself becomes the load in place.
+        body = tuple(load if m is child else (_replace_edge(m, child, load) if isinstance(m, Fold) else m) for m in node.body)
+        out = out.with_bodies((Body(body),))
+    return out
 
 
 def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Site) -> Graph:
@@ -278,7 +291,8 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
     if ws in match.graph.nodes:
         raise RuleSkipped(f"seam already cut — {ws} exists")
     anc = _ancestor_axes(tile_op, child)
-    axes = _child_axes(child, tuple(free), anc)
+    sweeps = tuple(st.sweep for st in stores if st.sweep is not None)
+    axes = _child_axes(child, (*free, *sweeps), anc)
     ws_index = tuple(Var(a.name) for a in axes)
     ws_dtype = _ws_dtype(child, getattr(root.op, "inputs", None) or {})
     spelled = spell(tile_op, "PLACE", child, all_sites=sites(tile_op))

--- a/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
@@ -39,7 +39,7 @@ def _peel(body: Body) -> tuple[list, list[Stmt]]:
     """Split a body into ``(free_axes, per_cell_stmts)``.
 
     The outer chain of **free** loops becomes the parallel axes. At every level of the
-    chain a leading run of pure stmts (``Load`` / ``Assign`` / ``Init`` — loop-invariant
+    chain a leading run of pure stmts (``Load`` / ``Assign`` / ``Init`` / ``Select`` — loop-invariant
     loads hoisted above or between the free loops, e.g. a broadcast row scale ``rs[m]``
     read once per ``m``) is sunk into the per-cell body, re-evaluated per cell. The chain
     stops at the first reduce loop, branch, or non-pure stmt — everything from there down
@@ -49,7 +49,7 @@ def _peel(body: Body) -> tuple[list, list[Stmt]]:
     cur = list(body)
     while True:
         i = 0
-        while i < len(cur) and isinstance(cur[i], (Load, Assign, Init)):
+        while i < len(cur) and isinstance(cur[i], (Load, Assign, Init, Select)):
             i += 1
         head, rest = cur[:i], cur[i:]
         if len(rest) != 1 or not isinstance(rest[0], Loop) or rest[0].is_reduce:
@@ -76,18 +76,22 @@ def _route_prologue(pending: list, loop: Loop, suffix_reads: set[str]) -> tuple[
     need = set(deep_reads(list(loop.body)))
     take: set[int] = set()
     dup: dict[int, dict[str, str]] = {}
+    # Reads by stmts that stay AHEAD of the loop: the suffix, plus — walking backwards — every
+    # pending stmt that does not sink (a raw loop, a fold, a kept stmt). A value one of those
+    # reads cannot move past it into the λ, or it would read an undefined name.
+    outside = set(suffix_reads)
     for i in range(len(pending) - 1, -1, -1):
         s = pending[i]
-        if not isinstance(s, (Load, Assign, Select)):
-            continue  # a fold / raw loop / Init never sinks; its results read as free names
-        defs = set(s.defines())
+        defs = set(s.defines()) if isinstance(s, (Load, Assign, Select)) else set()
         if not defs & need:
+            outside |= set(deep_reads([s]))  # a fold / raw loop / Init never sinks
             continue
-        if defs & suffix_reads:
+        if defs & outside:
             if isinstance(s, Load) and not s.deps() and not any(e.free_vars() for e in s.index or ()):
                 dup[i] = {nm: f"{nm}__stat" for nm in defs}
                 take.add(i)
                 continue
+            outside |= set(s.deps())
             continue  # feeds both sides and cannot be duplicated — the λ read stays free
         take.add(i)
         need |= set(s.deps())

--- a/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
@@ -27,7 +27,7 @@ from emmy.compiler.ir.pure.fold import Fold, deep_defines, deep_reads
 from emmy.compiler.ir.stmt import Assign, Body, Init, Load, Loop, Select, Write
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.tile import Placement, TileOp, split_effects
-from emmy.compiler.pipeline.passes.lowering.tile._classify import classify
+from emmy.compiler.pipeline.passes.lowering.tile._classify import classify, pair_softmax
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import _stamp_axes, fold_from_loop
 
 # --------------------------------------------------------------------------- #
@@ -147,28 +147,188 @@ def _lift_cell(cell: list[Stmt]) -> list:
 # --------------------------------------------------------------------------- #
 
 
-def _form_root(cell: list):
-    """Shape the lifted cell into the stored root: top-level folds hoist to the projection's
-    OPERANDS (in body order — an operand's λ may read an earlier operand's carried state), the
-    rest is the projection body. Operands lower BEFORE the body, so a fold reading a name the
-    body defines cannot hoist — it is restored to its verbatim loop (byte-exact by the parser's
-    gate) and stays a body member, and the check re-runs until it settles (a restored loop's defs
-    may strand another fold). A single bare fold with nothing else is the root node itself."""
-    kept = list(cell)
+def _chain(cell: list) -> list:
+    """Close every fold over the values it reads from the cell: a fold whose λ reads a name a
+    PURE cell stmt defines (a normalized row's scale, a sibling statistic's projected result)
+    takes that value through a zero-axis projection EDGE — the producing pure stmts as the
+    projection's body, the folds they read as its operands, any fold state the consumer also
+    reads passed through as a result — bound positionally to a new lift param. The chain is the
+    stored form (no fold is demoted for reading the body); a fold consumed only through edges
+    leaves the cell. Reads of a sibling fold's carried state stay direct: an operand's λ may read
+    an earlier operand's state (operands lower first), and the online-softmax pairing reads the
+    max's state off the denominator's lift by name."""
+    from emmy.compiler.ir.pure import Lambda  # noqa: PLC0415
+    from emmy.compiler.ir.stmt import Assign, Load, Select  # noqa: PLC0415
+
+    def _reads_of(t) -> set[str]:
+        if isinstance(t, Fold):
+            return set(deep_reads(list(t.lift.body))) - set(t.lift.params) - {n for x in t.lift.body for n in x.defines()}
+        return set(deep_reads([t]))
+
+    def names_of(s) -> set[str]:
+        """What ``s`` makes available to later stmts: a fold its carried STATE (the combine's
+        results — a planar fold's accumulators are not lift-body defs), a stmt its defs."""
+        if isinstance(s, Fold):
+            return deep_defines(s) | (set(s.combine.results) if s.combine is not None else set(s.lift.results if s.axis is None else ()))
+        return set(s.defines())
+
+    out = list(cell)
+    for i, f in enumerate(out):
+        if not isinstance(f, Fold) or f.axis is None:
+            continue
+        bound = {f.axis.name, *f.lift.params}
+        free = set(deep_reads([*f.lift.body])) - bound - {n for s in f.lift.body for n in s.defines()}
+        pure_defs = {n: j for j, s in enumerate(out[:i]) if isinstance(s, (Assign, Load, Select)) for n in s.defines()}
+        # A sibling fold's carried state read directly also chains — through the edge, as a
+        # pass-through result — when nothing else in the cell reads that sibling (a state the
+        # tail or another fold still reads stays a direct operand read: operands lower first).
+        needed = [n for n in free if n in pure_defs]
+        # The backward cone of the needed names over the earlier cell stmts: pure stmts join the
+        # projection body, folds become its operands (their state reads are then bound params).
+        members: set[int] = set()
+
+        _grow(out, i, members, list(needed), names_of)
+        # A sibling fold's carried state read directly also chains — through the edge, as a
+        # pass-through result — when every OTHER reader of that sibling is already in the cone
+        # (a state the tail or an outside fold still reads stays a direct operand read: operands
+        # lower first). Pulling one in can make another's readers all-in-cone; iterate.
+        while True:
+            added = False
+            for j, t in enumerate(out[:i]):
+                if j in members or not (isinstance(t, Fold) and t.axis is not None) or not (free & names_of(t)):
+                    continue
+                others = [k2 for k2, u in enumerate(out) if k2 != j and u is not f and _reads_of(u) & names_of(t)]
+                if all(k2 in members for k2 in others):
+                    members.add(j)
+                    needed.extend(sorted(free & names_of(t)))
+                    added = True
+            if not added:
+                break
+        if not needed:
+            continue
+        operands = tuple(out[j] for j in sorted(members) if isinstance(out[j], Fold))
+        body = tuple(out[j] for j in sorted(members) if not isinstance(out[j], Fold))
+        edge_states = {n for e in operands for n in names_of(e)}
+        passthrough = sorted((free & edge_states) - set(needed))
+        # A pure cone member some OTHER cell stmt also reads stays in the cell too; the edge's
+        # copy is α-renamed so the two spellings never define one name twice when both lower.
+        shared = {
+            n
+            for j in members
+            if not isinstance(out[j], Fold)
+            for n in out[j].defines()
+            if any(k2 not in members and k2 != i and n in _reads_of(u) for k2, u in enumerate(out))
+        }
+        # Renaming one member re-spells the whole pure cone: the kept cell copies read each
+        # other, so every pure member stays live in the cell once any does.
+        rename = {n: f"{n}__e{i}" for j in members if not isinstance(out[j], Fold) for n in out[j].defines()} if shared else {}
+        ren = _renamer(rename)
+        results = tuple(ren(n) for n in (*sorted(needed), *passthrough))
+        if rename:
+            body = tuple(s.rewrite(ren) for s in body)
+            lift = Lambda(
+                params=(*f.lift.params, *results),
+                body=Body(tuple(s.rewrite(ren) for s in f.lift.body)),
+                results=tuple(ren(r) if isinstance(r, str) else r for r in f.lift.results),
+            )
+        else:
+            lift = Lambda(params=(*f.lift.params, *results), body=f.lift.body, results=f.lift.results)
+        edge = Fold.projection(operands=operands, body=Body(body), results=results)
+        out[i] = replace(f, operands=(*f.operands, edge), lift=lift)
+    # A stmt every reader reaches through an edge lives there only: the edge's body / operands
+    # re-spell it, so a copy left in the cell would define the name twice when both lower. A
+    # fold's OUTSIDE reads are its λ's free names — what its params (the edges) do not bind.
+    in_edge = {
+        id(m)
+        for t in out
+        if isinstance(t, Fold)
+        for e in t.operands
+        if isinstance(e, Fold) and e.axis is None
+        for m in (*e.operands, *e.body)
+    }
+
+    def outside_reads(t) -> set[str]:
+        if isinstance(t, Fold):
+            return set(deep_reads(list(t.lift.body))) - set(t.lift.params) - {n for s in t.lift.body for n in s.defines()}
+        return set(deep_reads([t]))
+
+    # Liveness is a fixpoint: an in-edge stmt stays when something outside the edges reads it, or
+    # when a stmt that stays reads it.
+    live_ids = {id(s) for s in out if id(s) not in in_edge}
     while True:
-        body_defs = {n for s in kept if not isinstance(s, Fold) for n in deep_defines(s)}
-        demoted = False
-        for i, s in enumerate(kept):
-            if isinstance(s, Fold) and deep_reads(s.lower()) & body_defs:
-                kept[i] = s.loop
-                demoted = True
-        if not demoted:
+        grew = False
+        for s in out:
+            if id(s) in live_ids:
+                continue
+            names = names_of(s)
+            if any(id(t) in live_ids and t is not s and outside_reads(t) & names for t in out):
+                live_ids.add(id(s))
+                grew = True
+        if not grew:
             break
-    folds = tuple(s for s in kept if isinstance(s, Fold))
-    body = tuple(s for s in kept if not isinstance(s, Fold))
+    return [s for s in out if id(s) in live_ids]
+
+
+def _form_root(cell: list, *, chain: bool = False, sweeps: frozenset = frozenset()):
+    """Shape the cell into the stored root: top-level folds hoist to the projection's OPERANDS
+    (in body order — an operand's λ may read an earlier operand's carried state), the rest is
+    the projection body. Operands lower BEFORE the body, so a fold reading a name the body
+    defines cannot hoist: it stays a BODY member — a term is a legal body stmt — until
+    :func:`_chain` closes it over those values through a projection edge (``chain=True``, run
+    after the online-softmax pairing has consumed its sibling pair), after which it hoists. A
+    single bare fold with nothing else is the root node itself."""
+    kept = _chain(list(cell)) if chain else list(cell)
+    body_defs = {n for s in kept if not isinstance(s, Fold) for n in deep_defines(s)}
+    # A fold reading a boundary store's SWEEP axis runs once per swept element — it is a body
+    # member (a stored node in place), never an operand (operands lower ahead of the sweep).
+    folds = tuple(s for s in kept if isinstance(s, Fold) and not ((deep_reads(s.lower()) | stmt_axis_reads(s)) & (body_defs | sweeps)))
+    body = tuple(s for s in kept if not any(s is f for f in folds))
     if len(folds) == 1 and not body:
         return folds[0]
     return Fold.projection(body=Body(body), operands=folds)
+
+
+def stmt_axis_reads(s) -> set[str]:
+    """Every axis / value name a node's lowering reads (its coordinate exprs included)."""
+    return {v for st in s.lower() for e in _deep_exprs(st) for v in e.free_vars()}
+
+
+def _deep_exprs(st):
+    yield from st.exprs()
+    for b in st.nested():
+        for child in b:
+            yield from _deep_exprs(child)
+
+
+def _renamer(mapping: dict):
+    def ren(n: str) -> str:
+        return mapping.get(n, n)
+
+    return ren
+
+
+def _grow(out: list, i: int, members: set[int], frontier: list, names_of) -> None:
+    """Extend ``members`` with the backward cone of ``frontier`` over ``out[:i]``: the latest
+    definer of each name joins; a pure stmt's own reads join the frontier, a fold is a leaf."""
+    while frontier:
+        n = frontier.pop()
+        for j in range(i - 1, -1, -1):
+            s = out[j]
+            if j in members or n not in names_of(s):
+                continue
+            members.add(j)
+            if not isinstance(s, Fold):
+                frontier.extend(s.deps())
+            break
+
+
+def _chain_root(node, sweeps: frozenset = frozenset()):
+    """Re-form a projection root with its cell CLOSED (:func:`_chain`): every fold left in the
+    body for reading a body-defined value takes that value through a projection edge and hoists.
+    Runs after the pairing, which reads the ``(max, den)`` siblings by name."""
+    if not (isinstance(node, Fold) and node.axis is None and any(isinstance(s, Fold) for s in node.body)):
+        return node
+    return _form_root([*node.operands, *node.body], chain=True, sweeps=sweeps)
 
 
 def _order_free_by_output(node, free: list, stores: tuple = ()) -> tuple:
@@ -207,7 +367,8 @@ def recognized_tile(op: LoopOp, name: str = "") -> TileOp:
     cell = _lift_cell(list(cell))
     split = split_effects(tuple(cell))
     cell, stores = (list(split[0]), split[1]) if split is not None else (cell, ())
-    node = _form_root(cell)
+    sweeps = frozenset(st.sweep.name for st in stores if st.sweep is not None)
+    node = _chain_root(pair_softmax(_form_root(cell, sweeps=sweeps)), sweeps)
     if any(st.sweep is not None for st in stores) and isinstance(node, Fold) and node.axis is not None:
         # A sweep store rides a projecting zero-axis root (the materializer's flat-root arm
         # asserts ``sweep is None``) — wrap the bare fold in its empty projection.

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -108,7 +108,7 @@ from emmy.compiler.ir.tile.path import Site, sites
 from emmy.compiler.pipeline.fork import Fork, Level, build_fork_tree
 from emmy.compiler.pipeline.knob import family_of, schedule_pin_fingerprint, values_equal
 from emmy.compiler.pipeline.passes.lowering.tile import _legality as legal
-from emmy.compiler.pipeline.passes.lowering.tile._classify import fused_view
+from emmy.compiler.pipeline.passes.lowering.tile._classify import demoted_chain, fused_view
 from emmy.compiler.pipeline.passes.lowering.tile._pool import Block, PoolSpace, Segment
 from emmy.compiler.pipeline.search.space import (
     RASTER,
@@ -480,11 +480,16 @@ def _views(tile: TileOp, ctx) -> tuple[list[_Term], int]:
 
     No view's rows depend on whether its sibling produced any: each gate is a local predicate on
     its own term (a 16-bit atom, a resolvable fill, an inventory a value can spell against)."""
-    base = _Term(tile, tile.place.on_grid(), ctx)
+    # The per-cell reading of a CHAINED root is itself a derivation (``demoted_chain`` — the
+    # statistic back at the root, the column as its captured loop): the reduce tiers partition
+    # the root node, so that is the tree they schedule and materialize.
+    cell_op = demoted_chain(tile.op)
+    cell = replace(tile, op=cell_op) if cell_op is not tile.op else tile
+    base = _Term(cell, tile.place.on_grid(), ctx)
     pro = fused_view(tile)
     if pro is not None:
         fused = _view(tile, pro[0], ctx, free=(*tile.place.free, pro[1]), stores=pro[2])
-        return [_Term(tile, tile.place.on_grid(), ctx, ref=fused.sched), fused], 1
+        return [_Term(cell, tile.place.on_grid(), ctx, ref=fused.sched), fused], 1
     node = head(tile.op)
     if node is None or not is_contraction(node):
         return [base], 0

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -664,6 +664,19 @@ def _resolve_inputs(fx_node: Any, node_map: dict[str, NodeRef], g: Graph | None 
     return result
 
 
+# Fill-value tensor constructors and their static fill; ``None`` reads the fill from the call.
+_FILL_CONSTRUCTORS = {
+    "new_zeros": 0.0,
+    "zeros": 0.0,
+    "zeros_like": 0.0,
+    "ones": 1.0,
+    "ones_like": 1.0,
+    "new_full": None,
+    "full": None,
+    "full_like": None,
+}
+
+
 def _handle_placeholder(
     g: Graph,
     fx_node: Any,
@@ -1220,17 +1233,19 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
     # dtype/device template; receiver values do not participate in the result. Represent the
     # constructed tensor as a scalar plus an explicit broadcast so its FX metadata shape is
     # preserved even when the receiver has an unrelated shape.
-    if op_name in ("new_zeros", "new_full"):
+    # The ``_like`` forms and the receiver-less factories (``zeros``/``ones``/``full``, exported as
+    # leaves with no tensor input at all) construct the same way.
+    if op_name in _FILL_CONSTRUCTORS:
         from emmy.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to
 
-        if op_name == "new_full":
-            fill = fx_node.args[2] if len(fx_node.args) > 2 else (fx_node.kwargs or {}).get("fill_value")
+        fill = _FILL_CONSTRUCTORS[op_name]
+        scalar_id = None
+        if fill is None:
+            fill_position = 2 if op_name == "new_full" else 1
+            fill = fx_node.args[fill_position] if len(fx_node.args) > fill_position else (fx_node.kwargs or {}).get("fill_value")
             if not isinstance(fill, (int, float, bool)):
-                raise NotImplementedError(f"aten.new_full requires a static scalar fill value, got {fill!r}")
+                raise NotImplementedError(f"aten.{op_name} requires a static scalar fill value, got {fill!r}")
             scalar_id = input_ids[-1] if input_ids and isinstance(g.nodes[input_ids[-1]].op, ConstantOp) else None
-        else:
-            fill = 0.0
-            scalar_id = None
         if scalar_id is None:
             scalar_name = f"{name}_scalar"
             scalar_id = g.add_node(

--- a/emmy/serving/twins.py
+++ b/emmy/serving/twins.py
@@ -342,7 +342,13 @@ def _layer_signatures(trunk, config) -> list[tuple[str, str, int]]:
     for i, block in enumerate(trunk.layers):
         attn = at(types, i, "homogeneous")
         mlp = at(mlp_types, i, "sparse" if moe_block_parts(block.mlp) is not None else "dense")
-        inferred_heads, _width = _attention_query_layout(block.self_attn)
+        attention = getattr(block, "self_attn", None)
+        if attention is None:
+            raise NotImplementedError(
+                f"serving twins: layer {i} ({type(block).__name__}, {attn}) has no self_attn; "
+                "blocks whose token mixer is not attention (e.g. a gated delta net) have no serving program yet"
+            )
+        inferred_heads, _width = _attention_query_layout(attention)
         nheads = at(heads, i, inferred_heads)
         out.append((str(mlp), str(attn), int(nheads)))
     return out

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -985,3 +985,39 @@ def test_full_self_attn_tinyllama_seq512(_chain_tile_pins):
     (default on sm_90+) reorders FMAs vs cp.async. Catches order-of-magnitude regressions, not
     bit-equivalence."""
     _run_self_attn_tinyllama(seq_len=512, threshold=2.0)
+
+
+class _GqaDecodeBatch(torch.nn.Module):
+    """The Neptune ``decode_gqa`` spelling: the query heads of one KV group as a broadcast batch dim."""
+
+    def forward(self, q, k, v):
+        return F.scaled_dot_product_attention(
+            q.reshape(1, 2, 4, 1, 16), k.reshape(1, 2, 1, 64, 16), v.reshape(1, 2, 1, 64, 16), is_causal=False
+        ).reshape(1, 8, 1, 16)
+
+
+@requires_cuda
+@pytest.mark.parametrize("variant", ["plain", "gqa_batch"])
+def test_decode_sdpa_matches_torch(variant):
+    """One query over a populated key set — the shape every decode step takes. Three defects hid
+    behind it: the SDPA decomposition read the KEY length off the query (scores ``(1, 1)``, so the
+    output was ``ΣV``), the fused softmax·V view took the heads as the mma rows while V varied
+    per head (B must never read the row axis), and the GQA batch spelling sank ``1/den`` into the
+    joined expectation channel, streaming it against the running denominator (NaN)."""
+    torch.manual_seed(0)
+    if variant == "plain":
+        module, q = _Sdpa(), torch.randn(1, 8, 1, 16)
+        ref_shape = (1, 8, 64, 16)
+    else:
+        module, q = _GqaDecodeBatch(), torch.randn(1, 8, 1, 16)
+        ref_shape = (1, 2, 64, 16)
+    k, v = (torch.randn(*ref_shape) for _ in range(2))
+    backend, compiled, _graph, kernels = _trace(module, (q, k, v))
+    assert kernels
+    cq, ck, cv = q.cuda(), k.cuda(), v.cuda()
+
+    def rc():
+        with torch.no_grad():
+            return module(cq, ck, cv).cpu().flatten().numpy()
+
+    assert _max_diff(backend, compiled, {"q": q.numpy(), "k": k.numpy(), "v": v.numpy()}, rc) < 1e-4

--- a/tests/compiler/ir/test_expr_simplify_symbolic.py
+++ b/tests/compiler/ir/test_expr_simplify_symbolic.py
@@ -126,3 +126,14 @@ def test_static_axis_unchanged_behavior():
     assert ctx.ranges["a"] == Interval(0, 31)
     # i % 32 with i in [0,32) folds to i (literal path).
     assert BinaryExpr("%", Var("a"), Literal(32, "int")).simplify(ctx) == Var("a")
+
+
+def test_scaled_term_div_folds_through_a_larger_divisor():
+    """``(h*128 + c) / 1024`` with ``c < 128`` is ``h / 8``: the collapsed GQA-group index of a
+    decode sweep. Unfolded, every statistic indexed by it looked column-dependent and was replayed
+    per head-dim column by fusion."""
+    ctx = extend_simplify_ctx(extend_simplify_ctx(SimplifyCtx.empty(), Axis("h", 64)), Axis("c", 128))
+    idx = BinaryExpr("+", BinaryExpr("*", Var("h"), Literal(128, "int")), Var("c"))
+    assert BinaryExpr("/", idx, Literal(1024, "int")).simplify(ctx) == BinaryExpr("/", Var("h"), Literal(8, "int"))
+    rem = BinaryExpr("%", idx, Literal(1024, "int")).simplify(ctx)
+    assert rem == BinaryExpr("+", BinaryExpr("*", BinaryExpr("%", Var("h"), Literal(8, "int")), Literal(128, "int")), Var("c"))

--- a/tests/compiler/passes/test_decompose_rules.py
+++ b/tests/compiler/passes/test_decompose_rules.py
@@ -836,3 +836,19 @@ def test_transpose_fold_is_capability_and_shape_unconditional():
             target_mod.set_target(None)
         assert folded_m1, f"M=1 matvec weight must fold at {cap}"
         assert folded_m64, f"M>1 weight must fold at {cap} — the sub-sm_90 no-fold gate is deleted"
+
+
+def test_sdpa_scores_take_the_key_length_from_k():
+    """A decode step scores one query against every key: the scores and K^T shapes read the key
+    length off K, not the query (the query-length reading scored key 0 alone)."""
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("Q", (2, 1, 8)), node_id="Q")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("K", (2, 16, 8)), node_id="K")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("V", (2, 16, 8)), node_id="V")
+    g.add_node(op=SdpaOp(is_causal=False, scale=None), inputs=["Q", "K", "V"], output=Tensor("out", (2, 1, 8)), node_id="sdpa_out")
+    g.inputs, g.outputs = ["Q", "K", "V"], ["sdpa_out"]
+    result = _apply(g, "010_sdpa.py")
+    shapes = {n.output.name: tuple(d.as_static() for d in n.output.shape) for n in result.nodes.values()}
+    assert shapes["out_kt"] == (2, 8, 16)
+    assert shapes["out_scaled"] == (2, 1, 16)
+    assert shapes["out_softmax"] == (2, 1, 16)

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -29,7 +29,7 @@ from emmy.compiler.ir.stmt import Body, Loop
 from emmy.compiler.ir.stmt.leaves import ElementwiseImpl
 from emmy.compiler.ir.tile.ops import split_invariant_factors
 from emmy.compiler.pipeline import Pipeline
-from emmy.compiler.pipeline.passes.lowering.tile._classify import fused_view, pair_softmax
+from emmy.compiler.pipeline.passes.lowering.tile._classify import _chained_column, fused_view, pair_softmax
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import _same_program, _stamp_axes, fold_from_loop
 from emmy.compiler.pipeline.passes.lowering.tile._lift import recognized_tile
 
@@ -199,10 +199,14 @@ def test_pair_stays_above_the_free_sweep() -> None:
     # column; the pair stays at its own level — the sweep's per-ROW statistic — and the sweep's
     # contraction stays a raw body loop for the fused view to bind.
     tile = recognized_tile(LoopOp(body=_wrap_rows(_sweep_body()), inputs={}))
-    (stat,) = tile.op.operands
+    # The chain form: the sweep's column fold (it reads the sweep axis, so it is the root's one
+    # fold body member) is closed over the pair's normalize through a projection edge — the
+    # pair itself stays the plain (m, d) carrier at the head of that edge.
+    (col,) = [s for s in tile.op.body if isinstance(s, Fold)]
+    assert not tile.op.operands
+    stat, epi, _loop = _chained_column(col)
     assert stat.role is AxisRole.TWISTED and len(stat.combine.results) == 2, "the plain (m, d) pair"
-    assert any(isinstance(s, Assign) and s.op.name == "reciprocal" for s in tile.op.body)
-    assert any(isinstance(s, Loop) and s.is_reduce for s in tile.op.body), "the sweep contraction rides the body"
+    assert any(isinstance(s, Assign) and s.op.name == "reciprocal" for s in epi)
 
 
 def test_twisted_statistic_binds_the_sweep_as_one_contraction() -> None:
@@ -213,7 +217,8 @@ def test_twisted_statistic_binds_the_sweep_as_one_contraction() -> None:
     from emmy.compiler.ir.pure.fold import is_contraction
 
     tile = recognized_tile(LoopOp(body=_wrap_rows(_sweep_body()), inputs={}))
-    (stat,) = tile.op.operands
+    (col,) = [s for s in tile.op.body if isinstance(s, Fold)]
+    stat, _epi, _loop = _chained_column(col)
     assert stat.role is AxisRole.TWISTED, "the row statistic is the online-softmax pair"
 
     bound = fused_view(tile)

--- a/tests/compiler/passes/test_total_lift.py
+++ b/tests/compiler/passes/test_total_lift.py
@@ -279,8 +279,13 @@ def test_fold_reading_a_body_defined_name_is_restored_verbatim():
     tile = _tile(Body((Loop(axis=m, body=Body(cell)),)))
     node = tile.op
     assert isinstance(node, Fold) and node.axis is None and not node.operands
-    raw_loops = [s for s in node.body if isinstance(s, Loop) and s.is_reduce]
-    assert len(raw_loops) == 2, "the consumer restored beside the escape, order preserved"
+    # The escape stays a raw loop; the consumer reads its typed accumulator, which no projection
+    # edge can close over (an effectful producer), so it stays a body member — as a NODE, in
+    # place, lowering byte-exact beside the escape.
+    kinds = [("loop" if isinstance(s, Loop) and s.is_reduce else "fold" if isinstance(s, Fold) else "other") for s in node.body]
+    assert kinds[:2] == ["loop", "fold"], "the consumer beside the escape, order preserved"
+    # ``LoopOp`` normalization renames axes; the node's loop is the consumer's by extent and body length.
+    assert node.body[1].axis.extent == consumer.axis.extent and len(node.body[1].loop.body) == len(consumer.body)
 
 
 def test_non_distributing_lift_declines_to_planar():

--- a/tests/compiler/passes/test_total_lift.py
+++ b/tests/compiler/passes/test_total_lift.py
@@ -329,3 +329,46 @@ def test_recognize_fires_through_the_pipeline():
 
     tiles = [n.op for n in lowered.nodes.values() if isinstance(n.op, TileOp)]
     assert tiles, "the lift fired and nothing downstream traffics in LoopOp"
+
+
+def test_prologue_read_by_an_earlier_raw_loop_is_not_sunk_past_it():
+    """A pure prologue value read by a reduce loop that DECLINED the lift (so it stands raw, ahead
+    of a later reduce) must stay ahead of that raw loop. Sinking it into the later loop's λ leaves
+    the raw loop reading an undefined name — the decode-attention ``v1`` / ``v3`` miscompile."""
+    m = Axis("m", Dim(8))
+    k1, k2, k3 = (Axis(nm, Dim(1)) for nm in ("k", "k2", "k3"))
+    # ``sc`` feeds pass1 AND the epilogue-side chain, so pass1 cannot take it and stays raw.
+    prologue = (
+        Load(name="s", input="x", index=(Var("m"),)),
+        Assign(name="sc", op=ElementwiseImpl("add"), args=("s", "s")),
+    )
+    pass1 = Loop(axis=k1, body=Body((Accum(name="mx", value="sc", op=ElementwiseImpl("maximum"), axes=("k",)),)))
+    mid = (
+        Assign(name="sh", op=ElementwiseImpl("subtract"), args=("sc", "mx")),
+        Assign(name="ex", op=ElementwiseImpl("exp"), args=("sh",)),
+    )
+    pass2 = Loop(axis=k2, body=Body((Accum(name="den", value="ex", op=ElementwiseImpl("add"), axes=("k2",)),)))
+    tail = (
+        Assign(name="pr", op=ElementwiseImpl("divide"), args=("ex", "den")),
+        Load(name="vv", input="v", index=(Var("m"),)),
+        Assign(name="pv", op=ElementwiseImpl("multiply"), args=("vv", "pr")),
+    )
+    pass3 = Loop(axis=k3, body=Body((Accum(name="acc", value="pv", op=ElementwiseImpl("add"), axes=("k3",)),)))
+    cell = (*prologue, pass1, *mid, pass2, *tail, pass3, Write(output="out", index=(Var("m"),), value="acc"))
+    tile = _tile(Body((Loop(axis=m, body=Body(cell)),)))
+
+    # Every name a stmt reads is defined by an earlier stmt at the same or an enclosing level.
+    def check(body, defined):
+        for s in body:
+            if isinstance(s, Loop):
+                check(list(s.body), set(defined) | {s.axis.name})
+                defined |= set(deep_defines(s))
+                continue
+            reads = set(s.deps()) if not isinstance(s, Fold) else set()
+            assert reads <= defined, f"{s} reads {sorted(reads - defined)} before definition"
+            defined |= set(s.defines()) if not isinstance(s, Fold) else set(deep_defines(s))
+
+    from emmy.compiler.ir.pure.fold import deep_defines
+
+    root = tile.op
+    check(list(root.lower()), {a.name for a in tile.place.free})

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -1457,3 +1457,31 @@ def test_trace_clamp_matches_torch_eager():
     with torch.no_grad():
         want = m(gate, up).numpy()
     np.testing.assert_allclose(next(iter(outs.values())), want, rtol=1e-5, atol=1e-6)
+
+
+def test_trace_factory_constructors_and_like_forms_match_eager():
+    """``torch.ones``/``zeros``/``full`` export as input-less leaves; ``ones_like`` carries a template.
+
+    Before, a zero-input factory produced no graph node at all, so its consumer lost an operand
+    and failed later with an unrelated error (the ``triu``/``masked_fill`` chunk-mask idiom).
+    """
+    import numpy as np
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.backend.numpy import NumpyBackend
+    from emmy.compiler.trace.torch import trace_module
+
+    class Factories(nn.Module):
+        def forward(self, x):
+            ones = torch.ones(x.shape[-1], x.shape[-1], dtype=x.dtype)
+            full = torch.full((x.shape[-1],), 2.5, dtype=x.dtype)
+            like = torch.ones_like(x) - torch.zeros_like(x)
+            return x * ones.sum(dim=0) + full + like
+
+    x = torch.randn(2, 3, 4)
+    graph = trace_module(Factories(), (x,))
+    backend = NumpyBackend()
+    result, _ = backend.run(backend.compile(graph), input_data={graph.inputs[0]: x.numpy()})
+    got = next(iter(result.outputs.values()))
+    np.testing.assert_allclose(got, Factories()(x).numpy(), rtol=1e-5, atol=1e-5)

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -457,6 +457,7 @@
  "tests/serving/generation/test_generate_gpu.py::test_generate_loop_runs_end_to_end@cuda": 6.6,
  "tests/serving/generation/test_generate_gpu.py::test_generate_oracle_matches_eager_fp16@cuda": 6.5,
  "tests/serving/generation/test_generate_gpu.py::test_slice_last_logits_lowers_cold@cuda": 5.5,
+ "tests/serving/generation/test_generate_loop.py::test_slice_last_logits_wrapper_matches_full_logits": 5.0,
  "tests/serving/generation/test_runner_batched_gpu.py::test_runner_batched_matches_eager@cuda": 8.4,
  "tests/serving/generation/test_runner_batched_gpu.py::test_runner_batched_symbolic_matches_eager@cuda": 13.1,
  "tests/serving/test_moe_split.py::test_exl3_laguna_dense_and_sparse_blocks_preserve_float32_residuals": 0.1,


### PR DESCRIPTION
## Summary

Four commits, each reproducible from a committed golden or a Neptune `operators.sh` setup. No fusion stop-gaps: the three readable-seam refusals an earlier revision of this branch carried are gone, replaced by making the stored tree able to hold what fusion produces.

**Frontend**
- `torch.zeros/ones/full` (+`_like`) were silently dropped by the tracer; `--serving-twins` refuses a block without `self_attn` instead of an `AttributeError`.
- The SDPA decomposition read the key length off the query: any `q_len != kv_len` shape (every decode step) scored key 0 only and emitted `ΣV`.

**Lift**
- `_route_prologue` sank a value read by an earlier raw reduce loop into a later loop's λ → `nvcc: identifier "v1" is undefined`. `_peel` hoists `Select` (a causal-mask select no longer strands a free axis: grid-1 scalar 543 µs → 0.8 µs). f16 `sigmoid` computes in f32 and rounds once.
- `fused_view`'s B operand must not read the row axis; the softmax pairing declines a channel whose value cone reads a sibling state; `_div_mod_decompose` folds `(h*128 + c) / 1024` → `h / 8`. Strict failures print element counts and error stats.

**Recognition — chain root formation** (the substantive change)
The stored tree demoted any fold that read a value the projection body defined back to a raw loop, and a raw loop has no `PLACE` site — so the k-norm → RoPE → `Q·Kᵀ` region (and every sweep-reading column fold) lost its nodes and could never be cut. Root formation now closes each fold over what it reads through a zero-axis projection edge (λ stays closed; the `make_cone` prologue generalized), keeps sweep-reading folds as body nodes, and lowers loop-invariant edges once ahead of the loop. `fused_view` reads the chain; the per-cell reading is the chain undone (`demoted_chain`), so the reduce tiers, map rows, pool-space pins and emitted kernels are unchanged. Cuts under a sweep are legal; `PLACE@a2`-style keys resolve (strict `a`+ordinal parse retried as the stamped axis name). Kernel identities of computed-A goldens move (accepted).

Demonstrated on Qwen3-0.6B layer 0 s512 attention-stats (RTX 5090): every node has a seam; `PLACE@a2=cut` and `PLACE@fold.fold.a4=cut` realize as 4–5 µs pieces. The cut that wins — the k cone as the dot's B operand — needs the both-computed bilinear binding the binder still declines; that is the remaining gap, a binding rather than a seam. Attention P·V / o_proj forms on the A100 corpus and the Neptune decode/prefill losses remain tuner/tier work tracked in #583.

## Test plan
- [x] `make test` green on this branch (full suite); `make lint`
- [x] RTX 5090 repros: decode_causal / decode_gqa strict pass (were ΣV); Qwen3-0.6B s512 attention-stats cold and under each PLACE cut; gemma-4 canonical golden validates identically (pre-existing `configs[22]` only)
- [x] A100 (agent): kernel corpus Emmy 1.56× / 1.39× over eager on layer totals; all 16 Neptune decode setups pass strict (measured against the pre-chain fixes; goldens re-key under the chain form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)