### PR TITLE
Fix normalized attention cuts, FP8 expert serving, and cut legality

### DIFF
--- a/emmy/commands/trace.py
+++ b/emmy/commands/trace.py
@@ -99,7 +99,12 @@ def handle_trace(args):
         except (OSError, ValueError) as exc:
             logger.error("invalid serving config: %s", exc)
             sys.exit(2)
-        graphs = capture_twin_graphs(args.input, decode_bucket=0, prefill_bucket=0)
+        # The release audit's graph set (``emmy eval golden``): the symbolic programs plus the
+        # config's static widths — a golden traced from fewer graphs leaves the audit with gaps.
+        if serving.static_only:
+            graphs = capture_twin_graphs(args.input, decode_bucket=1, prefill_bucket=0, symbolic=False, static_only=True)
+        else:
+            graphs = capture_twin_graphs(args.input, decode_bucket=0, prefill_bucket=0, extra_widths=serving.static_widths, symbolic=True)
         source_name = args.input.rstrip("/").rsplit("/", 1)[-1].partition("@")[0]
         destination = args.output or f"{source_name}.serving-twins.golden.yaml"
         try:

--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -143,7 +143,10 @@ memory, the dtype decode is absorbed at the fragment load, and a compatible scal
 generic constant folder deliberately excludes storage-decode cones because materializing them would expand the
 buffer into its compute dtype. Scale pairing is the general `<key>_scale` / `<key>_scale_inv` rule — it subsumes the
 `.weight` → `.weight_scale` convention and covers non-`.weight` leaves (gpt-oss's 3-D expert params,
-`…experts.gate_up_proj` + `…experts.gate_up_proj_scale`).
+`…experts.gate_up_proj` + `…experts.gate_up_proj_scale`). DeepSeek-lineage `weight_scale_inv` names the inverse of
+the quantization scale, which is the stored dequant multiplier: both suffixes therefore reconstruct the weight by
+multiplication. Only a checkpoint contract that explicitly declares a reciprocal dequant multiplier may select the
+division path; the key suffix alone never does.
 
 When an official FP8 declaration also specifies dynamic activations, `loader.quant.spell_dynamic_fp8_activations`
 wraps each eligible linear input in the checkpoint's per-row amax, zero-safe scale, encode, decode, and scale algebra.

--- a/emmy/compiler/loader/quant.py
+++ b/emmy/compiler/loader/quant.py
@@ -74,6 +74,17 @@ _EXL3_SIBLING_LEAVES = ("suh", "svh", "mcg", "mul1", "su", "sv")
 _AWQ4_LOGICAL_SHIFTS = (0, 16, 4, 20, 8, 24, 12, 28)
 
 
+def scale_is_reciprocal(scale_key: str) -> bool:  # noqa: ARG001 — the key is the one fact a caller has
+    """Whether a checkpoint's stored scale is the RECIPROCAL of the dequant multiplier. It never
+    is: DeepSeek's ``weight_scale_inv`` (Laguna, DeepSeek-V3/V4 lineage) names the inverse of the
+    QUANTIZATION scale — ``q = w / s`` stored beside ``s`` — so the dequant is ``q * s`` exactly
+    as for ``weight_scale`` (DeepSeek's own ``weight_dequant`` and vLLM's block-fp8 path
+    multiply by it). Dividing by it, as the suffix once suggested here, scaled every
+    ``_scale_inv`` weight by ``1/s²``. The ``inverse=`` plumbing stays for a checkpoint that
+    declares a true reciprocal; the suffix alone never selects it."""
+    return False
+
+
 def dequantize(weight: np.ndarray, scale: np.ndarray, *, inverse: bool = False) -> np.ndarray:
     """Apply a quantization scale to a decoded weight, deriving the block from the shapes.
 
@@ -393,7 +404,7 @@ def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
         if qc is not None and key in fp8_keys and not _is_skipped(key, patterns):
             scale_key = next((k for k in (key + "_scale", key + "_scale_inv") if k in index), None)
             if scale_key is not None:
-                out[key] = dequantize(sources[key], sources[scale_key], inverse=scale_key.endswith("_inv"))
+                out[key] = dequantize(sources[key], sources[scale_key], inverse=scale_is_reciprocal(scale_key))
                 consumed.add(scale_key)
                 continue
         out[key] = sources[key]
@@ -528,7 +539,7 @@ def _spell_one(graph: Graph, nid: str, *, fmt: str, scale_key: str, scale_shape:
         shape=shape,
         out_dtype=out.dtype,
         out_name=out.name,
-        inverse=scale_key.endswith("_inv"),
+        inverse=scale_is_reciprocal(scale_key),
         grid=grid,
         block=block,
         degenerate=degenerate,

--- a/emmy/compiler/loader/quant.py
+++ b/emmy/compiler/loader/quant.py
@@ -311,12 +311,39 @@ def _exl3_codebook(index, base: str) -> int:
     return 1 if base + ".mcg" in index else 2 if base + ".mul1" in index else 0
 
 
+def fp8_weight_profile(hf_config) -> tuple[str, tuple[int, int] | None, list[str]] | None:
+    """``(fmt, weight block, skip patterns)`` when ``hf_config`` declares fp8 weights, else ``None``.
+
+    Read off ``quantization_config`` BEFORE :func:`strip_engine_quant_config` drops it: the
+    storage format token, the 2-D block one scale covers (``None`` = one per-tensor scale) and
+    the module patterns the quantizer left unconverted (:func:`_skip_patterns`). A weight-free
+    twin derives its scale shapes from this profile and the traced weight shapes alone."""
+    qc = getattr(hf_config, "quantization_config", None)
+    if qc is None:
+        return None
+    if not isinstance(qc, dict):
+        qc = {key: getattr(qc, key, None) for key in ("quant_method", "fmt", "weight_block_size", *_SKIP_KEYS)}
+    if qc.get("quant_method") != "fp8":
+        return None
+    block = qc.get("weight_block_size")
+    fmt = "f8e5m2" if qc.get("fmt") == "e5m2" else "f8e4m3"
+    return fmt, (None if block is None else tuple(int(b) for b in block)), _skip_patterns(qc)
+
+
+_SKIP_KEYS = ("ignored_layers", "modules_to_not_convert", "ignore")
+
+
+def _skip_patterns(qc: dict) -> list[str]:
+    """The module patterns a ``quantization_config`` leaves unquantized, every spelling pooled."""
+    return [pat for key in _SKIP_KEYS for pat in (qc.get(key) or [])]
+
+
 def _is_skipped(weight_key: str, patterns: list[str]) -> bool:
     """Whether the weight's module is excluded from quantization.
 
