### PR TITLE
Stop recording a split piece as a rival of the whole op it came from

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1159,6 +1159,16 @@ is what stops measurements from a manual sweep evaporating.
   loop dialect that carries `S_*` features, and falls back to the deepest one in the tile dialect. The mma
   tile-lowering keeps no `LoopOp` in `.source`, so without that fallback every tensor-core kernel was silently
   unrecordable. Both paths digest to the same `op_sig` a tune would write, verified on an RTX 4090.
+- **A row's key and its features must describe the same work**, or the pool it lands in is not a comparison. The two
+  arrive by different routes — the key from the fork point, the features from the kernel that actually ran — and a
+  structural fork can break the correspondence: when it splits a site, one piece's own `source_chain` may still bottom
+  out at the un-split site, so the piece gets filed as a rival of the whole op. The recorder compares the kernel's
+  `S_ext_*` extents against its fork point's and drops the row when they differ. Extents are what settles it because
+  tiling and split-K rewrite the loop nest but preserve them, so a kernel that realizes the whole fork point runs the
+  fork point's extents. Measured on the RTX 5090 freeze written before the check, nine pools held such a pair: a 5.9 µs
+  row scored against a 131 ms one, both honest at about 35 TFLOP/s, a median 8192x apart in work. Consumers cannot
+  repair this after the fact, which is why the reader (`data/group.py`'s `group_measured`) also keys on the extents —
+  the writer stops producing the rows, the reader stops trusting the ones already written.
 - The kernels of one variant (a split-K main kernel plus its combine kernel) are grouped under one fork point and
   recorded as ONE leaf for the whole variant. If every kernel in a graph loses its fork point, the recorder warns
   loudly rather than silently recording nothing. Rows that were flagged (a pin that did not match, a wrong answer, an

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1159,16 +1159,22 @@ is what stops measurements from a manual sweep evaporating.
   loop dialect that carries `S_*` features, and falls back to the deepest one in the tile dialect. The mma
   tile-lowering keeps no `LoopOp` in `.source`, so without that fallback every tensor-core kernel was silently
   unrecordable. Both paths digest to the same `op_sig` a tune would write, verified on an RTX 4090.
-- **A row's key and its features must describe the same work**, or the pool it lands in is not a comparison. The two
-  arrive by different routes — the key from the fork point, the features from the kernel that actually ran — and a
-  structural fork can break the correspondence: when it splits a site, one piece's own `source_chain` may still bottom
-  out at the un-split site, so the piece gets filed as a rival of the whole op. The recorder compares the kernel's
-  `S_ext_*` extents against its fork point's and drops the row when they differ. Extents are what settles it because
-  tiling and split-K rewrite the loop nest but preserve them, so a kernel that realizes the whole fork point runs the
-  fork point's extents. Measured on the RTX 5090 freeze written before the check, nine pools held such a pair: a 5.9 µs
-  row scored against a 131 ms one, both honest at about 35 TFLOP/s, a median 8192x apart in work. Consumers cannot
+- **A row's key and its features must account for the same thing**, or the pool it lands in is not a comparison. The
+  two arrive by different routes — the key from the fork point, the features from the kernel that actually ran. A fork
+  point realized as SEVERAL kernels is where it breaks: the grouping below exists to sum those into one leaf, but it
+  can only sum kernels that resolved to the same fork point, and one piece's own `source_chain` may bottom out at the
+  un-split one while its sibling's does not. The piece is then recorded alone, as a rival of the whole op. The
+  recorder compares the kernel's `S_ext_*` extents against its fork point's and drops the row when they differ:
+  tiling and split-K rewrite the loop nest but preserve the extents, so a kernel realizing the whole fork point runs
+  the fork point's extents. Measured on the RTX 5090 freeze written before the check, nine pools held such a pair — a
+  fused `rms_norm`→linear megakernel beside a row for one kernel of the same op's unfused realization, a 5.9 µs norm
+  kernel against a 131 ms whole-op row; where the sibling was recorded too, the pair costs 24–191 µs. The extents are
+  a detector, not a work measure — their product double-counts for a sweep riding a reduction, which is why
+  `implausible_value_reason` abstains from its own `free × reduce` formula on that stamp shape. Consumers cannot
   repair this after the fact, which is why the reader (`data/group.py`'s `group_measured`) also keys on the extents —
-  the writer stops producing the rows, the reader stops trusting the ones already written.
+  the writer stops producing the rows, the reader stops trusting the ones already written. The guard is not the whole
+  repair: the unfused realization still gets no leaf of its own, because its kernels never resolve to a common fork
+  point for the summing to find.
 - The kernels of one variant (a split-K main kernel plus its combine kernel) are grouped under one fork point and
   recorded as ONE leaf for the whole variant. If every kernel in a graph loses its fork point, the recorder warns
   loudly rather than silently recording nothing. Rows that were flagged (a pin that did not match, a wrong answer, an

--- a/emmy/compiler/pipeline/search/bench_record.py
+++ b/emmy/compiler/pipeline/search/bench_record.py
@@ -36,15 +36,31 @@ Rows are keyed with the tune's own recipes (same ``node_key`` / ``op_sig`` /
 diagnostics skip — and stamped with a ``bench-…`` ``run_id`` so freeze headers show the
 provenance.
 
-**The invariant that keeps a pool comparable: a row's key and its features must describe
-the same work.** They arrive by different routes — the key from the offer site, the
-features from the kernel that ran — and a structural fork can break the correspondence:
-when it splits a site, one piece's own source chain may still bottom out at the un-split
-site, so the piece is filed as a rival of the whole. Nothing downstream can tell:
+**The invariant that keeps a pool comparable: a row's key and its features must account
+for the same thing.** They arrive by different routes — the key from the offer site, the
+features from the kernel that ran — and nothing above makes them agree. A site realized as
+SEVERAL kernels is where it breaks: the grouping above exists to sum those into one leaf,
+but it can only sum kernels that resolved to the same site, and one piece's own source
+chain may bottom out at the un-split site while its sibling's does not. The piece is then
+filed alone, as a rival of the whole op, and nothing downstream can tell.
+
 :func:`bench_leaves` therefore compares the recorded kernel's ``S_ext_*`` extents against
-its site's and drops the row when they differ. Measured on the RTX 5090 freeze written
-before the check, nine pools held such a pair — a 5.9 µs row scored against a 131 ms one,
-both honest at about 35 TFLOP/s, a median 8192x apart in work.
+its site's and drops the row when they differ. On the RTX 5090 freeze written before the
+check, nine pools held such a pair: a fused ``rms_norm``->linear megakernel beside a row
+for one kernel of the same op's unfused realization — a 5.9 µs norm kernel against a 131 ms
+whole-op row. In the four where the sibling was also recorded, under its own key, the pair
+costs 24-191 µs against the fused row's 28-212 ms.
+
+The extents are a DETECTOR, not a work measure. Their product double-counts for these
+kernels, a sweep riding the reduction, which is why
+:func:`~.db.implausible_value_reason` abstains from its own ``free x reduce`` formula on
+exactly this stamp shape. What the mismatch proves is that the row does not account for
+its site, which is enough to know it must not be recorded under it.
+
+**This guard is not the whole repair.** It stops a wrong row; it does not produce the right
+one. The unfused realization still has no leaf of its own, because its kernels never
+resolved to a common site for the summing above to find — so the tune's data still cannot
+say that on these shapes not fusing wins by two to three orders of magnitude.
 """
 
 from __future__ import annotations

--- a/emmy/compiler/pipeline/search/bench_record.py
+++ b/emmy/compiler/pipeline/search/bench_record.py
@@ -35,6 +35,16 @@ Rows are keyed with the tune's own recipes (same ``node_key`` / ``op_sig`` /
 ``context_key``), parentless with ``depth=0`` — the no-tree-schema marker the fork
 diagnostics skip — and stamped with a ``bench-…`` ``run_id`` so freeze headers show the
 provenance.
+
+**The invariant that keeps a pool comparable: a row's key and its features must describe
+the same work.** They arrive by different routes — the key from the offer site, the
+features from the kernel that ran — and a structural fork can break the correspondence:
+when it splits a site, one piece's own source chain may still bottom out at the un-split
+site, so the piece is filed as a rival of the whole. Nothing downstream can tell:
+:func:`bench_leaves` therefore compares the recorded kernel's ``S_ext_*`` extents against
+its site's and drops the row when they differ. Measured on the RTX 5090 freeze written
+before the check, nine pools held such a pair — a 5.9 µs row scored against a 131 ms one,
+both honest at about 35 TFLOP/s, a median 8192x apart in work.
 """
 
 from __future__ import annotations
@@ -86,6 +96,14 @@ def mint_bench_run_id() -> str:
     return f"bench-{datetime.now(UTC):%Y%m%dT%H%M%SZ}-{uuid4().hex[:8]}"
 
 
+def _extents(knobs: dict | None) -> tuple:
+    """The ``S_ext_*`` loop extents in a knob row, sorted — what the kernel actually ran over.
+
+    The one part of the structural stamp that says how much WORK was done, and so the one part two rows
+    must share before their latencies can be compared."""
+    return tuple(sorted((k, v) for k, v in (knobs or {}).items() if k.startswith("S_ext_")))
+
+
 def _offer_site(op) -> object | None:
     """The pre-descent offer op a compiled kernel lowered from. Preferred: the deepest
     loop-dialect ancestor carrying ``S_*`` stamps (the ``two_level`` decomposition-row
@@ -130,12 +148,14 @@ def bench_leaves(compiled, bench, *, status: str = "ok") -> list[BenchLeaf]:
     per_launch = list(getattr(bench, "per_launch", None) or []) if bench is not None else []
     entries = []  # (nid, op, launch, sig-or-None) in launch order
     sig_by_nid: dict[str, str] = {}
+    site_extents: dict[str, tuple] = {}  # sig -> the offer site's own extents, for the integrity check below
     for idx, nid in enumerate(nids):
         op = compiled.nodes[nid].op
         site = _offer_site(op)
         sig = digest(*sorted((k, v) for k, v in site.knobs.items() if k.startswith("S_"))) if site is not None else None
         if sig is not None:
             sig_by_nid[nid] = sig
+            site_extents[sig] = _extents(site.knobs)
         entries.append((nid, op, per_launch[idx] if idx < len(per_launch) else None, sig))
 
     def attributed(nid: str, hops: int = 4) -> str | None:
@@ -181,6 +201,23 @@ def bench_leaves(compiled, bench, *, status: str = "ok") -> list[BenchLeaf]:
         # most-tunables op is the group's knob identity.
         main = max(g["ops"], key=lambda o: sum(1 for k in (o.knobs or {}) if not k.startswith(("S_", "H_"))))
         knobs = dict(main.knobs or {})
+        # A row's POOL KEY is its offer site's structure and its recorded FEATURES are this kernel's, and
+        # nothing above makes those describe the same work. When a structural fork splits a site, one piece's
+        # own source chain can bottom out at the un-split site, so the piece is filed as a rival of the whole
+        # — its latency compared against a config computing thousands of times more. Extents are what settles
+        # it: a kernel realizing the whole site runs the site's extents (tiling and split-K rewrite the nest
+        # but preserve them), so a mismatch means this row measures something else and must not be recorded
+        # under this key. Dropped rather than re-keyed: the key it SHOULD carry is its own site's, and if its
+        # source chain could name that we would not be here.
+        if _extents(knobs) != site_extents.get(sig, _extents(knobs)):
+            logger.warning(
+                "[record-nodes] op %s: kernel extents %s do not match the offer site's %s — the row would "
+                "measure a fraction of the pool it keys into; skipped",
+                sig[:12],
+                dict(_extents(knobs)),
+                dict(site_extents[sig]),
+            )
+            continue
         if status != "ok":
             leaves.append(BenchLeaf(op_sig=sig, knobs=knobs, value_us=FAIL_SENTINEL_US, variance=None, n_samples=None, status=status))
             continue

--- a/tests/compiler/pipeline/search/test_bench_record.py
+++ b/tests/compiler/pipeline/search/test_bench_record.py
@@ -2,8 +2,9 @@
 
 Every row carries two structural facts that arrive by different routes: its POOL KEY, digested from the
 pre-descent offer site, and its FEATURES, taken from the kernel that actually ran. Nothing made them agree, and
-when they disagree the row is filed as a rival of configs that did different work — which is how a 5.9 µs
-kernel came to be scored against a 131 ms one, both honest measurements at about 35 TFLOP/s.
+when they disagree the row accounts for a piece of its pool's work while claiming to be a rival of the whole —
+which is how a 5.9 µs ``rms_norm`` kernel came to be scored against the 131 ms fused megakernel it was split out
+of.
 """
 
 from __future__ import annotations
@@ -13,7 +14,8 @@ from dataclasses import dataclass
 from emmy.compiler.ir.cuda.ir import CudaOp
 from emmy.compiler.pipeline.search.bench_record import FAIL_SENTINEL_US, bench_leaves
 
-# One reduce axis vs two: the fused-versus-split pair every mixed pool in the RTX 5090 freeze turned out to be.
+# The fused rms_norm->linear megakernel and one kernel of the same op's unfused realization — the pair every
+# mixed pool in the RTX 5090 freeze turned out to hold.
 WHOLE = {"S_reduce_add": 2.0, "S_ext_free_prod": 69632.0, "S_ext_reduce_prod": 14745600.0, "S_ext_n_reduce_axis": 2.0}
 PIECE = {"S_reduce_add": 1.0, "S_ext_free_prod": 30720.0, "S_ext_reduce_prod": 3840.0, "S_ext_n_reduce_axis": 1.0}
 

--- a/tests/compiler/pipeline/search/test_bench_record.py
+++ b/tests/compiler/pipeline/search/test_bench_record.py
@@ -1,0 +1,122 @@
+"""``bench_leaves`` — turning a benched graph into rows the tune DB can compare.
+
+Every row carries two structural facts that arrive by different routes: its POOL KEY, digested from the
+pre-descent offer site, and its FEATURES, taken from the kernel that actually ran. Nothing made them agree, and
+when they disagree the row is filed as a rival of configs that did different work — which is how a 5.9 µs
+kernel came to be scored against a 131 ms one, both honest measurements at about 35 TFLOP/s.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from emmy.compiler.ir.cuda.ir import CudaOp
+from emmy.compiler.pipeline.search.bench_record import FAIL_SENTINEL_US, bench_leaves
+
+# One reduce axis vs two: the fused-versus-split pair every mixed pool in the RTX 5090 freeze turned out to be.
+WHOLE = {"S_reduce_add": 2.0, "S_ext_free_prod": 69632.0, "S_ext_reduce_prod": 14745600.0, "S_ext_n_reduce_axis": 2.0}
+PIECE = {"S_reduce_add": 1.0, "S_ext_free_prod": 30720.0, "S_ext_reduce_prod": 3840.0, "S_ext_n_reduce_axis": 1.0}
+
+
+@dataclass
+class _Launch:
+    time_ms: float
+    samples: tuple = ()
+
+
+@dataclass
+class _Bench:
+    per_launch: list
+
+
+@dataclass
+class _Node:
+    op: object
+    inputs: tuple = ()
+
+
+class _Graph:
+    """The three things ``bench_leaves`` asks a compiled graph for."""
+
+    def __init__(self, ops: list[CudaOp]) -> None:
+        self.nodes = {f"k{i}": _Node(op) for i, op in enumerate(ops)}
+
+    def topological_order(self) -> list[str]:
+        return list(self.nodes)
+
+    def producer(self, buf: str):
+        return self.nodes[buf]
+
+
+@dataclass
+class _Site:
+    """The offer op a kernel lowered from, as ``_offer_site`` reads it: a dialect tag and a knob row.
+
+    A stub rather than a real ``LoopOp`` because a real one validates its body at construction, and a valid
+    body would be pages of noise covering nothing this module does — ``bench_leaves`` never looks past these
+    two attributes."""
+
+    knobs: dict
+    dialect: str = "loop"
+    source: object = None
+
+
+def _kernel(site_knobs: dict, own_knobs: dict) -> CudaOp:
+    """A CUDA kernel whose source chain bottoms at a loop-dialect offer site."""
+    return CudaOp(knobs=own_knobs, source=_Site(site_knobs))
+
+
+def test_one_kernel_realizing_its_whole_site_records_a_row():
+    op = _kernel({**WHOLE, "S_n_load": 6.0}, {**WHOLE, "TILE": "mma_m16n8k16_f16_f32/f2x2/k4", "WORK": "w2x8"})
+    (leaf,) = bench_leaves(_Graph([op]), _Bench([_Launch(0.25, (0.25, 0.25))]))
+
+    assert leaf.value_us == 250.0
+    assert leaf.knobs["WORK"] == "w2x8"
+    assert leaf.n_samples == 2  # a single-kernel group keeps its own bench stats
+
+
+def test_a_split_piece_is_not_recorded_against_the_whole_ops_pool(caplog):
+    """The defect this check exists for. A structural fork splits the site, and one piece's own source chain
+    still bottoms at the UN-split site — so without the check it is filed as a rival of the whole op and its
+    latency compared against a config doing thousands of times more work."""
+    piece = _kernel({**WHOLE, "S_n_load": 6.0}, {**PIECE, "REDUCE": "coop", "WORK": "t128"})
+
+    with caplog.at_level("WARNING"):
+        leaves = bench_leaves(_Graph([piece]), _Bench([_Launch(0.0059)]))
+
+    assert leaves == []
+    assert "do not match the offer site" in caplog.text
+
+
+def test_a_failed_bench_is_screened_the_same_way():
+    """A ``bench_fail`` row is a durable negative example, so it is just as wrong to file it under a pool whose
+    work it never attempted."""
+    good = _kernel({**WHOLE, "S_n_load": 6.0}, {**WHOLE, "WORK": "w2x8"})
+    piece = _kernel({**WHOLE, "S_n_load": 6.0}, {**PIECE, "WORK": "t128"})
+
+    assert [leaf.value_us for leaf in bench_leaves(_Graph([good]), None, status="bench_fail")] == [FAIL_SENTINEL_US]
+    assert bench_leaves(_Graph([piece]), None, status="bench_fail") == []
+
+
+def test_kernels_sharing_a_site_are_summed_into_one_row():
+    """A fragment kernel's own tiny latency must never become the site's row, so a site's kernels contribute
+    ONE leaf valued at their summed launch time. The extent check must not fire here: the group's knob
+    identity is its most-tunable op, which is the kernel realizing the site."""
+    site = {**WHOLE, "S_n_load": 6.0}
+    main = _kernel(site, {**WHOLE, "TILE": "mma_m16n8k16_f16_f32/f2x2/k4", "WORK": "w2x8", "STAGE": "d1/sync"})
+    epilogue = _kernel(site, {**WHOLE, "WORK": "w1x1"})
+    (leaf,) = bench_leaves(_Graph([main, epilogue]), _Bench([_Launch(0.25), _Launch(0.01)]))
+
+    assert leaf.value_us == 260.0
+    assert leaf.knobs["STAGE"] == "d1/sync"  # the most-tunable op is the group's knob identity
+    assert leaf.n_samples is None  # cross-kernel samples do not align, so a summed variance would be fiction
+
+
+def test_two_sites_stay_two_rows():
+    """Distinct offer sites never pool, whatever their kernels' latencies."""
+    a = _kernel({**WHOLE, "S_n_load": 6.0}, {**WHOLE, "WORK": "w2x8"})
+    b = _kernel({**PIECE, "S_n_load": 5.0}, {**PIECE, "WORK": "w1x8"})
+    leaves = bench_leaves(_Graph([a, b]), _Bench([_Launch(0.25), _Launch(0.006)]))
+
+    assert len({leaf.op_sig for leaf in leaves}) == 2
+    assert sorted(leaf.value_us for leaf in leaves) == [6.0, 250.0]


### PR DESCRIPTION
The write-side half of the 22 221× regret #586 turned up. Independent of that PR — different files, branched off
`main` — but the same defect seen from the other end.

## The defect

A bench row carries two structural facts that arrive by different routes:

- its **pool key**, `op_sig`, digested from the **pre-descent offer site** (`bench_record.py:25` says so
  explicitly: "NOT the terminal kernel's");
- its **features**, taken from `main.knobs` — the kernel that actually ran.

Nothing made them agree. A fork point realized as **several kernels** is where it breaks. The grouping in
`bench_leaves` exists to sum those into one leaf — but it can only sum kernels that resolved to the same fork point,
and one piece's own `source_chain` can bottom out at the un-split one while its sibling's does not. The piece is
then recorded alone, as a rival of the whole op.

## What it was, concretely

All **nine** affected pools on the RTX 5090 freeze are the same thing: a **fused `rms_norm`→linear megakernel**
beside a row for **one kernel of the same op's unfused realization**.

| row | structure | latency |
|---|---|---|
| piece | `rsqrt=1, reduce_add=1, loads=5` — the RMSNorm kernel | ~6 µs |
| sibling | `rsqrt=0, reduce_add=1, loads=2` — the matmul, under its **own** `op_sig` | ~180 µs |
| whole | `rsqrt=1, reduce_add=2, loads=6` — the fused megakernel | 28–212 ms |

In four of the nine the sibling was recorded too, so the unfused pair's real cost is visible: **24–191 µs** against
the fused row's 28–212 ms. In the other five the sibling was not recorded at all. Every fused row is **scalar tier**
(`WORK: t*`, no `TILE`) and every piece is warp/mma — `S_warp_eligible` is set on the piece and absent on the whole.

A part's latency is not the realization's cost, which is what makes the row wrong regardless of the magnitudes.

## The fix

`bench_leaves` compares the recorded kernel's `S_ext_*` extents against its fork point's and drops the row when they
differ, logging what it dropped and why.

**Extents are the detector, not a work measure.** Tiling and split-K rewrite the loop nest but preserve the extents,
so a kernel realizing the whole fork point runs the fork point's extents. Their *product* is not a work measure for
these kernels — a sweep rides the reduction, so it double-counts, which is exactly why `implausible_value_reason`
abstains from its own `free × reduce` formula on this stamp shape. What a mismatch proves is that the row does not
account for its fork point, and that is enough.

The check is on `main` — the op whose knobs get recorded — so it does not fire on the legitimate summed multi-kernel
group, where `main` is the kernel realizing the fork point and the fragment beside it is what gets summed in.

**Dropped rather than re-keyed.** The key such a row *should* carry is its own fork point's, and if its source chain
could name that we would not be in this situation. A wrong row silently deleted is recoverable by re-tuning; a wrong
row silently re-keyed is not.

`bench_fail` rows are screened the same way — a negative example filed under a pool whose work it never attempted is
just as wrong as a positive one.

## What this does NOT fix

The guard stops a wrong row; it does not produce the right one. The unfused realization still gets **no leaf of its
own**, because its kernels never resolve to a common fork point for the summing to find. So the tune's data still
cannot express the comparison these nine pools were groping at — and on this evidence that comparison matters a
lot: unfused looks two to three orders of magnitude faster on these shapes, and every fused row lands on the scalar
tier. Worth its own investigation; noted in `plans/offline-prior-scale-and-collection-redesign.md`.

## Coverage

`bench_leaves` had **no tests**. It has five now: the ordinary single-kernel row, the split piece being rejected, the
`bench_fail` path, the summed multi-kernel group the check must *not* fire on, and two distinct sites staying two
rows.

## Relationship to #586

#586 keys the *reader* (`group_measured`) on the extents as well, and both are needed: this stops the writer
producing such rows, that stops the reader trusting the ones already written — every existing tune DB and the v3
freeze included. Neither supersedes the other and they touch no common file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXPHwChs61iSChSCddZJoG
