### PR TITLE
Report how well the prior ranks, over pools that were actually benched

### DIFF
--- a/.agents/skills/collect-node-data/SKILL.md
+++ b/.agents/skills/collect-node-data/SKILL.md
@@ -10,9 +10,10 @@ description: >-
 
 The autotune `node` table (`SearchDB`, default `~/.cache/emmy/autotune.db`) is a **cross-hardware** dataset of
 search-tree value-of-position rows — the leaf measurements the future offline prior trains on, with the full feature
-dict the prior sees. It is read by `emmy eval prior --dataset nodes` (per-card fork sibling-ranking + leaf
-reachability) and feeds prior diagnostics. Because your dev box (and most of the fleet) has no local CUDA GPU, the
-data for any given card must be **measured on that card** and brought back.
+dict the prior sees. It is read by `emmy eval prior --dataset nodes` (Spearman + regret per card and compile
+regime, plus the per-card fork sibling-ranking and leaf reachability) and feeds prior diagnostics. Because your dev
+box (and most of the fleet) has no local CUDA GPU, the data for any given card must be **measured on that card** and
+brought back.
 
 This skill does exactly that for one GPU, in a single budgeted run on the box: get a server (an existing one the
 user provides, or rent one) → set up emmy → the golden sweep (`scripts/remote_node_collect.py`, driving

--- a/.agents/skills/tune-kernels/SKILL.md
+++ b/.agents/skills/tune-kernels/SKILL.md
@@ -258,8 +258,8 @@ Start with:
 ```bash
 emmy eval variants --kernel <substring>
 emmy eval failures
-emmy eval online --dataset nodes --kernel <substring>
-emmy eval online --dataset nodes --blame --ablate --kernel <substring>
+emmy eval prior --dataset nodes --kernel <substring>
+emmy eval prior --dataset nodes --blame --ablate --kernel <substring>
 ```
 
 For a serving golden, run the unified release audit on the pinned GPU; it validates that every structural target has
@@ -267,8 +267,7 @@ the exact config-derived realization matrix before reproducing and auditing it:
 
 ```bash
 emmy eval golden <canonical-golden.yaml> --serving-config <models/slug.env>
-emmy eval offline --kernel <substring>
-emmy eval online --dataset golden --kernel <substring>
+emmy eval prior --dataset golden --kernel <substring>
 ```
 
 Classify every meaningful loss:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ it before answering any CLI-flag question. Quickstart for the common paths:
 | `emmy compile <model_or_ir> [--layer N] [--ir STAGE] [--dynamic …] [--target sm_NN]` | trace + run the compiler; print or save any IR stage |
 | `emmy run <model_or_ir_or_--code> [--bench]` | compile + execute on the CUDA backend, check accuracy, optionally bench vs eager / `torch.compile` |
 | `emmy tune <target> [--bench] [--gpus N]` | two-level autotune; writes the online prior + tune DB |
-| `emmy eval {knobs,online,offline,golden,variants,failures} [--dataset {golden,db,nodes}]` | inspect the priors / tune DB |
+| `emmy eval {knobs,prior,golden,variants,failures} [--dataset {golden,db,nodes}]` | inspect the priors / tune DB |
 | `emmy {pull,trace,generate,inspect,compare} …` | model download, IR tracing, the naive generation oracle, IR inspection, dump diffing |
 
 Quick test models / scripts (for local iteration):

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -252,6 +252,14 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
   option. Each step in that order is called a tier.
 - **Calibration** — A check of whether a learned model ranks measured candidates well enough to influence
   compilation.
+- **Regret** — What choosing by prediction costs, as a ratio to the best measured option: 1.00 means the choice was
+  the fastest one available, 1.40 that it runs forty percent slower than something that was there. Reported over a
+  set of candidates that were all actually measured, since the comparison needs the true best.
+- **Rank correlation** — How closely a model's ordering of candidates follows the measured one, on a scale from
+  +1 (identical order) through 0 (no relationship). It judges a whole set, where regret judges only the top of it.
+- **Golden rank** — Where a recorded golden configuration lands in the model's ordering of the candidates it
+  competed against. A screen rather than a measure of speed: it says the model found a good configuration late,
+  never how much slower the one it preferred actually runs.
 - **Quarantine** — The state in which an online model may continue learning but is not trusted to choose deployed
   schedules.
 - **CatBoost** — The machine-learning library Emmy uses for its online schedule-ranking model.

--- a/docs/docs/tutorials/08-inside-the-prior.md
+++ b/docs/docs/tutorials/08-inside-the-prior.md
@@ -169,18 +169,28 @@ buried, while making sure the offline factor's arbitrary magnitude never touches
 
 ## See it yourself
 
-Evaluate each half against the golden configurations — where each recorded configuration ranks among the candidates it
-competed against:
+Evaluate both halves against the golden configurations — where each recorded configuration ranks among the candidates
+it competed against. Both halves are reported side by side, labelled, because they fail for different reasons:
 
 ```bash
-emmy eval offline
-emmy eval online
+emmy eval prior --dataset golden
 ```
+
+A rank is only a screen. It says where a good configuration landed in the ordering, never what missing it costs — two
+neighbouring ranks in a large pool can be a fraction of a percent apart or three times apart. The question a rank
+cannot answer is asked over configurations that were actually measured, which is the next page's dataset:
+
+```bash
+emmy eval prior --dataset nodes
+```
+
+That one reports, per card and compile setting, how closely the model's ordering follows the hardware's and what its
+best guess costs against the fastest configuration measured.
 
 Print the feature row the model actually sees for each golden:
 
 ```bash
-emmy eval online --features
+emmy eval prior --dataset golden --features
 ```
 
 And refit the offline half from the golden configurations, with cross-validation, no GPU required:

--- a/docs/docs/tutorials/09-storage-checks-and-limits.md
+++ b/docs/docs/tutorials/09-storage-checks-and-limits.md
@@ -169,17 +169,22 @@ Gathered in one place, honestly.
 The per-fork views need a tuning database, or a frozen snapshot in its place:
 
 ```bash
-emmy eval online --dataset nodes
-emmy eval online --dataset nodes --blame
-emmy eval online --dataset nodes --ablate
+emmy eval prior --dataset nodes
+emmy eval prior --dataset nodes --blame
+emmy eval prior --dataset nodes --ablate
 ```
 
+The first of those also reports what the measurements can say and the golden rankings cannot: per card and compile
+setting, how closely each half's ordering follows the hardware's, and what its best guess costs against the fastest
+configuration measured. Every number carries the count of comparison sets behind it, because the small ones are
+excluded rather than averaged in — most sets in the current snapshot are too small for some of the numbers.
+
 And the two halves can be compared against candidate artifacts without touching the installed ones, which is how two
-fits are judged against each other:
+fits are judged against each other, with `--json` writing the report in the same shape a fit records:
 
 ```bash
-emmy eval offline --offline-file /tmp/candidate-weights.json
-emmy eval online --online-file /tmp/candidate-checkpoint.json
+emmy eval prior --offline-file /tmp/candidate-weights.json --json /tmp/candidate.json
+emmy eval prior --online-file /tmp/candidate-checkpoint.json --json /tmp/incumbent.json
 ```
 
 ## Where to go next

--- a/emmy/commands/dataset_args.py
+++ b/emmy/commands/dataset_args.py
@@ -33,7 +33,7 @@ def add_dataset_args(parser, *, default: str, with_min_variants: bool = False) -
         choices=["golden", "db", "nodes"],
         default=default,
         help="Measurement-data source: 'golden' (recorded golden configs), 'db' (tune DB perf rows), or 'nodes' "
-        f"(tune DB search-tree node store, for `eval online`). Default: {default}.",
+        f"(tune DB search-tree node store — or a measurement freeze — for `eval prior`). Default: {default}.",
     )
     parser.add_argument(
         "--db",

--- a/emmy/commands/eval.py
+++ b/emmy/commands/eval.py
@@ -1,15 +1,15 @@
-"""``emmy eval <knobs|offline|online|golden|variants|failures>`` — evaluate the tuning machinery.
+"""``emmy eval <knobs|prior|golden|variants|failures>`` — evaluate the tuning machinery.
 
-Six subcommands:
+Five subcommands:
 
 - ``eval knobs``     — print the registered knob schema, then (with a tune DB)
   per-knob **regret** + a knob-interaction matrix (the analysis below).
-- ``eval offline``  — evaluate the cold-start ``OfflinePrior`` (``search/golden_eval``
-  is the golden-eval glue around it) on the golden configs: the golden's **rank**
-  under the prior over the enumeration (the position the tuner's patience must reach).
-- ``eval online``     — evaluate the online ``OnlinePrior`` on the golden
-  configs: the greedy pipeline pick vs golden (per-knob ``found/golden``), the
-  golden's rank under the prior, and (``--features``) the regressor input vector.
+- ``eval prior``     — how well the prior RANKS: one report over benched pools
+  (``--dataset nodes``: Spearman + regret, what a wrong pick costs) or over the golden
+  corpus (``--dataset golden``: the golden-rank screen, plus the greedy pipeline pick vs
+  golden). BOTH prior halves are reported, labelled — they fail for different reasons.
+  The cells are assembled by ``search/prior/report.py`` and rendered here; ``emmy fit``
+  still emits its own metrics layout and moves onto these cells with the fold harness.
 - ``eval golden``    — validate one canonical golden YAML against the pinned serving
   configuration and live GPU, then reproduce its rows and audit the exact serving matrix.
 - ``eval variants``  — per-kernel leaderboard of the tune DB's measured variants
@@ -53,6 +53,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from statistics import median
 
+from emmy import storage
 from emmy.commands.compile import resolve_tune_db
 from emmy.commands.dataset_args import add_dataset_args, require_source, resolve_offline_arg, resolve_online_arg
 from emmy.commands.table import GREEN as _GREEN
@@ -60,6 +61,8 @@ from emmy.commands.table import RED as _RED
 from emmy.commands.table import YELLOW as _YELLOW
 from emmy.commands.table import Col, col_widths, knob_columns, render_table
 from emmy.compiler.pipeline.search.data import Dataset
+from emmy.compiler.pipeline.search.pool import DEFAULT_SAMPLE
+from emmy.compiler.pipeline.search.prior import report as report_mod
 
 logger = logging.getLogger(__name__)
 
@@ -76,11 +79,11 @@ def _realization_label(name: str, pins) -> str:
 
 
 def register_eval_command(subparsers) -> None:
-    """``emmy eval <knobs|online|offline>`` — evaluate the tuning knobs, the
-    online prior, or the cold-start OfflinePrior against the golden configs."""
+    """``emmy eval <knobs|prior|golden|variants|failures>`` — evaluate the tuning knobs or
+    the prior's ranking."""
     parser = subparsers.add_parser(
         "eval",
-        help="Evaluate tuning knobs / the online prior / the offline prior against golden configs",
+        help="Evaluate the tuning knobs / how well the prior ranks candidate pools",
     )
     sub = parser.add_subparsers(dest="eval_target", required=True)
 
@@ -88,25 +91,9 @@ def register_eval_command(subparsers) -> None:
     add_dataset_args(pk, default="db", with_min_variants=True)
     pk.set_defaults(func=handle_eval_knobs)
 
-    ph = sub.add_parser(
-        "offline",
-        aliases=["analytic"],  # pre-rename spelling
-        help="Evaluate the cold-start OfflinePrior on the golden configs (golden's rank under the prior over the enumeration)",
-    )
-    ph.add_argument(
-        "--offline-file",
-        "--analytic-file",  # pre-rename spelling
-        dest="offline_file",
-        help="Offline weights artifact (JSON) to score with, for A/Bing candidate fits. "
-        "Default: EMMY_OFFLINE_FILE or the repo-checked offline_weights.json.",
-    )
-    add_dataset_args(ph, default="golden")
-    ph.set_defaults(func=handle_eval_offline)
-
     pp = sub.add_parser(
-        "online",
-        aliases=["prior"],  # pre-rename spelling
-        help="Evaluate the online prior on the golden configs (greedy pick vs golden + golden's rank under the prior)",
+        "prior",
+        help="Report how well each prior half ranks — over benched pools (--dataset nodes) or the golden corpus",
     )
     pp.add_argument(
         "--online-file",
@@ -119,20 +106,28 @@ def register_eval_command(subparsers) -> None:
         "--offline-file",
         "--analytic-file",  # pre-rename spelling
         dest="offline_file",
-        help="Offline weights artifact (JSON) for the offline blocks of this eval. "
+        help="Offline weights artifact (JSON) to score the offline half with, for A/Bing candidate fits. "
         "Default: EMMY_OFFLINE_FILE or the repo-checked offline_weights.json.",
     )
     add_dataset_args(pp, default="golden")
     pp.add_argument(
+        "--pool-sample",
+        type=int,
+        default=DEFAULT_SAMPLE,
+        help=f"--dataset golden: candidates drawn per pool during enumeration (default {DEFAULT_SAMPLE}; 0 enumerates "
+        "every row). Recorded in the report header — a rank is only comparable against a fit that drew the same way.",
+    )
+    pp.add_argument("--json", dest="json_out", metavar="PATH", help="Also write the report as JSON, for diffing two runs.")
+    pp.add_argument(
         "--features",
         action="store_true",
-        help="Also print the exact feature vector the prior (CatBoost) regresses on per golden config (features.knob_features).",
+        help="--dataset golden: also print the exact feature vector the prior regresses on per golden config (features.knob_features).",
     )
     pp.add_argument(
         "--blame",
         action="store_true",
-        help="With --dataset nodes: per-feature blame table — which features' terms pushed each missed fork's wrong pick, "
-        "regret-weighted per fork family (diagnostic, not a gate metric).",
+        help="With --dataset nodes: per-feature blame table — which features' terms pushed each missed fork's wrong "
+        "pick, regret-weighted per fork family (diagnostic, not a gate metric).",
     )
     pp.add_argument(
         "--ablate",
@@ -140,7 +135,7 @@ def register_eval_command(subparsers) -> None:
         help="With --dataset nodes: ablation Δ table — each family's median regret change with one feature masked "
         "(<0 = actively misleading), with per-feature fork support.",
     )
-    pp.set_defaults(func=handle_eval_online)
+    pp.set_defaults(func=handle_eval_prior)
 
     pg = sub.add_parser(
         "golden",
@@ -234,36 +229,234 @@ def _check_offline_artifact() -> None:
     OfflinePrior()
 
 
-def handle_eval_offline(args) -> None:
-    """``eval offline`` — the cold-start OfflinePrior's rank of each golden."""
-    require_source(args, {"golden"}, "eval offline ranks recorded golden configs — --dataset db has no golden to rank.")
-    resolve_offline_arg(args)
-    _check_offline_artifact()
-    _emit_offline_eval(args.kernel)
+def _prior_halves():
+    """The two halves the report labels, in the order a failure is diagnosed in: the offline half decides what a
+    cold sweep measures at all, so its ranking is upstream of everything the online half ever sees.
+
+    An unfitted online half is dropped with a line saying so rather than reported. It would score every row the
+    same constant, which reads as a model with no ranking ability — indistinguishable in a table from a trained
+    model that collapsed, which is a real and different failure."""
+    from emmy import config  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.prior import OfflinePrior, OnlinePrior  # noqa: PLC0415
+
+    halves = [("offline", OfflinePrior())]
+    online = OnlinePrior.load()
+    if online.fitted:
+        halves.append(("online", online))
+    else:
+        logger.info("No fitted online prior at %s — reporting the offline half only (run `emmy tune`).", config.online_path())
+    return halves
 
 
-def handle_eval_online(args) -> None:
-    """``eval online`` — the online prior on the golden configs: the greedy pick vs
-    golden, the golden's rank under the prior, and (with ``--features``) the
-    regressor input vector. With ``--dataset db`` instead reports the prior's pick
-    reachability over the tune DB's *measured* variants (the orthogonal view); with
-    ``--dataset nodes`` reports fork sibling regret + leaf reachability over the tune
-    DB's search-tree node store (the search-faithful, partial-config view)."""
+def _node_rows(args):
+    """The search-tree rows both node-dataset views read, loaded ONCE. ``--db`` takes a live tune DB or a
+    measurement-freeze directory; ``load_node_rows`` sniffs which.
+
+    ``--kernel`` matches the op LABEL, since the store's own op identity is a digest with nothing readable in
+    it. The label is a function of the row's ``S_*`` features, which every node of one op shares, so a filter
+    keeps or drops a whole op atomically — a pool is never split against its own siblings."""
+    from emmy.compiler.pipeline.search.data import load_node_rows, op_label  # noqa: PLC0415
+
+    db_path = Path(args.db) if args.db else resolve_tune_db()
+    if not db_path.exists():
+        logger.error("no tune DB or measurement freeze at %s — pass --db or run `emmy tune` first.", db_path)
+        sys.exit(2)
+    rows = load_node_rows(db_path)
+    return db_path, [r for r in rows if args.kernel in op_label(r.features)] if args.kernel else rows
+
+
+def _measured_report(db_path, rows, args, halves):
+    """``eval prior --dataset nodes`` — the report over benched pools.
+
+    The grouping, its key and every admission rule are :func:`group_measured`'s, so this reads the same pools
+    the training-data work will."""
+    from emmy.compiler.pipeline.search.data.group import group_measured  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.prior.report import EvalReport, measured_cells  # noqa: PLC0415
+
+    groups, dropped = group_measured(rows)
+    header = {
+        "dataset": "nodes",
+        "source": str(db_path),
+        "kernel": args.kernel,
+        "rows": len(rows),
+        "groups": len(groups),
+        "dropped": dropped,
+    }
+    return EvalReport(header, [c for half, prior in halves for c in measured_cells(half, groups, prior.score_rows)])
+
+
+def _golden_report(args, halves):
+    """``eval prior --dataset golden`` — the report over the recorded golden corpus.
+
+    Built by ``emmy fit``'s own case builder over the FULL featurization, not the fit's ``D_*`` view. The view
+    is a property of the model being fitted, and this command scores two model classes: the linear half reads
+    only its own weight names, so its ranks are identical either way, while the online half regresses on the
+    ``S_*`` / ``H_*`` columns a narrow view drops and would otherwise be asked about a kernel with no shape."""
+    from emmy.commands.fit import build_golden_groups  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.prior.report import EvalReport, golden_cells  # noqa: PLC0415
+
+    logger.info("Building golden pools (each golden under its own card's context) ...")
+    groups, skipped = build_golden_groups("*", sample=args.pool_sample, kernel=args.kernel)
+    header = {
+        "dataset": "golden",
+        "source": "recorded golden corpus",
+        "kernel": args.kernel,
+        "pool_sample": args.pool_sample,
+        "groups": len(groups),
+        "positives": sum(len(g.golden_ids) for g in groups),
+        "skipped": len(skipped),
+    }
+    return EvalReport(header, [c for half, prior in halves for c in golden_cells(half, groups, prior.score_rows)])
+
+
+def handle_eval_prior(args) -> None:
+    """``eval prior`` — how well each prior half ranks a candidate pool.
+
+    Two datasets, two different questions, one report schema (see ``search/prior/report.py``): benched pools
+    say what a wrong pick COST, golden pools only say where the known-good row landed. ``--dataset golden``
+    additionally runs the deploy-faithful check the ranks are a screen for — the greedy pipeline pick vs the
+    recorded golden, with the deployable -O3 latency of the prior's pick beside it."""
     resolve_online_arg(args)
     resolve_offline_arg(args)
     _check_offline_artifact()
+    require_source(
+        args,
+        {"golden", "nodes"},
+        "eval prior ranks candidate pools: use --dataset golden (recorded goldens) or --dataset nodes (a tune DB "
+        "or a measurement freeze). --dataset db reads only fully-decided leaf rows, with no op identity or compile "
+        "regime to group them by — pass the same DB with --dataset nodes.",
+    )
     if (args.blame or args.ablate) and args.dataset != "nodes":
         logger.error("--blame/--ablate attribute fork records — they need --dataset nodes.")
         sys.exit(2)
-    if args.dataset == "db":
-        _emit_online_db_reachability(args)
+    halves = _prior_halves()
+    nodes = None if args.dataset == "golden" else _node_rows(args)
+    report = _golden_report(args, halves) if nodes is None else _measured_report(*nodes, args, halves)
+    _emit_report(report)
+    if args.json_out:
+        storage.write_json(Path(args.json_out), report.to_json(), indent=2)
+        logger.info("wrote %s", args.json_out)
+    if nodes is None:
+        _emit_golden_deploy_check(args)
+    else:
+        _emit_fork_blocks(nodes[1], args, halves)
+
+
+def _metric(block: dict, key: str, fmt: str) -> str:
+    """One metric value with the pools it was computed over, or ``—`` when nothing in the cell qualified.
+
+    The count is appended only where the block carries one, which is where the metric has a size minimum and so
+    can cover fewer pools than the cell holds."""
+    value = block.get(key)
+    if value is None:
+        return "—"
+    return f"{fmt.format(value)} ({block['groups']})" if "groups" in block else fmt.format(value)
+
+
+# Per dataset: the axis columns, then ``(header, cells(cell))`` for each metric column. The axes are the ones the
+# report keyed its cells on — the renderer names them rather than discovering them, so a column order is a
+# decision made here and not a side effect of dict insertion.
+_REPORT_TABLES = {
+    "nodes": (
+        ["half", "gpu", "H_opt"],
+        [
+            ("rho", lambda c: _metric(c.metrics["spearman"], "median", "{:+.2f}")),
+            ("regret@1", lambda c: _metric(c.metrics["regret1"], "median", "{:.2f}x")),
+            ("worst@1", lambda c: _metric(c.metrics["regret1"], "worst", "{:.2f}x")),
+            (f"regret@{report_mod.TOPK}", lambda c: _metric(c.metrics[f"regret{report_mod.TOPK}"], "median", "{:.2f}x")),
+        ],
+    ),
+    "golden": (
+        ["half", "gpu", "tier", "pool"],
+        [
+            ("rank", lambda c: _metric(c.metrics["rank"], "median", "{:g}")),
+            ("rank(opt)", lambda c: _metric(c.metrics["rank"], "median_optimistic", "{:g}")),
+            *((f"top{k}", lambda c, k=k: f"{c.metrics[f'top{k}']['count']}/{c.groups - c.unscored}") for k in (1, 10, 50)),
+        ],
+    ),
+}
+
+_REPORT_CAPTIONS = {
+    "nodes": [
+        "ranking quality over benched pools (rho: +1 = the model orders them as the hardware does;",
+        "regret: 1.00x = the pick IS the measured best). Each number's (n) is the pools it covers.",
+    ],
+    "golden": [
+        "golden rank — a SCREEN, not a gate: it says where a verified config landed, never what",
+        "missing it costs. Only regret over benched pools (--dataset nodes) measures that.",
+    ],
+}
+
+
+def _emit_report(report) -> None:
+    """Print an :class:`EvalReport` — the provenance header, then one table of cells.
+
+    Which columns appear follows the report's dataset, since that is what decided which metrics the cells carry.
+    The ``pools`` column is the cell's own total, annotated when the model could not score some of them: an
+    unscored pool is not a small one, and a report that dropped it silently would show a healthy corpus with no
+    sign that part of the deploy surface is unmeasured."""
+    head = report.header
+    logger.info("")
+    logger.info("[prior] %s dataset — %s", head.get("dataset", "?"), head.get("source", ""))
+    # Every remaining header key, whatever the dataset put there. Printed generically so a builder that starts
+    # recording a new provenance field does not also have to teach this about it — a count nobody prints is a
+    # count nobody checks.
+    provenance = ", ".join(f"{k}={head[k]}" for k in head if k not in ("dataset", "source", "dropped") and head[k] is not None)
+    if provenance:
+        logger.info("  %s", provenance)
+    if dropped := head.get("dropped"):
+        logger.info("  rows dropped before grouping: %s", ", ".join(f"{n} {why}" for why, n in sorted(dropped.items())))
+    if not report.cells:
+        logger.info("  no candidate pools to score")
         return
-    if args.dataset == "nodes":
-        _emit_online_nodes(args)
-        return
+
+    axes, metrics = _REPORT_TABLES[head["dataset"]]
+    columns = [Col(a) for a in (*axes, "pools")] + [Col(name) for name, _ in metrics]
+    rows = [
+        [cell.axes.get(a, "") for a in axes]
+        + [str(cell.groups) + (f" ({cell.unscored} unscored)" if cell.unscored else "")]
+        + [render(cell) for _, render in metrics]
+        for cell in report.cells
+    ]
+    logger.info("")
+    for line in _REPORT_CAPTIONS[head["dataset"]]:
+        logger.info("  %s", line)
+    for line in render_table(columns, rows, rule=True, indent="  "):
+        logger.info("%s", line)
+
+
+def _emit_fork_blocks(nodes, args, halves) -> None:
+    """The per-fork view over the search tree: what following the prior's pick at each FORK costs, bucketed by the
+    knob family the fork decides, plus the golden-anchored descent.
+
+    It answers something the cells above structurally cannot. They score pools of benched leaves, while a search is
+    a sequence of partial-knob decisions most of whose subtrees were never explored — a golden sitting in a subtree
+    nothing measured is silence that reads as health."""
+    from emmy.compiler.pipeline.search.prior import diagnostics  # noqa: PLC0415
+
+    for half, prior in halves:
+        logger.info("")
+        logger.info("=== %s prior — per-fork view ===", half)
+        logger.info("%s", diagnostics.node_report(prior, nodes))
+        if args.blame or args.ablate:
+            logger.info("")
+            logger.info("%s", diagnostics.attribution_report(prior, nodes, blame=args.blame, ablate=args.ablate))
+
+
+def _emit_golden_deploy_check(args) -> None:
+    """The deploy-faithful half of ``eval prior --dataset golden``: the greedy tile-pipeline pick vs the
+    recorded golden, per shape, with the deployable (-O3) latency of the prior's pick read from the online
+    reservoir where one exists. This is what the golden RANK is only a screen for — a rank says where the
+    verified row sat in the enumeration, this says what actually gets compiled."""
+    from emmy.compiler.pipeline.search.prior import OnlinePrior, diagnostics  # noqa: PLC0415
+
     if args.features:
         _emit_golden_features(args.kernel)
-    _emit_online_eval(args.kernel)
+    prior = OnlinePrior.load()
+    # Deployable (-O3) perf of the prior's pick vs golden, read from the reservoir (no
+    # re-bench); empty when there's no tuned -O3 data (column shows '—').
+    perf = diagnostics.golden_deploy_perf(prior, args.kernel) if prior.fitted else {}
+    _emit_prior_golden_check(_golden_configs(args.kernel), perf=perf)
 
 
 def handle_eval_golden(args) -> None:
@@ -738,141 +931,6 @@ def _golden_configs(kernel_filter: str | None):
     return configs
 
 
-def _emit_offline_eval(kernel_filter: str | None) -> None:
-    """``eval offline`` body: the cold-start ``OfflinePrior`` (``search/golden_eval``
-    is the golden-eval glue around it) — no online data, no GPU, no measurements.
-    One streamed line per golden config with the golden's **rank** under the prior
-    over the enumeration (the position the tuner's patience must reach) + per-knob
-    ``found/golden`` (mismatches red), summarized as median + top-k coverage."""
-    from statistics import median  # noqa: PLC0415
-
-    from emmy.compiler.context import Context  # noqa: PLC0415
-    from emmy.compiler.pipeline.knob import tuning_knob_items  # noqa: PLC0415
-    from emmy.compiler.pipeline.search.golden_eval import evaluate_record  # noqa: PLC0415
-
-    configs = _golden_configs(kernel_filter)
-    ranks: list[int] = []
-    entries: list[tuple] = []  # ("row", lead_cells, gold, got) | ("err", name, message)
-    for g in configs:
-        gold = dict(tuning_knob_items(g.knobs))
-        try:
-            ctx = Context.from_target(g.compute_cap, gpu_name=g.gpu_name)  # the golden's own card, not the live host's
-            ranked = evaluate_record(g, ctx)
-            got, rank, pool = ranked.best, ranked.rank, ranked.pool
-        except Exception as e:  # noqa: BLE001 — one shape's error shouldn't abort the report
-            entries.append(("err", g.name, " ".join(f"{type(e).__name__}: {e}".split())[:100]))
-            continue
-        matched = sum(1 for k in gold if _knob_eq(k, gold[k], got))
-        lead = [g.name, (f"{matched}/{len(gold)}", _ratio_color(matched, len(gold))), str(rank) if rank is not None else "?", str(pool)]
-        entries.append(("row", lead, gold, got))
-        if rank is not None:
-            ranks.append(rank)
-    cols = [Col("kernel"), Col("m/t"), Col("rank"), Col("pool")]
-    _emit_golden_table(cols, entries, "knobs (found/golden; red = mismatch)")
-    if ranks:
-        n = len(ranks)
-        cov = "  ".join(f"top{k}={sum(r < k for r in ranks)}/{n}" for k in (1, 10, 25, 50, 100))
-        logger.info("")
-        logger.info("  offline golden rank — median=%d  %s", int(median(ranks)), cov)
-
-
-def _emit_online_eval(kernel_filter: str | None) -> None:
-    """``eval online`` body: the online ``OnlinePrior`` on the golden configs —
-    the golden's rank under the prior over the full enumeration (offline) followed
-    by the greedy tile-pipeline pick vs golden (the real selection). Reads the
-    prior JSON (``EMMY_ONLINE_FILE`` / ``--prior``; option-0 when none loaded)."""
-    from emmy import config  # noqa: PLC0415
-    from emmy.compiler.pipeline.search.prior import OnlinePrior, diagnostics  # noqa: PLC0415
-
-    prior = OnlinePrior.load()
-    logger.info("")
-    if prior.fitted:
-        logger.info(diagnostics.golden_prior_eval(prior, kernel_filter))
-    else:
-        logger.info("No fitted prior at %s — greedy falls to option-0 (run `emmy tune`).", config.online_path())
-
-    configs = _golden_configs(kernel_filter)
-    # Deployable (-O3) perf of the prior's pick vs golden, read from the reservoir (no
-    # re-bench); empty when there's no tuned -O3 data (column shows '—').
-    perf = diagnostics.golden_deploy_perf(prior, kernel_filter) if prior.fitted else {}
-    _emit_prior_golden_check(configs, perf=perf)
-
-
-def _emit_online_db_reachability(args) -> None:
-    """``eval online --dataset db`` body: the prior's pick **reachability** over the
-    tune DB's *measured* variants — per op structure, does the online prior's
-    predicted-fastest config recover the measured-best leaf? The orthogonal counter
-    to the golden views: it scores the same prior over the DB rows instead of the
-    curated goldens. Reuses the diagnostics machinery (the prior's ``_dataset`` is
-    irrelevant here — the groups come from the DB)."""
-    from emmy import config  # noqa: PLC0415
-    from emmy.compiler.pipeline.search.prior import diagnostics, load_prior  # noqa: PLC0415
-
-    db_path = Path(args.db) if args.db else resolve_tune_db()
-    if not db_path.exists():
-        logger.error("no tune DB at %s — pass --db or run `emmy tune` first.", db_path)
-        return
-    # FallbackPrior: the online CatBoost when fitted, else the cold OfflinePrior — the same ranking compile/run use.
-    prior = load_prior()
-    # Group DB variants by their full S_* signature — the (sig → Samples) mapping
-    # diagnostics.reachability scores.
-    groups = Dataset.from_db(db_path, kernel=args.kernel).group_by_op()
-    logger.info("")
-    if not prior.fitted:
-        logger.info("No fitted prior at %s — run `emmy tune`; the cold OfflinePrior ranks by D_* geometry only.", config.online_path())
-    rr = diagnostics.reachability(prior, groups)
-    if not rr:
-        logger.info("No op structure has ≥2 measured leaf configs in the DB — nothing to score.")
-        return
-    ratios = [r[3] for r in rr]
-    logger.info("[prior] pick reachability over DB variants — does the prior recover each op's measured best?")
-    logger.info("  mean %.2fx  median %.2fx  worst %.2fx   (1.00 = optimum)", _mean(ratios), median(ratios), max(ratios))
-    for label, best_us, pick_us, ratio, n in sorted(rr, key=lambda r: -r[3]):
-        flag = "  <-- misses best" if ratio > 1.2 else ""
-        logger.info("    %-26s  best %8.2fus  pick %8.2fus  (%.2fx, %d configs)%s", label, best_us, pick_us, ratio, n, flag)
-
-
-def _emit_online_nodes(args) -> None:
-    """``eval online --dataset nodes`` body: fork sibling regret (what following the
-    prior's per-fork pick costs vs each fork's best-reachable latency, bucketed by
-    the knob family the fork decides) plus leaf reachability / calibration over the
-    tune DB's search-tree ``node`` store. The search-faithful counterpart to
-    ``--dataset db`` (which only scores fully-decided leaf variants).
-
-    Reported ONCE PER PRIOR HALF, explicitly labeled — the composite ``FallbackPrior``
-    would answer with whichever half is active, mixing two distinct failure modes: the
-    cold ``OfflinePrior`` decides what a cold sweep measures at all (its regret ⇒ fix
-    the offline weights / features), while the online ``OnlinePrior`` owns deploys
-    once trustworthy (its regret ⇒ a training-data / featurization problem). Splitting
-    the blocks makes the diagnostic say WHERE the problem is."""
-    from emmy import config  # noqa: PLC0415
-    from emmy.compiler.pipeline.search.data.freeze import load_node_rows  # noqa: PLC0415
-    from emmy.compiler.pipeline.search.prior import OfflinePrior, OnlinePrior, diagnostics  # noqa: PLC0415
-
-    db_path = Path(args.db) if args.db else resolve_tune_db()
-    if not db_path.exists():
-        logger.error("no tune DB at %s — pass --db or run `emmy tune` first.", db_path)
-        return
-    # ``--db`` takes the live sqlite DB or a measurement freeze — load_node_rows sniffs.
-    nodes = load_node_rows(db_path)
-    online = OnlinePrior.load()
-    calib = f"calibration={online.calibration:+.2f}" if online.calibration is not None else "calibration=n/a"
-    halves: list[tuple[str, object]] = [
-        ("=== offline prior (cold-start ranking — decides what a cold sweep measures) ===", OfflinePrior()),
-        (f"=== online prior (CatBoost, {calib} — owns deploys once trustworthy) ===", online),
-    ]
-    for header, prior in halves:
-        logger.info("")
-        logger.info("%s", header)
-        if not prior.fitted:
-            logger.info("  not fitted (no checkpoint at %s) — run `emmy tune` to train it.", config.online_path())
-            continue
-        logger.info("%s", diagnostics.node_report(prior, nodes, kernel_filter=args.kernel))
-        if args.blame or args.ablate:
-            logger.info("")
-            logger.info("%s", diagnostics.attribution_report(prior, nodes, kernel_filter=args.kernel, blame=args.blame, ablate=args.ablate))
-
-
 def _mean(xs: list[float]) -> float:
     return sum(xs) / len(xs) if xs else 0.0
 
@@ -927,7 +985,7 @@ def _emit_prior_golden_check(configs: list, *, title: bool = True, perf: dict | 
     don't duplicate rows. A trailing ``TOTAL`` row carries per-knob match counts over the
     deduped rows + the exactly-reproduced row count. Rows print with column-aligned
     ``found/golden`` knobs (canonical order). ``title`` prints the
-    ``Golden reproduction — … prior: <path>`` banner (``eval online``); ``eval golden``
+    ``Golden reproduction — … prior: <path>`` banner (``eval prior``); ``eval golden``
     passes ``title=False`` for just the table."""
     import logging as _logging  # noqa: PLC0415
 

--- a/emmy/commands/fit.py
+++ b/emmy/commands/fit.py
@@ -184,7 +184,7 @@ def _keep_sets(records) -> dict[tuple, frozenset]:
 
 
 def build_golden_groups(
-    features_spec: str = DEFAULT_FEATURES, *, sample: int = 0, seed: int = 0
+    features_spec: str = DEFAULT_FEATURES, *, sample: int = 0, seed: int = 0, kernel: str | None = None
 ) -> tuple[list[GoldenGroup], list[tuple[str, str, str]]]:
     """Enumerate each embedded golden program, pin its recorded row, and
     featurize every row, as :class:`Group` records (name, tier, card, pinned rows,
@@ -202,7 +202,7 @@ def build_golden_groups(
     groups against positives in the metrics header.
 
     Matmul goldens enumerate via ``golden_eval._enumerate`` — the SAME gate-narrowed
-    pool ``eval offline`` and the greedy deploy rank over (fp32 → thread tier,
+    pool ``eval prior --dataset golden`` and the greedy deploy rank over (fp32 → thread tier,
     fp16/bf16 → warp tier; the block-DAG rework moved the scalar↔warp choice to a
     structural fork, so a real fp16 matmul ranks within the warp tier alone, no
     scalar rows in the pool). A dynamic (``.dynM``) golden enumerates the pool of its
@@ -210,6 +210,12 @@ def build_golden_groups(
     (its own weight set). Reduce / pointwise goldens trace their snippet and capture the restored
     schedule fork's rows (``_snippet_rows``); a regime the live tree doesn't fork
     (pointwise) reports un-enumerable rather than reconstructing a search space that no longer exists.
+
+    ``kernel`` keeps only goldens whose name contains it — a narrowing VIEW of the corpus, for iterating on
+    one kernel without paying for the rest. Each retained golden's rank is unchanged by it: the keep-sets are
+    still computed over the whole corpus, so a pool retains the same rows under the same draw. What does change
+    is which goldens MERGE — a dropped sibling is one fewer verified row in the pool it shared — so a filtered
+    run's group and positive counts are its own, and only an unfiltered run compares against a fit.
 
     ``sample`` draws that many candidates per pool DURING enumeration (0 enumerates every row).
     The draw is a pure function of ``(pool size, sample, seed)`` and never looks at a row, so two
@@ -245,7 +251,8 @@ def build_golden_groups(
     # come out in the order they always did.
     by_pool: dict[tuple, list] = defaultdict(list)
     for g in GOLDEN_RECORDS:
-        by_pool[g.pool_key].append(g)
+        if kernel is None or kernel in g.name:
+            by_pool[g.pool_key].append(g)
 
     for members in by_pool.values():
         g = members[0]  # the pool is a property of the KEY; every member spells it identically

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1370,9 +1370,9 @@ both halves answer, projecting the packed matrix onto each model's own columns w
 where a score comes from.
 
 - A MEASURED pool (`--dataset nodes`: freeze or `node`-table rows, every candidate benched, grouped by
-  `(gpu, op_sig, H_opt)`) can answer what a wrong pick COST — Spearman over the pool, and regret at k=1 (the deploy
-  question: the pick ships, so its latency IS the cost) and k=10 (the tuning question: bench the top ten, keep the
-  measured best). This is the half that tracks deployed speed.
+  `(gpu, kernel signature, H_opt)`) can answer what a wrong pick COST — Spearman over the pool, and regret at k=1
+  (the deploy question: the pick ships, so its latency IS the cost) and k=10 (the tuning question: bench the top ten,
+  keep the measured best). This is the half that tracks deployed speed.
 - A GOLDEN pool (`--dataset golden`: an enumeration with the verified-optimum row marked) can only answer WHERE the
   known-good row landed, and is reported as a SCREEN. A rank is blind to the latency gap behind it, and the corpus
   aggregate is dominated by pools small enough to rank by accident, so golden cells are stratified by pool size.
@@ -1381,20 +1381,24 @@ where a score comes from.
 `H_opt`; golden: `gpu` × `tier` × pool-size bucket; both plus `half` — along with how many pools keyed into them, how
 many the model could not score at all, and — where a metric has a size minimum and so covers fewer pools than the
 cell holds — that metric's own count. The minimums differ (regret needs two rows, Spearman five, regret@10 eleven),
-so on the v3 freeze's 410 pools those counts are 339, 211 and 81. An aggregate that averaged the excluded pools in
+so on the v3 freeze's 336 pools those counts are 297, 216 and 90. An aggregate that averaged the excluded pools in
 would be reporting mostly arithmetic.
 
-**The extents are part of the measured key, beside `op_sig`.** `op_sig` digests the **pre-descent offer op's**
-stamps — it names where a decision was offered, not what got computed — so one site can be realized as a single
-kernel or as several. Nine pools of the RTX 5090 freeze paired a fused `rms_norm`→linear megakernel with a row for
-just one kernel of the same op's unfused realization: a 5.9 µs norm kernel filed as a rival of a 131 ms whole-op
-row. A part's latency is not the realization's cost — where the sibling kernel was recorded too, the pair costs
-24–191 µs against the fused row's 28–212 ms. Every `S_ext_*` stamp therefore joins the key. Differing extents are
-what make the mismatch detectable and nothing more: the extent product is not a work measure for these kernels
-(a sweep rides the reduction, so it double-counts — `implausible_value_reason` abstains from its own
-`free × reduce` formula on exactly this stamp shape). That makes the grouping key a REFINEMENT of
-`fold_node_rows(by="op")`'s, which splits on `op_sig` alone — deliberately, since a fold must keep a whole op's
-tree on one side while a comparison must not merge rows that computed different things.
+**A measured pool is keyed on the KERNEL, not on the site that offered it.** The key digests the row's own `S_*`
+stamps — the same digest `Identity.op_sig` computes for an op, asked of the kernel that ran. Two kernels of one
+structure on one card are ONE tuning problem whatever produced them, which is already how the deploy path joins
+evidence: `Prior.evidence_pick` and `policy/greedy._db_measured_pick` both index on the `S_*` signature. It is safe
+because the identity strategy stamps a kernel **at birth**, in recognition, before `020_schedule` offers the first
+fork — so nothing a schedule fork decides can move an `S_*` value, and sibling schedules cannot be split apart.
+
+Keying on the recorded `op_sig` column gets it wrong in both directions, and the RTX 5090 freeze shows both. It
+**over-merges**, because `op_sig` digests the *pre-descent offer op*: nine pools paired a fused `rms_norm`→linear
+megakernel with a row for just one kernel of the same op's unfused realization — a 5.9 µs norm kernel filed as a
+rival of a 131 ms whole-op row, where the unfused pair actually costs 24–191 µs. And it **fragments**: 73 structures
+were searched in two separate pools, the losing pool's best landing a median 1.46× behind the winning pool's (p90
+3.89×, worst 14×) — the same kernel tuned twice because a placement cut minted one copy of it. Against `op_sig` the
+kernel key gives 336 pools rather than 401, but more rows sitting beside a rival (3778 of 3817 against 3760) and a
+median pool of 7 rather than 5; the pool count falls because merging is the point.
 
 **`--dataset golden` also runs the deploy-faithful check the rank is only a screen for**: the greedy tile-pipeline
 pick vs the recorded golden, per shape, with the deployable `-O3` latency of the prior's pick beside it

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1154,7 +1154,7 @@ a `configs` list), beside a `manifest.json` holding the provenance header and th
   listed file missing, a per-file digest mismatch, or an un-instantiable row — never a silent fallback.
   `load_node_rows` sniffs a path (directory = freeze, sqlite file = DB, a v1 JSONL freeze is refused with a re-freeze
   pointer) and yields `NodeRow`s from either, which is what lets every nodes consumer
-  (`eval online --dataset nodes --db`, `Dataset.from_node_rows` / `fold_node_rows`) take a freeze interchangeably
+  (`eval prior --dataset nodes --db`, `Dataset.from_node_rows` / `fold_node_rows`) take a freeze interchangeably
   with the live DB.
 - Rows loaded from a freeze have no parent and `depth=0`, which is how the diagnostics recognize that no tree
   structure is available. The fork-regret view skips them, and the golden-anchored descent prints its loud "no
@@ -1356,12 +1356,41 @@ come from an unpinned `REDUCE`. Golden rows attach to the run's SHAPE rather tha
 whose shape matches no greedy kernel — because greedy deployed a split partial+finalize pair — still prints and still
 lands in the record.
 
-## Part 8: Evaluating the prior (`emmy eval`)
+## Part 8: Evaluating the prior (`emmy eval prior`)
 
-`emmy eval` is how you find out whether the prior is any good and, when it isn't, where it goes wrong. The views
-below run over the goldens, the tune DB's `node` table, or a measurement freeze.
+`emmy eval prior` is how you find out whether the prior is any good and, when it isn't, where it goes wrong. It runs
+over the goldens, the tune DB's `node` table, or a measurement freeze, and it reports BOTH halves of the composite
+prior, each labelled — they fail for different reasons, so an unlabelled "prior" number destroys the diagnostic.
 
-**A golden's rank counts ties against it** (`eval offline` / `eval online`, via `golden_eval.evaluate_record`). The
+**Two datasets, two questions, one report.** `search/prior/report.py` assembles both into one serialisable schema
+(`--json`), so comparing two models is a `diff`. `emmy fit` still writes its own metrics layout and adopts these
+cells with the fold harness. The report computes nothing itself:
+`search/metrics.py` owns every metric's definition, and `Prior.score_rows(group)` — the pool-shaped scoring surface
+both halves answer, projecting the packed matrix onto each model's own columns with its own absent-value fill — is
+where a score comes from.
+
+- A MEASURED pool (`--dataset nodes`: freeze or `node`-table rows, every candidate benched, grouped by
+  `(gpu, op_sig, H_opt)`) can answer what a wrong pick COST — Spearman over the pool, and regret at k=1 (the deploy
+  question: the pick ships, so its latency IS the cost) and k=10 (the tuning question: bench the top ten, keep the
+  measured best). This is the half that tracks deployed speed.
+- A GOLDEN pool (`--dataset golden`: an enumeration with the verified-optimum row marked) can only answer WHERE the
+  known-good row landed, and is reported as a SCREEN. A rank is blind to the latency gap behind it, and the corpus
+  aggregate is dominated by pools small enough to rank by accident, so golden cells are stratified by pool size.
+
+**Every cell publishes what it covered.** Cells carry the axes they were keyed on as a dict — measured: `gpu` ×
+`H_opt`; golden: `gpu` × `tier` × pool-size bucket; both plus `half` — along with how many pools keyed into them, how
+many the model could not score at all, and a per-metric group count. The metrics have different minimums (regret
+needs two rows, Spearman five, regret@10 eleven), so on the v3 freeze's 401 pools those counts are 344, 211 and 81.
+An aggregate that averaged the excluded pools in would be reporting mostly arithmetic.
+
+**`--dataset golden` also runs the deploy-faithful check the rank is only a screen for**: the greedy tile-pipeline
+pick vs the recorded golden, per shape, with the deployable `-O3` latency of the prior's pick beside it
+(`golden_deploy_perf`, read from the reservoir with no re-bench).
+
+**`--dataset db` is rejected.** Those rows are fully-decided leaves with no op identity or compile regime to group a
+comparison set by; the same DB read as `--dataset nodes` has both.
+
+**A golden's rank counts ties against it** (via `search/metrics.dual_rank`). The
 golden's rank counts every candidate scoring strictly better PLUS every candidate that ties with it and was emitted
 earlier. A tie is counted as a loss because greedy's argmin, faced with equal scores, takes whichever came first.
 Counting only strictly-better candidates would report rank 0 for every row inside a plateau of equal scores, which
@@ -1371,14 +1400,19 @@ the one that gates, and the strictly-better **optimistic** rank is reported besi
 The gap between them is the width of the tie plateau at the golden's score, and thus an early warning that the scores
 are saturating.
 
-**Golden evaluations build their features for the golden's own GPU.** `eval offline` / `eval online` rebuild each
-golden's compile context as `Context.from_target(compute_cap, gpu_name=…)`, using the GPU recorded in the golden file
-along with its known SM count and smem specs — never the host's. Building them for the host's context makes golden
-ranks machine-dependent, because the occupancy features then describe tiles for a GPU that is not the one the row came
-from. The offline fitter's case builder always did this correctly; the
-eval now matches it.
+**Golden evaluations build their features for the golden's own GPU.** They go through ONE case builder — `emmy fit`'s
+`build_golden_groups`, which `eval prior --dataset golden` calls — so the eval and the fit see the same corpus, the
+same sampling draw and the same rows. Each golden's compile context is rebuilt as
+`Context.from_target(compute_cap, gpu_name=…)`, using the GPU recorded in the golden file along with its known SM
+count and smem specs — never the host's. Building them for the host's context makes golden ranks machine-dependent,
+because the occupancy features then describe tiles for a GPU that is not the one the row came from.
 
-**Fork-sibling regret** (`eval online --dataset nodes`, via `iter_nodes` → `diagnostics.node_report`) measures, **per
+The eval builds its pools over the FULL featurization while a fit trains under its trainer's feature view. The view is
+a property of the model being fitted, and the eval scores two model classes: the linear half reads only its own weight
+names, so its ranks are identical either way, while the online half regresses on the `S_*` / `H_*` columns a narrow
+view drops and would otherwise be asked about a kernel with no shape.
+
+**Fork-sibling regret** (`eval prior --dataset nodes`, via `iter_nodes` → `diagnostics.node_report`) measures, **per
 GPU**, what following the prior's choice at each fork costs. It groups nodes by `parent_key` and computes
 `value_us(the child the prior predicted best) / value_us(the truly best child)`; 1.00x means the prior steers into the
 best subtree reachable from there, and ties in predicted score count against the prior, since greedy breaks them by
@@ -1418,10 +1452,10 @@ setting matched (the `golden_deploy_perf` convention). This is a diagnostic, not
 sibling is near-equal is fine, and the gap column is what tells you so.
 
 Both halves accept a candidate artifact for A/Bs: `--online-file` (legacy `--prior`) swaps the online checkpoint
-(`EMMY_ONLINE_FILE`), and `--offline-file` (on `eval offline` / `eval online`; env `EMMY_OFFLINE_FILE`) swaps the
+(`EMMY_ONLINE_FILE`), and `--offline-file` (env `EMMY_OFFLINE_FILE`) swaps the
 offline weights artifact — comparing two fits is running the same eval against two files and diffing the reports.
 
-**Which feature is to blame** (`eval online --dataset nodes --blame / --ablate`). Both views consume one shared
+**Which feature is to blame** (`eval prior --dataset nodes --blame / --ablate`). Both views consume one shared
 per-fork record (`diagnostics.fork_records`: the siblings, their rows in feature form, their scores, the
 tie-pessimistic pick and the measured best), so all three views agree on what "the pick" means by construction. They
 score through the `Prior`'s feature-level entry points — `mean_score_features` / `mean_scores_features` take a row

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1385,10 +1385,14 @@ so on the v3 freeze's 410 pools those counts are 339, 211 and 81. An aggregate t
 would be reporting mostly arithmetic.
 
 **The extents are part of the measured key, beside `op_sig`.** `op_sig` digests the **pre-descent offer op's**
-stamps — it names where a decision was offered, not what got computed — so one site can be realized as kernels
-doing wildly different amounts of work (a fused op against one kernel of a split pair). Nine pools of the RTX 5090
-freeze mixed two workloads a median 8192x apart, filing a 5.9 µs row and a 131 ms row as competitors when both ran
-at about 35 TFLOP/s. Every `S_ext_*` stamp therefore joins the key. That makes the grouping key a REFINEMENT of
+stamps — it names where a decision was offered, not what got computed — so one site can be realized as a single
+kernel or as several. Nine pools of the RTX 5090 freeze paired a fused `rms_norm`→linear megakernel with a row for
+just one kernel of the same op's unfused realization: a 5.9 µs norm kernel filed as a rival of a 131 ms whole-op
+row. A part's latency is not the realization's cost — where the sibling kernel was recorded too, the pair costs
+24–191 µs against the fused row's 28–212 ms. Every `S_ext_*` stamp therefore joins the key. Differing extents are
+what make the mismatch detectable and nothing more: the extent product is not a work measure for these kernels
+(a sweep rides the reduction, so it double-counts — `implausible_value_reason` abstains from its own
+`free × reduce` formula on exactly this stamp shape). That makes the grouping key a REFINEMENT of
 `fold_node_rows(by="op")`'s, which splits on `op_sig` alone — deliberately, since a fold must keep a whole op's
 tree on one side while a comparison must not merge rows that computed different things.
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1379,9 +1379,18 @@ where a score comes from.
 
 **Every cell publishes what it covered.** Cells carry the axes they were keyed on as a dict — measured: `gpu` ×
 `H_opt`; golden: `gpu` × `tier` × pool-size bucket; both plus `half` — along with how many pools keyed into them, how
-many the model could not score at all, and a per-metric group count. The metrics have different minimums (regret
-needs two rows, Spearman five, regret@10 eleven), so on the v3 freeze's 401 pools those counts are 344, 211 and 81.
-An aggregate that averaged the excluded pools in would be reporting mostly arithmetic.
+many the model could not score at all, and — where a metric has a size minimum and so covers fewer pools than the
+cell holds — that metric's own count. The minimums differ (regret needs two rows, Spearman five, regret@10 eleven),
+so on the v3 freeze's 410 pools those counts are 339, 211 and 81. An aggregate that averaged the excluded pools in
+would be reporting mostly arithmetic.
+
+**The extents are part of the measured key, beside `op_sig`.** `op_sig` digests the **pre-descent offer op's**
+stamps — it names where a decision was offered, not what got computed — so one site can be realized as kernels
+doing wildly different amounts of work (a fused op against one kernel of a split pair). Nine pools of the RTX 5090
+freeze mixed two workloads a median 8192x apart, filing a 5.9 µs row and a 131 ms row as competitors when both ran
+at about 35 TFLOP/s. Every `S_ext_*` stamp therefore joins the key. That makes the grouping key a REFINEMENT of
+`fold_node_rows(by="op")`'s, which splits on `op_sig` alone — deliberately, since a fold must keep a whole op's
+tree on one side while a comparison must not merge rows that computed different things.
 
 **`--dataset golden` also runs the deploy-faithful check the rank is only a screen for**: the greedy tile-pipeline
 pick vs the recorded golden, per shape, with the deployable `-O3` latency of the prior's pick beside it

--- a/emmy/compiler/pipeline/search/data/__init__.py
+++ b/emmy/compiler/pipeline/search/data/__init__.py
@@ -4,10 +4,10 @@ DB, the online-prior reservoir, and the digest-pinned measurement freeze): one
 :class:`ShapeKey` structural identity, the freeze writer/loader (``freeze.py``), and
 ``group.py``'s :class:`Group` — one candidate pool packed as a matrix plus one label per
 row, the comparison set a ranking question is asked over, with :class:`GoldenGroup` the
-kind whose labels MARK the rows goldens verified rather than measuring them. Pools are
-built by plain functions there (``group_measured`` for benched rows, ``pack_features``
-for the packing both kinds share). See ``sample.py`` for the featurization-fidelity
-contract.
+kind whose labels MARK the rows goldens verified and :class:`MeasuredGroup` the kind whose
+labels ARE the measured microseconds. Pools are built by plain functions there
+(``group_measured`` for benched rows, ``pack_features`` for the packing both kinds share).
+See ``sample.py`` for the featurization-fidelity contract.
 
 Nothing here may import :mod:`~..prior` — the data layer describes candidates and
 their labels; deciding what a score MEANS is the layer above (guarded by
@@ -18,7 +18,7 @@ from __future__ import annotations
 from emmy.compiler.pipeline.search.data.dataset import Dataset
 from emmy.compiler.pipeline.search.data.freeze import FREEZE_KIND, FREEZE_VER, freeze_reason, load_freeze, load_node_rows, write_freeze
 from emmy.compiler.pipeline.search.data.sample import KERNEL_NAME_RE, Sample
-from emmy.compiler.pipeline.search.data.shape import ShapeKey
+from emmy.compiler.pipeline.search.data.shape import ShapeKey, is_matmul, op_label
 
 __all__ = [
     "FREEZE_KIND",
@@ -28,7 +28,9 @@ __all__ = [
     "Sample",
     "ShapeKey",
     "freeze_reason",
+    "is_matmul",
     "load_freeze",
     "load_node_rows",
+    "op_label",
     "write_freeze",
 ]

--- a/emmy/compiler/pipeline/search/data/freeze.py
+++ b/emmy/compiler/pipeline/search/data/freeze.py
@@ -30,7 +30,7 @@ NO load-time ``feat_ver`` gate (the v1 rule): features are re-derived by live co
 stored ``feat_ver`` / ``knob_ver`` / ``encoding_ver`` are provenance, not a contract.
 :func:`load_node_rows` is the interchange seam: it sniffs a path and yields ``NodeRow``s
 from either a live sqlite DB (file) or a freeze (directory), so the nodes-dataset
-consumers (``eval online --dataset nodes``, ``Dataset.from_node_rows`` /
+consumers (``eval prior --dataset nodes``, ``Dataset.from_node_rows`` /
 ``fold_node_rows``) accept both. Loaded rows carry ``parent_key=None`` / ``depth=0`` /
 ``visits=0``: the fork diagnostics skip parentless rows and the golden-anchored descent
 treats them as tree-less, so a freeze degrades to the leaf-level metrics. A v1 JSONL

--- a/emmy/compiler/pipeline/search/data/group.py
+++ b/emmy/compiler/pipeline/search/data/group.py
@@ -343,9 +343,18 @@ class GoldenGroup(Group):
         return cls(key, name, tier, gpu, shape, dynamic, packed[0], matrix, len(matrix) if total is None else total, golden_ids=ids)
 
 
+def _extent_key(feats: dict) -> tuple:
+    """The loop extents a row's kernel actually ran over — the ``S_ext_*`` stamps, sorted.
+
+    What makes two measured latencies comparable at all. Every stamped row carries the whole set (the
+    stamp pass emits them unconditionally), so a missing one would be a row from a vocabulary this
+    featurizer version cannot read, which the admission filter has already rejected."""
+    return tuple(sorted((k, v) for k, v in feats.items() if k.startswith("S_ext_")))
+
+
 def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
     """Benched :class:`~..db.NodeRow`s as groups labelled with measured µs, keyed
-    ``(gpu, op_sig, H_opt)`` — one group per set of configs that genuinely competed, plus a count of
+    ``(gpu, op_sig, H_opt, extents)`` — one group per set of configs that genuinely competed, plus a count of
     what was dropped and why.
 
     Takes ``NodeRow``s rather than :class:`Sample`s because three of the four decisions below read
@@ -354,11 +363,20 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
 
     Each part of the key is load-bearing, and each has a plausible wrong answer:
 
-    - **``op_sig``, not the ``S_*`` signature.** Descent stamps its own deltas into the ``S_*``
-      features, so keying on them would split alternative schedules for ONE op into separate groups
-      and destroy the comparison the metric is asking for. ``op_sig`` is the DB's own op identity and
-      survives the freeze round-trip verbatim. It is also the axis ``fold_node_rows(by="op")`` splits
-      on, so grouping and folding coincide by construction rather than by coincidence.
+    - **``op_sig``, not the full ``S_*`` signature.** Descent stamps its own deltas into the ``S_*``
+      features, so keying on the whole signature would split alternative schedules for ONE op apart and
+      destroy the comparison the metric is asking for. Measured over the RTX 5090 freeze it also MERGES
+      what ``op_sig`` rightly keeps apart, collapsing 410 pools to 336. ``op_sig`` is a digest over the
+      **pre-descent offer op's** stamps and survives the freeze round-trip verbatim.
+    - **The EXTENTS, beside ``op_sig``, because the offer site is not the work.** ``op_sig`` names where
+      a decision was offered; one site can be realized as kernels that compute different amounts. Nine
+      pools of that freeze mixed two workloads a median 8192x apart — a 5.9 µs row and a 131 ms row filed
+      as competitors, both honest measurements of different kernels at ~35 TFLOP/s. Latency is only
+      comparable between rows that did the same work, so every ``S_ext_*`` stamp joins the key. It costs
+      almost nothing: it splits 9 pools of 401 and leaves 339 with the two rows regret needs (was 344),
+      after which NO ``S_*`` stamp varies within any pool at all. ``(S_ext_free_prod,
+      S_ext_reduce_prod)`` alone gives the identical partition; the full tuple is spelled because "the
+      extents" is the thing being said, not two fields that happened to suffice.
     - **``H_opt`` from the features, never ``context_key``.** (Present and numeric by then: the
       admission filter has already rejected a row missing its ``H_*`` stamps.) A live DB spells the regime as
       ``digest(Context, cap, flags)`` and a freeze spells the same one ``capX.Y-OZ``, so grouping on
@@ -366,6 +384,12 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
       came from. It looks like the first-class column; that is the trap. The regimes must not pool
       either way — ``-O1`` and ``-O3`` invert often enough that a merged group measures neither.
     - **``gpu``.** Cards never pool.
+
+    This key is a REFINEMENT of ``fold_node_rows(by="op")``'s, which splits on ``op_sig`` alone. The two
+    answer different questions and should not be made to agree: a fold must keep a whole op's tree on one
+    side or the value-correlated parent/child chains leak across the split, while a comparison must not
+    merge rows that computed different things. Refinement is what makes both safe at once — a group never
+    straddles two folds.
 
     Admission is :func:`freeze_reason`, the sanity filter the freeze writer already applies — not a
     second list of rules. It rejects a non-leaf (whose ``value_us`` is a min over its explored subtree,
@@ -396,10 +420,14 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
         elif not r.op_sig or not r.gpu:
             dropped["unkeyed"] += 1
         else:
-            buckets[(r.gpu, r.op_sig, r.features["H_opt"])].append(r)
+            buckets[(r.gpu, r.op_sig, r.features["H_opt"], _extent_key(r.features))].append(r)
 
     groups = []
-    for (gpu, op_sig, h_opt), grp in sorted(buckets.items()):
+    for (gpu, op_sig, h_opt, extents), grp in sorted(buckets.items()):
         feats = [knob_features(r.features) for r in grp]
-        groups.append(MeasuredGroup.from_measured(f"{gpu}/{op_sig}@O{h_opt:g}", gpu, op_sig, h_opt, [r.value_us for r in grp], feats))
+        # The extents ride in the key string too: two realizations of one offer site over different work are
+        # now two groups, and a report keys its per-pool rows on this.
+        free, reduce = dict(extents).get("S_ext_free_prod", 0.0), dict(extents).get("S_ext_reduce_prod", 0.0)
+        key = f"{gpu}/{op_sig}@O{h_opt:g}/{free:g}x{reduce:g}"
+        groups.append(MeasuredGroup.from_measured(key, gpu, op_sig, h_opt, [r.value_us for r in grp], feats))
     return groups, dict(dropped)

--- a/emmy/compiler/pipeline/search/data/group.py
+++ b/emmy/compiler/pipeline/search/data/group.py
@@ -1,9 +1,11 @@
 """``Group`` — one candidate pool plus its labels: the comparison set every ranking question is asked over.
 
 A group is one shape's featurized candidate pool on one card, with whatever supervision exists for it. The
-base carries one label per row and says nothing about what the numbers mean, because that is all a ranking
-metric needs. :class:`GoldenGroup` is the kind that means something more — its labels MARK the rows goldens
-verified rather than measuring them, so it alone can answer which rows are the answer.
+base carries the pool and its identity and nothing about supervision, because the two kinds of it are not
+one thing: :class:`GoldenGroup` holds the row INDICES goldens verified, so it alone can answer which rows are
+the answer, and :class:`MeasuredGroup` holds a benched latency PER ROW, so it alone can answer what a wrong
+pick cost. Nothing generic reads either — the metrics take plain sequences and never see a group — so a
+single label column on the base would be a field with no consumer and two mutually exclusive meanings.
 
 Groups are built by plain functions — :func:`group_measured` below for benched rows, and the golden one in
 ``emmy/commands/fit.py``, because case building needs the snippet tracer that ``pipeline/`` must not import —
@@ -168,12 +170,6 @@ class Group:
     # (a report axis) this decides folds; unlike ``tier`` (a label) it is load-bearing.
     shape: str
     dynamic: bool
-    # ONE label per row — what is KNOWN about it. The base carries only that much, because that is all a
-    # ranking metric needs: it correlates or scores against a column of numbers and does not care what they
-    # mean. What they mean is the subclass's business, and :class:`GoldenGroup` is the one that has an answer
-    # (its labels mark rows, not measure them). A measured pool needs no subclass: its labels ARE the
-    # measurement, in microseconds, lower = faster.
-    labels: np.ndarray = field(repr=False)
     feat_names: tuple[str, ...]
     feats: np.ndarray = field(repr=False)
     # The size of the candidate pool ``feats`` was drawn from, equal to ``len(feats)`` unless the
@@ -187,19 +183,6 @@ class Group:
     # The last ``matrix()`` projection, ``((names, fill), array)`` — a cache, not part of the group's value, so
     # it stays out of ``__eq__`` / ``repr``. See :meth:`matrix`.
     _cache: tuple | None = field(default=None, repr=False, compare=False)
-
-    @classmethod
-    def from_measured(cls, key: str, gpu: str, op_sig: str, latency_us: Sequence[float], feats: list[dict[str, float]]) -> Group:
-        """A pool where every row was benched, labelled with its own measured µs.
-
-        ``op_sig`` serves as both ``name`` and ``shape`` — a measured pool IS one op, so there is no second
-        identity to spell — and ``tier`` is empty, because the golden tiers are a closed report vocabulary
-        about how a CASE was built and a sixth value would mean nothing to the two places that read it.
-
-        No ``total`` either: a measured pool is not a sample of a larger enumeration, it is exactly the
-        configs someone ran, and a rank against anything else would be against candidates never measured."""
-        names, matrix, dynamic = pack_features(feats)
-        return cls(key, op_sig, "", gpu, op_sig, dynamic, np.asarray(latency_us, dtype=float), names, matrix, len(matrix))
 
     def matrix(self, names: list[str], *, fill: float = 0.0) -> np.ndarray:
         """The pool projected onto ``names`` — column ``j`` is the stored ``names[j]`` column, or ``fill``
@@ -241,6 +224,57 @@ class Group:
 
 
 @dataclass(frozen=True)
+class MeasuredGroup(Group):
+    """A pool whose labels ARE the measurement — one benched latency in microseconds per row, lower = faster.
+
+    The counterpart of :class:`GoldenGroup`: there the labels mark which rows are the answer, here they say how
+    fast each row ran. What the two kinds have in common is all the base needs, which is why a ranking metric
+    takes the base and this class adds only the one fact the base has nowhere to put.
+
+    :attr:`h_opt` is the compile regime every row in the pool was measured under. It is part of the grouping key
+    (:func:`group_measured`) rather than a description of it: ``-O1`` and ``-O3`` reorder the same candidates
+    often enough that a pool spanning both would measure neither, so the regime is what makes these rows
+    comparable at all. A report reads it as an axis, and it is a FIELD rather than a lookup into the packed
+    ``H_opt`` column for a mechanical reason: :meth:`Group.matrix` memoizes exactly one projection, so asking
+    for the single-column one right before a model asks for its own would evict and rebuild the model's
+    projection for every group — two full strided copies each, on the path whose measurements made that cache
+    exist in the first place."""
+
+    # One benched latency in MICROSECONDS per row, lower = faster. Lives here rather than on the base because
+    # nothing generic reads it: the metrics take plain sequences and never see a group, so a label on the base
+    # would be a column with no consumer and two mutually exclusive meanings.
+    latency_us: np.ndarray = field(kw_only=True, repr=False)
+    h_opt: float = field(kw_only=True)
+
+    @classmethod
+    def from_measured(
+        cls, key: str, gpu: str, op_sig: str, h_opt: float, latency_us: Sequence[float], feats: list[dict[str, float]]
+    ) -> MeasuredGroup:
+        """A pool where every row was benched, labelled with its own measured µs.
+
+        ``op_sig`` serves as both ``name`` and ``shape`` — a measured pool IS one op, so there is no second
+        identity to spell — and ``tier`` is empty, because the golden tiers are a closed report vocabulary
+        about how a CASE was built and a sixth value would mean nothing to the two places that read it.
+
+        No ``total`` either: a measured pool is not a sample of a larger enumeration, it is exactly the
+        configs someone ran, and a rank against anything else would be against candidates never measured."""
+        names, matrix, dynamic = pack_features(feats)
+        return cls(
+            key,
+            op_sig,
+            "",
+            gpu,
+            op_sig,
+            dynamic,
+            names,
+            matrix,
+            len(matrix),
+            latency_us=np.asarray(latency_us, dtype=float),
+            h_opt=h_opt,
+        )
+
+
+@dataclass(frozen=True)
 class GoldenGroup(Group):
     """A pool whose labels mark the rows a GOLDEN verified — the fit's supervision.
 
@@ -250,15 +284,13 @@ class GoldenGroup(Group):
     by taking this type. A discriminator field would have moved that check to runtime and to every caller.
     """
 
-    @property
-    def golden_ids(self) -> tuple[int, ...]:
-        """The rows a golden verified, ascending — the index set the rank metrics take.
-
-        Several goldens can land on one pool (the same shape recorded twice, or under two names), so this is
-        a SET. Deploy ships one config, so any of them ranked first is a win, which is why the fit's
-        per-group term is the best rank over it and the reported one the matching dual rank. At one golden
-        both collapse to the single-golden functions exactly."""
-        return tuple(int(i) for i in np.flatnonzero(self.labels))
+    # The rows a golden verified, ascending and deduplicated — the index set the rank metrics take. Several
+    # goldens can land on one pool (the same shape recorded twice, or under two names), so this is a SET.
+    # Deploy ships one config, so any of them ranked first is a win, which is why the fit's per-group term is
+    # the best rank over it and the reported one the matching dual rank. At one golden both collapse to the
+    # single-golden functions exactly. Stored as the indices themselves: the metrics take indices, so a
+    # per-row marker column would only be an encoding to decode back on every read.
+    golden_ids: tuple[int, ...] = field(kw_only=True)
 
     @classmethod
     def from_dicts(
@@ -291,8 +323,8 @@ class GoldenGroup(Group):
         total: int | None = None,
     ) -> GoldenGroup:
         """The same over an already-packed pool — the entry point for a builder that had to pack before it
-        could know which goldens landed in it, which is every builder that deduplicates pools. ``goldens``
-        are row indices; the marker encoding is this class's business and no caller needs to know it.
+        could know which goldens landed in it, which is every builder that deduplicates pools. ``goldens`` is
+        one row index or several, in any order, with duplicates; what is stored is the sorted set.
 
         ``tier`` must agree with the routing stamp the rows carry, and disagreeing is a hard error. The two
         reach here by different routes — the stamp through the featurizer, the tier from the source record's
@@ -307,12 +339,11 @@ class GoldenGroup(Group):
                 f"the source record's flag and its featurized rows disagree about the weight set"
             )
         rows = (goldens,) if isinstance(goldens, int) else goldens
-        labels = np.zeros(len(matrix), dtype=float)
-        labels[list({int(i) for i in rows})] = 1.0
-        return cls(key, name, tier, gpu, shape, dynamic, labels, packed[0], matrix, len(matrix) if total is None else total)
+        ids = tuple(sorted({int(i) for i in rows}))
+        return cls(key, name, tier, gpu, shape, dynamic, packed[0], matrix, len(matrix) if total is None else total, golden_ids=ids)
 
 
-def group_measured(rows) -> tuple[list[Group], dict[str, int]]:
+def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
     """Benched :class:`~..db.NodeRow`s as groups labelled with measured µs, keyed
     ``(gpu, op_sig, H_opt)`` — one group per set of configs that genuinely competed, plus a count of
     what was dropped and why.
@@ -370,5 +401,5 @@ def group_measured(rows) -> tuple[list[Group], dict[str, int]]:
     groups = []
     for (gpu, op_sig, h_opt), grp in sorted(buckets.items()):
         feats = [knob_features(r.features) for r in grp]
-        groups.append(Group.from_measured(f"{gpu}/{op_sig}@O{h_opt:g}", gpu, op_sig, [r.value_us for r in grp], feats))
+        groups.append(MeasuredGroup.from_measured(f"{gpu}/{op_sig}@O{h_opt:g}", gpu, op_sig, h_opt, [r.value_us for r in grp], feats))
     return groups, dict(dropped)

--- a/emmy/compiler/pipeline/search/data/group.py
+++ b/emmy/compiler/pipeline/search/data/group.py
@@ -368,13 +368,21 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
       destroy the comparison the metric is asking for. Measured over the RTX 5090 freeze it also MERGES
       what ``op_sig`` rightly keeps apart, collapsing 410 pools to 336. ``op_sig`` is a digest over the
       **pre-descent offer op's** stamps and survives the freeze round-trip verbatim.
-    - **The EXTENTS, beside ``op_sig``, because the offer site is not the work.** ``op_sig`` names where
-      a decision was offered; one site can be realized as kernels that compute different amounts. Nine
-      pools of that freeze mixed two workloads a median 8192x apart — a 5.9 µs row and a 131 ms row filed
-      as competitors, both honest measurements of different kernels at ~35 TFLOP/s. Latency is only
-      comparable between rows that did the same work, so every ``S_ext_*`` stamp joins the key. It costs
-      almost nothing: it splits 9 pools of 401 and leaves 339 with the two rows regret needs (was 344),
-      after which NO ``S_*`` stamp varies within any pool at all. ``(S_ext_free_prod,
+    - **The EXTENTS, beside ``op_sig``, because the offer site is not the computation.** ``op_sig`` names
+      where a decision was offered, and one site can be realized either as a single kernel or as several.
+      Nine pools of that freeze paired a FUSED ``rms_norm``->linear megakernel with a row for just ONE
+      KERNEL of the same op's unfused realization — a 5.9 µs norm kernel filed as a rival of a 131 ms
+      whole-op row. A part's latency is not the realization's cost: in the four pools where the sibling
+      kernel was recorded too, the pair costs 24-191 µs against the fused row's 28-212 ms.
+
+      Differing extents are what make that detectable, and detection is all they are claimed for here. The
+      extent PRODUCT is not a work measure for these kernels — a sweep rides the reduction, so the product
+      double-counts, which is why :func:`~..db.implausible_value_reason` abstains from its own
+      ``free x reduce`` formula on exactly this stamp shape. The rows are incomparable because one accounts
+      for the whole op and the other for a piece of it, not because of a measured work ratio.
+
+      It costs almost nothing: it splits 9 pools of 401 and leaves 339 with the two rows regret needs (was
+      344), after which NO ``S_*`` stamp varies within any pool at all. ``(S_ext_free_prod,
       S_ext_reduce_prod)`` alone gives the identical partition; the full tuple is spelled because "the
       extents" is the thing being said, not two fields that happened to suffice.
     - **``H_opt`` from the features, never ``context_key``.** (Present and numeric by then: the

--- a/emmy/compiler/pipeline/search/data/group.py
+++ b/emmy/compiler/pipeline/search/data/group.py
@@ -50,6 +50,7 @@ import numpy as np
 
 from emmy.compiler.pipeline.search.data.freeze import freeze_reason
 from emmy.compiler.pipeline.search.features import ROUTING_FEATURES, is_dynamic_row, knob_features
+from emmy.compiler.structural import digest
 
 # The default feature view: the ``D_*`` geometry/occupancy features plus the two ``MMA_*`` atom features that
 # vary between a pool's candidates — ``MMA_tier`` (the warp/scalar tier discriminator) and ``MMA_acc_bits``
@@ -343,18 +344,19 @@ class GoldenGroup(Group):
         return cls(key, name, tier, gpu, shape, dynamic, packed[0], matrix, len(matrix) if total is None else total, golden_ids=ids)
 
 
-def _extent_key(feats: dict) -> tuple:
-    """The loop extents a row's kernel actually ran over — the ``S_ext_*`` stamps, sorted.
+def kernel_sig(feats: dict) -> str:
+    """The op signature of the kernel a row actually measured, digested from its own ``S_*`` stamps.
 
-    What makes two measured latencies comparable at all. Every stamped row carries the whole set (the
-    stamp pass emits them unconditionally), so a missing one would be a row from a vocabulary this
-    featurizer version cannot read, which the admission filter has already rejected."""
-    return tuple(sorted((k, v) for k, v in feats.items() if k.startswith("S_ext_")))
+    Exactly what :meth:`~...passes.identity.Identity.op_sig` computes for an op, applied to the row's
+    recorded stamps instead — so this is the SAME identity, asked of the kernel that ran rather than of the
+    site it came from. On the RTX 5090 freeze the two agree for 83% of rows; the rest are where the
+    distinction matters."""
+    return digest(*sorted((k, float(v)) for k, v in feats.items() if k.startswith("S_")))
 
 
 def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
     """Benched :class:`~..db.NodeRow`s as groups labelled with measured µs, keyed
-    ``(gpu, op_sig, H_opt, extents)`` — one group per set of configs that genuinely competed, plus a count of
+    ``(gpu, kernel_sig, H_opt)`` — one group per set of configs that genuinely competed, plus a count of
     what was dropped and why.
 
     Takes ``NodeRow``s rather than :class:`Sample`s because three of the four decisions below read
@@ -363,28 +365,25 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
 
     Each part of the key is load-bearing, and each has a plausible wrong answer:
 
-    - **``op_sig``, not the full ``S_*`` signature.** Descent stamps its own deltas into the ``S_*``
-      features, so keying on the whole signature would split alternative schedules for ONE op apart and
-      destroy the comparison the metric is asking for. Measured over the RTX 5090 freeze it also MERGES
-      what ``op_sig`` rightly keeps apart, collapsing 410 pools to 336. ``op_sig`` is a digest over the
-      **pre-descent offer op's** stamps and survives the freeze round-trip verbatim.
-    - **The EXTENTS, beside ``op_sig``, because the offer site is not the computation.** ``op_sig`` names
-      where a decision was offered, and one site can be realized either as a single kernel or as several.
-      Nine pools of that freeze paired a FUSED ``rms_norm``->linear megakernel with a row for just ONE
-      KERNEL of the same op's unfused realization — a 5.9 µs norm kernel filed as a rival of a 131 ms
-      whole-op row. A part's latency is not the realization's cost: in the four pools where the sibling
-      kernel was recorded too, the pair costs 24-191 µs against the fused row's 28-212 ms.
+    - **The KERNEL's own signature, not the offer site's** (:func:`kernel_sig`, the digest the row's
+      recorded ``op_sig`` column holds when the two agree, which is 83% of the RTX 5090 freeze). Two kernels
+      of the same structure on the same card are ONE tuning problem whatever produced them — which is
+      already how the deploy path joins evidence (``Prior.evidence_pick`` and
+      ``policy/greedy._db_measured_pick`` both index on the ``S_*`` signature), so this makes the
+      comparison sets agree with the tier that consumes them.
 
-      Differing extents are what make that detectable, and detection is all they are claimed for here. The
-      extent PRODUCT is not a work measure for these kernels — a sweep rides the reduction, so the product
-      double-counts, which is why :func:`~..db.implausible_value_reason` abstains from its own
-      ``free x reduce`` formula on exactly this stamp shape. The rows are incomparable because one accounts
-      for the whole op and the other for a piece of it, not because of a measured work ratio.
+      Keying on the recorded ``op_sig`` instead gets it wrong in both directions, and the freeze shows
+      both. It **over-merges**: ``op_sig`` digests the PRE-DESCENT offer op, and a site realized as several
+      kernels can leave one piece filed as a rival of the whole — nine pools paired a fused
+      ``rms_norm``->linear megakernel with a row for a single kernel of the same op's unfused realization,
+      a 5.9 µs norm kernel against a 131 ms whole-op row. And it **fragments**: 73 structures were searched
+      in two separate pools, the losing pool's best landing a median 1.46x behind the winning pool's
+      (p90 3.89x, worst 14x) — the same kernel tuned twice, once badly, because the two arrived from
+      different sites.
 
-      It costs almost nothing: it splits 9 pools of 401 and leaves 339 with the two rows regret needs (was
-      344), after which NO ``S_*`` stamp varies within any pool at all. ``(S_ext_free_prod,
-      S_ext_reduce_prod)`` alone gives the identical partition; the full tuple is spelled because "the
-      extents" is the thing being said, not two fields that happened to suffice.
+      Measured against ``op_sig``: 336 pools rather than 401, but MORE rows sitting beside a rival
+      (3778 of 3817, against 3760) and a median pool of 7 rather than 5. Pool count falls because merging
+      is the point; what a metric needs is rivals per row.
     - **``H_opt`` from the features, never ``context_key``.** (Present and numeric by then: the
       admission filter has already rejected a row missing its ``H_*`` stamps.) A live DB spells the regime as
       ``digest(Context, cap, flags)`` and a freeze spells the same one ``capX.Y-OZ``, so grouping on
@@ -392,21 +391,6 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
       came from. It looks like the first-class column; that is the trap. The regimes must not pool
       either way — ``-O1`` and ``-O3`` invert often enough that a merged group measures neither.
     - **``gpu``.** Cards never pool.
-
-    This key is a REFINEMENT of ``fold_node_rows(by="op")``'s, which splits on ``op_sig`` alone. The two
-    answer different questions and should not be made to agree: a fold must keep a whole op's tree on one
-    side or the value-correlated parent/child chains leak across the split, while a comparison must not
-    merge rows that computed different things. Refinement is what makes both safe at once — a group never
-    straddles two folds.
-
-    Admission is :func:`freeze_reason`, the sanity filter the freeze writer already applies — not a
-    second list of rules. It rejects a non-leaf (whose ``value_us`` is a min over its explored subtree,
-    a coverage bound rather than something anyone benched), a row spelled in a retired featurizer
-    vocabulary, and a row failing the shared plausibility predicates. That last one is why re-deriving
-    the filter here would have been a defect rather than a duplication: an implausibly fast row becomes
-    the group's ``min`` and every regret in the group is then measured against a latency no kernel
-    produced. A freeze has passed this at write time, so on freeze input it drops nothing — which is
-    exactly why the rule cannot be verified against a freeze, and why it must not be re-spelled.
 
     ONE rule is this function's own: **``bench_fail`` excluded.** ``freeze_reason`` deliberately keeps
     failures, as durable negative examples; a pool being ranked by measured latency wants them gone,
@@ -428,14 +412,10 @@ def group_measured(rows) -> tuple[list[MeasuredGroup], dict[str, int]]:
         elif not r.op_sig or not r.gpu:
             dropped["unkeyed"] += 1
         else:
-            buckets[(r.gpu, r.op_sig, r.features["H_opt"], _extent_key(r.features))].append(r)
+            buckets[(r.gpu, kernel_sig(r.features), r.features["H_opt"])].append(r)
 
     groups = []
-    for (gpu, op_sig, h_opt, extents), grp in sorted(buckets.items()):
+    for (gpu, sig, h_opt), grp in sorted(buckets.items()):
         feats = [knob_features(r.features) for r in grp]
-        # The extents ride in the key string too: two realizations of one offer site over different work are
-        # now two groups, and a report keys its per-pool rows on this.
-        free, reduce = dict(extents).get("S_ext_free_prod", 0.0), dict(extents).get("S_ext_reduce_prod", 0.0)
-        key = f"{gpu}/{op_sig}@O{h_opt:g}/{free:g}x{reduce:g}"
-        groups.append(MeasuredGroup.from_measured(key, gpu, op_sig, h_opt, [r.value_us for r in grp], feats))
+        groups.append(MeasuredGroup.from_measured(f"{gpu}/{sig}@O{h_opt:g}", gpu, sig, h_opt, [r.value_us for r in grp], feats))
     return groups, dict(dropped)

--- a/emmy/compiler/pipeline/search/data/shape.py
+++ b/emmy/compiler/pipeline/search/data/shape.py
@@ -10,6 +10,11 @@ then derives both the histogram and this key with the current compiler.
 matmul dimensions. Generic golden records start from ``from_s_features`` and replay
 their stored schedule prefix through the same offer-aware classifier as deployment,
 which supplies the otherwise-unstamped flash and pre-split computed-A kind signal.
+
+:func:`is_matmul` and :func:`op_label` read the same histogram without building a key:
+the first is the op-kind predicate the key's own constructor uses, the second the human
+name a report captions a measured pool with and a ``--kernel`` filter matches against.
+They live here because they are readings of the stamped row, not of any one consumer.
 """
 
 from __future__ import annotations
@@ -204,3 +209,26 @@ class ShapeKey:
         if self.is_dyn:
             out["S_ext_n_symbolic_axis"] = 1.0
         return out
+
+
+def is_matmul(s: dict) -> bool:
+    """Histogram heuristic for "these ``S_*`` features describe a matmul": a product feeding a
+    reduce-add over >=2 distinct inputs.
+
+    ``S_n_mma`` is NOT usable as the marker: the stamp pass runs at fusion end, before the tile
+    tier emits ``Mma`` stmts, so it is 0.0 on every stamped row — gating on it made golden
+    coverage permanently empty and dropped every fp16 golden from the rank/deploy joins (the same
+    trap :meth:`ShapeKey.from_s_features` documents)."""
+    return bool(s.get("S_reduce_add", 0) and s.get("S_pw_multiply", 0) and s.get("S_n_distinct_input", 0) >= 2)
+
+
+def op_label(s: dict) -> str:
+    """A human name for the op a stamped ``S_*`` histogram describes — its kind and its extents.
+
+    The one spelling of "what is this measured pool", used to caption a per-op row and to match a
+    ``--kernel`` filter against the node store, whose own op identity is a digest with nothing
+    readable in it. Extra non-``S_*`` keys are ignored, so a full feature dict may be passed
+    directly."""
+    kind = "matmul" if is_matmul(s) else ("reduce" if (s.get("S_reduce_add", 0) or s.get("S_reduce_max", 0)) else "pointwise")
+    free, red = int(s.get("S_ext_free_max", 0)), int(s.get("S_ext_reduce_max", 0))
+    return f"{kind:9} free={free}" + (f" red={red}" if red else "")

--- a/emmy/compiler/pipeline/search/db.py
+++ b/emmy/compiler/pipeline/search/db.py
@@ -527,7 +527,7 @@ class SearchDB:
             if magic and magic != b"SQLite format 3\x00":  # empty file = valid empty DB
                 hint = (
                     " — this looks like a v1 JSONL measurement freeze; freezes are now per-GPU YAML directories, "
-                    "accepted only by the nodes-dataset consumers, e.g. `eval online --dataset nodes --db`"
+                    "accepted only by the nodes-dataset consumers, e.g. `eval prior --dataset nodes --db`"
                     if magic.startswith(b"{")
                     else ""
                 )
@@ -894,7 +894,7 @@ class SearchDB:
 
     def iter_nodes(self, *, context_key: str | None = None, op_sig: str | None = None) -> Iterator[NodeRow]:
         """Yield one :class:`NodeRow` per stored search-tree node (the value-of-position
-        dataset backing ``eval online --dataset nodes``). Self-contained — no join.
+        dataset backing ``eval prior --dataset nodes``). Self-contained — no join.
         A read-only open of a pre-``node`` DB has no such table, so this degrades to
         yielding nothing instead of raising (mirrors ``iter_perf_samples``'
         missing-column degrade). Optional ``context_key`` / ``op_sig`` scope to one

--- a/emmy/compiler/pipeline/search/prior/base.py
+++ b/emmy/compiler/pipeline/search/prior/base.py
@@ -39,10 +39,14 @@ import math
 import statistics
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from emmy.compiler.pipeline.search.metrics import spearman
+
+if TYPE_CHECKING:
+    from emmy.compiler.pipeline.search.data.group import Group
 
 logger = logging.getLogger(__name__)
 
@@ -247,6 +251,31 @@ class Prior(ABC):
     def mean_scores_features(self, feats_list: list[dict]) -> list[float]:
         """Batched :meth:`mean_score_features`; override for a vectorized predict."""
         return [self.mean_score_features(f) for f in feats_list]
+
+    @abstractmethod
+    def score_rows(self, group: Group) -> np.ndarray | None:
+        """This model's ranking QUALITY for every row of a packed candidate pool — higher = predicted faster.
+        ``None`` when this model cannot score the pool at all (the linear model asked for a dynamic weight set
+        it never fit); a model with nothing fitted yet still answers, with a constant.
+
+        The pool-shaped scoring surface, and the third one this class has after :meth:`mean_scores` (knob dicts)
+        and :meth:`mean_scores_features` (feature dicts). It exists because the dict surfaces cannot be used on
+        the pools these questions are actually asked over: a matmul enumeration runs to ~10^5 rows, and the
+        per-row dict of ~63 floats that made the fit OOM would make an evaluation OOM for the same reason. The
+        packed matrix is that representation done once, and each implementation here projects it onto its OWN
+        column list with its OWN absent-value fill (see :meth:`Group.matrix`) — which is the whole reason this
+        cannot be one shared function over ``feat_names``.
+
+        Polarity is deliberately the opposite of :meth:`mean_score`'s. This returns quality because that is what
+        the fitted model classes compute and what the rank metrics take; the deployed score is the monotone
+        ``exp(-scale·quality)`` of it, and a caller wanting the cost family (:func:`~..metrics.topk_regret`,
+        :func:`~..metrics.spearman`) negates. Both orders are read as ORDER only, so the negation is exact.
+
+        The pool must carry every column the model reads. A group packed under a narrow feature view — the fit's
+        ``D_*`` view, say — answers the linear model correctly, because its weight names are inside that view,
+        while the online model's ``S_*`` / ``H_*`` columns would all fill absent and its predictions would be
+        about a kernel with no shape. Which columns a group carries is the BUILDER's decision, so an evaluation
+        that scores both halves builds its pools over the full featurization."""
 
     def explain_features(self, feats: dict) -> dict[str, float] | None:
         """Signed per-term decomposition of this model's opinion on a featurized row,

--- a/emmy/compiler/pipeline/search/prior/diagnostics.py
+++ b/emmy/compiler/pipeline/search/prior/diagnostics.py
@@ -15,34 +15,12 @@ from __future__ import annotations
 import statistics
 from dataclasses import dataclass
 
-from emmy.compiler.pipeline.search.data import Dataset, ShapeKey
+from emmy.compiler.pipeline.search.data import Dataset, ShapeKey, is_matmul, op_label
 from emmy.compiler.pipeline.search.metrics import spearman, topk_pick, topk_regret
 
 
 def _n_tunable(knobs: dict) -> int:
     return sum(1 for k in knobs if not k.startswith(("S_", "H_")))
-
-
-def _matmul_sig(d: dict) -> bool:
-    """Histogram heuristic for "this op group is a matmul": a product feeding a
-    reduce-add over ≥2 distinct inputs. ``S_n_mma`` is NOT usable as the marker:
-    the stamp pass runs at fusion end, before the tile tier emits ``Mma`` stmts,
-    so it is 0.0 on every stamped row — gating on it made golden coverage
-    permanently empty and dropped every fp16 golden from the rank/deploy joins
-    (see ``ShapeKey.from_s_features``)."""
-    return bool(d.get("S_reduce_add", 0) and d.get("S_pw_multiply", 0) and d.get("S_n_distinct_input", 0) >= 2)
-
-
-def _op_label(sig: tuple) -> str:
-    d = dict(sig)
-    if _matmul_sig(d):
-        kind = "matmul"
-    elif d.get("S_reduce_add", 0) or d.get("S_reduce_max", 0):
-        kind = "reduce"
-    else:
-        kind = "pointwise"
-    free, red = int(d.get("S_ext_free_max", 0)), int(d.get("S_ext_reduce_max", 0))
-    return f"{kind:9} free={free}" + (f" red={red}" if red else "")
 
 
 def reachability(prior, groups: dict) -> list[tuple]:
@@ -68,7 +46,7 @@ def reachability(prior, groups: dict) -> list[tuple]:
         best_us, picked = min(lats), topk_pick(preds, lats, 1)
         if best_us <= 0:  # a label that is not a latency; a ratio against it would be meaningless
             continue
-        out.append((_op_label(sig), best_us, lats[picked], lats[picked] / best_us, len(leaves)))
+        out.append((op_label(dict(sig)), best_us, lats[picked], lats[picked] / best_us, len(leaves)))
     return out
 
 
@@ -100,7 +78,7 @@ def _golden_coverage(groups: dict) -> tuple[int, int]:
     have = set()
     for sig in groups:
         d = dict(sig)
-        if _matmul_sig(d):
+        if is_matmul(d):
             have.add(ShapeKey.from_s_features(d))
     golden_keys = {g.shape_key for g in GOLDEN_RECORDS if g.is_matmul}
     covered = sum(1 for k in golden_keys if k in have)
@@ -138,7 +116,7 @@ def golden_prior_eval(prior, kernel_filter: str | None = None) -> str:
     index: dict[ShapeKey, dict] = {}
     for sig in Dataset.from_prior(prior).group_by_op():
         d = dict(sig)
-        if not _matmul_sig(d):
+        if not is_matmul(d):
             continue
         index.setdefault(ShapeKey.from_s_features(d), {k: v for k, v in d.items() if k.startswith("S_")})
 
@@ -213,7 +191,7 @@ def golden_deploy_perf(prior, kernel_filter: str | None = None) -> dict[str, flo
     index: dict[ShapeKey, list] = {}
     for sig, samples in Dataset.from_prior(prior).group_by_op().items():
         d = dict(sig)
-        if not _matmul_sig(d):
+        if not is_matmul(d):
             continue
         o3 = [s for s in samples if int(s.all_knobs().get("H_opt", 0)) == 3]
         if not o3:
@@ -365,7 +343,7 @@ def fork_records(prior, nodes) -> list[ForkRecord]:
         best_i = min(range(len(sibs)), key=lambda i: values[i])
         family = _fork_family(by_key.get(parent_key), sibs)
         records.append(
-            ForkRecord(_node_op_label(sibs[0].features), family, topk_regret(scores, values, 1), sibs, fvecs, scores, picked_i, best_i)
+            ForkRecord(op_label(sibs[0].features), family, topk_regret(scores, values, 1), sibs, fvecs, scores, picked_i, best_i)
         )
     return records
 
@@ -399,15 +377,6 @@ def _regret_lines(records: list[tuple[str, str, float, int]]) -> list[str]:
     agg = {f: [r for _, fam, r, _ in records if fam == f] for f in fams}
     lines.append(f"      {'ALL (median)':{w}}  " + "  ".join(cell(agg[f]) for f in fams) + f"  {len(records)}")
     return lines
-
-
-def _node_op_label(features: dict) -> str:
-    """The op label for a single ``node`` row — derived from its ``S_*`` features, the
-    same labels :func:`reachability` rows carry, so ``--kernel`` filters the node store
-    by op kind/shape (e.g. ``matmul`` / ``reduce`` / ``free=512``). All nodes of one op
-    share these features, so filtering keeps/drops a whole op atomically — parent and
-    children never split."""
-    return _op_label(tuple(sorted((k, v) for k, v in features.items() if k.startswith("S_"))))
 
 
 def _node_gpu_block(prior, gpu: str, gnodes: list) -> list[str]:
@@ -454,12 +423,12 @@ def _usable_nodes(nodes, kernel_filter: str | None) -> tuple[list, int, int]:
     nodes = [n for n in nodes if n.status == "ok" and n.feat_ver == FEATURIZER_VERSION]
     total = len(nodes)
     if kernel_filter:
-        nodes = [n for n in nodes if kernel_filter in _node_op_label(n.features)]
+        nodes = [n for n in nodes if kernel_filter in op_label(n.features)]
     return nodes, stale, total
 
 
 def node_report(prior, nodes, *, kernel_filter: str | None = None) -> str:
-    """The ``eval online --dataset nodes`` block. Groups the node store **by card**
+    """The ``eval prior --dataset nodes`` per-fork block. Groups the node store **by card**
     (``NodeRow.gpu``) and, per card, reports the fork sibling regret (the metric unique
     to this dataset — :func:`sibling_regret`) plus leaf reachability / calibration. Per-card grouping is what
     makes a cross-hardware dataset (H100, H200, …) evaluate correctly — same-die SKUs
@@ -706,7 +675,7 @@ def _golden_anchor_block(prior, gpu: str, gnodes: list, kernel_filter: str | Non
     for g in goldens:
         pin_suffix = "" if g.pin_map == {"FAST_MATH": False} else f" [{dict(g.pins)}]"
         name = g.name + pin_suffix
-        op_nodes = [n for n in gnodes if _matmul_sig(n.features) and ShapeKey.from_s_features(n.features) == g.shape_key]
+        op_nodes = [n for n in gnodes if is_matmul(n.features) and ShapeKey.from_s_features(n.features) == g.shape_key]
         if not op_nodes:
             no_data += 1
             lines.append(f"      {name:{w}}  NO TREE DATA for this shape on this card")
@@ -850,7 +819,7 @@ def _ablation_lines(prior, records: list[ForkRecord], *, min_support: int = 5) -
 
 
 def attribution_report(prior, nodes, *, kernel_filter: str | None = None, blame: bool = True, ablate: bool = False) -> str:
-    """The ``eval online --dataset nodes --blame / --ablate`` block: per-feature
+    """The ``eval prior --dataset nodes --blame / --ablate`` block: per-feature
     regret attribution over the node store's fork records. Fork records are built
     per card (fork identity never crosses cards) but the tables POOL them: regret is
     a within-fork ratio, so cards and compile regimes pool safely — unlike

--- a/emmy/compiler/pipeline/search/prior/fallback.py
+++ b/emmy/compiler/pipeline/search/prior/fallback.py
@@ -61,7 +61,7 @@ class FallbackPrior(Prior):
 
     @property
     def fitted(self) -> bool:
-        # Reflects the ONLINE model (so diagnostics / `eval online` report whether
+        # Reflects the ONLINE model (so diagnostics / `eval prior` report whether
         # real tuning data exists). The policies no longer gate on this — they
         # always call score()/mean_score(), which fall back to offline when cold.
         return self.online.fitted
@@ -98,6 +98,9 @@ class FallbackPrior(Prior):
 
     def explain_features(self, feats: dict) -> dict[str, float] | None:
         return self._deploy.explain_features(feats)
+
+    def score_rows(self, group):
+        return self._deploy.score_rows(group)
 
     @property
     def masking_exact(self) -> bool:

--- a/emmy/compiler/pipeline/search/prior/fit/cv.py
+++ b/emmy/compiler/pipeline/search/prior/fit/cv.py
@@ -50,8 +50,7 @@ import statistics
 
 from emmy.compiler.pipeline.search.data.group import GoldenGroup
 from emmy.compiler.pipeline.search.metrics import best_dual_rank
-
-TOP_KS = (1, 10, 25, 50, 100)
+from emmy.compiler.pipeline.search.prior.report import TOP_KS
 
 # The ``skipped`` reason for golden kinds the fitter has no case builder for
 # (attention / rms_norm / softmax) — counted per card as ``out_of_scope``, distinct from

--- a/emmy/compiler/pipeline/search/prior/offline.py
+++ b/emmy/compiler/pipeline/search/prior/offline.py
@@ -217,3 +217,11 @@ class OfflinePrior(Prior):
         """Per-term decomposition of the quality score, summing to it exactly — the linear model's per-weight
         terms or the tree's TreeSHAP values. See each model's ``explain_features`` for its invariant."""
         return self._model.explain_features(feats)
+
+    def score_rows(self, group):
+        """The whole packed pool's ranking quality — straight through to the model, which is the object that
+        knows its own columns. This adapter adds nothing here precisely because there is no knob dict to
+        featurize: the pool arrives already packed, which is the same form ``emmy fit`` trains and scores it
+        in, so a golden's rank under a fitted artifact and under this deployed prior are the same number by
+        construction rather than by two paths agreeing."""
+        return self._model.score_rows(group)

--- a/emmy/compiler/pipeline/search/prior/online.py
+++ b/emmy/compiler/pipeline/search/prior/online.py
@@ -117,6 +117,20 @@ class OnlinePrior(Prior):
         x = np.array([[f.get(c, np.nan) for c in self._cols] for f in feats_list], dtype=float)
         return [float(v) for v in np.exp(self._model.predict(x))]
 
+    def score_rows(self, group):
+        """The whole packed pool's ranking quality — ``-log(predicted µs)``, so higher = predicted faster,
+        matching the fitted model classes' polarity (see :meth:`Prior.score_rows`).
+
+        Negating the LOG rather than the µs is not a shortcut: the regressor's output IS log-latency, and the
+        rank metrics read order only, so this skips an ``exp`` that could overflow on a row the model prices
+        absurdly and could not change a single comparison.
+
+        An unfit model returns zeros, the constant :meth:`mean_score` returns for the same reason — a report
+        then shows this half ranking at chance instead of failing, which is what a cold checkpoint should look
+        like. Absent columns fill to ``NaN``, the same missing-value bucket ``fit`` trained against."""
+        x = group.matrix(list(self._cols), fill=np.nan) if self._model is not None else None
+        return np.zeros(len(group.feats)) if x is None else -np.asarray(self._model.predict(x), dtype=float)
+
     # --- persistence ------------------------------------------------------
 
     def to_json(self) -> dict | None:

--- a/emmy/compiler/pipeline/search/prior/report.py
+++ b/emmy/compiler/pipeline/search/prior/report.py
@@ -29,10 +29,10 @@ pool buckets onto measured cells and guarantee empty rows, so each builder decla
 **Every cell publishes what it was computed over.** ``groups`` is how many pools keyed into it and ``unscored``
 how many of those the model could not score at all. The measured metrics each add their OWN group count, because
 they have different minimums: regret needs a pool of at least two rows (a one-row pool is trivially perfect) and
-Spearman at least :data:`MIN_SPEARMAN_ROWS`. On the v3 freeze's 410 pools that is 339 and 211 — so an aggregate
+Spearman at least :data:`MIN_SPEARMAN_ROWS`. On the v3 freeze's 336 pools that is 297 and 216 — so an aggregate
 that quietly averaged the excluded pools in would be reporting mostly arithmetic. ``regret@10`` is the strictest:
-it needs eleven rows, which 81 pools have, so at the freeze's median pool size of five it excludes most of the
-corpus. The rank metrics have no minimum, so they carry no count of their own.
+it needs eleven rows, which 90 pools have, so at the freeze's median pool size of seven it still excludes most of
+the corpus. The rank metrics have no minimum, so they carry no count of their own.
 
 Polarity is handled once, here. ``score`` returns ranking QUALITY (higher = predicted faster, the
 :meth:`Prior.score_rows` contract); the regret and correlation families take a cost (lower = faster), so this
@@ -57,7 +57,7 @@ from emmy.compiler.pipeline.search.metrics import best_dual_rank, spearman, topk
 # Deliberately below the deploy gate's :data:`~.base._CALIBRATION_MIN_GROUP` (8), which is the same statistic on
 # a different job. That one decides whether a model may own deploys, over the model's OWN reservoir, where more
 # rows are always available and a false pass is expensive. This one describes an external corpus of fixed size:
-# raising it to 8 would drop the freeze well below its 211 measurable pools and report a card as unmeasured
+# raising it to 8 would drop the freeze well below its 216 measurable pools and report a card as unmeasured
 # rather than measured noisily.
 MIN_SPEARMAN_ROWS = 5
 

--- a/emmy/compiler/pipeline/search/prior/report.py
+++ b/emmy/compiler/pipeline/search/prior/report.py
@@ -1,0 +1,221 @@
+"""How well does a prior RANK — as a table of cells, one serializable schema, two questions.
+
+Hand a model a candidate pool (:class:`~..data.group.Group`), take the scores, and report what the ordering
+was worth. This module is where that becomes a number. It computes nothing itself — :mod:`..metrics` owns every
+metric's definition — it decides nothing about what to score, and it prints nothing: it takes groups and a
+scoring callable and assembles :class:`EvalReport`, which serializes. Turning that into text is the CLI's job
+(``emmy/commands/eval.py``), where the console-table renderer already lives.
+
+``emmy eval prior`` is the caller today; ``emmy fit``'s metrics file moves onto the same cells with the fold
+harness, so the two commands' numbers become comparable by construction rather than by two paths agreeing.
+
+**Two questions, and they are not interchangeable.**
+
+- A MEASURED pool (:class:`~..data.group.MeasuredGroup`: freeze or tune-DB rows, every candidate benched) can
+  answer what a wrong pick COST. That is :func:`measured_cells` — Spearman over the pool and regret at the top
+  of the ranking — and it is the question that tracks deployed speed.
+- A GOLDEN pool (:class:`~..data.group.GoldenGroup`: an enumeration with a verified-optimum row marked) can only
+  answer WHERE the known-good row landed. That is :func:`golden_cells`, and it is reported as a SCREEN: a rank
+  is blind to the latency gap behind it, so ranks 1 and 555 of a 164k-row pool may be 0.5% apart or 3x apart,
+  and the corpus's rank aggregate is dominated by pools small enough to rank by accident (44% under 100
+  candidates). Hence the pool-size axis — a top-1 rate is only readable against the pool it was scored over.
+
+**Cells carry the axes they were keyed on, as a dict.** Measured pools key on ``gpu`` x ``H_opt``; golden pools
+on ``gpu`` x ``tier`` x pool-size bucket; both carry ``half``, because the composite prior's two halves fail for
+different reasons — the offline half decides what a cold sweep measures at all, the online half owns deploys
+once trustworthy — and one unlabelled number would hide which. A fixed axis tuple would force the golden side's
+pool buckets onto measured cells and guarantee empty rows, so each builder declares its own.
+
+**Every cell publishes what it was computed over.** ``groups`` is how many pools keyed into it and ``unscored``
+how many of those the model could not score at all. The measured metrics each add their OWN group count, because
+they have different minimums: regret needs a pool of at least two rows (a one-row pool is trivially perfect) and
+Spearman at least :data:`MIN_SPEARMAN_ROWS`. On the v3 freeze's 401 pools that is 344 and 211 — so an aggregate
+that quietly averaged the excluded pools in would be reporting mostly arithmetic. ``regret@10`` is the strictest:
+it needs eleven rows, and at the freeze's median pool size of five it excludes most of the corpus. The rank
+metrics have no minimum, so they carry no count of their own.
+
+Polarity is handled once, here. ``score`` returns ranking QUALITY (higher = predicted faster, the
+:meth:`Prior.score_rows` contract); the regret and correlation families take a cost (lower = faster), so this
+module negates. Both are read as ORDER only, so the negation is exact for a model fitted on ranks as much as
+for one that regresses microseconds.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from emmy.compiler.pipeline.search.data.group import GoldenGroup, Group, MeasuredGroup
+from emmy.compiler.pipeline.search.metrics import best_dual_rank, spearman, topk_regret
+
+# Minimum pool size a Spearman is reported over. Two rows make ``rho`` computable and meaningless: it is +1 or
+# -1 with nothing in between, so a cell of small pools would report a correlation built out of coin flips.
+#
+# Deliberately below the deploy gate's :data:`~.base._CALIBRATION_MIN_GROUP` (8), which is the same statistic on
+# a different job. That one decides whether a model may own deploys, over the model's OWN reservoir, where more
+# rows are always available and a false pass is expensive. This one describes an external corpus of fixed size:
+# raising it to 8 would drop the freeze from 211 pools to well under half of that and report a card as unmeasured
+# rather than measured noisily.
+MIN_SPEARMAN_ROWS = 5
+
+# The tuning question's frontier width: bench the model's top ``TOPK`` predictions and keep the measured best.
+# The deploy question is the same metric at k=1, which is why both are reported side by side — a model can be
+# fine to tune with and wrong to deploy from.
+TOPK = 10
+
+# Golden top-k coverage. One ladder, imported by the fold harness (``fit/cv.py``) too, so a fit's metrics file
+# and an eval report cannot report coverage at different cut-offs and be compared as though they agreed.
+TOP_KS = (1, 10, 25, 50, 100)
+
+# Pool-size buckets for the golden axis: ``(exclusive upper bound, label)``, last bound ``None`` = everything
+# above. A rank is only readable against its pool size, and the corpus spans three orders of magnitude.
+POOL_BUCKETS: tuple[tuple[int | None, str], ...] = ((100, "<100"), (1_000, "<1k"), (10_000, "<10k"), (None, ">=10k"))
+
+# ``score(group) -> quality per row``, or ``None`` when this model cannot score the pool at all.
+Scorer = Callable[[Group], "np.ndarray | None"]
+
+
+def pool_bucket(total: int) -> str:
+    """The pool-size bucket label for a pool of ``total`` candidates."""
+    return next(label for bound, label in POOL_BUCKETS if bound is None or total < bound)
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One row of the report: the axes it was keyed on, what it covered, and its metrics.
+
+    ``metrics`` maps a metric name to that metric's own block. A block carries ``groups`` — the pools it was
+    actually computed over — only where that metric has a size minimum and so can differ from ``groups -
+    unscored``; a value of ``None`` was computable for nothing in the cell."""
+
+    axes: dict[str, str]
+    groups: int
+    unscored: int
+    metrics: dict[str, dict]
+
+    def to_json(self) -> dict:
+        return {"axes": dict(self.axes), "groups": self.groups, "unscored": self.unscored, "metrics": self.metrics}
+
+
+@dataclass(frozen=True)
+class EvalReport:
+    """A whole run: the provenance that makes two reports comparable, plus the cells.
+
+    ``header`` records what was scored and how — the dataset, its source, the enumeration draw, the drop counts
+    the builder published. Two reports are only comparable when those match, which is exactly why they ship
+    inside the artifact rather than in the prose around it."""
+
+    header: dict
+    cells: list[Cell]
+
+    def to_json(self) -> dict:
+        return {"header": self.header, "cells": [c.to_json() for c in self.cells]}
+
+
+def _round(x: float | None, digits: int) -> float | None:
+    """Round for a DIFF: a metrics file is compared with ``diff``, and float noise in the last places would
+    make two runs of the same fit look like a change."""
+    return None if x is None else round(float(x), digits)
+
+
+def _median(vals: list[float], digits: int) -> float | None:
+    return _round(statistics.median(vals), digits) if vals else None
+
+
+def _cells(groups: Sequence[Group], score: Scorer, axes_of, metrics_of, *, half: str) -> list[Cell]:
+    """Bucket ``groups`` by ``axes_of``, score each, and hand the survivors to ``metrics_of``.
+
+    The scoring pass is here rather than in each metric builder because ``None`` — this model cannot score this
+    pool — is a report fact, not a metric fact: a linear model that fitted no dynamic weight set answers
+    ``None`` for every symbolic-axis pool, and a cell that dropped those silently would show a healthy static
+    corpus and no sign that half the deploy surface is unscored."""
+    buckets: dict[tuple, list] = {}
+    unscored: dict[tuple, int] = {}
+    for g in groups:
+        axes = axes_of(g)
+        key = tuple(axes.items())
+        buckets.setdefault(key, [])
+        unscored.setdefault(key, 0)
+        scores = score(g)
+        if scores is None:
+            unscored[key] += 1
+        else:
+            buckets[key].append((g, np.asarray(scores, dtype=float)))
+    out = []
+    for key in sorted(buckets):
+        entries = buckets[key]
+        out.append(
+            Cell(
+                axes={"half": half, **dict(key)},
+                groups=len(entries) + unscored[key],
+                unscored=unscored[key],
+                metrics=metrics_of(entries),
+            )
+        )
+    return out
+
+
+# --- measured pools: what the ordering cost ------------------------------------------------------------
+
+
+def _measured_metrics(entries: list[tuple[MeasuredGroup, np.ndarray]]) -> dict:
+    """Spearman and regret over benched pools — the quality vector is negated into a cost so it and the measured
+    microseconds read the same direction (see the module docstring)."""
+    rhos: list[float] = []
+    regrets: dict[int, list[float]] = {1: [], TOPK: []}
+    for g, quality in entries:
+        cost, measured = (-quality).tolist(), g.latency_us.tolist()
+        for k, acc in regrets.items():
+            if (r := topk_regret(cost, measured, k)) is not None:
+                acc.append(r)
+        if len(measured) >= MIN_SPEARMAN_ROWS and (rho := spearman(cost, measured)) is not None:
+            rhos.append(rho)
+    out = {"spearman": {"median": _median(rhos, 3), "groups": len(rhos)}}
+    for k, acc in regrets.items():
+        # The WORST group travels with the median because the distribution is one-sided: regret floors at 1.00,
+        # so a median near 1.00 with a 4x tail is a model that is usually right and occasionally catastrophic —
+        # which is what a deploy actually feels, and what a median alone cannot say.
+        out[f"regret{k}"] = {"median": _median(acc, 3), "worst": _round(max(acc), 3) if acc else None, "groups": len(acc)}
+    return out
+
+
+def measured_cells(half: str, groups: Sequence[MeasuredGroup], score: Scorer) -> list[Cell]:
+    """Cells over benched pools, keyed ``gpu`` x ``H_opt`` — the axes :func:`~..data.group.group_measured`
+    already grouped on, minus the op identity that separates the pools within a cell."""
+    return _cells(groups, score, lambda g: {"gpu": g.gpu, "H_opt": f"O{g.h_opt:g}"}, _measured_metrics, half=half)
+
+
+# --- golden pools: where the verified row landed --------------------------------------------------------
+
+
+def _golden_metrics(entries: list[tuple[GoldenGroup, np.ndarray]]) -> dict:
+    """The golden rank screen, under both tie conventions.
+
+    A pool with several verified rows is scored on the best of them (:func:`~..metrics.best_dual_rank`): deploy
+    ships one config, so any acceptable one ranked first is the same win."""
+    ranks = [best_dual_rank(quality, g.golden_ids) for g, quality in entries]
+    pessimistic, optimistic = [r for r, _ in ranks], [o for _, o in ranks]
+    # No per-metric ``groups`` here, unlike the measured side: no rank metric has a size minimum, so every
+    # block's count would be the cell's own scored total and the cell already publishes that. The top-k
+    # denominator is ``groups - unscored``.
+    out = {"rank": {"median": _median(pessimistic, 1), "median_optimistic": _median(optimistic, 1)}}
+    for k in TOP_KS:
+        out[f"top{k}"] = {"count": sum(r < k for r in pessimistic)}
+    return out
+
+
+def golden_cells(half: str, groups: Sequence[GoldenGroup], score: Scorer) -> list[Cell]:
+    """Cells over golden pools, keyed ``gpu`` x ``tier`` x pool-size bucket.
+
+    The pool bucket is what makes the rank readable: without it a corpus whose small pools rank perfectly and
+    whose large ones rank at chance reports one flattering middle number."""
+    return _cells(
+        groups,
+        score,
+        lambda g: {"gpu": g.gpu, "tier": g.tier or "-", "pool": pool_bucket(g.total)},
+        _golden_metrics,
+        half=half,
+    )

--- a/emmy/compiler/pipeline/search/prior/report.py
+++ b/emmy/compiler/pipeline/search/prior/report.py
@@ -29,10 +29,10 @@ pool buckets onto measured cells and guarantee empty rows, so each builder decla
 **Every cell publishes what it was computed over.** ``groups`` is how many pools keyed into it and ``unscored``
 how many of those the model could not score at all. The measured metrics each add their OWN group count, because
 they have different minimums: regret needs a pool of at least two rows (a one-row pool is trivially perfect) and
-Spearman at least :data:`MIN_SPEARMAN_ROWS`. On the v3 freeze's 401 pools that is 344 and 211 — so an aggregate
+Spearman at least :data:`MIN_SPEARMAN_ROWS`. On the v3 freeze's 410 pools that is 339 and 211 — so an aggregate
 that quietly averaged the excluded pools in would be reporting mostly arithmetic. ``regret@10`` is the strictest:
-it needs eleven rows, and at the freeze's median pool size of five it excludes most of the corpus. The rank
-metrics have no minimum, so they carry no count of their own.
+it needs eleven rows, which 81 pools have, so at the freeze's median pool size of five it excludes most of the
+corpus. The rank metrics have no minimum, so they carry no count of their own.
 
 Polarity is handled once, here. ``score`` returns ranking QUALITY (higher = predicted faster, the
 :meth:`Prior.score_rows` contract); the regret and correlation families take a cost (lower = faster), so this
@@ -57,7 +57,7 @@ from emmy.compiler.pipeline.search.metrics import best_dual_rank, spearman, topk
 # Deliberately below the deploy gate's :data:`~.base._CALIBRATION_MIN_GROUP` (8), which is the same statistic on
 # a different job. That one decides whether a model may own deploys, over the model's OWN reservoir, where more
 # rows are always available and a false pass is expensive. This one describes an external corpus of fixed size:
-# raising it to 8 would drop the freeze from 211 pools to well under half of that and report a card as unmeasured
+# raising it to 8 would drop the freeze well below its 211 measurable pools and report a card as unmeasured
 # rather than measured noisily.
 MIN_SPEARMAN_ROWS = 5
 

--- a/scripts/freeze_node_store.py
+++ b/scripts/freeze_node_store.py
@@ -16,7 +16,7 @@ same DB twice yields the same digests.
     ./venv/bin/python scripts/freeze_node_store.py --note "three-slice sweep, 4090+5090"
 
 The source DB is never modified. Evals accept the freeze wherever they accept the DB:
-``emmy eval online --dataset nodes --db <freeze-dir>``.
+``emmy eval prior --dataset nodes --db <freeze-dir>``.
 """
 
 from __future__ import annotations

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
+from unittest.mock import patch
+
+from tests.compiler.pipeline.search.helpers import GPU_5090 as _GPU
 
 
 def _make_tune_db(path: Path, variants: list[tuple[str, str, dict, float]]) -> None:
@@ -565,79 +568,117 @@ def test_failures_old_db_without_error_column(run_cli, tmp_path):
     assert "(no error recorded)" in stdout
 
 
-# --- eval online --dataset db --------------------------------------------------
+# --- eval prior ----------------------------------------------------------------
 
 
-def test_prior_db_reachability_smoke(run_cli, tmp_path):
-    """``eval online --dataset db`` on a 2-row DB renders the aggregate reachability
-    view — the groups must reach ``diagnostics.reachability`` as ``Sample``s, not
-    ``(knobs, latency)`` tuples (the shape mismatch that crashed it)."""
+def test_prior_rejects_the_leaf_only_db_dataset(run_cli, tmp_path):
+    """``--dataset db`` reads fully-decided leaf rows with no op identity or compile regime on them, so there is
+    nothing to group a comparison set by. The same DB read as ``--dataset nodes`` has both, and the error says
+    so rather than emitting an empty table."""
     db = tmp_path / "r.db"
-    # A realistic stamped matmul histogram (``_matmul_sig``: product → reduce-add
-    # over 2 distinct inputs). Real rows never carry ``S_n_mma > 0`` — the stamp
-    # runs before the tile tier emits ``Mma`` — so the label keys on the histogram.
-    mm = {"S_ext_free_prod": 1024.0, "S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0}
-    _make_tune_db(
-        db,
-        [
-            ("a", "k_matmul", {"BM": 8, **mm}, 30.0),
-            ("b", "k_matmul", {"BM": 16, **mm}, 10.0),
-        ],
-    )
-    rc, stdout, stderr = run_cli("eval", "online", "--dataset", "db", "--db", str(db), "--online-file", str(tmp_path / "missing.json"))
-    assert rc == 0, f"stderr: {stderr}"
-    assert "pick reachability over DB variants" in stdout
-    assert "matmul" in stdout  # the op-label row rendered
-    assert "traceback" not in (stdout + stderr).lower()
+    _make_tune_db(db, [("a", "k_matmul", {"BM": 8}, 30.0)])
+    rc, stdout, stderr = run_cli("eval", "prior", "--dataset", "db", "--db", str(db))
+    assert rc == 2
+    assert "--dataset nodes" in stdout + stderr
 
 
-def test_pre_rename_cli_aliases(run_cli, tmp_path):
-    """The pre-rename spellings — the ``eval prior`` subcommand and the ``--prior``
-    flag — keep working as aliases for the renamed ``eval online`` / ``--online-file``."""
-    db = tmp_path / "r.db"
-    mm = {"S_ext_free_prod": 1024.0, "S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0}
-    _make_tune_db(
-        db,
-        [
-            ("a", "k_matmul", {"BM": 8, **mm}, 30.0),
-            ("b", "k_matmul", {"BM": 16, **mm}, 10.0),
-        ],
-    )
-    rc, stdout, stderr = run_cli("eval", "prior", "--dataset", "db", "--db", str(db), "--prior", str(tmp_path / "missing.json"))
-    assert rc == 0, f"stderr: {stderr}"
-    assert "pick reachability over DB variants" in stdout
-
-
-def test_prior_nodes_smoke(run_cli, tmp_path):
-    """``eval online --dataset nodes`` renders the fork sibling-ranking AND the leaf
-    reachability over the search-tree node store (one fork, two leaf children) —
-    ONCE PER PRIOR HALF, explicitly labeled, so a regret number is never ambiguous
-    about which ranker (offline vs online) produced it. With no fitted checkpoint
-    the offline block carries the metrics and the online block says it's unfitted."""
+def test_prior_reports_both_halves_over_benched_pools(run_cli, tmp_path):
+    """``eval prior --dataset nodes`` renders the shared report over the node store: one cell per card and
+    compile regime, labelled by prior half. With no fitted checkpoint the online half is named as absent
+    rather than answered for — a cold model scores every row the same constant, which in a table is
+    indistinguishable from a trained model that collapsed."""
     from emmy.compiler.pipeline.search.db import NodeRow, SearchDB
 
     db_path = tmp_path / "n.db"
     db = SearchDB(db_path)
-    s = {"S_ext_free_prod": 1024.0, "S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0}
+    s = {"S_ext_free_prod": 1024.0, "S_ext_reduce_max": 512.0, "S_loop_depth": 2.0, "H_cc": 120.0, "H_opt": 3.0}
     db.record_nodes(
         [
-            NodeRow("P", None, "ctx", "mm", s, 1.0, 1),
-            NodeRow("c8", "P", "ctx", "mm", {**s, "BN": 32, "BM": 8}, 1.0, 2),
-            NodeRow("c64", "P", "ctx", "mm", {**s, "BN": 32, "BM": 64}, 3.0, 2),
+            NodeRow("P", None, "ctx", "mm", s, 1.0, 1, gpu=_GPU, is_leaf=False),
+            NodeRow("c8", "P", "ctx", "mm", {**s, "BN": 32, "BM": 8}, 3.0, 2, gpu=_GPU, is_leaf=True),
+            NodeRow("c64", "P", "ctx", "mm", {**s, "BN": 32, "BM": 64}, 1.0, 2, gpu=_GPU, is_leaf=True),
         ]
     )
     db.close()
-    rc, stdout, stderr = run_cli(
-        "eval", "online", "--dataset", "nodes", "--db", str(db_path), "--online-file", str(tmp_path / "missing.json")
+    rc, stdout, stderr = run_cli("eval", "prior", "--dataset", "nodes", "--db", str(db_path), "--online-file", str(tmp_path / "no.json"))
+    assert rc == 0, f"stderr: {stderr}"
+    assert "No fitted online prior" in stdout  # the online half is named absent, not reported as flat
+    assert "ranking quality over benched pools" in stdout
+    assert "offline" in stdout and "O3" in stdout
+    # The per-fork view still runs beside the cells: it answers what a pool of benched leaves cannot, and it is
+    # retired with the rest of the fork machinery rather than by the report landing.
+    assert "per-fork view" in stdout and "node store: 3 nodes" in stdout
+    assert "traceback" not in (stdout + stderr).lower()
+
+
+def test_report_renders_both_dataset_kinds_with_their_own_columns():
+    """The renderer picks its columns from the report's dataset, since that is what decided which metrics the
+    cells carry. Both branches are exercised here rather than through a corpus build, which costs minutes."""
+    import emmy.commands.eval as eval_cmd
+    from emmy.compiler.pipeline.search.data.group import GoldenGroup, MeasuredGroup
+    from emmy.compiler.pipeline.search.prior.report import EvalReport, golden_cells, measured_cells
+
+    feats = [{"D_a": float(i)} for i in range(3)]
+    by_d_a = lambda g: g.matrix(["D_a"])[:, 0]  # noqa: E731 — a one-line scorer stub
+    measured = MeasuredGroup.from_measured("g/op@O3", "g", "op", 3.0, [30.0, 20.0, 10.0], feats)
+    golden = GoldenGroup.from_dicts("g/k", "k", "warp", "g", "k", 0, feats, 50_000)
+
+    lines: list[str] = []
+    with patch.object(eval_cmd.logger, "info", lambda fmt, *a: lines.append(str(fmt) % a if a else str(fmt))):
+        eval_cmd._emit_report(EvalReport({"dataset": "nodes", "source": "freeze"}, measured_cells("offline", [measured], by_d_a)))
+        eval_cmd._emit_report(EvalReport({"dataset": "golden", "source": "corpus"}, golden_cells("online", [golden], by_d_a)))
+    text = "\n".join(lines)
+
+    assert "rho" in text and "regret@1" in text and "1.00x (1)" in text
+    assert "SCREEN" in text  # the golden block says what a rank is not
+    assert "top1" in text and "0/1" in text  # the golden ranks last under this scorer
+    assert ">=10k" in text  # and its pool bucket, without which the rank is unreadable
+
+
+def test_an_unmeasurable_metric_renders_a_dash_rather_than_a_number():
+    """Nothing in the cell qualified — which must not read as a value of zero."""
+    import emmy.commands.eval as eval_cmd
+    from emmy.compiler.pipeline.search.data.group import MeasuredGroup
+    from emmy.compiler.pipeline.search.prior.report import EvalReport, measured_cells
+
+    one_row = MeasuredGroup.from_measured("g/op@O3", "g", "op", 3.0, [10.0], [{"D_a": 1.0}])
+    cells = measured_cells("offline", [one_row], lambda g: g.matrix(["D_a"])[:, 0])
+
+    lines: list[str] = []
+    with patch.object(eval_cmd.logger, "info", lambda fmt, *a: lines.append(str(fmt) % a if a else str(fmt))):
+        eval_cmd._emit_report(EvalReport({"dataset": "nodes", "source": "freeze"}, cells))
+
+    assert cells[0].metrics["regret1"]["median"] is None
+    assert "—" in "\n".join(lines)
+
+
+def test_prior_writes_the_report_as_json(run_cli, tmp_path):
+    """``--json`` writes the cells, so two runs are compared with ``diff`` instead of by eye.
+
+    Also pins the pre-rename ``--prior`` spelling of ``--online-file``: it lives in shell profiles and scripts."""
+    from emmy.compiler.pipeline.search.db import NodeRow, SearchDB
+
+    db_path = tmp_path / "n.db"
+    db = SearchDB(db_path)
+    s = {"S_ext_free_prod": 1024.0, "S_ext_reduce_max": 512.0, "S_loop_depth": 2.0, "H_cc": 120.0, "H_opt": 3.0}
+    db.record_nodes(
+        [
+            NodeRow("c8", None, "ctx", "mm", {**s, "BM": 8}, 3.0, 2, gpu=_GPU, is_leaf=True),
+            NodeRow("c64", None, "ctx", "mm", {**s, "BM": 64}, 1.0, 2, gpu=_GPU, is_leaf=True),
+        ]
+    )
+    db.close()
+    out = tmp_path / "report.json"
+    rc, _stdout, stderr = run_cli(
+        "eval", "prior", "--dataset", "nodes", "--db", str(db_path), "--json", str(out), "--prior", str(tmp_path / "no.json")
     )
     assert rc == 0, f"stderr: {stderr}"
-    assert "=== offline prior" in stdout
-    assert "=== online prior" in stdout
-    assert "node store: 3 nodes" in stdout  # the offline block's metrics
-    assert "fork sibling regret" in stdout
-    assert "leaf reachability" in stdout
-    assert "not fitted" in stdout  # the online block, with no checkpoint, says so instead of silently answering offline
-    assert "traceback" not in (stdout + stderr).lower()
+    obj = json.loads(out.read_text())
+    assert obj["header"]["dataset"] == "nodes" and obj["header"]["groups"] == 1
+    (cell,) = obj["cells"]
+    assert cell["axes"] == {"half": "offline", "gpu": _GPU, "H_opt": "O3"}
+    assert set(cell["metrics"]) == {"spearman", "regret1", "regret10"}
+    assert cell["metrics"]["regret1"]["groups"] == 1
 
 
 def test_nodes_dataset_rejected_by_db_only_subcommand(run_cli, tmp_path):
@@ -757,42 +798,6 @@ def test_bare_families_canonicalizes_axis_suffixed_knobs():
     assert got == {"TILE": "f2x4", "WORK": "t16x8", "STAGE": "d3/smem-tma", "REDUCE": "g2a"}
     # bare keys pass through; first key wins a family collision (single-node picks in practice)
     assert _bare_families({"TILE": "a", "TILE@x": "b"}) == {"TILE": "a"}
-
-
-def test_offline_eval_scores_each_golden_under_its_own_card(monkeypatch):
-    """``eval offline`` must featurize a golden under the golden's OWN card
-    (``Context.from_target(cap, gpu_name=...)``), never the live host's. With the
-    ``gpu_name`` dropped, the SM count fell back to the host device (or the GPU-less
-    default), so the occupancy features priced tiles for a card that doesn't exist —
-    the eval said rank 0 on gemma goldens the real 4090 misdeployed 12-29x. The fitter
-    (now ``emmy fit``'s case builder) already passed it; this pins the eval side to match."""
-    from types import SimpleNamespace
-
-    import emmy.commands.eval as eval_cmd
-
-    golden = SimpleNamespace(
-        name="gemma4_12b.q_proj",
-        knobs={"TILE": "mma_m16n8k16_f16_f32/f4x4/k2", "WORK": "w2x2"},
-        gpu_name="NVIDIA GeForce RTX 4090",
-        compute_cap=(8, 9),
-    )
-    from emmy.compiler.pipeline.search.golden_eval import Ranked
-
-    seen: list = []
-
-    def fake_evaluate_record(record, ctx):
-        seen.append(ctx)
-        return Ranked(dict(record.knobs), 0, 1, 0)
-
-    monkeypatch.setattr(eval_cmd, "_golden_configs", lambda _f: [golden])
-    monkeypatch.setattr("emmy.compiler.pipeline.search.golden_eval.evaluate_record", fake_evaluate_record)
-    eval_cmd._emit_offline_eval(None)
-
-    assert len(seen) == 1
-    ctx = seen[0]
-    assert ctx.gpu_name == "NVIDIA GeForce RTX 4090"
-    assert ctx.sm_count == 128  # the 4090's registered SM count, regardless of the host GPU
-    assert ctx.compute_capability == (8, 9)
 
 
 def test_offer_audit_flags_unrealized_entries_and_fall_through(monkeypatch, caplog):

--- a/tests/compiler/pipeline/search/data/test_group.py
+++ b/tests/compiler/pipeline/search/data/test_group.py
@@ -45,10 +45,30 @@ def test_the_key_separates_cards_ops_and_nvcc_regimes():
     assert len(groups) == 4 and all(len(g.feats) == 1 for g in groups)
 
 
+def test_one_offer_site_over_different_work_is_not_one_group():
+    """``op_sig`` names where a decision was OFFERED, not what got computed: it digests the pre-descent offer
+    op's stamps, and one site can be realized as kernels doing wildly different amounts of work — a fused op
+    against one kernel of a split pair. Both rows are honest measurements; comparing their latencies is not.
+
+    Left merged this cost a real number: nine pools of the RTX 5090 freeze mixed two workloads a median 8192x
+    apart, and the report priced a 5.9 µs row against a 131 ms one as a 22 221x miss when both ran at about
+    35 TFLOP/s."""
+    small = _feats(S_ext_free_prod=30720.0, S_ext_reduce_prod=3840.0, REDUCE="coop")
+    large = _feats(S_ext_free_prod=69632.0, S_ext_reduce_prod=14745600.0, REDUCE="coop")
+    # Both latencies are plausible for their OWN extents — the point is the grouping, so neither row may be
+    # one the plausibility gate would have dropped anyway.
+    rows = [_row("small", value_us=2000.0, features=small), _row("large", value_us=131496.0, features=large)]
+
+    groups, dropped = group_measured(rows)
+    assert not dropped
+    assert [g.latency_us.tolist() for g in groups] == [[2000.0], [131496.0]]
+
+
 def test_one_op_scheduled_two_ways_stays_one_group():
-    """The reason the key is ``op_sig`` and not the structural signature: these two rows are alternative
-    SCHEDULES for one op, and a key that split them would leave two groups of one row each — nothing to
-    rank, and the comparison the metric exists for silently gone."""
+    """The other side of the same line: the key is ``op_sig`` plus the EXTENTS, not the whole structural
+    signature. These two rows are alternative SCHEDULES for one op over identical extents — descent moved an
+    ``S_*`` stamp that is not one — and a key that split them would leave two groups of one row each,
+    nothing to rank, and the comparison the metric exists for silently gone."""
     rows = [
         _row("a", value_us=200.0, features=_feats(TILE="f2x2", S_loop_depth=3.0)),
         _row("b", value_us=400.0, features=_feats(TILE="f8x8", S_loop_depth=2.0)),  # descent moved an S_* stamp

--- a/tests/compiler/pipeline/search/data/test_group.py
+++ b/tests/compiler/pipeline/search/data/test_group.py
@@ -26,7 +26,7 @@ def test_configs_that_competed_land_in_one_group():
     rows = [_row(f"n{i}", value_us=200.0 + 100 * i, features=_feats(TILE=f"f2x{2 + i}")) for i in range(4)]
     (group,), dropped = group_measured(rows)
     assert not dropped
-    assert group.labels.tolist() == [200.0, 300.0, 400.0, 500.0]
+    assert group.latency_us.tolist() == [200.0, 300.0, 400.0, 500.0]
     assert len(group.feats) == 4 and group.gpu == _GPU
 
 
@@ -67,7 +67,7 @@ def test_a_branchs_value_is_not_a_measurement():
     ]
     (group,), dropped = group_measured(rows)
     assert dropped == {"non-leaf (branch or pre-enrichment row)": 2}
-    assert group.labels.tolist() == [500.0]
+    assert group.latency_us.tolist() == [500.0]
 
 
 def test_a_failed_bench_carries_a_sentinel_not_a_latency():
@@ -79,7 +79,7 @@ def test_a_failed_bench_carries_a_sentinel_not_a_latency():
     ]
     (group,), dropped = group_measured(rows)
     assert dropped == {"bench_fail": 1}
-    assert group.labels.tolist() == [500.0]
+    assert group.latency_us.tolist() == [500.0]
 
 
 def test_every_row_is_either_grouped_or_counted():
@@ -102,14 +102,28 @@ def test_every_row_is_either_grouped_or_counted():
 def test_only_a_golden_pool_can_be_asked_which_rows_are_the_answer():
     """The two kinds differ in what can be ASKED of them, which is why they are two types. A measured pool
     has no ``golden_ids`` at all — not an empty one, not a raising one — so a rank metric that needs them
-    says so by taking :class:`GoldenGroup`, and nothing has to check a flag at runtime."""
+    says so by taking :class:`GoldenGroup`, and nothing has to check a flag at runtime. The supervision lives
+    on the subclasses for the same reason: on the base it would be one field with two meanings."""
     rows = [_row(f"n{i}", value_us=200.0 + 100 * i, features=_feats(TILE=f"f2x{2 + i}")) for i in range(3)]
     (measured,), _ = group_measured(rows)
     golden = GoldenGroup.from_dicts("g/x", "x", "warp", "g", "x", 1, [{"D_a": float(i)} for i in range(3)])
 
-    assert measured.labels.tolist() == [200.0, 300.0, 400.0]  # the measurement IS the label
+    assert measured.latency_us.tolist() == [200.0, 300.0, 400.0]  # per row, in microseconds
     assert golden.golden_ids == (1,)
     assert isinstance(golden, Group) and not hasattr(measured, "golden_ids")
+    assert not hasattr(golden, "latency_us")  # and the reverse: a golden pool has no measurement to report
+
+
+def test_a_measured_pool_carries_the_regime_it_was_measured_under():
+    """``h_opt`` is on the group, not recovered from its packed columns, because it is what DECIDED the
+    group: rows measured under different nvcc regimes never competed. A report keys a cell on it, so it has
+    to survive the trip from the row to the pool."""
+    rows = [
+        _row("a", value_us=200.0, features=_feats(opt=3.0)),
+        _row("b", value_us=300.0, features=_feats(opt=1.0)),
+    ]
+    groups, _ = group_measured(rows)
+    assert sorted(g.h_opt for g in groups) == [1.0, 3.0]
 
 
 def test_goldens_go_in_as_row_indices_and_come_back_as_row_indices():
@@ -135,5 +149,5 @@ def test_a_row_the_freeze_would_refuse_is_refused_here_too():
         _row("phantom", value_us=0.05, features=_feats(TILE="f8x8")),
     ]
     groups, dropped = group_measured(rows)
-    assert [g.labels.tolist() for g in groups] == [[500.0]]
+    assert [g.latency_us.tolist() for g in groups] == [[500.0]]
     assert sorted(dropped) == ["implausible value", "stale feat_ver 1 != current 3"]

--- a/tests/compiler/pipeline/search/data/test_group.py
+++ b/tests/compiler/pipeline/search/data/test_group.py
@@ -30,25 +30,40 @@ def test_configs_that_competed_land_in_one_group():
     assert len(group.feats) == 4 and group.gpu == _GPU
 
 
-def test_the_key_separates_cards_ops_and_nvcc_regimes():
-    """Three axes, three reasons. Cards never pool. Ops never pool — and ``op_sig`` is the DB's own identity,
-    not the ``S_*`` signature, which descent stamps its own deltas into and which would therefore split one
-    op's alternative schedules apart. Regimes never pool because ``-O1`` and ``-O3`` invert."""
+def test_the_key_separates_cards_and_nvcc_regimes():
+    """Two axes, two reasons. Cards never pool. Regimes never pool because ``-O1`` and ``-O3`` invert."""
     rows = [
         _row("a", value_us=200.0, features=_feats(opt=3.0)),
-        _row("b", value_us=300.0, features=_feats(opt=1.0)),  # same op, other regime
-        _row("c", value_us=400.0, features=_feats(opt=3.0), op_sig="other"),
+        _row("b", value_us=300.0, features=_feats(opt=1.0)),  # same kernel, other regime
         _row("d", value_us=500.0, features=_feats(opt=3.0), gpu=_GPU2),
     ]
     groups, dropped = group_measured(rows)
     assert not dropped
-    assert len(groups) == 4 and all(len(g.feats) == 1 for g in groups)
+    assert len(groups) == 3 and all(len(g.feats) == 1 for g in groups)
+
+
+def test_the_same_kernel_from_two_sites_is_one_tuning_problem():
+    """The key is the KERNEL's structure, not the ``op_sig`` column, which digests the pre-descent offer op.
+
+    A kernel a placement cut minted is an independent kernel — ``_cut.py`` mints it and the identity strategy
+    stamps it at birth — so tuning it is the same question as tuning an identical kernel nobody split, and
+    the deploy path already joins their evidence that way (``Prior.evidence_pick`` indexes on ``S_*``).
+    Keyed on ``op_sig`` the two land in different pools and get searched twice: on the RTX 5090 freeze 73
+    structures were fragmented like that, the losing pool's best coming in a median 1.46x behind the
+    winning pool's."""
+    rows = [
+        _row("from-a-cut", value_us=200.0, features=_feats(TILE="f2x2"), op_sig="site-of-the-fused-parent"),
+        _row("standalone", value_us=150.0, features=_feats(TILE="f4x4"), op_sig="its-own-site"),
+    ]
+    (group,), dropped = group_measured(rows)
+    assert not dropped
+    assert sorted(group.latency_us.tolist()) == [150.0, 200.0]
 
 
 def test_one_offer_site_over_different_work_is_not_one_group():
-    """``op_sig`` names where a decision was OFFERED, not what got computed: it digests the pre-descent offer
-    op's stamps, and one site can be realized as a single kernel or as several. Both rows are then honest
-    measurements — of a whole op and of a piece of one — and comparing their latencies is not.
+    """The over-merging half of the same mistake. ``op_sig`` names where a decision was OFFERED, not what got
+    computed, so one site can be realized as a single kernel or as several — and then both rows are honest
+    measurements, of a whole op and of a piece of one, while comparing their latencies is not.
 
     Left merged this cost a real number: nine pools of the RTX 5090 freeze paired a fused rms_norm->linear
     megakernel with one kernel of the same op's unfused realization, and the report priced a 5.9 µs norm
@@ -61,17 +76,19 @@ def test_one_offer_site_over_different_work_is_not_one_group():
 
     groups, dropped = group_measured(rows)
     assert not dropped
-    assert [g.latency_us.tolist() for g in groups] == [[2000.0], [131496.0]]
+    assert sorted(g.latency_us.tolist() for g in groups) == [[2000.0], [131496.0]]
 
 
-def test_one_op_scheduled_two_ways_stays_one_group():
-    """The other side of the same line: the key is ``op_sig`` plus the EXTENTS, not the whole structural
-    signature. These two rows are alternative SCHEDULES for one op over identical extents — descent moved an
-    ``S_*`` stamp that is not one — and a key that split them would leave two groups of one row each,
-    nothing to rank, and the comparison the metric exists for silently gone."""
+def test_alternative_schedules_of_one_kernel_stay_one_group():
+    """Two schedules of one kernel share every ``S_*`` stamp, so they share a pool — which is what makes a
+    pool a comparison at all.
+
+    They share them by construction, not by luck: the identity strategy stamps a kernel at BIRTH, in
+    recognition, before ``020_schedule`` offers the first fork — that pass's own error text says so. Nothing
+    a schedule fork decides can move an ``S_*`` value, which is what makes keying on them safe."""
     rows = [
-        _row("a", value_us=200.0, features=_feats(TILE="f2x2", S_loop_depth=3.0)),
-        _row("b", value_us=400.0, features=_feats(TILE="f8x8", S_loop_depth=2.0)),  # descent moved an S_* stamp
+        _row("a", value_us=200.0, features=_feats(TILE="f2x2", WORK="w1x8")),
+        _row("b", value_us=400.0, features=_feats(TILE="f8x8", WORK="w4x2")),
     ]
     (group,), _ = group_measured(rows)
     assert len(group.feats) == 2

--- a/tests/compiler/pipeline/search/data/test_group.py
+++ b/tests/compiler/pipeline/search/data/test_group.py
@@ -47,12 +47,12 @@ def test_the_key_separates_cards_ops_and_nvcc_regimes():
 
 def test_one_offer_site_over_different_work_is_not_one_group():
     """``op_sig`` names where a decision was OFFERED, not what got computed: it digests the pre-descent offer
-    op's stamps, and one site can be realized as kernels doing wildly different amounts of work — a fused op
-    against one kernel of a split pair. Both rows are honest measurements; comparing their latencies is not.
+    op's stamps, and one site can be realized as a single kernel or as several. Both rows are then honest
+    measurements — of a whole op and of a piece of one — and comparing their latencies is not.
 
-    Left merged this cost a real number: nine pools of the RTX 5090 freeze mixed two workloads a median 8192x
-    apart, and the report priced a 5.9 µs row against a 131 ms one as a 22 221x miss when both ran at about
-    35 TFLOP/s."""
+    Left merged this cost a real number: nine pools of the RTX 5090 freeze paired a fused rms_norm->linear
+    megakernel with one kernel of the same op's unfused realization, and the report priced a 5.9 µs norm
+    kernel against a 131 ms whole-op row as a 22 221x miss."""
     small = _feats(S_ext_free_prod=30720.0, S_ext_reduce_prod=3840.0, REDUCE="coop")
     large = _feats(S_ext_free_prod=69632.0, S_ext_reduce_prod=14745600.0, REDUCE="coop")
     # Both latencies are plausible for their OWN extents — the point is the grouping, so neither row may be

--- a/tests/compiler/pipeline/search/prior/test_prior_fit.py
+++ b/tests/compiler/pipeline/search/prior/test_prior_fit.py
@@ -7,7 +7,7 @@ guarantees the extraction from the original fit script must keep:
 2. The fit-time rank evaluation and the deployed :class:`OfflinePrior` scoring
    order candidates identically for the shipped incumbent weights — including the
    atomic-free interaction, which both sides now read through one shared definition.
-   That is the invariant that makes fit-time golden ranks transfer to ``eval offline``
+   That is the invariant that makes fit-time golden ranks transfer to ``eval prior``
    and greedy-deploy ranks.
 """
 

--- a/tests/compiler/pipeline/search/prior/test_report.py
+++ b/tests/compiler/pipeline/search/prior/test_report.py
@@ -1,0 +1,152 @@
+"""The evaluation report — cells, exclusions, and the two questions it keeps apart.
+
+Everything here is synthetic: the report computes no metric of its own (``search/metrics.py`` owns those and
+has its own tests) and reads no file. What it DOES own is which pools a number covers, and that is what these
+tests pin — an aggregate that quietly averaged in the pools it could not measure would look healthier than the
+model is, which is the failure this whole module exists to prevent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from emmy.compiler.pipeline.search.data.group import GoldenGroup, MeasuredGroup
+from emmy.compiler.pipeline.search.prior.report import EvalReport, golden_cells, measured_cells, pool_bucket
+
+
+def _measured(key: str, latencies: list[float], *, gpu: str = "card-a", h_opt: float = 3.0) -> MeasuredGroup:
+    """A benched pool whose rows carry one feature, ``D_a``, ascending — so a scorer that ranks by ``D_a``
+    ranks them in a known order and the metric values are hand-checkable."""
+    feats = [{"D_a": float(i)} for i in range(len(latencies))]
+    return MeasuredGroup.from_measured(key, gpu, key, h_opt, latencies, feats)
+
+
+def _golden(key: str, n_rows: int, golden_row: int, *, total: int | None = None, tier: str = "warp") -> GoldenGroup:
+    feats = [{"D_a": float(i)} for i in range(n_rows)]
+    return GoldenGroup.from_dicts(key, key, tier, "card-a", key, golden_row, feats, total)
+
+
+def _by_d_a(group):
+    """Ranks a pool by its ``D_a`` column DESCENDING — quality, higher = predicted faster."""
+    return group.matrix(["D_a"])[:, 0]
+
+
+def test_regret_is_the_ratio_the_pick_costs_over_the_measured_best():
+    """A perfect ranking is 1.00x; a model that picks the second-best pays exactly that row's ratio."""
+    # ``_by_d_a`` calls row 2 fastest. Make row 2 the measured best, then make it the measured worst.
+    perfect = measured_cells("offline", [_measured("k", [30.0, 20.0, 10.0])], _by_d_a)[0]
+    missed = measured_cells("offline", [_measured("k", [10.0, 20.0, 30.0])], _by_d_a)[0]
+
+    assert perfect.metrics["regret1"]["median"] == 1.0
+    assert missed.metrics["regret1"]["median"] == 3.0  # picked 30 µs where 10 µs was there
+    assert perfect.metrics["spearman"] is not None  # computed only above the minimum pool size — see below
+
+
+def test_a_pool_too_small_for_a_metric_is_excluded_and_the_count_says_so():
+    """Each metric has its own minimum and its own group count. A cell holding a one-row pool, a three-row
+    pool and a twelve-row pool covers a different number of pools with each metric, and the difference is
+    the whole reason the counts travel with the values."""
+    groups = [_measured("one", [10.0]), _measured("three", [30.0, 20.0, 10.0]), _measured("twelve", [float(12 - i) for i in range(12)])]
+    cell = measured_cells("offline", groups, _by_d_a)[0]
+
+    assert cell.groups == 3
+    assert cell.metrics["regret1"]["groups"] == 2  # the one-row pool has no second candidate to be wrong about
+    assert cell.metrics["spearman"]["groups"] == 1  # needs five rows
+    assert cell.metrics["regret10"]["groups"] == 1  # needs eleven — a top-10 over ten rows is the whole pool
+
+
+def test_a_pool_the_model_cannot_score_is_counted_not_dropped():
+    """A linear model with no dynamic weight set answers ``None`` for every symbolic-axis pool. Dropping
+    those silently would report a healthy static corpus with no sign that the rest is unmeasured."""
+    groups = [_measured("a", [20.0, 10.0]), _measured("b", [20.0, 10.0])]
+    cell = measured_cells("offline", groups, lambda g: None if g.key == "b" else _by_d_a(g))[0]
+
+    assert (cell.groups, cell.unscored) == (2, 1)
+    assert cell.metrics["regret1"]["groups"] == 1
+
+
+def test_measured_cells_key_on_card_and_compile_regime():
+    """Cards never pool, and neither do nvcc regimes — ``-O1`` and ``-O3`` reorder the same candidates."""
+    groups = [
+        _measured("a", [20.0, 10.0], gpu="card-a", h_opt=3.0),
+        _measured("b", [20.0, 10.0], gpu="card-a", h_opt=1.0),
+        _measured("c", [20.0, 10.0], gpu="card-b", h_opt=3.0),
+    ]
+    cells = measured_cells("offline", groups, _by_d_a)
+
+    assert [(c.axes["gpu"], c.axes["H_opt"]) for c in cells] == [("card-a", "O1"), ("card-a", "O3"), ("card-b", "O3")]
+    assert all(c.axes["half"] == "offline" for c in cells)
+
+
+def test_golden_cells_stratify_by_pool_size():
+    """A rank is only readable against the pool it was scored over: a corpus whose small pools rank
+    perfectly and whose large ones rank at chance must not report one flattering middle number."""
+    assert [pool_bucket(n) for n in (5, 99, 100, 999, 1_000, 9_999, 10_000, 10**6)] == [
+        "<100",
+        "<100",
+        "<1k",
+        "<1k",
+        "<10k",
+        "<10k",
+        ">=10k",
+        ">=10k",
+    ]
+    groups = [_golden("small", 3, 2, total=40), _golden("huge", 3, 0, total=200_000)]
+    cells = golden_cells("offline", groups, _by_d_a)
+
+    assert [c.axes["pool"] for c in cells] == ["<100", ">=10k"]
+    assert cells[0].metrics["rank"]["median"] == 0  # ``_by_d_a`` ranks row 2 first, and row 2 is the golden
+    assert cells[1].metrics["rank"]["median"] == 2  # the golden is row 0, which this scorer ranks last
+    assert (cells[0].metrics["top1"]["count"], cells[1].metrics["top1"]["count"]) == (1, 0)
+
+
+def test_a_pool_with_several_verified_rows_is_scored_on_the_best_of_them():
+    """Deploy ships one config, so any acceptable one ranked first is the same win."""
+    feats = [{"D_a": float(i)} for i in range(4)]
+    both = GoldenGroup.from_dicts("k", "k", "warp", "card-a", "k", (0, 3), feats)
+    (cell,) = golden_cells("offline", [both], _by_d_a)
+
+    assert cell.metrics["rank"]["median"] == 0  # row 3 ranks first; row 0 ranking last does not count against it
+
+
+def test_the_report_serializes_to_a_diffable_schema():
+    """Two runs of the same evaluation must produce byte-identical JSON — it is compared with ``diff``."""
+    cells = measured_cells("offline", [_measured("k", [30.0, 20.0, 10.0])], _by_d_a)
+    report = EvalReport({"dataset": "nodes", "source": "freeze"}, cells)
+    obj = report.to_json()
+
+    assert obj["header"] == {"dataset": "nodes", "source": "freeze"}
+    assert obj["cells"][0]["axes"] == {"half": "offline", "gpu": "card-a", "H_opt": "O3"}
+    assert obj["cells"][0]["groups"] == 1 and obj["cells"][0]["unscored"] == 0
+    assert EvalReport({"dataset": "nodes", "source": "freeze"}, cells).to_json() == obj
+
+
+def test_both_halves_are_labelled_in_one_report():
+    """The two halves fail for different reasons, so an unlabelled number destroys the diagnostic."""
+    groups = [_measured("k", [30.0, 20.0, 10.0])]
+    cells = measured_cells("offline", groups, _by_d_a) + measured_cells("online", groups, lambda g: -_by_d_a(g))
+
+    assert [c.axes["half"] for c in cells] == ["offline", "online"]
+    assert [c.metrics["regret1"]["median"] for c in cells] == [1.0, 3.0]  # each half's own answer
+
+
+def test_only_the_metrics_with_a_size_minimum_carry_their_own_count():
+    """A count that could only ever equal the cell's own scored total is noise repeated once per metric — and
+    on the golden side that is every one of them, since no rank metric excludes a pool for being small."""
+    (measured,) = measured_cells("offline", [_measured("k", [30.0, 20.0, 10.0])], _by_d_a)
+    (golden,) = golden_cells("offline", [_golden("k", 3, 0)], _by_d_a)
+
+    assert all("groups" in block for block in measured.metrics.values())
+    assert not any("groups" in block for block in golden.metrics.values())
+
+
+def test_quality_is_negated_into_a_cost_exactly_once():
+    """The rank family takes quality (higher = faster) and the regret family a cost (lower = faster). Getting
+    that backwards silently reverses every answer, so it is pinned on a pool where the two disagree."""
+    group = _measured("k", [10.0, 20.0, 30.0])  # row 0 is fastest; ``_by_d_a`` calls row 2 fastest
+    (cell,) = measured_cells("offline", [group], _by_d_a)
+
+    assert cell.metrics["spearman"] is not None
+    (flipped,) = measured_cells("offline", [group], lambda g: -_by_d_a(g))
+    assert flipped.metrics["regret1"]["median"] == 1.0  # the flipped scorer agrees with the hardware
+    assert np.isclose(cell.metrics["regret1"]["median"], 3.0)

--- a/tests/compiler/pipeline/search/prior/test_score_rows.py
+++ b/tests/compiler/pipeline/search/prior/test_score_rows.py
@@ -1,0 +1,96 @@
+"""``Prior.score_rows`` — the pool-shaped scoring surface every prior answers.
+
+The dict surfaces (``mean_scores`` / ``mean_scores_features``) cannot be used on the pools a ranking question
+is actually asked over: a matmul enumeration runs to ~10^5 rows and the per-row dict representation is what
+made the fit OOM. This one takes the packed pool. What each implementation must get right is its OWN column
+list and its OWN absent-value fill — which is why it cannot be one shared function — and one polarity, since
+the fitted model classes compute quality (higher = faster) while the online model regresses latency.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from emmy.compiler.pipeline.search.data.group import GoldenGroup
+from emmy.compiler.pipeline.search.prior.fallback import FallbackPrior
+from emmy.compiler.pipeline.search.prior.linear_model import LinearModel
+from emmy.compiler.pipeline.search.prior.offline import OfflinePrior
+from emmy.compiler.pipeline.search.prior.online import OnlinePrior
+
+
+def _group(feats: list[dict], *, tier: str = "thread") -> GoldenGroup:
+    return GoldenGroup.from_dicts("card/k", "k", tier, "card", "k", 0, feats)
+
+
+def _linear(**weights) -> OfflinePrior:
+    return OfflinePrior(
+        model=LinearModel(
+            weights=dict(weights), weights_dynamic=dict(weights), scale=1.0, atomic_free_weight=0.0, atomic_free_split_threshold=4.0
+        )
+    )
+
+
+def _stamp(dynamic: float = 0.0) -> dict:
+    """The routing stamp the featurizer writes on every row — 0.0 when no axis is symbolic, never absent."""
+    return {"S_ext_n_symbolic_axis": dynamic}
+
+
+def test_the_linear_half_scores_a_whole_pool_by_its_own_weights():
+    """Higher quality = predicted faster, and the model reads only the columns it has weights for — extra
+    columns in the pool are ignored rather than being an error."""
+    prior = _linear(D_a=2.0)
+    scores = prior.score_rows(_group([{**_stamp(), "D_a": 1.0, "D_unused": 99.0}, {**_stamp(), "D_a": 3.0}]))
+
+    assert scores.tolist() == [2.0, 6.0]
+
+
+def test_a_narrower_feature_view_does_not_move_the_linear_halfs_ranks():
+    """Why ``eval prior --dataset golden`` may build its pools over the FULL featurization while ``emmy fit``
+    trains under a narrow ``D_*`` view, and still report the same rank: the model projects the pool onto its
+    own weight names, so every column outside them is inert."""
+    prior = _linear(D_a=2.0)
+    narrow = [{**_stamp(), "D_a": 1.0}, {**_stamp(), "D_a": 3.0}]
+    wide = [{**row, "S_ext_free_prod": 4096.0, "H_opt": 3.0, "MMA_a_bits": 16.0} for row in narrow]
+
+    assert prior.score_rows(_group(narrow)).tolist() == prior.score_rows(_group(wide)).tolist()
+
+
+def test_the_linear_half_declines_a_pool_it_fitted_no_weight_set_for():
+    """``None``, not an exception and not a silent zero: an unfittable cross-validation fold and an
+    all-static fit both hit this, and a report has to count the pools rather than average them in."""
+    static_only = LinearModel(
+        weights={"D_a": 1.0}, weights_dynamic=None, scale=1.0, atomic_free_weight=0.0, atomic_free_split_threshold=4.0
+    )
+    prior = OfflinePrior(model=static_only)
+
+    assert prior.score_rows(_group([{**_stamp(), "D_a": 1.0}])) is not None
+    assert prior.score_rows(_group([{**_stamp(1.0), "D_a": 1.0}], tier="dyn")) is None
+
+
+def test_the_online_half_returns_quality_not_latency():
+    """It regresses ``log(latency µs)``, so the pool-shaped surface has to invert the polarity — otherwise
+    every rank the report computes off it is exactly backwards."""
+    prior = OnlinePrior(iterations=40)
+    # A single feature that IS the latency: BM=8 rows are slow, BM=64 rows are fast.
+    prior.add_rows([({**_stamp(), "BM": 8.0}, 100.0)] * 40 + [({**_stamp(), "BM": 64.0}, 5.0)] * 40)
+    prior.fit()
+
+    scores = prior.score_rows(_group([{**_stamp(), "BM": 8.0}, {**_stamp(), "BM": 64.0}]))
+    assert scores[1] > scores[0]  # the faster config scores HIGHER quality
+    assert prior.mean_score({**_stamp(), "BM": 64.0}) < prior.mean_score({**_stamp(), "BM": 8.0})  # µs: lower is better
+
+
+def test_an_unfit_online_half_answers_a_constant_rather_than_failing():
+    """A cold checkpoint must render as a model with no ranking ability, not crash a report."""
+    assert OnlinePrior().score_rows(_group([{"D_a": 1.0}, {"D_a": 2.0}])).tolist() == [0.0, 0.0]
+
+
+def test_the_composite_answers_with_the_half_that_owns_deploys():
+    """``FallbackPrior`` forwards to whichever half is live, exactly as its other scoring surfaces do — so a
+    report over the deployed prior decomposes the model that actually makes decisions."""
+    offline = _linear(D_a=2.0)
+    composite = FallbackPrior(OnlinePrior(), offline)  # online unfit → not trustworthy → offline owns deploys
+    group = _group([{**_stamp(), "D_a": 1.0}, {**_stamp(), "D_a": 3.0}])
+
+    assert not composite.trustworthy
+    assert np.array_equal(composite.score_rows(group), offline.score_rows(group))


### PR DESCRIPTION
One evaluation report, and the metric that tracks deployed speed beside the one that does not.

## What this is for

Whether the prior is any good has been judged by **golden rank** — where a recorded verified-optimum config lands when
the model scores its whole enumerated candidate pool. That metric was measured not to track the thing we care about:
44% of the corpus has pools under 100 candidates and contributes more top-1 hits than all 630 hard pools combined, a
rank is blind to the latency gap behind it, and CatBoost beat linear on held-out golden rank while being *worse* on
hardware. So golden rank is demoted to a screen, and ranking quality gains **Spearman** and **regret** measured over
pools where every candidate was actually benched.

There were also two golden-rank paths — `eval offline` and `eval online` — over different corpus subsets, scored by
different objects, summarised four different ways, and only `emmy fit` emitted anything machine-readable. This
collapses them into one.

## What lands

**`search/prior/report.py`** — `Cell`, `EvalReport`, `measured_cells`, `golden_cells`. It computes no metric itself
(`search/metrics.py` owns those), decides nothing about what to score, and prints nothing: it takes groups and a
scoring callable and returns something that serializes. Rendering is the CLI's job, where the console-table helper
already lives. `--json` writes the schema, so comparing two runs is a `diff`. `emmy fit` still emits its own metrics
layout and adopts these cells with the fold harness — the two share `TOP_KS` today so their coverage ladders cannot
drift apart in the meantime.

Two questions, kept apart because they are not interchangeable:

- a **measured** pool can answer what a wrong pick COST — Spearman, and regret at k=1 (the deploy question: the pick
  ships, so its latency IS the cost) and k=10 (the tuning question: bench the top ten, keep the measured best);
- a **golden** pool can only answer WHERE the known-good row landed, and is reported as a screen, stratified by pool
  size so a top-1 rate is readable against the pool it was scored over.

Every cell carries the axes it was keyed on as a dict — measured: `gpu` × `H_opt`; golden: `gpu` × `tier` × pool
bucket; both plus `half` — how many pools keyed into it, how many the model could not score at all, and, where a
metric has a size minimum and so covers fewer pools than the cell holds, that metric's own count.

**`Prior.score_rows(group)`** — the pool-shaped scoring surface, on the base with implementations in all three priors.
It returns ranking QUALITY (higher = predicted faster) or `None`. It exists because the dict surfaces cannot be used on
the pools these questions are asked over: a matmul enumeration runs to ~10⁵ rows, and the per-row dict that made the
fit OOM would make an evaluation OOM the same way. Each implementation projects the packed matrix onto its own columns
with its own absent-value fill, which is why it cannot be one shared function.

**`MeasuredGroup(Group)`** — the counterpart of `GoldenGroup`, carrying the per-row measured microseconds and `h_opt`,
the compile regime the pool was measured under. `h_opt` is part of the grouping key rather than a description of it
(`-O1` and `-O3` reorder the same candidates), and it is a field rather than a lookup into the packed `H_opt` column
for a mechanical reason: `Group.matrix` memoizes exactly one projection, so asking for the single-column one right
before a model asks for its own would evict and rebuild the model's projection for every group.

**Supervision moves off the base.** `Group.labels` is gone; `GoldenGroup` stores `golden_ids` and `MeasuredGroup`
stores `latency_us`. This was the open question from the previous PR, deferred until the report existed to settle it,
and the report settles it: nothing generic reads a label column — the metrics take plain sequences and never see a
group — so on the base it was one field with two mutually exclusive meanings. Removing it also deletes the marker
encode and its `flatnonzero` decode.

**`is_matmul` / `op_label` → `search/data/shape.py`** — they were `_matmul_sig` / `_op_label` / `_node_op_label` in
`diagnostics.py`: three spellings of one reading, in two argument shapes. Now one, beside `ShapeKey`, which reads the
same stamped histogram.

**`emmy eval prior`** replaces `eval offline` and `eval online`, reporting both halves as a labelled axis — they fail
for different reasons, so an unlabelled number destroys the diagnostic. `--dataset db` is rejected with a message
pointing at `--dataset nodes`, which reads the same DB and has the op identity and compile regime a comparison set
needs. `--dataset golden` still runs the deploy-faithful greedy-pick-vs-golden check the ranks are a screen for.

## Decisions worth knowing about

**The eval builds golden pools over the FULL featurization, not the fit's `D_*` view.** The view is a property of the
model being fitted, and the eval scores two model classes: the linear half reads only its own weight names, while the
online half regresses on the `S_*` / `H_*` columns a narrow view drops and would otherwise be asked about a kernel
with no shape. Measured on the `gemma4_12b.q_proj` corpus: **65 groups both ways, identical group keys, zero rank
differences** at 59 columns vs 94 — so the wide view neither splits nor merges pools differently, and the offline
half's ranks are unchanged. Pinned by a unit test too.

**The fork / node-tree block stays reachable one more PR.** `--blame` / `--ablate` and `diagnostics.node_report` still
run under `eval prior --dataset nodes`. Deleting the emitter here would orphan ~450 lines in `diagnostics.py` plus
`Dataset.from_node_rows` and the `masking_exact` chain, which the fork-machinery teardown removes together with their
docs, skills and tests. It also still answers something the cells cannot: a search is a sequence of partial-knob
decisions most of whose subtrees were never explored, and a golden sitting in an unexplored subtree is silence that
reads as health.

**A measured pool is keyed on the KERNEL, not on the site that offered it.** The report's first run put a 22 221×
worst-case regret on the board. It was not a model failure — it was the grouping key, and the key was wrong in two
opposite directions at once.

`op_sig` digests the **pre-descent offer op** (`bench_record.py:25` says so explicitly), so it names where a
decision was offered, not what got computed. That makes it **over-merge**: nine pools paired a fused
`rms_norm`→linear megakernel with a row for just *one kernel* of the same op's unfused realization — a 5.9 µs norm
kernel (`rsqrt=1, reduce_add=1, loads=5`) filed as a rival of the 131 ms whole op (`reduce_add=2, loads=6`). Where
the sibling matmul was recorded too, under its own `op_sig`, the unfused pair actually costs 24–191 µs.

It also **fragments**, which is the larger cost. **73 structures** were searched in two separate pools — the same
kernel tuned twice because a placement cut minted one copy of it — and the losing pool's best came in a **median
1.46×** behind the winning pool's (p90 3.89×, worst 14×; 58 of 73 exceed 10%). One concrete pair: identical `S_*`,
identical card and regime, one pool finding 144.56 µs and the other 111.93 µs for the same kernel.

So the key is now the row's own `S_*` digest — the same digest `Identity.op_sig` computes for an op, asked of the
kernel that ran. A kernel a cut minted is an independent kernel and tuning it is the same question as tuning an
identical kernel nobody split. That is not a new idea here: **the deploy path already joins evidence this way** —
`Prior.evidence_pick` and `policy/greedy._db_measured_pick` both index on the `S_*` signature — so this makes the
comparison sets agree with the tier that consumes them.

It is safe against the obvious objection because the compiler settles it: the identity strategy stamps a kernel **at
birth**, in recognition, before `020_schedule` offers the first fork (that pass's own error text says so). Nothing a
schedule fork decides can move an `S_*` value, so sibling schedules cannot be split apart.

| key | pools | rows beside a rival | median pool | mixed |
|---|---|---|---|---|
| `op_sig` | 401 | 3760 | 5 | 9 |
| **the kernel's own `S_*`** | **336** | **3778 / 3817** | **7** | **0** |

The pool count falls because merging is the point; what a metric needs is rivals per row.

**`build_golden_groups` gains a `kernel` filter** so the eval can iterate on one kernel without paying for the corpus.
Keep-sets stay computed over the whole corpus, so a retained golden's rows and rank are unchanged; what changes is
which goldens merge, so a filtered run's counts are its own.

## Verification

- `make test` green (3058 passed), `make lint` green.
- `emmy eval prior --dataset nodes --db _tune/autotune-freeze-v3-rtx5090`: **336 pools**, **297** with ≥2 rows
  (regret), **216** with ≥5 (Spearman), **90** with ≥11 (regret@10), 143 `bench_fail` rows dropped and counted.
- The first thing the report found was a bug in its own input — see below. The write-side half of it is #587.
- `emmy eval prior --dataset golden --kernel gemma4_12b.q_proj` renders per card × tier × pool bucket, writes JSON,
  and still emits the greedy-pick-vs-golden table.
- An architect review ran on the staged diff. Its blocking findings are applied: the "shared with `emmy fit`" claim
  (which the code did not yet make) is corrected everywhere it appeared, and the hand-rolled table renderer is gone —
  `render` moved into `commands/eval.py` and calls the existing `render_table`, which is what the upward-import
  objection was really pointing at. Also applied: supervision pushed onto the subclasses, the per-metric group count
  dropped from golden cells where it could only ever restate the cell total, `score_rows` made `@abstractmethod`,
  `MIN_SPEARMAN_ROWS` cross-referenced against the deploy gate's own minimum, a stale command in
  `scripts/freeze_node_store.py`, and a docstring that narrated PR sequencing.

## Not in this PR

The fork-machinery teardown (`node_report`, `attribution_report`, `--blame`/`--ablate`, `Dataset.from_node_rows`, the
`masking_exact` chain, and their docs / skills / tests), `reachability` and `_calibration` being subsumed, and moving
`emmy fit`'s metrics onto these cells — which is where `cv._per_card` and `cv._median` stop being a parallel spelling
of the same aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXPHwChs61iSChSCddZJoG