-    ``quant_method: fp8`` lists module names in ``modules_to_not_convert``;
-    compressed-tensors lists them in ``ignore``, where a ``re:`` prefix marks a
-    regex. Plain entries match the module path exactly or as a dotted prefix /
+    ``quant_method: fp8`` lists module names in ``modules_to_not_convert`` (the DeepSeek
+    lineage writes ``ignored_layers``); compressed-tensors lists them in ``ignore``, where a
+    ``re:`` prefix marks a regex. Plain entries match the module path exactly or as a dotted prefix /
     suffix component (``"lm_head"`` matches both ``lm_head`` and
     ``model.lm_head``; a parent-module entry covers its children).
     """
@@ -361,7 +388,7 @@ def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
     qc = _fp8_quant_config(model_dir)
     exl3 = _exl3_quant_config(model_dir) is not None
     awq = _awq_quant_config(model_dir)
-    patterns = list(qc.get("modules_to_not_convert") or []) + list(qc.get("ignore") or []) if qc else []
+    patterns = _skip_patterns(qc) if qc else []
 
     by_shard: dict[str, list[str]] = {}
     for key, shard in index.items():
@@ -813,7 +840,7 @@ def spell_quantized_constants(graph: Graph, model_id_or_path: str) -> int:
         return _spell_awq4_constants(graph, model_dir, awq)
     if qc is None:
         return 0
-    patterns = list(qc.get("modules_to_not_convert") or []) + list(qc.get("ignore") or [])
+    patterns = _skip_patterns(qc)
     index = _build_index(model_dir)
 
     spelled = 0

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -205,6 +205,15 @@ the column minus the edge regenerating the raw column loop), and the per-cell re
 reduce tiers schedule and materialize. Cuts under a sweep are legal: the sweep axis is an iteration axis of the cut
 piece, not a captured value.
 
+A chained column over TWO statistics (normalized Q against normalized K — attention's score fold) binds as one
+contraction whose A and B are BOTH computed cones, each sourcing its own statistic (`bind_bilinear`'s chained
+both-computed arm; `fused_view` reads the sweep column through it). The fill evaluates a computed B per slab cell
+(its statistic with it — the `b` children are fill-realized sites, never a partition of their own), so the fused
+form stands and is priced like any other; the `b` seam is the cut that turns the per-query replay of the key
+statistic into a materialized operand the mma tier streams. A seam standing in for a contraction operand holds what
+the fused slab stored — the contraction's 16-bit output dtype, not the f32 its cone computed in — so the
+materialized B is a slab the warp atoms can copy.
+
 A row carries NO view ownership: the derived contraction view offers only warp tiles (a computed operand's scalar
 list is empty) and the per-cell view only scalar / per-cell ones, so the row's `WORK` tier decodes its view by
 construction — replay is a function of `(stored op, row)` and nothing else. The union carries two obligations:

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -730,7 +730,11 @@ Cut legality is structural: single-component CLOSED children only (`_captured_va
 role; the multi-result prologue of a cone that passes its statistic through stays uncut by the component gate), and
 the pure-copy degenerate
 (cutting an empty-body root projection's only operand, whose parent would merely copy the workspace out — the
-non-terminating case) is refused. Loop fusion stops at `__cut_` workspace producers — a decided placement is not
+non-terminating case) is refused. A piece is a RAW loop body: the tree's λ-local SSA names flatten into one scope,
+so each piece is minted under canonical sequential names, and a second spelling of the same stmts — the fused
+reading's store-side prefix, which re-evaluates the tail's stat-free cone stmts beside the statistic prologue — is
+α-renamed (`__p`) where it is derived, as the chain formation renames a shared member. Loop fusion stops at
+`__cut_` workspace producers — a decided placement is not
 fusion's to undo (tune-mode slicing re-enters fusion with the pieces as ordinary pairs). The old `020_cut_edge` /
 `025_sink_row_reduce` / `032_fuse_finalize` realizers stay retired; their non-default placements return only as
 routing entries re-seeded by fresh `--ab` evidence (phase 5 — the 020-era `cut_cone_*` schedule entries stamp the

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -566,6 +566,13 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
             if id(st) not in seen:
                 seen.add(id(st))
                 prefix.append(st)
+    # The prefix RE-EVALUATES cone stmts on the store side, so it is a second spelling of their
+    # names: α-renamed (``__p``), as the chain formation spells a shared member, so a piece that
+    # flattens both sides into one scope (a PLACE cut's parent) never defines a name twice.
+    rename = {nm: f"{nm}__p" for st in prefix for nm in st.defines()}
+    ren = lambda n: rename.get(n, n)  # noqa: E731
+    prefix = [st.rewrite(ren) for st in prefix]
+    tail = [st.rewrite(ren) for st in tail]
     # A combine tail projects the channels to ONE value, so it stores once; with no tail every
     # fold's accumulator is stored raw, each exactly once (the split partial's slot-per-channel).
     stored = sorted(tuple(w.values) for w in writes)

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -368,6 +368,28 @@ def demoted_chain(op):
     return Fold.projection(operands=tuple(operands), body=Body(tuple(body)))
 
 
+def _split_chain(edge: Fold, a_cone: list, b_cone: list):
+    """Partition a chain edge between the two cones that read it: each side takes the backward
+    cone (within the edge body) of the edge results it reads, plus the ONE statistic fold those
+    stmts read. ``None`` when a side needs two statistics or the sides share one."""
+    from emmy.compiler.ir.pure.fold import deep_reads as _dr  # noqa: PLC0415
+
+    results = set(edge.lift.results)
+    by_state = {n: e for e in edge.operands if isinstance(e, Fold) for n in (e.combine.results if e.combine is not None else ())}
+    out = []
+    taken: set[int] = set()
+    for cone in (a_cone, b_cone):
+        needs = _dr(cone) & results
+        members = list(Body(tuple(edge.body)).backward_cone(sorted(needs)).members) if needs else []
+        stats = {id(by_state[n]): by_state[n] for s in (*members,) for n in s.deps() if n in by_state}
+        stats.update({id(by_state[n]): by_state[n] for n in needs if n in by_state})
+        if len(stats) > 1 or any(i in taken for i in stats):
+            return None
+        taken |= set(stats)
+        out.append((next(iter(stats.values()), None), members))
+    return out[0], out[1]
+
+
 def _unchain(col: Fold) -> tuple[Fold, Fold | None]:
     """``col`` with its one zero-axis projection edge detached — the column fold as it read before
     root formation closed it (its λ reading the edge's results as free names) — and that edge."""
@@ -426,6 +448,20 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
                 at = body.index(folds[0])
                 chain = (chain[0], [*body[:at], *chain[1]], chain[2])
                 body = body[at + 1 :]
+    if chain is None and not node.operands and len(stores) == 1 and stores[0].sweep is not None:
+        # A chained column over TWO statistics (normalized Q against normalized K): the bilinear
+        # binder reads it with the sweep as the column axis and each side's statistic on its cone.
+        folds = [s for s in body if isinstance(s, Fold)]
+        if len(folds) == 1 and folds[0].axis is not None and free:
+            n_ax = stores[0].sweep
+            r = bind_bilinear(folds[0], free[-1].name, n_ax.name, frozenset(a.name for a in free) | {n_ax.name})
+            if r is not None:
+                con, epi = r
+                at = body.index(folds[0])
+                tail = [*body[:at], *epi, *body[at + 1 :]]
+                from emmy.compiler.ir.tile.ir import Store  # noqa: PLC0415
+
+                return Fold.projection(body=Body(tuple(tail)), operands=(con,)), n_ax, (Store(write=stores[0].write),)
     if chain is None:
         if len(node.operands) != 1:
             return None
@@ -796,18 +832,22 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
     if f.axis is None or f.combine is None:
         return None
     stat = sweep = None
+    edge = None
     bound_values: frozenset = frozenset()
     if f.operands:
-        # The CHAIN form: root formation closed this fold over a statistic's projected epilogue
-        # through one projection edge. Bind the bare fold and hang the statistic + epilogue on
-        # the computed-A cone as its source (``make_cone(stat=…)``) — the one reading the
-        # demoted-loop form reached only through ``fused_view``.
-        chain = _chained_column(f)
-        if chain is None:
+        # The CHAIN form: root formation closed this fold over the values it reads through one
+        # projection edge (a statistic's projected epilogue, or two of them — one per side).
+        # Bind the bare fold and hang each side's statistic + epilogue on that side's cone as
+        # its source (``make_cone(stat=…)``) — the reading the demoted-loop form reached only
+        # through ``fused_view``.
+        chain = _chained_column(f)  # one statistic: its cone source; two: split per side below
+        bare, edge = _unchain(f)
+        if edge is None or any(isinstance(e, Fold) and e.axis is None for e in bare.operands):
             return None  # a fold composing other producers — another stage's shape
-        stat, sweep, _ = chain
-        f, edge = _unchain(f)
-        bound_values = frozenset(edge.lift.results)  # the edge's results — row-invariant values the cone may read
+        f = bare
+        bound_values = frozenset(edge.lift.results)  # the edge's results — row-invariant values the cones may read
+        if chain is not None:
+            stat, sweep, _ = chain
     ops = component_ops(f.combine)
     if ops is None or len(set(ops)) != 1:
         return None  # the carrier is not a product of ONE ⊕ monoid
@@ -914,8 +954,38 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
             return None
         consumed.update(id(s) for s in cone)
         b_edges = [Fold.projection(body=Body(tuple(cone)))]
+    elif edge is not None and len(reads) == 1:
+        # Both sides computed over a chained edge — attention's normalized Q and normalized K,
+        # each side's cone reading its own statistic's projected scale. Each cone hangs its
+        # statistic + epilogue as its source; the fill evaluates a computed B per slab cell,
+        # and the ``b`` seam is the cut that materializes the normalized keys.
+        h = hoisted()
+        if h is not None:
+            return h
+        lift = reads[0][0]
+        other = next(a for a in lift.args if a != a_arg)
+        # Which ⊗ argument is the row side is a property of the cones' indices, not of the
+        # argument order: try the lift's order, then the swap.
+        rest = [s for s in body if id(s) not in consumed]
+        a_cone = b_cone = None
+        for a_try, b_try in ((a_arg, other), (other, a_arg)):
+            a_cone = _cone(rest, a_try, n_name, k_name, axes, bound_values)
+            b_cone = _cone(rest, b_try, m_name, k_name, axes, bound_values)
+            if a_cone is not None and b_cone is not None:
+                break
+        if a_cone is None or b_cone is None:
+            return None
+        split = _split_chain(edge, a_cone, b_cone)
+        if split is None:
+            return None
+        (a_stat, a_epi), (b_stat, b_epi) = split
+        consumed.update(id(s) for s in a_cone)
+        consumed.update(id(s) for s in b_cone)
+        a_edge = make_cone(a_cone, k_name, stat=a_stat, sweep=tuple(a_epi))
+        b_edges = [make_cone(b_cone, k_name, stat=b_stat, sweep=tuple(b_epi))]
     else:
-        # Both sides computed — the W8A8 double-decode pair binds through the mul-hoist alone.
+        # Both sides computed with no chain — the W8A8 double-decode pair binds through the
+        # mul-hoist alone.
         return hoisted()
     if any(id(s) not in consumed for s in body):
         return None  # an unaccounted λ stmt — a shape this binding does not understand

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -36,6 +36,7 @@ from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, deep_defines
 from emmy.compiler.ir.stmt import Body, Load, Loop, Write
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.stmt.body import _member_reads
+from emmy.compiler.ir.stmt.normalize import rename_ssa_sequential
 from emmy.compiler.ir.tile.ir import effect_tail
 from emmy.compiler.ir.tile.ops import axis_names
 from emmy.compiler.ir.tile.path import Site, family_sites, resolve, sites, spell
@@ -329,14 +330,18 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
     # --- the CHILD piece: the seam subtree, its value stored to the workspace ------------------
     child_stmts = [*child.lower(), Write(output=ws, index=ws_index, value=child_name)]
     child_body = _nest(child_stmts, axes)
-    child_op = LoopOp(body=Body(tuple(child_body)))
+    child_op = LoopOp(body=rename_ssa_sequential(Body(tuple(child_body))))
 
     # --- the PARENT piece: the tree with the seam edge → a workspace Load ----------------------
     load = Load(name=child_name, input=ws, index=ws_index)
     parent_tree = _replace_edge(tile_op, child, load)
     parent_cell = effect_tail(parent_tree.lower(), stores)
     parent_body = _nest(list(parent_cell), list(free))
-    parent_op = LoopOp(body=Body(tuple(parent_body)))
+    # A piece is a RAW loop body: the tree's λ-local SSA names (each lift names its own loads
+    # ``in0``…) flatten into one scope, where a name two λs share collides. Canonical sequential
+    # names make the flattened body a valid single-scope program; the re-recognition lifts and
+    # renames the piece again, so nothing downstream reads these names.
+    parent_op = LoopOp(body=rename_ssa_sequential(Body(tuple(parent_body))))
 
     frag = Graph()
     for inp in root.inputs:

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -150,6 +150,21 @@ def route_cut(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> t
     return None, None
 
 
+def _is_contraction_operand(root, child) -> bool:
+    """Whether ``child`` is the ``a`` edge or a channel's ``b`` edge of some contraction in the tree."""
+    from emmy.compiler.ir.pure.fold import is_contraction  # noqa: PLC0415
+
+    def walk(node) -> bool:
+        if not isinstance(node, Fold):
+            return False
+        if is_contraction(node) and (node.a is child or any(ch.b is child for ch in node.channels)):
+            return True
+        members = (*node.operands, *(m for m in node.body if isinstance(m, Fold))) if node.axis is None else node.operands
+        return any(walk(e) for e in members if isinstance(e, Fold))
+
+    return walk(root)
+
+
 def _child_axes(child, free: tuple, ancestors: tuple) -> list[Axis]:
     """The seam value's index space — the enclosing iteration axes the child's lowered body
     reads (its own bound axes excluded), in enclosing order: the parent placement's free axes,
@@ -247,8 +262,15 @@ def _ws_dtype(child, inputs: dict):
     # stored through an ``int*`` workspace: every decoded weight rounded to an integer, a
     # whole-model ``max_diff`` of 0.27 against a 0.005 gate. Only an explicit declared dtype (the
     # branch above) may make a seam integer.
-    for st in lowered:
-        for ld in Body((st,)).loads:
+    # The seam holds what the fused form's operand slab would have stored: the TENSOR the cone
+    # reads (an indexed load), not a scalar constant it also reads — a normalize cone's eps /
+    # count constants are f32 scalars beside f16 activations, and typing the seam off them
+    # makes an f32 B operand no warp atom can copy into its slab.
+    loads = [ld for st in lowered for ld in Body((st,)).loads]
+    for indexed in (True, False):
+        for ld in loads:
+            if bool(any(e.free_vars() for e in ld.index or ())) != indexed:
+                continue
             t = (inputs or {}).get(ld.input)
             if t is not None and np.issubdtype(t.dtype.np, np.floating):
                 return t.dtype
@@ -295,6 +317,12 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
     axes = _child_axes(child, (*free, *sweeps), anc)
     ws_index = tuple(Var(a.name) for a in axes)
     ws_dtype = _ws_dtype(child, getattr(root.op, "inputs", None) or {})
+    if _is_contraction_operand(tile_op, child) and out.dtype.nbytes == 2:
+        # A seam standing in for a CONTRACTION OPERAND holds what the fused form's operand slab
+        # stored: the fill rounds a computed operand to the atom's 16-bit element on the slab
+        # store, so the materialized operand takes the contraction's 16-bit output dtype — the
+        # same numerics, and a B slab the warp atoms can copy (only ``a`` has a converting fill).
+        ws_dtype = out.dtype
     spelled = spell(tile_op, "PLACE", child, all_sites=sites(tile_op))
     logger.info("placement: cutting %s (%s → %s + residue) on %s", spelled, root.id, ws, out.name)
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -824,10 +824,17 @@ def _fill_realized(parent: _Node | None, site: Site) -> bool:
     prologue stripes a cone's statistic ONE ROW PER WARP, the warp's 32 lanes striding the fold and
     closing it on the shuffle butterfly (``lowering/kernel/_stage.sync_stat_fill``) — a single
     hardwired partition, so any value here would stamp a knob no kernel realizes."""
-    if parent is None or not is_contraction(parent.site.node) or isinstance(parent.site.node.a, Load):
+    if parent is None or not is_contraction(parent.site.node):
         return False
     depth = len(parent.site.segments)
-    return len(site.segments) > depth and site.segments[depth] == "a"
+    if len(site.segments) <= depth:
+        return False
+    role = site.segments[depth]
+    if role == "a":
+        return not isinstance(parent.site.node.a, Load)
+    # A computed B CONE (a zero-axis projection) is evaluated by the same fill per slab cell, its
+    # statistic with it; an inline B fold WITH an axis is a real nested schedule site.
+    return role == "b" and all(isinstance(ch.b, Fold) and ch.b.axis is None for ch in parent.site.node.channels if isinstance(ch.b, Fold))
 
 
 def _band_of(plan: ReducePlan) -> Workers | None:

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -784,25 +784,30 @@ def _reduce_specs(term: _Term, node) -> list[ReducePlan]:
     A cross-CTA split is offered here only in COMPOSITE with the transposed band — every split
     candidate in the catalog is one, so the loop below states the catalog's shape rather than
     adding a rule."""
-    pin = term.pin("REDUCE", node)
-    if pin is not None:
-        return [_consumed_split(term, node, ReducePlan.parse(pin, Workers.parse(WORK.raw())))]
-    extent = _hint_extent(node.axis)
-    cands = [ReducePlan()]
     inner = _inner_free(term.place)
     k_static = node.axis.extent.as_static() if node.axis.extent.is_static else None
     # Term-wide, so it is asked ONCE, not per candidate.
     epilogue = legal.coop_band_epilogue(projection_tail(term.tile))
+
+    def band_legal(p: ReducePlan, *, pinned: bool) -> bool:
+        # The transposed band's own requirements: the geometry (shared with the contraction tier)
+        # plus this tier's epilogue condition. A pin meets the same test, as a refusal.
+        if not p.coop_transposed:
+            return True
+        return legal.enforce(legal.coop_band_geometry(p, k_static, inner), pinned=pinned) and legal.enforce(epilogue, pinned=pinned)
+
+    pin = term.pin("REDUCE", node)
+    if pin is not None:
+        plan = _consumed_split(term, node, ReducePlan.parse(pin, Workers.parse(WORK.raw())))
+        band_legal(plan, pinned=True)
+        return [plan]
+    extent = _hint_extent(node.axis)
+    cands = [ReducePlan()]
     for p in coop_reduce_moves():
         if p.needs_split and not _splittable_axis(term, node):
             continue  # the axis is already a slice — its cross-CTA partition was consumed
-        if p.coop_transposed:
-            # The band's own requirements: the geometry (shared with the contraction tier) plus
-            # this tier's epilogue condition.
-            if not legal.enforce(legal.coop_band_geometry(p, k_static, inner), pinned=False):
-                continue
-            if not legal.enforce(epilogue, pinned=False):
-                continue
+        if not band_legal(p, pinned=False):
+            continue
         if p.coop <= extent and p.reg <= extent and p not in cands:
             cands.append(p)
     return cands
@@ -975,6 +980,9 @@ def _contraction_reduces(term: _Term, node, plan: TilePlan) -> list[ReducePlan]:
     pin = term.pin("REDUCE", node)
     if pin is not None:
         pinned = _consumed_split(term, node, ReducePlan.parse(pin, Workers.parse(WORK.raw())))
+        ext = node.axis.extent
+        # A pin meets the transposed band's geometry as a refusal, not an emitter crash.
+        legal.enforce(legal.coop_band_geometry(pinned, ext.as_static() if ext.is_static else None, _inner_free(term.place)), pinned=True)
         if pinned.needs_split:
             return [pinned]
         if pinned.coop > 1 or pinned.reg > 1:

--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -168,7 +168,11 @@ an `AutoModel` trunk yields hidden states instead of logits (the serving plugin'
   way every routed expert keeps its PACKED CODES. EXL3 stores experts as per-expert MODULES, so `_expert_slot`
   reports an expert index and `_stack_exl3_experts` stacks each `(layer, projection, leaf)` triple into one
   E-leading tensor, putting `suh` in its 128-blocked form and trimming `svh` to the logical out extent — the
-  shapes `spell_trellis_inputs` declares, so a launch's per-expert slice needs no reshape. The store also carries
+  shapes `spell_trellis_inputs` declares, so a launch's per-expert slice needs no reshape. DeepSeek-lineage FP8
+  checkpoints use the same per-expert module layout for ordinary 2-D weights and block scales;
+  `_stack_expert_modules` preserves FP8 bits on the uint8 carrier, stacks scales as float32, concatenates gate and up
+  along the output axis, and leaves down weights in checkpoint orientation. Ignored dense layers take the same path
+  without scales. The store also carries
   `codebooks[layer][input_name]`, the marker-derived codebook id the speller stamps on each decode, plus `dir` and
   `trunk` (`"values"` / `"codes"`) — what a caller needs to re-source a coded trunk. Never the
   whole dict at once — a 20B checkpoint's whole-dict value form is ~42 GB of host RAM. `load_quantized_twin` stays the

--- a/emmy/compiler/trace/huggingface.py
+++ b/emmy/compiler/trace/huggingface.py
@@ -1410,7 +1410,8 @@ def load_quantized_split(
 ):
     """Architecture twin + expert store for a quantized (MoE) checkpoint — SHARD-STREAMED.
 
-    The serving load path for a quantized checkpoint whose experts must stay fp8 (gpt-oss):
+    The serving load path for a quantized checkpoint whose experts must stay fp8 (gpt-oss
+    and the DeepSeek / Laguna per-expert-module lineage):
     never materializes the whole dequantized dict (a 20B checkpoint dequantizes to ~42 GB of
     host values — the whole-dict ``load_dequantized_state_dict`` OOMs a 60 GB box). Instead:
 
@@ -1419,13 +1420,15 @@ def load_quantized_split(
     - The DENSE trunk (attention projections + biases, norms, router, embeddings, lm_head)
       streams per shard: fp8 weights dequantize by their ``<key>_scale`` partner, everything
       casts to ``dtype``, and the tensors attach via ``load_state_dict(assign=True)``. The
-      3-D expert params are skipped — they stay meta on the twin.
+      expert params are skipped — they stay meta on the twin.
     - The EXPERT tensors are collected into a per-layer store keyed by the expert program's
       INPUT names: fp8 weights as RAW BITS on the uint8 carrier plus their f32 scale
       tensors (the runner spells the dequant in-graph via ``spell_quantized_inputs`` and
       uploads 1-byte weights — the whole point of the fp8 checkpoint), biases (and any
-      unquantized expert weights) as ``dtype`` value tensors. An interleaved gate/up layout
-      de-interleaves here — bits, scale and bias alike (:func:`deinterleave_gate_up`).
+      unquantized expert weights) as ``dtype`` value tensors. Per-expert checkpoint modules
+      stack into the same E-leading inputs, concatenating gate and up along the output axis.
+      An interleaved gate/up layout de-interleaves here — bits, scale and bias alike
+      (:func:`deinterleave_gate_up`).
 
     EXL3 (``fmt == "exl3"``) follows the same split with the trellis format's own shapes, while
     every routed expert keeps its PACKED CODES. Experts arrive as per-expert modules, so each
@@ -1469,6 +1472,7 @@ def load_quantized_split(
         _exl3_quant_config,
         _fp8_quant_config,
         _is_skipped,
+        _skip_patterns,
         dequantize,
         dequantize_awq4,
         scale_is_reciprocal,
@@ -1484,7 +1488,7 @@ def load_quantized_split(
 
     qc = _fp8_quant_config(model_dir) or {}
     awq = _awq_quant_config(model_dir)
-    patterns = list(qc.get("modules_to_not_convert") or []) + list(qc.get("ignore") or [])
+    patterns = _skip_patterns(qc)
     exl3 = _exl3_quant_config(model_dir) is not None
     index = _build_index(model_dir)
     by_shard: dict[str, list[str]] = {}

--- a/emmy/compiler/trace/huggingface.py
+++ b/emmy/compiler/trace/huggingface.py
@@ -1197,6 +1197,10 @@ _EXPERT_LEAVES = {
 # gate_up weight has no single activation-side basis to restore (see ``spell_trellis_inputs``).
 _EXL3_EXPERT_PROJ = {"gate_proj": "w_gate", "up_proj": "w_up", "down_proj": "w_down"}
 _EXL3_EXPERT_LEAF = {"trellis": "", "suh": "_suh", "svh": "_svh"}
+# The per-expert-module fp8 / dense lineage: one 2-D weight per expert projection, with its
+# block scale (DeepSeek's ``weight_scale_inv`` is the dequant MULTIPLIER — see
+# :func:`~emmy.compiler.loader.quant.scale_is_reciprocal`).
+_PER_EXPERT_LEAF = {"weight": "", "weight_scale_inv": "_scale", "weight_scale": "_scale"}
 
 
 def _auto_config_from_pretrained(model_dir):
@@ -1241,6 +1245,11 @@ def _expert_slot(key: str):
         return layer, name, None
     if len(tail) == 3 and tail[0].isdigit() and tail[1] in _EXL3_EXPERT_PROJ and tail[2] in _EXL3_EXPERT_LEAF:
         return layer, _EXL3_EXPERT_PROJ[tail[1]] + _EXL3_EXPERT_LEAF[tail[2]], int(tail[0])
+    if len(tail) == 3 and tail[0].isdigit() and tail[1] in _EXL3_EXPERT_PROJ and tail[2] in _PER_EXPERT_LEAF:
+        # The per-expert-MODULE fp8 lineage (DeepSeek / Laguna): ``experts.<e>.<proj>.weight`` with
+        # its block ``weight_scale_inv`` (or a plain bf16 ``weight`` on an ignored layer). The
+        # loader stacks them into the E-leading ``w_gate_up`` / ``w_down`` program inputs.
+        return layer, _EXL3_EXPERT_PROJ[tail[1]] + _PER_EXPERT_LEAF[tail[2]], int(tail[0])
     return None
 
 
@@ -1281,6 +1290,34 @@ def _stack_exl3_experts(layer: int, by_name: dict, model) -> dict:
         elif (stacked.shape[1] * 16, stacked.shape[2] * 16) != (-(-k // HAD_BLOCK) * HAD_BLOCK, -(-n // HAD_BLOCK) * HAD_BLOCK):
             raise ValueError(f"expert store: layer {layer} {name!r} codes {tuple(stacked.shape[1:])} do not pad the twin's {(n, k)}")
         out[name] = stacked.contiguous()
+    return out
+
+
+def _stack_expert_modules(layer: int, by_name: dict, model) -> dict:  # noqa: ARG001 — same signature as the EXL3 stacker
+    """Stack one MoE layer's per-expert-module fp8 (or dense) tensors into the E-leading program
+    inputs the runner feeds: ``w_gate_up`` is the ``[gate | up]`` concatenation along the output
+    axis (the de-interleaved convention the expert wrapper's ``chunk(2)`` reads), ``w_down`` as
+    stored, and their block scales concatenated the same way. fp8 bits stay on the ``uint8``
+    carrier; scales are f32 values. Expert order is the checkpoint's own index and must be
+    gapless."""
+    import torch  # noqa: PLC0415
+
+    order = {name: sorted(d) for name, d in by_name.items()}
+    n_e = len(next(iter(order.values())))
+    stacked: dict = {}
+    for name, indices in order.items():
+        if indices != list(range(n_e)):
+            raise ValueError(f"expert store: layer {layer} input {name!r} covers experts {indices[:4]}... — expected 0..{n_e - 1}")
+        stacked[name] = torch.stack([by_name[name][e] for e in indices], dim=0)
+    out: dict = {}
+    for suffix in ("", "_scale"):
+        gate, up = stacked.get("w_gate" + suffix), stacked.get("w_up" + suffix)
+        if gate is not None and up is not None:
+            out["w_gate_up" + suffix] = torch.cat([gate, up], dim=1).contiguous()
+        elif gate is not None or up is not None:
+            raise ValueError(f"expert store: layer {layer} has a gate without an up projection (or the reverse) at {suffix or 'weight'}")
+        if (down := stacked.get("w_down" + suffix)) is not None:
+            out["w_down" + suffix] = down.contiguous()
     return out
 
 
@@ -1434,6 +1471,7 @@ def load_quantized_split(
         _is_skipped,
         dequantize,
         dequantize_awq4,
+        scale_is_reciprocal,
     )
     from emmy.compiler.loader.safetensors import _build_index  # noqa: PLC0415
 
@@ -1527,7 +1565,8 @@ def load_quantized_split(
                     if expert is None:
                         layers_store.setdefault(layer, {})[name] = t
                     else:
-                        fmt = "exl3"
+                        if t.dtype == torch.int16 or name.endswith(("_suh", "_svh")):
+                            fmt = "exl3"
                         per_expert.setdefault(layer, {}).setdefault(name, {})[expert] = t
                         if t.dtype == torch.int16:
                             codebooks.setdefault(layer, {})[name] = _exl3_codebook(index, k[: -len(".trellis")])
@@ -1553,7 +1592,7 @@ def load_quantized_split(
                     scale_key = next((c for c in (k + "_scale", k + "_scale_inv") if c in index), None)
                     if scale_key is not None and not _is_skipped(k, patterns):
                         s = _open(str(index[scale_key])).get_tensor(scale_key)
-                        vals = dequantize(t.float().numpy(), s.float().numpy(), inverse=scale_key.endswith("_inv"))
+                        vals = dequantize(t.float().numpy(), s.float().numpy(), inverse=scale_is_reciprocal(scale_key))
                         state[_checkpoint_to_model_key(k)] = torch.from_numpy(vals).to(dtype)
                         continue
                     t = t.float()  # unpaired / skipped fp8: exact value decode, no scale
@@ -1563,7 +1602,9 @@ def load_quantized_split(
     # per-expert dict alive across the whole loop peaks at 2× (GLM-4.5-Air: 50 GiB, which no 60 GB
     # box survives). Dropping each layer's sources as it stacks keeps the peak at one layer over.
     for layer in sorted(per_expert):
-        layers_store.setdefault(layer, {}).update(_stack_exl3_experts(layer, per_expert.pop(layer), model))
+        by_name = per_expert.pop(layer)
+        stack = _stack_exl3_experts if any(t.dtype == torch.int16 for d in by_name.values() for t in d.values()) else _stack_expert_modules
+        layers_store.setdefault(layer, {}).update(stack(layer, by_name, model))
 
     # De-interleave the gate/up family once, so the wrapper's chunk-half split holds.
     trunk = getattr(model, "model", model)

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -257,7 +257,7 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   reinterprets via `.view`), a scale input keeps its traced f32. This is what lets input-sourced fp8 expert weights
   (`loader.quant.spell_quantized_inputs`, see the compiler ARCHITECTURE's quantized-checkpoints section) feed the
   expert programs; indirect operands compose (bits + scale slices both table-resolved).
-  **Quantized-checkpoint serving load (gpt-oss fp8, MoE M3):** `EmmyGenRunner.create` detects a quantized checkpoint
+  **Quantized-checkpoint serving load (FP8, MoE M3):** `EmmyGenRunner.create` detects a quantized checkpoint
   (`quantized_checkpoint_dir`) and takes `load_quantized_split` (trace ARCHITECTURE): config-built META twin,
   dense trunk shard-streamed in as real values, expert tensors kept fp8 as a per-layer store of program-input-named
   tensors (bits on the uint8 carrier + f32 scales + `dtype` biases, gate/up de-interleaved). `from_model` then
@@ -267,7 +267,9 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   examples as its last entries. Every per-expert input — weights, biases, scales — is a per-launch slice of the
   store's E-stacked device tensors; the fixed-slot tier builds one pointer table per input kind, so the k-slot
   T=1 dispatch stays capture-legal with fp8 experts. VRAM: ~19 GB expert bits + dense fp16 + tables on the 32 GB
-  card, the rest is vLLM's KV budget.
+  card, the rest is vLLM's KV budget. Gpt-oss checkpoints already store E-leading expert tensors; the DeepSeek /
+  Laguna lineage stores one module per expert, so the split loader stacks each layer into the same program inputs,
+  concatenating gate/up weights and block scales along their output axis while leaving ignored dense layers unscaled.
   **EXL3 experts.** The loader stacks each per-expert checkpoint module into E-leading
   codes and padded channel-vector tensors. Gate and up remain separate program inputs.
   `spell_trellis_inputs` replaces each logical weight input and its linear consumer with the

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -105,6 +105,11 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `build_attention_split_wrapper` / `trace_split` path serving uses. Backs the file-scoped `emmy eval golden
   GOLDEN_YAML --serving-config PATH` release audit and serving-image gate;
   `scripts/capture_gen_twins.py` remains the full-checkpoint diagnostic capture.
+  Coded routed experts are spelled weight-free so the golden records the program serving deploys, not the f16 GEMM
+  the trace promised: EXL3 from the allocation sidecar (`…@b4`, one twin per rate profile), fp8 from the config's
+  `quantization_config` alone (`loader.quant.fp8_weight_profile` — format token, `weight_block_size`, skip patterns;
+  `…@f8e4m3` carries `w_gate_up` / `w_down` as bits + block scales tiled over the traced weight shapes), with the
+  plain twin kept beside it only for a profile whose layers the quantizer left unconverted (Laguna's last four).
   Query-head discovery validates the classic `q_proj` signature and can identify DeepSeek's complete low-rank
   `q_a_proj` / `q_b_proj` plus shared-`kv_proj` layout, but executable split capture rejects the latter.
   The in-model audit selects a different config-only provider for DeepSeek V4: one exact full-layer trace per distinct

--- a/emmy/serving/twins.py
+++ b/emmy/serving/twins.py
@@ -184,7 +184,7 @@ def capture_twin_graphs(
     import torch  # noqa: PLC0415
     from transformers import AutoConfig, AutoModel  # noqa: PLC0415
 
-    from emmy.compiler.loader.quant import strip_engine_quant_config  # noqa: PLC0415
+    from emmy.compiler.loader.quant import fp8_weight_profile, strip_engine_quant_config  # noqa: PLC0415
     from emmy.compiler.loader.safetensors import split_revision  # noqa: PLC0415
     from emmy.compiler.trace.huggingface import (  # noqa: PLC0415
         build_attention_split_wrapper,
@@ -202,6 +202,7 @@ def capture_twin_graphs(
             "residuals do not fit the (q, k, v) seam; use capture_in_model_graphs for its full-layer audit provider"
         )
     storage = coded_tensor_storage(model, cfg, revision=revision)
+    fp8 = fp8_weight_profile(text)
     strip_engine_quant_config(text)
     text.vocab_size = 32  # the twins are decoder halves — the embedding/lm_head are never traced
     if (text.pad_token_id or 0) >= text.vocab_size:
@@ -287,6 +288,8 @@ def capture_twin_graphs(
                 expert_name = f"expert{name}{suffix}"
                 if storage:
                     graphs.update(_spell_expert_twins(expert_name, graph, storage))
+                elif fp8 is not None:
+                    graphs.update(_spell_fp8_expert_twins(expert_name, graph, fp8, members))
                 else:
                     graphs[expert_name] = graph
     return _spell_coded_twins(graphs, storage, layer_scopes=layer_scopes) if storage else graphs
@@ -426,6 +429,34 @@ def _expert_examples(experts, rows: int, hidden: int, dtype, *, split_gate_up: b
             torch.zeros(tuple(experts.down_proj_bias.shape[1:]), dtype=dtype),
         ]
     return args
+
+
+def _spell_fp8_expert_twins(name: str, graph: Graph, profile, layers: set[int]) -> dict[str, Graph]:
+    """The fp8 routed-expert twins of one profile, weight-free.
+
+    Serving spells the expert program from the per-layer store (``spell_quantized_inputs`` with
+    the store's bits + scale shapes); the golden must record that program, not the f16 GEMM
+    the trace promised. ``name@<fmt>`` carries ``w_gate_up`` / ``w_down`` as fp8 bits with the
+    block scales the config's ``weight_block_size`` tiles over the traced weight shapes, for
+    the layers the quantizer converted; the plain ``name`` stays beside it when any layer of the
+    profile kept its experts unquantized (Laguna's last four layers deploy f16). ``profile`` is
+    :func:`loader.quant.fp8_weight_profile`'s reading of the config."""
+    from emmy.compiler.loader.quant import _is_skipped, spell_quantized_inputs  # noqa: PLC0415
+
+    fmt, block, patterns = profile
+    coded = {i for i in layers if not _is_skipped(f"model.layers.{i}.mlp.experts.weight", patterns)}
+    out: dict[str, Graph] = {}
+    if coded:
+        specs = {}
+        for inp in ("w_gate_up", "w_down"):
+            n, k = (int(d.as_static()) for d in graph.nodes[inp].output.shape)
+            specs[inp] = (fmt, (1, 1) if block is None else (-(-n // block[0]), -(-k // block[1])), "f32")
+        spelled = graph.copy()
+        spell_quantized_inputs(spelled, specs)
+        out[f"{name}@{fmt}"] = spelled
+    if layers - coded:
+        out[name] = graph
+    return out
 
 
 def _spell_expert_twins(name: str, graph: Graph, storage: dict) -> dict[str, Graph]:

--- a/emmy/serving/twins.py
+++ b/emmy/serving/twins.py
@@ -177,10 +177,11 @@ def capture_twin_graphs(
     ``{"pre32": Graph, "post32": …, "pre256": …, "pre-sym": …}`` plus ``-global``
     variants of each when the model has ``full_attention`` layers — the same names
     ``scripts/capture_gen_twins.py`` writes. ``extra_widths`` adds release-specific decode or
-    prefill buckets. On an EXL3 checkpoint each
-    twin holding coded weights is replaced by its spelled forms, one per rate profile
-    (``…@b4``). ``static_only`` is the deliberate exception: it accepts only the proven
-    decode-1/prefill-0 envelope and emits M=1 without any standard or symbolic twins."""
+    prefill buckets. On an EXL3 checkpoint each twin holding coded weights is replaced by its
+    spelled forms, one per rate profile (``…@b4``). An FP8 expert twin is replaced by the
+    config-declared storage form (``…@f8e4m3``), retaining a plain form only when its layer
+    profile includes unconverted experts. ``static_only`` is the deliberate exception: it accepts
+    only the proven decode-1/prefill-0 envelope and emits M=1 without any standard or symbolic twins."""
     import torch  # noqa: PLC0415
     from transformers import AutoConfig, AutoModel  # noqa: PLC0415
 

--- a/tests/compiler/cli/test_trace.py
+++ b/tests/compiler/cli/test_trace.py
@@ -98,10 +98,13 @@ def test_trace_serving_twins_writes_one_exact_inventory_with_explicit_provenance
 
     document = load_golden_file(output)
     records = load_golden_records(document)
+    # The audit's graph set (``emmy eval golden``): the symbolic programs plus the config's static widths.
     assert captured == {
         "model": str(tmp_path / "local-checkpoint"),
         "decode_bucket": 0,
         "prefill_bucket": 0,
+        "extra_widths": (1, 64, 512, 1024),
+        "symbolic": True,
     }
     assert document["model"] == "cloudriftai/model-exl3@0123456789abcdef0123456789abcdef01234567"
     assert {record.name.split(".", 1)[0] for record in records} == {"pre1@b2", "expert512@b2"}
@@ -148,8 +151,10 @@ def test_trace_serving_twins_static_only_release_forwards_exact_scope(monkeypatc
 
     assert captured == {
         "model": "org/model",
-        "decode_bucket": 0,
+        "decode_bucket": 1,
         "prefill_bucket": 0,
+        "symbolic": False,
+        "static_only": True,
     }
     records = load_golden_records(load_golden_file(output))
     assert {(record.bindings, record.pins) for record in records} == {((("num_tokens", 1),), (("FAST_MATH", False),))}

--- a/tests/compiler/loader/test_quant.py
+++ b/tests/compiler/loader/test_quant.py
@@ -218,10 +218,13 @@ def test_spell_2d_block_interleaved_reshape_pair(tmp_path):
     assert any(isinstance(lop, ReshapeOp) for lop in scale_node.op.load_ops)
 
 
-def test_spell_inverse_scale_divides(tmp_path):
+def test_spell_scale_inv_multiplies(tmp_path):
+    """DeepSeek's ``weight_scale_inv`` names the dequant MULTIPLIER (the inverse of the
+    quantization scale), not a reciprocal to divide by — ``q * s``, as its own ``weight_dequant``
+    and vLLM's block-fp8 path compute it."""
     g, _bits, _scale = _spelled(tmp_path, scale_shape=(8, 1), inverse=True)
     names = [n.op.op.name for n in _ops_by_type(g, ElementwiseOp)]
-    assert "divide" in names and "multiply" not in names
+    assert "multiply" in names and "divide" not in names
 
 
 def test_spell_e5m2_selects_its_cast(tmp_path):
@@ -475,7 +478,9 @@ def _torch_ref(bits, scale_np, *, fmt="f8e4m3", inverse=False):
         s = s.reshape(())
     else:
         s = np.repeat(np.repeat(s, vals.shape[0] // s.shape[0], axis=0), vals.shape[1] // s.shape[1], axis=1)
-    return vals / s if inverse else vals * s
+    # ``inverse`` selects the ``weight_scale_inv`` key; the stored value is the multiplier either way.
+    del inverse
+    return vals * s
 
 
 def _run_spelled(graph: Graph, model_dir: str) -> np.ndarray:

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
 from emmy.compiler.context import Context
 from emmy.compiler.dim import Dim
 from emmy.compiler.dtype import F16
@@ -243,3 +245,13 @@ def test_contraction_operand_seam_takes_the_output_dtype(monkeypatch) -> None:
     ws = [n for n in out.nodes.values() if "__cut_" in n.id and isinstance(n.op, (LoopOp, TileOp))]
     assert ws, [n.id for n in out.nodes.values()]
     assert any(n.output.dtype == F16 for n in ws), [(n.id, str(n.output.dtype)) for n in ws]
+
+
+def test_pinned_transposed_coop_band_refuses_without_a_free_axis_to_sweep(monkeypatch) -> None:
+    """A REDUCE pin meets the transposed band's legality as a refusal, never a crash: at one row
+    the rms statistic has no innermost free axis for the band's 32 lanes to sweep (unpinned,
+    the catalog simply omits the band)."""
+    monkeypatch.setenv("EMMY_WORK", "t256")
+    monkeypatch.setenv("EMMY_REDUCE", "coop-t")
+    with pytest.raises(ValueError, match="innermost free axis"):
+        _compile(_rms_graph(S=1), None, monkeypatch)

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -20,7 +20,7 @@ from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import MatmulOp, RmsNormOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
-from emmy.compiler.pipeline import CUDA_PASSES, Pipeline
+from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
 from emmy.compiler.pipeline.pipeline import Run
 from emmy.compiler.pipeline.search.golden import GoldenRecord
@@ -223,3 +223,23 @@ def test_a_cut_taken_at_a_fork_mid_batch_still_reaches_the_stamp(monkeypatch) ->
 
 
 # --- routing entries drive the same realizer -------------------------------------------------------
+
+
+def test_contraction_operand_seam_takes_the_output_dtype(monkeypatch) -> None:
+    """A seam standing in for a contraction OPERAND holds what the fused slab stored — the atom's
+    16-bit element — not the f32 its cone computed in: typed f32 (an f32-computing norm over f16
+    keys), the materialized B could feed no warp atom (only ``a`` has a converting fill)."""
+    from emmy.compiler.ir.loop import LoopOp
+    from emmy.compiler.ir.tile import TileOp
+    from emmy.compiler.pipeline.search.pins import pinned_knobs
+    from tests.compiler.passes.test_recognize_boundary_rules import _normed_sdpa_graph
+
+    g = _normed_sdpa_graph()
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    with pinned_knobs({"PLACE@b": "cut"}):
+        out, _ = Run(pipeline=Pipeline.build(TILE_PASSES), ctx=Context.from_target((12, 0))).resolve(
+            g, lambda fp: flatten_leaves(fp.options)[0]
+        )
+    ws = [n for n in out.nodes.values() if "__cut_" in n.id and isinstance(n.op, (LoopOp, TileOp))]
+    assert ws, [n.id for n in out.nodes.values()]
+    assert any(n.output.dtype == F16 for n in ws), [(n.id, str(n.output.dtype)) for n in ws]

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -608,8 +608,8 @@ def test_norm_linear_symbolic_m_offers_warp_rows():
     assert any(_is_warp_row(r) for r in rows)
 
 
-def _mlp_gate_up_graph() -> Graph:
-    S, H, inter = 32, 1024, 3072
+def _mlp_gate_up_graph(S: int = 32) -> Graph:
+    H, inter = 1024, 3072
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (1, Dim(S), Dim(H)), dtype=F16), node_id="x")
     g.add_node(InputOp(), [], Tensor("wn", (Dim(H),), dtype=F16), node_id="wn")
@@ -872,3 +872,89 @@ def test_normed_q_k_scores_bind_both_computed_cones_with_a_cuttable_b_seam():
     assert is_contraction(node) and isinstance(node.a, Fold) and isinstance(node.channels[0].b, Fold), "both operands computed"
     seams = [spell(pro[0], "PLACE", s.node) for s in cuttable_seams(pro[0], pro[2], (*tile.place.free, pro[1]))]
     assert "PLACE@b" in seams, seams
+
+
+def _m1_norm_gate_up_body() -> Body:
+    """One row of norm → gate/up → SiLU·up as loop fusion leaves it: the row statistic, its
+    epilogue, the SiLU's fill constant (``one``) loaded ahead of the column sweep, and the
+    combine tail reading it after the two-channel contraction."""
+    lit0 = Literal(0, "int")
+    stat = Loop(
+        axis=Axis("k0", Dim(64)),
+        body=Body(
+            (
+                Load(names=("xs",), input="x", index=(lit0, lit0, Var("k0"))),
+                Assign(name="xf", op="copy", args=("xs",), dtype=F32),
+                Assign(name="sq", op="multiply", args=("xf", "xf")),
+                Accum(name="ss", value="sq", op="add", axes=("k0",)),
+            )
+        ),
+    )
+    col = Loop(
+        axis=Axis("k", Dim(64)),
+        body=Body(
+            (
+                Load(names=("xc",), input="x", index=(lit0, lit0, Var("k"))),
+                Load(names=("wn",), input="w", index=(Var("k"),)),
+                Assign(name="xcf", op="copy", args=("xc",), dtype=F32),
+                Assign(name="wnf", op="copy", args=("wn",), dtype=F32),
+                Assign(name="sc", op="multiply", args=("rs", "xcf")),
+                Assign(name="nm", op="multiply", args=("sc", "wnf")),
+                Assign(name="nh", op="copy", args=("nm",), dtype=F16),
+                Load(names=("g",), input="wg", index=(Var("k"), Var("n"))),
+                Assign(name="pg", op="multiply", args=("g", "nh")),
+                Accum(name="ag", value="pg", op="add", axes=("k",)),
+                Load(names=("u",), input="wu", index=(Var("k"), Var("n"))),
+                Assign(name="pu", op="multiply", args=("nh", "u")),
+                Accum(name="au", value="pu", op="add", axes=("k",)),
+            )
+        ),
+    )
+    sweep = Loop(
+        axis=Axis("n", Dim(128)),
+        body=Body(
+            (
+                col,
+                Assign(name="ng", op="negative", args=("ag",)),
+                Assign(name="eg", op="exp", args=("ng",)),
+                Assign(name="dn", op="add", args=("one", "eg")),
+                Assign(name="sg", op="reciprocal", args=("dn",)),
+                Assign(name="si", op="multiply", args=("ag", "sg")),
+                Assign(name="o", op="multiply", args=("au", "si")),
+                Write(output="out", index=(lit0, lit0, Var("n")), value="o"),
+            )
+        ),
+    )
+    return Body(
+        (
+            stat,
+            Load(names=("cnt",), input="count", index=(lit0,)),
+            Assign(name="mean", op="divide", args=("ss", "cnt")),
+            Load(names=("eps",), input="eps", index=(lit0,)),
+            Assign(name="ve", op="add", args=("eps", "mean")),
+            Assign(name="rs", op="rsqrt", args=("ve",)),
+            Load(names=("one",), input="silu_one", index=(lit0,)),
+            sweep,
+        )
+    )
+
+
+def test_fused_view_tail_prefix_is_alpha_renamed_from_the_statistic_prologue():
+    """At one row the fused gate/up reading prepends the tail's stat-free cone stmts (the
+    SiLU's fill constant) so the store side re-evaluates them — a SECOND spelling of names the
+    statistic prologue also defines. A PLACE cut flattens both into one raw loop body (the
+    parent piece), so the copies must carry their own names or the piece defines a name twice
+    and the cut is refused (Qwen3.8 ``PLACE@a0=cut`` on norm→gate/up M=1)."""
+    from emmy.compiler.ir.tile import Placement, TileOp
+    from emmy.compiler.ir.tile.ir import effect_tail
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import fused_view
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import _nest
+    from emmy.compiler.pipeline.passes.lowering.tile._lift import recognized_tile
+
+    tile = recognized_tile(LoopOp(body=_m1_norm_gate_up_body()))
+    pro = fused_view(TileOp(op=tile.op, place=Placement(free=tuple(tile.place.free)), stores=tuple(tile.stores)))
+    assert pro is not None, "the one-row norm→gate/up must bind the fused (computed-A) reading"
+    tree, n_ax, stores = pro
+    assert any(s.name.endswith("__p") for s in tree.body if isinstance(s, Load)), [s for s in tree.body]
+    # The parent piece of any cut is this flattening; it must be a valid single-scope program.
+    LoopOp(body=Body(tuple(_nest(effect_tail(tree.lower(), stores), [*tile.place.free, n_ax]))))

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -22,11 +22,12 @@ from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import Literal, Var
 from emmy.compiler.ir.frontend.ir import LinearOp, RmsNormOp
+from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.pure.fold import Fold, deep_defines, deep_reads, stmt_axis_names
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
 from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
 from emmy.compiler.ir.tile import TileOp
-from emmy.compiler.pipeline import TILE_PASSES, Pipeline
+from emmy.compiler.pipeline import LOOP_PASSES, TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import _same_program, fold_from_loop
 from emmy.compiler.pipeline.pipeline import Run
@@ -848,3 +849,26 @@ def test_masked_score_cone_keeps_its_predicate_per_cell():
     pro, cell, _stats = cone_seam(fold.a, fold.axis.name)
     assert any(isinstance(s, Select) for s in cell), "the mask predicates the per-cell weight"
     assert not any(isinstance(s, Select) for s in pro), "the mask is k-varying — it never joins the row prologue"
+
+
+def test_normed_q_k_scores_bind_both_computed_cones_with_a_cuttable_b_seam():
+    """Gemma-shaped attention scores: RMSNorm'd Q against RMSNorm'd K. Root formation chains the
+    score fold over both statistics' projected scales; the binder reads it as ONE contraction
+    whose A and B are both computed cones, each sourcing its own statistic. The ``b`` seam —
+    the normalized keys — is then a legal cut: the form that turns the per-query replay of the
+    key statistic into a materialized operand the mma tier streams."""
+    from emmy.compiler.ir.pure.fold import is_contraction
+    from emmy.compiler.ir.tile.path import spell
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import fused_view
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams
+    from emmy.compiler.pipeline.passes.lowering.tile._lift import recognized_tile
+
+    g = Pipeline.build(LOOP_PASSES).run(_normed_sdpa_graph())
+    scores = next(n for n in g.nodes.values() if isinstance(n.op, LoopOp) and n.id.endswith("_scaled"))
+    tile = recognized_tile(scores.op, name=scores.id)
+    pro = fused_view(tile)
+    assert pro is not None, "the chained score column binds through the fused view"
+    node = pro[0].operands[0]
+    assert is_contraction(node) and isinstance(node.a, Fold) and isinstance(node.channels[0].b, Fold), "both operands computed"
+    seams = [spell(pro[0], "PLACE", s.node) for s in cuttable_seams(pro[0], pro[2], (*tile.place.free, pro[1]))]
+    assert "PLACE@b" in seams, seams

--- a/tests/compiler/trace/test_huggingface.py
+++ b/tests/compiler/trace/test_huggingface.py
@@ -882,3 +882,36 @@ def test_pack_expert_state_shape_mismatch_raises():
     state = {"m.experts.0.down_proj.weight": torch.randn(3, 4)}  # transposed vs expected
     with pytest.raises(ValueError, match="expert packing"):
         _pack_expert_state(model, state)
+
+
+def test_expert_slot_reads_per_expert_fp8_modules_and_stacks_them():
+    """DeepSeek / Laguna store routed experts one MODULE per expert — ``experts.<e>.<proj>.weight``
+    with a block ``weight_scale_inv`` — not the transformers-v5 E-stacked 3-D tensors. They map
+    to the same E-leading program inputs: ``w_gate_up`` is ``[gate | up]`` along the output axis
+    (the de-interleaved convention the expert wrapper's ``chunk(2)`` reads), ``w_down`` as
+    stored, block scales concatenated alike, fp8 bits on the ``uint8`` carrier."""
+    import torch
+
+    from emmy.compiler.trace.huggingface import _expert_slot, _stack_expert_modules
+
+    assert _expert_slot("model.layers.12.mlp.experts.3.gate_proj.weight") == (12, "w_gate", 3)
+    assert _expert_slot("model.layers.12.mlp.experts.3.up_proj.weight_scale_inv") == (12, "w_up_scale", 3)
+    assert _expert_slot("model.layers.12.mlp.experts.0.down_proj.weight") == (12, "w_down", 0)
+    assert _expert_slot("model.layers.12.mlp.experts.0.down_proj.bias") is None
+
+    e, inter, hidden = 2, 4, 8
+    by_name = {
+        "w_gate": {i: torch.full((inter, hidden), 10 * i + 1, dtype=torch.uint8) for i in range(e)},
+        "w_up": {i: torch.full((inter, hidden), 10 * i + 2, dtype=torch.uint8) for i in range(e)},
+        "w_down": {i: torch.full((hidden, inter), 10 * i + 3, dtype=torch.uint8) for i in range(e)},
+        "w_gate_scale": {i: torch.full((1, 1), float(i + 1)) for i in range(e)},
+        "w_up_scale": {i: torch.full((1, 1), float(i + 5)) for i in range(e)},
+        "w_down_scale": {i: torch.full((1, 1), float(i + 9)) for i in range(e)},
+    }
+    out = _stack_expert_modules(12, by_name, model=None)
+    assert set(out) == {"w_gate_up", "w_down", "w_gate_up_scale", "w_down_scale"}
+    assert out["w_gate_up"].shape == (e, 2 * inter, hidden) and out["w_gate_up"].dtype == torch.uint8
+    assert out["w_gate_up"][1, 0, 0] == 11 and out["w_gate_up"][1, inter, 0] == 12, "[gate | up] halves per expert"
+    assert out["w_down"].shape == (e, hidden, inter)
+    assert out["w_gate_up_scale"].shape == (e, 2, 1) and out["w_gate_up_scale"][1].flatten().tolist() == [2.0, 6.0]
+    assert out["w_down_scale"][0].item() == 9.0

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -212,6 +212,7 @@
  "tests/compiler/passes/test_online_softmax_channels.py::test_fill_decline_names_the_gate_it_actually_hit": 8.5,
  "tests/compiler/passes/test_online_softmax_channels.py::test_fill_rejects_a_pinned_byte_transport_by_naming_its_own_ring": 9.1,
  "tests/compiler/passes/test_online_softmax_channels.py::test_twisted_statistic_contraction_realizes_the_warp_tier": 1.93,
+ "tests/compiler/passes/test_placement_routing.py::test_contraction_operand_seam_takes_the_output_dtype": 14.78,
  "tests/compiler/passes/test_placement_routing.py::test_norm_linear_cone_cut_recurses_to_the_full_cascade": 5.05,
  "tests/compiler/passes/test_pool_space.py::test_a_real_space_addresses_what_it_iterates[flash_pair]": 1.26,
  "tests/compiler/passes/test_pool_space.py::test_a_real_space_addresses_what_it_iterates[fused_norm_linear]": 1.65,

--- a/tests/serving/test_twins_coded.py
+++ b/tests/serving/test_twins_coded.py
@@ -534,3 +534,46 @@ def test_model_tag_may_pin_the_rung(spec, want):
     """A coded checkpoint's rung lives on a branch, and the rungs differ in exactly the bit
     allocation the keys carry — so the ``model:`` tag may pin one."""
     assert split_revision(spec) == want
+
+
+def test_fp8_expert_twins_spell_bits_and_block_scales_and_keep_the_unconverted_profile():
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn
+
+    from emmy.compiler.loader.quant import fp8_weight_profile
+    from emmy.serving.gen_runner import trace_split
+    from emmy.serving.twins import _spell_fp8_expert_twins
+
+    class Expert(nn.Module):
+        def forward(self, x, w_gate_up, w_down):
+            gate, up = nn.functional.linear(x, w_gate_up).chunk(2, dim=-1)
+            return nn.functional.linear(nn.functional.silu(gate) * up, w_down)
+
+    h, inter = 3072, 1024
+    graph = trace_split(
+        Expert(),
+        tuple(torch.zeros(*shape, dtype=torch.float16) for shape in ((1, h), (2 * inter, h), (h, inter))),
+        None,
+    )
+    config = type("Cfg", (), {})()
+    config.quantization_config = {
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+        "ignored_layers": ["lm_head", "model.layers.44.mlp.experts"],
+    }
+    profile = fp8_weight_profile(config)
+    assert profile == ("f8e4m3", (128, 128), ["lm_head", "model.layers.44.mlp.experts"])
+
+    twins = _spell_fp8_expert_twins("expert-sparse-sliding", graph, profile, {1, 44})
+    assert set(twins) == {"expert-sparse-sliding@f8e4m3", "expert-sparse-sliding"}
+    spelled = twins["expert-sparse-sliding@f8e4m3"]
+    spelled.validate()
+    assert spelled.inputs == ["x", "w_gate_up", "w_down", "w_gate_up_scale", "w_down_scale"]
+    assert spelled.nodes["w_gate_up"].output.dtype.name == "f8e4m3"
+    # Block scales are declared at the interleaved (grid, 1) layout the dequant cone broadcasts.
+    assert tuple(d.as_static() for d in spelled.nodes["w_gate_up_scale"].output.shape) == (16, 1, 24, 1)
+    assert tuple(d.as_static() for d in spelled.nodes["w_down_scale"].output.shape) == (24, 1, 8, 1)
+    assert twins["expert-sparse-sliding"] is graph
+    # Every layer converted: no plain twin. A config without fp8 spells nothing.
+    assert list(_spell_fp8_expert_twins("e", graph, profile, {1, 2})) == ["e@f8e4m3"]
+    assert fp8_weight_profile(type("Cfg", (), {"quantization_config": {"quant_method": "exl3"}})()) is None


### PR DESCRIPTION
## Summary

Follow-up to #584 on the round-two golden findings. The normalized Q·K score fold now keeps a schedulable contraction and a materializable `b` seam, while the later failures found during exact serving and placement replay are covered in the same branch.

- Split a chained score column by operand so normalized Q and normalized K bind as computed contraction cones. A contraction-operand seam uses the 16-bit dtype stored by the fused slab, allowing the materialized B operand to reach the warp tier.
- Load DeepSeek / Laguna per-expert FP8 checkpoint modules into the E-leading expert store, concatenate gate/up weights and block scales along the output axis, and treat `weight_scale_inv` as the stored dequant multiplier. All supported skip-list spellings share one parser.
- Spell routed-expert FP8 serving twins weight-free from the checkpoint config, retaining the plain twin only for profiles with unconverted expert layers. `emmy trace --serving-twins` now captures the same symbolic and static graph set as the release audit.
- Apply the normal transposed cooperative-band legality checks to pinned rows, and canonicalize SSA names in cut pieces so an invalid pin refuses cleanly and a flattened piece cannot define the same name twice.
- Refresh the complete test-duration baseline so the new contraction-seam test participates in CI worker balancing.

RTX 5090, Qwen3-0.6B layer 0 seq 512 attention-statistics golden: cold fused 23.2 ms; `PLACE@b=cut` 221 µs, 2.08× faster than eager, with strict accuracy passing. Cold greedy still deploys the fused form; evidence or pins price the cut.

## Verification

- Rebased onto `main` at `f7e236ca`.
- `make test-durations`: 3,050 passed, 574 skipped, 1 expected failure.
- `make test`: 3,050 passed, 574 skipped, 1 expected failure.
- Focused loader, trace, serving-twin, and trace-CLI tests: 133 passed, 1 skipped.
- `make lint`: Ruff and format checks pass.
- RTX 5090 strict replay and timing above.