### PR TITLE
Add tuned A100 kernel corpus replay

### DIFF
--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -55,6 +55,204 @@ concrete per kernel, per card.
 5. Host provisioning traps (recorded for reuse): fresh CloudRift boxes need `apt-get update` before
    `python3.12-venv`; V100 needs torch cu126 + `cupy-cuda12x==13.6.0` + `fastrlock` (nvrtc 13 dropped Volta).
 
+## Platform a100x1 — latest tuned routing evidence (2026-08-23)
+
+The A100 corpus now includes two positive routing realizations measured at deployable `-O3` on the exact
+NVIDIA A100-SXM4-80GB (`GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`):
+
+| seq | target | routing realization | Emmy | fused/cold Emmy | eager | result |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| 512 | score + softmax statistics | `PLACE@b=cut` | 299.69 µs | 21232 µs | 745.47 µs | 2.49x eager |
+| 1 | post-attention norm + gate/up + SiLU | `PLACE@map=cut` | 66.97 µs | 4612 µs | 154.62 µs | 2.31x eager |
+
+Both routing realizations passed strict Emmy-versus-eager correctness. All nine sequence-1 targets and seven of nine
+sequence-512 targets now carry verified pins in the committed experiment goldens; the sequence-512 softmax·V and
+post-attention norm + gate/up + SiLU targets remain unpinned.
+
+This is direct tuning evidence, not yet a matching experiment snapshot. The recipe replays only these committed
+goldens and performs no search, but the clean latest-`main` replay is still pending. The historical section and
+`results_a100x1.tar.gz` below remain the 2026-08-21 run and do not measure the two new routing realizations.
+
+## Platform a100x1 — historical chain-form replay (2026-08-21)
+
+### Question
+
+`main` now carries the chain root formation: a fold closes over the values its projection body defines, so the RoPE
+gathers and the k-norm no longer survive as their own kernels — they become part of the score kernel's tree. That
+re-keys every computed-A attention target. Which committed realizations survive the re-key, what do the re-keyed
+targets cost once they are tuned again on this card, and — now that every fold is a node with a `PLACE` seam — does
+any cut beat the fused form on the targets that lose?
+
+### Identity diff
+
+Both inventories were re-traced from `Qwen/Qwen3-0.6B@c1899de2` layer 0 and every target name was compared with the
+committed golden. A surviving identity kept its committed knobs and measurements verbatim.
+
+| seq | committed | re-traced | carried verbatim | re-keyed or unpinned | absorbed by the score kernel |
+| --- | ---: | ---: | ---: | ---: | --- |
+| 512 | 12 | 9 | 6 | 3 | RoPE cos gather, RoPE sin gather, k-norm + RoPE |
+| 1 | 10 | 9 | 6 | 3 | q/k norm + RoPE |
+
+The three re-keyed targets per sequence are the score/statistics kernel, softmax·V, and o_proj + residual. The last
+two keep their names but had no committed schedule (their knob maps have never been recordable), so they were tuned
+from scratch as well.
+
+### Protocol
+
+Each re-keyed target was hybrid-tuned on this card: agent proposals drawn from the card's own measured schedules plus
+every `PLACE` seam the recognize rule enumerates, then `emmy tune --max-candidates 48 --patience 12 --seed 0` under a
+per-target wall budget, with an isolated tuning DB, online checkpoint, and cubin cache. Every finalist was re-measured
+at deployable `-O3` against the cold greedy pick, then verified in a fresh `emmy run --golden … --target … --bench
+--strict` process. The recipe then replayed both committed goldens in five fresh
+`emmy run --golden … --bench --strict --bench-backends eager,tcompile,emmy --warmup 10 --iters 100` processes with an
+empty per-task tuning DB, online checkpoint, and cubin cache.
+
+### Per-kernel result (median of five processes, µs)
+
+`greedy` is the cold pick re-benched in the same process; `deployed` is the committed realization where one exists and
+the greedy pick otherwise.
+
+| seq | target | role | eager | torch.compile | greedy | deployed | vs eager | vs tcompile |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 512 | k_mean_20f978 | input RMSNorm | 191.54 | 8.69 | 3.82 | 3.17 | 60.4x | 2.74x |
+| 512 | k_linear_reduce_06a42b | v_proj | 12.97 | 13.70 | 83.03 | 17.50 | 0.74x | 0.78x |
+| 512 | k_linear_1fd3d5 | q_proj + reshape to heads | 100.64 | 21.65 | 132.97 | 22.35 | 4.50x | 0.97x |
+| 512 | k_linear_a09c5a | k_proj + reshape to heads | 59.86 | 14.73 | 71.21 | 17.28 | 3.46x | 0.85x |
+| 512 | k_sdpa_linear_reduce_c0a378 | softmax·V, computed V | 45.78 | 46.04 | 159.57 | 159.57 | 0.29x | 0.29x |
+| 512 | k_linear_sdpa_reduce_e24efe | o_proj + residual | 60.16 | 61.27 | 315.39 | 190.46 | 0.32x | 0.32x |
+| 512 | k_linear_mean_reduce_dc067d | post-attn norm + gate/up + SiLU | 246.39 | 49.62 | 67.27 | 67.27 | 3.66x | 0.74x |
+| 512 | k_linear_6b4b5f | down_proj + residual | 32.09 | 37.21 | 303.10 | 46.57 | 0.69x | 0.80x |
+| 512 | k_sdpa_mean_reduce_29d3df | q/k norm + RoPE + scores + softmax stats | 745.29 | failed | 21286.91 | 19609.60 | 0.04x | — |
+| 1 | k_mean_b8e46d | input RMSNorm | 121.85 | 2.89 | 3.05 | 2.38 | 51.2x | 1.21x |
+| 1 | k_linear_reduce_7ef15d | v_proj | 7.42 | 7.21 | 12.39 | 4.74 | 1.57x | 1.52x |
+| 1 | k_linear_49a16b | q_proj + reshape to heads | 35.09 | 6.79 | 21.45 | 4.84 | 7.25x | 1.40x |
+| 1 | k_linear_dfb21f | k_proj + reshape to heads | 33.67 | 5.25 | 11.06 | 4.74 | 7.10x | 1.11x |
+| 1 | k_sdpa_linear_reduce_d0f5c0 | softmax·V, computed V | 11.91 | 10.62 | 25.22 | 20.72 | 0.57x | 0.51x |
+| 1 | k_linear_sdpa_reduce_14c8c7 | o_proj + residual | 14.06 | 12.16 | 36.86 | 24.44 | 0.58x | 0.50x |
+| 1 | k_linear_mean_reduce_549927 | post-attn norm + gate/up + SiLU | 154.62 | 16.38 | 4605.95 | 393.22 | 0.39x | 0.04x |
+| 1 | k_linear_2dcd0c | down_proj + residual | 9.57 | 7.64 | 35.13 | 9.46 | 1.01x | 0.81x |
+| 1 | k_sdpa_mean_reduce_0a2624 | q/k norm + RoPE + scores + softmax stats | 334.55 | failed | 39.82 | 36.53 | 9.16x | — |
+
+Every target measured in all five repeats of both rows: the two `torch.compile`-less targets are ordered last in their
+golden, so their strict failure no longer costs the later targets their measurement.
+
+Layer totals as the sum of those medians: sequence 512 is 1494.7 eager, 252.9 Inductor (eight of nine targets), 22423
+untuned Emmy and 20134 deployed Emmy; sequence 1 is 722.7 eager, 68.9 Inductor (eight of nine), 4791 untuned and 501
+deployed. Sequence 1 improves on the previous revision (522 → 501 µs, 1.44x eager). Sequence 512 does not: one target,
+the fused score/statistics kernel, is 19610 µs of the 20134 µs total. Over the other eight targets the sequence-512
+layer is 524 µs against 749 µs eager, or 1.43x.
+
+### Why the fused score kernel costs 19.6 ms
+
+Its tile IR is unambiguous. The kernel places `free=(head, query)` and sweeps the key axis on the store; inside that
+sweep it runs the whole k cone per cell — a 128-element k-norm fold over `to_4`, then the k RoPE — so every k vector is
+recomputed once per query row rather than once per key. At sequence 512 that is 512x redundant arithmetic, and it is
+the whole cost: 21243.9 µs of the 21286.9 µs untuned total is that single kernel, at 94% occupancy and 34 registers.
+No thread tier changes it (`WORK=t256/t512/t1024` measure 21558 / 21835 / 22126 µs; `coop-t` measures 37873 µs).
+
+### Cut options
+
+The recognize rule enumerates three seams on the score root — bare `PLACE` (the score dot `acc2`), `PLACE@a2` (the
+q-norm fold), and `PLACE@fold.fold.a4` (the k-norm fold) — plus one on the softmax·V root. Every one was measured at
+deployable `-O3` against the fused form in the same process.
+
+| seq | target | fused | cut option | cut | verdict |
+| --- | --- | ---: | --- | ---: | --- |
+| 512 | k_sdpa_mean_reduce_29d3df | 21289.98 | `PLACE@fold.fold.a4=cut` (k-norm fold) | 19625.98 | 1.08x — committed |
+| 512 | k_sdpa_mean_reduce_29d3df | 21289.98 | `PLACE@a2=cut` (q-norm fold) | 335166.47 | 0.06x |
+| 512 | k_sdpa_mean_reduce_29d3df | 21289.98 | both seams | 335165.44 | 0.06x |
+| 512 | k_sdpa_linear_reduce_c0a378 | 159.57 | `PLACE=cut` | 4466.69 | 0.04x |
+| 512 | k_linear_sdpa_reduce_e24efe | 315.39 | `PLACE=cut` | 366.59 | 0.86x |
+| 1 | k_sdpa_linear_reduce_d0f5c0 | 25.17 | `PLACE=cut` | 26.22 | 0.96x |
+| 1 | k_linear_sdpa_reduce_14c8c7 | 36.82 | `PLACE=cut` | 37.56 | 0.98x |
+| 1 | k_sdpa_mean_reduce_0a2624 | 39.58 | no legal seam on this tree | — | — |
+
+One cut wins, and it is the k-norm fold: materializing that reduction once removes 8% of the redundant work and is now
+the first committed placement routing in the corpus. The seam that would matter is not in the set. Cutting `a2`
+promotes the key axis to a free axis of the residue, whose grid becomes 4.2M blocks and whose cost rises 16x, because
+the k cone is then recomputed with no reuse at all. What the target needs is the RoPE'd k vector materialized once as
+the dot's B operand; that is a binding the contraction binder still declines, not a seam the placement fork can spell.
+For the softmax·V and o_proj forms the cut is a straight loss: it splits a working mma contraction into a scalar
+producer plus a workspace zero-fill (`__zp524288`, 48.5 µs on its own in the o_proj cut).
+
+### Schedules that measure but cannot be recorded
+
+Four targets measured a deployable win that the golden's one-knob-map-per-realization format rejects. A multi-kernel
+target whose kernels include a knob-free one (an elementwise epilogue such as `k_add_5`, or `k_sdpa_reduce_fe4eb9` at
+sequence 1) always fails the merge: that kernel records the empty value for every schedule family while the others
+record the pinned value, so `realized_tuning_knobs` sees `WORK: '' != 't512'` and returns nothing. The pin itself is
+uniform and replays, so these four realizations record the exact `--ab` pin instead of the merged realized map, and
+each was re-verified by replaying the committed golden in a fresh strict process.
+
+| seq | target | greedy | recorded pin | deployed |
+| --- | --- | ---: | --- | ---: |
+| 512 | k_linear_sdpa_reduce_e24efe | 315.39 | `WORK=w8x2,TILE=mma_m16n8k16_f16_f32/f1x8/k8,STAGE=d2/smem` | 190.46 |
+| 1 | k_linear_sdpa_reduce_14c8c7 | 36.86 | `WORK=t512,REDUCE=coop-t` | 24.44 |
+| 1 | k_sdpa_linear_reduce_d0f5c0 | 25.22 | `WORK=t512,REDUCE=coop-t` | 20.72 |
+| 1 | k_sdpa_mean_reduce_0a2624 | 39.82 | `WORK=t128,REDUCE=coop/r2` | 36.53 |
+
+### Repeat variation
+
+Every target's five paired latencies agree to within 0.6% of their median (0.57% at sequence 1, 0.52% at 512), and
+every committed realization reproduces its tuning-time `-O3` measurement to within 0.5%.
+
+### Defects this round surfaced
+
+1. **The online-prior refit aborts the tune.** `emmy tune` raises `_catboost.CatBoostError: All features are either
+   constant or ignored` from `OnlinePrior.fit`, reached through `measure_proposals`' `prior.maybe_refit()`, when the
+   first measured proposal contributes a run of rows whose feature vectors are identical. It killed the whole
+   invocation for four of the six re-keyed targets on a cold online checkpoint. Re-running the same command against a
+   checkpoint that already carries a varied dataset succeeds, which is the workaround used here.
+2. **The tune-lane bench watchdog censors an expensive target completely.** Every candidate of the 21 ms fused score
+   kernel exceeds the 2 s accumulated-GPU-time budget and is marked `bench_fail`, so a full 1800 s search ranked
+   nothing at all and wrote no `ranking` block. `EMMY_BENCH_RUN_TIMEOUT_S` raises the budget; at 60 s the search
+   instead spent its whole 2400 s in re-lowering without completing a candidate, so this target's schedules were
+   priced by direct `emmy run --ab` instead.
+3. **`torch.compile` still cannot compile the RoPE-bearing attention reference** on PyTorch 2.13.0, so `--strict`
+   rejects those two targets in every repeat and both rows report `failed`. This is the same Inductor limitation the
+   previous run recorded.
+4. **A bare `PLACE=cut` pin re-cuts every piece it produces.** Because the pin is authoritative on each freshly
+   recognized tree, the resolution recurses through the fragments; on the sequence-512 score tree a single
+   `emmy compile --ir tile` under that pin had not terminated after ten minutes. Named seams resolve promptly.
+
+### Conclusion
+
+The re-key is mostly benign: six of nine realizations per sequence carried over verbatim and reproduce their committed
+numbers, and sequence 1 is faster than the previous revision (1.44x eager). Sequence 512 regressed by construction —
+folding the k cone into the score kernel made it recompute that cone once per (query, key) pair, which costs 19.6 ms
+against 745 µs eager and turns a 1.56x layer win into a 0.07x loss. The placement fork is real and usable: its seams
+enumerate, resolve by name, and one of them is now committed evidence, but the seam that would undo this particular
+regression is a contraction binding rather than a placement.
+
+### Limitations
+
+- Layer-0 evidence only, one model, one card; never a whole-model claim.
+- Both rows report `failed` because `--strict` requires a `torch.compile` latency the two RoPE-bearing targets cannot
+  produce. Every other target passed strict Emmy-vs-eager correctness in all five repeats.
+- The Inductor column is missing for those two targets, so no geometric mean over the full corpus is available; the
+  measured denominators are stated above.
+- A target's program includes the producers its output needs, so the attention targets overlap and the layer total is
+  a sum of overlapping sub-programs on both the Emmy and the eager side, not a disjoint decomposition.
+- The five repeats share one deployed host and run back to back, so they capture process-level, not day-level,
+  variation.
+
+### Run and system
+
+- Status: failed (2/2 rows, `torch.compile` reference unavailable on the two RoPE-bearing targets; every target
+  measured in every repeat)
+- Result timestamp: 2026-08-21T23:03:34Z; run ID: `20260821T230334Z`
+- Rows: `…sl1_scommon` (row ID `551082cef77b`, 440.74 s) and `…sl512_scommon` (row ID `3a4d139974b8`, 2131.30 s)
+- Git revision: `213c443a`; dirty: false
+- Host: `riftvm`; Ubuntu 24.04.1 LTS; AMD EPYC 7742 64-Core Processor
+- GPU: NVIDIA A100-SXM4-80GB, UUID `GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`; PyTorch 2.13.0+cu130
+
+### Durable files
+
+- Raw-results archive: `results_a100x1.tar.gz`; archived root `2026-08-21_23-03-34/`
+- Members: both `*.experiment.yaml` records, both `*_artifacts.tar.gz` task archives (per-repeat verification JSON per
+  target, per-repeat logs and exit statuses, package freeze, replayed working golden), and the two runner logs
+- Committed goldens: `golden/qwen3-06b-s1_a100.golden.yaml`, `golden/qwen3-06b-s512_a100.golden.yaml`
+
 ## Platform sections
 
 ### rtx5090x1

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
@@ -1,0 +1,1423 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [hidden_states, position_embeddings_0, position_embeddings_1, attention_mask]
+  outputs: [add_7]
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_1_c1, f32, [1]]]
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_1_c1]
+    outputs: [[add_1_c1_bc, f32, [1, 1, 16, 1]]]
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_2_c1, f32, [1]]]
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_2_c1]
+    outputs: [[add_2_c1_bc, f32, [1, 1, 8, 1]]]
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_6_c1, f32, [1]]]
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_6_c1]
+    outputs: [[add_6_c1_bc, f32, [1, 1, 1]]]
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_c1, f32, [1]]]
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_c1]
+    outputs: [[add_c1_bc, f32, [1, 1, 1]]]
+  - id: attention_mask
+    op: input
+    outputs: [[attention_mask, f32, []]]
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_1_c2, f16, [1]]]
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_c2, f16, [1]]]
+  - id: hidden_states
+    op: input
+    outputs: [[hidden_states, f16, [1, 1, 1024]]]
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_norm_weight, f16, [128]]]
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_k_norm_weight]
+    outputs: [[p_attn_k_norm_weight_bc, f16, [1, 1, 8, 128]]]
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_proj_weight, f16, [1024, 1024]]]
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.o_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 2048]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_o_proj_weight, f16, [1024, 2048]]]
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_norm_weight, f16, [128]]]
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_q_norm_weight]
+    outputs: [[p_attn_q_norm_weight_bc, f16, [1, 1, 16, 128]]]
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [2048, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_proj_weight, f16, [2048, 1024]]]
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.v_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_v_proj_weight, f16, [1024, 1024]]]
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: input_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_input_layernorm_weight, f16, [1024]]]
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_input_layernorm_weight]
+    outputs: [[p_input_layernorm_weight_bc, f16, [1, 1, 1024]]]
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.down_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 3072]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_down_proj_weight, f16, [1024, 3072]]]
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.gate_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_gate_proj_weight, f16, [3072, 1024]]]
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.up_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_up_proj_weight, f16, [3072, 1024]]]
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: post_attention_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_post_attention_layernorm_weight, f16, [1024]]]
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_post_attention_layernorm_weight]
+    outputs: [[p_post_attention_layernorm_weight_bc, f16, [1, 1, 1024]]]
+  - id: position_embeddings_0
+    op: input
+    outputs: [[position_embeddings_0, f16, [1, 1, 128]]]
+  - id: position_embeddings_1
+    op: input
+    outputs: [[position_embeddings_1, f16, [1, 1, 128]]]
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_1_c1, f32, [1]]]
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_1_c1]
+    outputs: [[pow_1_c1_bc, f32, [1, 1, 1024]]]
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_2_c1, f32, [1]]]
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_2_c1]
+    outputs: [[pow_2_c1_bc, f32, [1, 1, 16, 128]]]
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_3_c1, f32, [1]]]
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_3_c1]
+    outputs: [[pow_3_c1_bc, f32, [1, 1, 8, 128]]]
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_4_c1, f32, [1]]]
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_4_c1]
+    outputs: [[pow_4_c1_bc, f32, [1, 1, 1024]]]
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c1, f16, [1]]]
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c2, f16, [1]]]
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c3, f16, [1]]]
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c1, f16, [1]]]
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c2, f16, [1]]]
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c3, f16, [1]]]
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c1, f16, [1]]]
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c2, f16, [1]]]
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c3, f16, [1]]]
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c1, f16, [1]]]
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c2, f16, [1]]]
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c3, f16, [1]]]
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [hidden_states]
+    outputs: [[to, f32, [1, 1, 1024]]]
+  - id: pow_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to, pow_1_c1_bc]
+    outputs: [[pow_1, f32, [1, 1, 1024]]]
+  - id: mean
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_1]
+    outputs: [[mean, f32, [1, 1, 1]]]
+  - id: add
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean, add_c1_bc]
+    outputs: [[add, f32, [1, 1, 1]]]
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add]
+    outputs: [[rsqrt, f32, [1, 1, 1]]]
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt]
+    outputs: [[rsqrt_bc, f32, [1, 1, 1024]]]
+  - id: mul
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to, rsqrt_bc]
+    outputs: [[mul, f32, [1, 1, 1024]]]
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul]
+    outputs: [[to_1, f16, [1, 1, 1024]]]
+  - id: mul_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_input_layernorm_weight_bc, to_1]
+    outputs: [[mul_1, f16, [1, 1, 1024]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_q_proj_weight]
+    outputs: [[linear, f16, [1, 1, 2048]]]
+  - id: linear_1
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_k_proj_weight]
+    outputs: [[linear_1, f16, [1, 1, 1024]]]
+  - id: linear_2
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_v_proj_weight]
+    outputs: [[linear_2, f16, [1, 1, 1024]]]
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c1, f16, [1]]]
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c2, f16, [1]]]
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c1, f16, [1]]]
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c2, f16, [1]]]
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c1, f16, [1]]]
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c2, f16, [1]]]
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c1, f16, [1]]]
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c2, f16, [1]]]
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_0]
+    outputs: [[unsqueeze, f16, [1, 1, 1, 128]]]
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 8, 1, 128]]]
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_1]
+    outputs: [[unsqueeze_1, f16, [1, 1, 1, 128]]]
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 8, 1, 128]]]
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 16, 1, 128]]]
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_1_c1, f16, [1]]]
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 1}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 16, 1, 128]]]
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_c1, f16, [1]]]
+  - id: view
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1, 128]}}
+    inputs: [linear]
+    outputs: [[view, f16, [1, 1, 16, 128]]]
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view]
+    outputs: [[to_2, f32, [1, 1, 16, 128]]]
+  - id: pow_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_2, pow_2_c1_bc]
+    outputs: [[pow_2, f32, [1, 1, 16, 128]]]
+  - id: mean_1
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_2]
+    outputs: [[mean_1, f32, [1, 1, 16, 1]]]
+  - id: add_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_1, add_1_c1_bc]
+    outputs: [[add_1, f32, [1, 1, 16, 1]]]
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_1]
+    outputs: [[rsqrt_1, f32, [1, 1, 16, 1]]]
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_1]
+    outputs: [[rsqrt_1_bc, f32, [1, 1, 16, 128]]]
+  - id: mul_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_2, rsqrt_1_bc]
+    outputs: [[mul_2, f32, [1, 1, 16, 128]]]
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_2]
+    outputs: [[to_3, f16, [1, 1, 16, 128]]]
+  - id: mul_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_q_norm_weight_bc, to_3]
+    outputs: [[mul_3, f16, [1, 1, 16, 128]]]
+  - id: transpose
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_3]
+    outputs: [[transpose, f16, [1, 16, 1, 128]]]
+  - id: mul_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose, unsqueeze_bc]
+    outputs: [[mul_6, f16, [1, 16, 1, 128]]]
+  - id: slice_1
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 1, 64]}, dim: 3, start: 0}
+    inputs: [transpose, slice_1_c1, slice_1_c2, slice_1_c3]
+    outputs: [[slice_1, f16, [1, 16, 1, 64]]]
+  - id: slice_2
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 1, 64]}, dim: 3, start: 64}
+    inputs: [transpose, slice_2_c1, slice_2_c2, slice_2_c3]
+    outputs: [[slice_2, f16, [1, 16, 1, 64]]]
+  - id: neg
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_2]
+    outputs: [[neg, f16, [1, 16, 1, 64]]]
+  - id: cat
+    op: torch.cat
+    inputs: [neg, slice_1, cat_c2]
+    outputs: [[cat, f16, [1, 16, 1, 128]]]
+  - id: mul_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat, unsqueeze_1_bc]
+    outputs: [[mul_7, f16, [1, 16, 1, 128]]]
+  - id: add_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_6, mul_7]
+    outputs: [[add_3, f16, [1, 16, 1, 128]]]
+  - id: view_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1, 128]}}
+    inputs: [linear_1]
+    outputs: [[view_1, f16, [1, 1, 8, 128]]]
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view_1]
+    outputs: [[to_4, f32, [1, 1, 8, 128]]]
+  - id: pow_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_4, pow_3_c1_bc]
+    outputs: [[pow_3, f32, [1, 1, 8, 128]]]
+  - id: mean_2
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_3]
+    outputs: [[mean_2, f32, [1, 1, 8, 1]]]
+  - id: add_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_2, add_2_c1_bc]
+    outputs: [[add_2, f32, [1, 1, 8, 1]]]
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_2]
+    outputs: [[rsqrt_2, f32, [1, 1, 8, 1]]]
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_2]
+    outputs: [[rsqrt_2_bc, f32, [1, 1, 8, 128]]]
+  - id: mul_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_4, rsqrt_2_bc]
+    outputs: [[mul_4, f32, [1, 1, 8, 128]]]
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_4]
+    outputs: [[to_5, f16, [1, 1, 8, 128]]]
+  - id: mul_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_k_norm_weight_bc, to_5]
+    outputs: [[mul_5, f16, [1, 1, 8, 128]]]
+  - id: transpose_1
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_5]
+    outputs: [[transpose_1, f16, [1, 8, 1, 128]]]
+  - id: mul_8
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose_1, n0]
+    outputs: [[mul_8, f16, [1, 8, 1, 128]]]
+  - id: slice_3
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 1, 64]}, dim: 3, start: 0}
+    inputs: [transpose_1, slice_3_c1, slice_3_c2, slice_3_c3]
+    outputs: [[slice_3, f16, [1, 8, 1, 64]]]
+  - id: slice_4
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 1, 64]}, dim: 3, start: 64}
+    inputs: [transpose_1, slice_4_c1, slice_4_c2, slice_4_c3]
+    outputs: [[slice_4, f16, [1, 8, 1, 64]]]
+  - id: neg_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_4]
+    outputs: [[neg_1, f16, [1, 8, 1, 64]]]
+  - id: cat_1
+    op: torch.cat
+    inputs: [neg_1, slice_3, cat_1_c2]
+    outputs: [[cat_1, f16, [1, 8, 1, 128]]]
+  - id: mul_9
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat_1, n1]
+    outputs: [[mul_9, f16, [1, 8, 1, 128]]]
+  - id: add_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_8, mul_9]
+    outputs: [[add_4, f16, [1, 8, 1, 128]]]
+  - id: view_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1, 128]}}
+    inputs: [linear_2]
+    outputs: [[view_2, f16, [1, 1, 8, 128]]]
+  - id: transpose_2
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [view_2]
+    outputs: [[transpose_2, f16, [1, 8, 1, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: 0.08838834764831845}
+    inputs: [add_3, add_4, transpose_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 16, 1, 128]]]
+  - id: transpose_3
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[transpose_3, f16, [1, 1, 16, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 1, -1]}}
+    inputs: [transpose_3]
+    outputs: [[reshape, f16, [1, 1, 2048]]]
+  - id: linear_3
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [reshape, p_attn_o_proj_weight]
+    outputs: [[linear_3, f16, [1, 1, 1024]]]
+  - id: add_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [hidden_states, linear_3]
+    outputs: [[add_5, f16, [1, 1, 1024]]]
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [add_5]
+    outputs: [[to_6, f32, [1, 1, 1024]]]
+  - id: pow_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_6, pow_4_c1_bc]
+    outputs: [[pow_4, f32, [1, 1, 1024]]]
+  - id: mean_3
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_4]
+    outputs: [[mean_3, f32, [1, 1, 1]]]
+  - id: add_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_3, add_6_c1_bc]
+    outputs: [[add_6, f32, [1, 1, 1]]]
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_6]
+    outputs: [[rsqrt_3, f32, [1, 1, 1]]]
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_3]
+    outputs: [[rsqrt_3_bc, f32, [1, 1, 1024]]]
+  - id: mul_10
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_6, rsqrt_3_bc]
+    outputs: [[mul_10, f32, [1, 1, 1024]]]
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 1}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul_10]
+    outputs: [[to_7, f16, [1, 1, 1024]]]
+  - id: mul_11
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_post_attention_layernorm_weight_bc, to_7]
+    outputs: [[mul_11, f16, [1, 1, 1024]]]
+  - id: linear_4
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_gate_proj_weight]
+    outputs: [[linear_4, f16, [1, 1, 3072]]]
+  - id: linear_5
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_up_proj_weight]
+    outputs: [[linear_5, f16, [1, 1, 3072]]]
+  - id: silu
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: silu}}
+    inputs: [linear_4]
+    outputs: [[silu, f16, [1, 1, 3072]]]
+  - id: mul_12
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [silu, linear_5]
+    outputs: [[mul_12, f16, [1, 1, 3072]]]
+  - id: linear_6
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_12, p_mlp_down_proj_weight]
+    outputs: [[linear_6, f16, [1, 1, 1024]]]
+  - id: add_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [add_5, linear_6]
+    outputs: [[add_7, f16, [1, 1, 1024]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      REDUCE: coop
+      WORK: t512
+    measurements:
+      emmy_us: 2.3804
+      reference_us: 121.8653
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_7ef15d.37e7fb9e7dd5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      REDUCE: coop-t
+      WORK: t512
+    measurements:
+      emmy_us: 4.7463
+      reference_us: 7.7227
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_49a16b.119bca97a211
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      REDUCE: coop-t
+      WORK: t512
+    measurements:
+      emmy_us: 4.8416
+      reference_us: 35.1407
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_dfb21f.68dcd44586ec
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      REDUCE: coop-t
+      WORK: t512
+    measurements:
+      emmy_us: 4.7415
+      reference_us: 33.8046
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_d0f5c0.128c6f715151
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE: coop-t
+      WORK: t512
+    measurements:
+      emmy_us: 20.8542
+      reference_us: 11.9701
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_14c8c7.b69c5cc0ab9b
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE: coop-t
+      WORK: t512
+    measurements:
+      emmy_us: 24.3855
+      reference_us: 14.1502
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_549927.f3a20e07e940
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      PLACE@map: cut
+    measurements:
+      emmy_us: 66.9696
+      reference_us: 154.624
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_2dcd0c.28b342e368a5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      REDUCE: coop-t
+      WORK: t512
+    measurements:
+      emmy_us: 9.4575
+      reference_us: 10.1218
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE: coop/r2
+      WORK: t128
+    measurements:
+      emmy_us: 36.4251
+      reference_us: 334.5396
+      reference_backend: torch-eager
+gpu_name: NVIDIA A100 80GB
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
@@ -1,0 +1,1427 @@
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [hidden_states, position_embeddings_0, position_embeddings_1, attention_mask]
+  outputs: [add_7]
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_1_c1, f32, [1]]]
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_1_c1]
+    outputs: [[add_1_c1_bc, f32, [1, 512, 16, 1]]]
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_2_c1, f32, [1]]]
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [add_2_c1]
+    outputs: [[add_2_c1_bc, f32, [1, 512, 8, 1]]]
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_6_c1, f32, [1]]]
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_6_c1]
+    outputs: [[add_6_c1_bc, f32, [1, 512, 1]]]
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[add_c1, f32, [1]]]
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [add_c1]
+    outputs: [[add_c1_bc, f32, [1, 512, 1]]]
+  - id: attention_mask
+    op: input
+    outputs: [[attention_mask, f32, []]]
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_1_c2, f16, [1]]]
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[cat_c2, f16, [1]]]
+  - id: hidden_states
+    op: input
+    outputs: [[hidden_states, f16, [1, 512, 1024]]]
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_norm_weight, f16, [128]]]
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_k_norm_weight]
+    outputs: [[p_attn_k_norm_weight_bc, f16, [1, 512, 8, 128]]]
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.k_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_k_proj_weight, f16, [1024, 1024]]]
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.o_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 2048]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_o_proj_weight, f16, [1024, 2048]]]
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_norm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [128]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_norm_weight, f16, [128]]]
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_3}], select: null}}]}
+    inputs: [p_attn_q_norm_weight]
+    outputs: [[p_attn_q_norm_weight_bc, f16, [1, 512, 16, 128]]]
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.q_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [2048, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_q_proj_weight, f16, [2048, 1024]]]
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: self_attn.v_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_attn_v_proj_weight, f16, [1024, 1024]]]
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: input_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_input_layernorm_weight, f16, [1024]]]
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_input_layernorm_weight]
+    outputs: [[p_input_layernorm_weight_bc, f16, [1, 512, 1024]]]
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.down_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024, 3072]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_down_proj_weight, f16, [1024, 3072]]]
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.gate_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_gate_proj_weight, f16, [3072, 1024]]]
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: mlp.up_proj.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [3072, 1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_mlp_up_proj_weight, f16, [3072, 1024]]]
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: post_attention_layernorm.weight
+      source_parts: {__tuple__: []}
+      source_shape: {__tuple__: [1024]}
+      source_dtype: float16
+      source_graph: null
+    outputs: [[p_post_attention_layernorm_weight, f16, [1024]]]
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources: {__tuple__: [{__index_source__: {input_idx: 0, coord_map: [{var: out_coord_2}], select: null}}]}
+    inputs: [p_post_attention_layernorm_weight]
+    outputs: [[p_post_attention_layernorm_weight_bc, f16, [1, 512, 1024]]]
+  - id: position_embeddings_0
+    op: input
+    outputs: [[position_embeddings_0, f16, [1, 512, 128]]]
+  - id: position_embeddings_1
+    op: input
+    outputs: [[position_embeddings_1, f16, [1, 512, 128]]]
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_1_c1, f32, [1]]]
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_1_c1]
+    outputs: [[pow_1_c1_bc, f32, [1, 512, 1024]]]
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_2_c1, f32, [1]]]
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_2_c1]
+    outputs: [[pow_2_c1_bc, f32, [1, 512, 16, 128]]]
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_3_c1, f32, [1]]]
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_3_c1]
+    outputs: [[pow_3_c1_bc, f32, [1, 512, 8, 128]]]
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[pow_4_c1, f32, [1]]]
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - {__index_source__: {input_idx: 0, coord_map: [{literal: {value: 0, dtype: int}}], select: null}}
+    inputs: [pow_4_c1]
+    outputs: [[pow_4_c1_bc, f32, [1, 512, 1024]]]
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c1, f16, [1]]]
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c2, f16, [1]]]
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_1_c3, f16, [1]]]
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c1, f16, [1]]]
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c2, f16, [1]]]
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_2_c3, f16, [1]]]
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c1, f16, [1]]]
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c2, f16, [1]]]
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_3_c3, f16, [1]]]
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c1, f16, [1]]]
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c2, f16, [1]]]
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[slice_4_c3, f16, [1]]]
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [hidden_states]
+    outputs: [[to, f32, [1, 512, 1024]]]
+  - id: pow_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to, pow_1_c1_bc]
+    outputs: [[pow_1, f32, [1, 512, 1024]]]
+  - id: mean
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_1]
+    outputs: [[mean, f32, [1, 512, 1]]]
+  - id: add
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean, add_c1_bc]
+    outputs: [[add, f32, [1, 512, 1]]]
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add]
+    outputs: [[rsqrt, f32, [1, 512, 1]]]
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt]
+    outputs: [[rsqrt_bc, f32, [1, 512, 1024]]]
+  - id: mul
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to, rsqrt_bc]
+    outputs: [[mul, f32, [1, 512, 1024]]]
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul]
+    outputs: [[to_1, f16, [1, 512, 1024]]]
+  - id: mul_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_input_layernorm_weight_bc, to_1]
+    outputs: [[mul_1, f16, [1, 512, 1024]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_q_proj_weight]
+    outputs: [[linear, f16, [1, 512, 2048]]]
+  - id: linear_1
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_k_proj_weight]
+    outputs: [[linear_1, f16, [1, 512, 1024]]]
+  - id: linear_2
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_1, p_attn_v_proj_weight]
+    outputs: [[linear_2, f16, [1, 512, 1024]]]
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c1, f16, [1]]]
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_1_c2, f16, [1]]]
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c1, f16, [1]]]
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_2_c2, f16, [1]]]
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c1, f16, [1]]]
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_3_c2, f16, [1]]]
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c1, f16, [1]]]
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c2, f16, [1]]]
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_0]
+    outputs: [[unsqueeze, f16, [1, 1, 512, 128]]]
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 8, 512, 128]]]
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs: {dim: 1}
+    inputs: [position_embeddings_1]
+    outputs: [[unsqueeze_1, f16, [1, 1, 512, 128]]]
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 8}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 8, 512, 128]]]
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze_1]
+    outputs: [[unsqueeze_1_bc, f16, [1, 16, 512, 128]]]
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_1_c1, f16, [1]]]
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 512}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {literal: {value: 0, dtype: int}}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [unsqueeze]
+    outputs: [[unsqueeze_bc, f16, [1, 16, 512, 128]]]
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[unsqueeze_c1, f16, [1]]]
+  - id: view
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1, 128]}}
+    inputs: [linear]
+    outputs: [[view, f16, [1, 512, 16, 128]]]
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view]
+    outputs: [[to_2, f32, [1, 512, 16, 128]]]
+  - id: pow_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_2, pow_2_c1_bc]
+    outputs: [[pow_2, f32, [1, 512, 16, 128]]]
+  - id: mean_1
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_2]
+    outputs: [[mean_1, f32, [1, 512, 16, 1]]]
+  - id: add_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_1, add_1_c1_bc]
+    outputs: [[add_1, f32, [1, 512, 16, 1]]]
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_1]
+    outputs: [[rsqrt_1, f32, [1, 512, 16, 1]]]
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_1]
+    outputs: [[rsqrt_1_bc, f32, [1, 512, 16, 128]]]
+  - id: mul_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_2, rsqrt_1_bc]
+    outputs: [[mul_2, f32, [1, 512, 16, 128]]]
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 16}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_2]
+    outputs: [[to_3, f16, [1, 512, 16, 128]]]
+  - id: mul_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_q_norm_weight_bc, to_3]
+    outputs: [[mul_3, f16, [1, 512, 16, 128]]]
+  - id: transpose
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_3]
+    outputs: [[transpose, f16, [1, 16, 512, 128]]]
+  - id: mul_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose, unsqueeze_bc]
+    outputs: [[mul_6, f16, [1, 16, 512, 128]]]
+  - id: slice_1
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 512, 64]}, dim: 3, start: 0}
+    inputs: [transpose, slice_1_c1, slice_1_c2, slice_1_c3]
+    outputs: [[slice_1, f16, [1, 16, 512, 64]]]
+  - id: slice_2
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 16, 512, 64]}, dim: 3, start: 64}
+    inputs: [transpose, slice_2_c1, slice_2_c2, slice_2_c3]
+    outputs: [[slice_2, f16, [1, 16, 512, 64]]]
+  - id: neg
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_2]
+    outputs: [[neg, f16, [1, 16, 512, 64]]]
+  - id: cat
+    op: torch.cat
+    inputs: [neg, slice_1, cat_c2]
+    outputs: [[cat, f16, [1, 16, 512, 128]]]
+  - id: mul_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat, unsqueeze_1_bc]
+    outputs: [[mul_7, f16, [1, 16, 512, 128]]]
+  - id: add_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_6, mul_7]
+    outputs: [[add_3, f16, [1, 16, 512, 128]]]
+  - id: view_1
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1, 128]}}
+    inputs: [linear_1]
+    outputs: [[view_1, f16, [1, 512, 8, 128]]]
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [view_1]
+    outputs: [[to_4, f32, [1, 512, 8, 128]]]
+  - id: pow_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_4, pow_3_c1_bc]
+    outputs: [[pow_3, f32, [1, 512, 8, 128]]]
+  - id: mean_2
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_3]
+    outputs: [[mean_2, f32, [1, 512, 8, 1]]]
+  - id: add_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_2, add_2_c1_bc]
+    outputs: [[add_2, f32, [1, 512, 8, 1]]]
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_2]
+    outputs: [[rsqrt_2, f32, [1, 512, 8, 1]]]
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_2]
+    outputs: [[rsqrt_2_bc, f32, [1, 512, 8, 128]]]
+  - id: mul_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_4, rsqrt_2_bc]
+    outputs: [[mul_4, f32, [1, 512, 8, 128]]]
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 8}, {__dim__: 128}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {var: out_coord_2}
+            - {var: out_coord_3}
+            select: null
+    inputs: [mul_4]
+    outputs: [[to_5, f16, [1, 512, 8, 128]]]
+  - id: mul_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_attn_k_norm_weight_bc, to_5]
+    outputs: [[mul_5, f16, [1, 512, 8, 128]]]
+  - id: transpose_1
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [mul_5]
+    outputs: [[transpose_1, f16, [1, 8, 512, 128]]]
+  - id: mul_8
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [transpose_1, n0]
+    outputs: [[mul_8, f16, [1, 8, 512, 128]]]
+  - id: slice_3
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 512, 64]}, dim: 3, start: 0}
+    inputs: [transpose_1, slice_3_c1, slice_3_c2, slice_3_c3]
+    outputs: [[slice_3, f16, [1, 8, 512, 64]]]
+  - id: slice_4
+    op: torch.slice
+    attrs: {shape: {__tuple__: [1, 8, 512, 64]}, dim: 3, start: 64}
+    inputs: [transpose_1, slice_4_c1, slice_4_c2, slice_4_c3]
+    outputs: [[slice_4, f16, [1, 8, 512, 64]]]
+  - id: neg_1
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: negative}}
+    inputs: [slice_4]
+    outputs: [[neg_1, f16, [1, 8, 512, 64]]]
+  - id: cat_1
+    op: torch.cat
+    inputs: [neg_1, slice_3, cat_1_c2]
+    outputs: [[cat_1, f16, [1, 8, 512, 128]]]
+  - id: mul_9
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [cat_1, n1]
+    outputs: [[mul_9, f16, [1, 8, 512, 128]]]
+  - id: add_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mul_8, mul_9]
+    outputs: [[add_4, f16, [1, 8, 512, 128]]]
+  - id: view_2
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1, 128]}}
+    inputs: [linear_2]
+    outputs: [[view_2, f16, [1, 512, 8, 128]]]
+  - id: transpose_2
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [view_2]
+    outputs: [[transpose_2, f16, [1, 8, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: 0.08838834764831845}
+    inputs: [add_3, add_4, transpose_2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 16, 512, 128]]]
+  - id: transpose_3
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [1, 2]}}
+    inputs: [scaled_dot_product_attention]
+    outputs: [[transpose_3, f16, [1, 512, 16, 128]]]
+  - id: reshape
+    op: torch.reshape
+    attrs: {shape: {__tuple__: [1, 512, -1]}}
+    inputs: [transpose_3]
+    outputs: [[reshape, f16, [1, 512, 2048]]]
+  - id: linear_3
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [reshape, p_attn_o_proj_weight]
+    outputs: [[linear_3, f16, [1, 512, 1024]]]
+  - id: add_5
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [hidden_states, linear_3]
+    outputs: [[add_5, f16, [1, 512, 1024]]]
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [add_5]
+    outputs: [[to_6, f32, [1, 512, 1024]]]
+  - id: pow_4
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: pow}}
+    inputs: [to_6, pow_4_c1_bc]
+    outputs: [[pow_4, f32, [1, 512, 1024]]]
+  - id: mean_3
+    op: torch.mean
+    attrs: {axis: -1}
+    inputs: [pow_4]
+    outputs: [[mean_3, f32, [1, 512, 1]]]
+  - id: add_6
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [mean_3, add_6_c1_bc]
+    outputs: [[add_6, f32, [1, 512, 1]]]
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: rsqrt}}
+    inputs: [add_6]
+    outputs: [[rsqrt_3, f32, [1, 512, 1]]]
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - {var: out_coord_0}
+            - {var: out_coord_1}
+            - {literal: {value: 0, dtype: int}}
+            select: null
+    inputs: [rsqrt_3]
+    outputs: [[rsqrt_3_bc, f32, [1, 512, 1024]]]
+  - id: mul_10
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [to_6, rsqrt_3_bc]
+    outputs: [[mul_10, f32, [1, 512, 1024]]]
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 512}, {__dim__: 1024}]}
+      sources:
+        __tuple__:
+        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {var: out_coord_1}, {var: out_coord_2}], select: null}
+    inputs: [mul_10]
+    outputs: [[to_7, f16, [1, 512, 1024]]]
+  - id: mul_11
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [p_post_attention_layernorm_weight_bc, to_7]
+    outputs: [[mul_11, f16, [1, 512, 1024]]]
+  - id: linear_4
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_gate_proj_weight]
+    outputs: [[linear_4, f16, [1, 512, 3072]]]
+  - id: linear_5
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_11, p_mlp_up_proj_weight]
+    outputs: [[linear_5, f16, [1, 512, 3072]]]
+  - id: silu
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: silu}}
+    inputs: [linear_4]
+    outputs: [[silu, f16, [1, 512, 3072]]]
+  - id: mul_12
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: multiply}}
+    inputs: [silu, linear_5]
+    outputs: [[mul_12, f16, [1, 512, 3072]]]
+  - id: linear_6
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [mul_12, p_mlp_down_proj_weight]
+    outputs: [[linear_6, f16, [1, 512, 1024]]]
+  - id: add_7
+    op: tensor.elementwise
+    attrs: {op: {__elementwise__: add}}
+    inputs: [add_5, linear_6]
+    outputs: [[add_7, f16, [1, 512, 1024]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      REDUCE: coop
+      WORK: t256
+    measurements:
+      emmy_us: 3.1764
+      reference_us: 191.6096
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_06a42b.975d5314f1c7
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 17.426
+      reference_us: 12.9707
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_1fd3d5.d0f217697284
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      STAGE: d1/smem-async
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      WORK: w4x1
+    measurements:
+      emmy_us: 22.2549
+      reference_us: 100.7909
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_a09c5a.f753cb04390b
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 17.2844
+      reference_us: 60.1009
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_c0a378.ace3043c96cf
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_e24efe.109440eff691
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      STAGE: d2/smem
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w8x2
+    measurements:
+      emmy_us: 190.6688
+      reference_us: 60.2027
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_dc067d.a2e77bf96bb2
+    bindings: {}
+    pins:
+      FAST_MATH: false
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_6b4b5f.a59ee74a4345
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      LOOPIFY: '0'
+      STAGE: d3/smem-async
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      WORK: w2x2
+    measurements:
+      emmy_us: 46.6651
+      reference_us: 32.4267
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      PLACE@b: cut
+    measurements:
+      emmy_us: 299.6907
+      reference_us: 745.472
+      reference_backend: torch-eager
+gpu_name: NVIDIA A100 80GB
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca

--- a/experiments/golden-bench-2026/kernels/recipe.yaml
+++ b/experiments/golden-bench-2026/kernels/recipe.yaml
@@ -1,5 +1,10 @@
 # One bounded model-derived corpus and its diagnostics. Every row is an ordinary matrix task on a shared per-GPU VM;
 # the study field keeps the headline common corpus, large-shape supplement, convergence check, and ablation separate.
+#
+# A row that names a `golden` replays `golden/<golden>.golden.yaml` instead of tracing and searching: those
+# schedules were tuned by the tune-kernels skill and committed beside this recipe, and the row only re-measures them
+# at deployable -O3. Rows with `golden: ""` keep the original trace + in-recipe search. Both paths end in the same
+# five fresh-process `emmy run --golden ... --bench --strict` repeats, so the two lanes produce the same evidence.
 command:
   stage:
     - emmy
@@ -7,6 +12,7 @@ command:
     - requirements.txt
     - Makefile
     - experiments/golden-bench-2026/kernels/recipe.yaml
+    - experiments/golden-bench-2026/kernels/golden
   strict: true
   run: |
     set -euo pipefail
@@ -23,7 +29,7 @@ command:
         final_status=1
       fi
       printf 'study=%s\nstatus=%s\n' "$study" "$$final_status" > $task_dir/status.txt
-      archive_tmp=$${task_dir}.artifacts.tar.gz
+      archive_tmp=$task_dir.artifacts.tar.gz
       tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
       mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
       exit "$$final_status"
@@ -40,26 +46,43 @@ command:
     devices="$gpu_device_ids"
     first_device=$${devices%%,*}
 
-    trace_args=(
-      ./venv/bin/emmy trace "$model_ref" --layer "$layer" --seq-len "$seq_len"
-      --model-provenance "$model_ref" --output $task_dir/working.yaml
-    )
-    "$${trace_args[@]}" 2>&1 | tee $task_dir/trace.log
-
-    if [ "$budget" = "0" ]; then
-      echo "tuning intentionally skipped for the cold greedy case" | tee $task_dir/tune.log
+    if [ -n "$golden" ]; then
+      cp $repo_dir/experiments/golden-bench-2026/kernels/golden/$golden.golden.yaml $task_dir/working.yaml
+      echo "replaying committed golden $golden" | tee $task_dir/trace.log
+      echo "search owned by the tune-kernels skill; this row only re-measures" | tee $task_dir/tune.log
     else
-      ./venv/bin/emmy tune --golden-file $task_dir/working.yaml --clean \
-        --devices "$$devices" --max-candidates "$budget" --patience "$patience" --seed "$seed" \
-        --dump-dir $task_dir/dump 2>&1 | tee $task_dir/tune.log
+      trace_args=(
+        ./venv/bin/emmy trace "$model_ref" --layer "$layer" --seq-len "$seq_len"
+        --model-provenance "$model_ref" --output $task_dir/working.yaml
+      )
+      "$${trace_args[@]}" 2>&1 | tee $task_dir/trace.log
+
+      if [ "$budget" = "0" ]; then
+        echo "tuning intentionally skipped for the cold greedy case" | tee $task_dir/tune.log
+      else
+        ./venv/bin/emmy tune --golden-file $task_dir/working.yaml --clean \
+          --devices "$$devices" --max-candidates "$budget" --patience "$patience" --seed "$seed" \
+          --dump-dir $task_dir/dump 2>&1 | tee $task_dir/tune.log
+      fi
     fi
 
+    # Every repeat runs even when one target fails its correctness/backend gate, so a single hard
+    # target cannot discard the other four fresh-process replays. The per-repeat exit status is
+    # preserved and the task still fails, so the failure is reported rather than hidden.
+    verification_status=0
     for repeat in 0 1 2 3 4; do
-      EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
+      if EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
         --golden $task_dir/working.yaml --bench --strict \
         --json $task_dir/verification/repeat-$$repeat --warmup 10 --iters 100 \
-        --bench-backends eager,tcompile,emmy 2>&1 | tee $task_dir/verification-$$repeat.log
+        --bench-backends eager,tcompile,emmy 2>&1 | tee $task_dir/verification-$$repeat.log; then
+        repeat_status=0
+      else
+        repeat_status=$$?
+        verification_status=$$repeat_status
+      fi
+      printf '%s\n' "$$repeat_status" > $task_dir/verification/repeat-$$repeat.status
     done
+    exit "$$verification_status"
   result_files:
     - artifacts.tar.gz
   timeout: 86400
@@ -75,15 +98,30 @@ matrices:
       patience: 4
       seed: 0
       fp8_mma: 0
+      golden: ""
       zip:
         deploy.gpu:
           - "NVIDIA Tesla V100 SXM3 32GB"
-          - "NVIDIA A100 80GB"
           - "NVIDIA GeForce RTX 4090"
           - "NVIDIA GeForce RTX 5090"
           - "NVIDIA H200 141GB"
           - "NVIDIA B200"
         deploy.gpu_count: 1
+
+  # The same common corpus on the A100, replaying the committed tuned goldens instead of searching.
+  - cross:
+      study: common
+      model_ref: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
+      layer: 0
+      budget: 0
+      patience: 0
+      seed: 0
+      fp8_mma: 0
+      deploy.gpu: "NVIDIA A100 80GB"
+      deploy.gpu_count: 1
+      zip:
+        seq_len: [1, 512]
+        golden: [qwen3-06b-s1_a100, qwen3-06b-s512_a100]
 
   # Dynamic-FP8 checkpoint layers on FP8-capable GPUs. A future golden filter will define the W8A8-only corpus.
   - cross:
@@ -95,6 +133,7 @@ matrices:
       patience: 4
       seed: 0
       fp8_mma: 1
+      golden: ""
       zip:
         deploy.gpu:
           - "NVIDIA GeForce RTX 4090"
@@ -113,6 +152,7 @@ matrices:
       patience: 3
       seed: 0
       fp8_mma: 1
+      golden: ""
       zip:
         deploy.gpu: ["NVIDIA H200 141GB", "NVIDIA B200"]
         deploy.gpu_count: 1
@@ -127,6 +167,7 @@ matrices:
       patience: 3
       seed: 0
       fp8_mma: 0
+      golden: ""
       zip:
         deploy.gpu: ["NVIDIA H200 141GB", "NVIDIA B200"]
         deploy.gpu_count: 1
@@ -141,6 +182,7 @@ matrices:
       patience: 4
       seed: [0, 1, 2]
       fp8_mma: 0
+      golden: ""
       deploy.gpu: "NVIDIA H200 141GB"
       deploy.gpu_count: 1
 
@@ -154,6 +196,7 @@ matrices:
       patience: 4
       seed: [0, 1, 2]
       fp8_mma: 1
+      golden: ""
       deploy.gpu: "NVIDIA H200 141GB"
       deploy.gpu_count: 1
 
@@ -164,6 +207,7 @@ matrices:
     seq_len: 512
     seed: 0
     fp8_mma: 0
+    golden: ""
     deploy.gpu: "NVIDIA H200 141GB"
     deploy.gpu_count: 1
     zip:

--- a/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_a100x1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9739f05420f8c8e09f2cb746ef197ec50e74ced1758c22c266f77adb9cc19099
+size 264002

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -37,8 +37,17 @@ def test_common_kernel_corpus_is_small_and_identical(project_root) -> None:
     assert all(task.recipe.deploy.gpu_count == 1 for task in tasks)
     assert {task.variant.params["seq_len"] for task in tasks} == {1, 512}
     assert {task.variant.params["model_ref"] for task in tasks} == {"Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca"}
-    assert all(task.variant.params["budget"] == 12 for task in tasks)
-    assert all(task.variant.params["patience"] == 4 for task in tasks)
+    a100_tasks = [task for task in tasks if task.recipe.deploy.gpu == "NVIDIA A100 80GB"]
+    searched_tasks = [task for task in tasks if task.recipe.deploy.gpu != "NVIDIA A100 80GB"]
+    assert {task.variant.params["golden"] for task in a100_tasks} == {
+        "qwen3-06b-s1_a100",
+        "qwen3-06b-s512_a100",
+    }
+    assert all(task.variant.params["budget"] == 0 for task in a100_tasks)
+    assert all(task.variant.params["patience"] == 0 for task in a100_tasks)
+    assert all(task.variant.params["golden"] == "" for task in searched_tasks)
+    assert all(task.variant.params["budget"] == 12 for task in searched_tasks)
+    assert all(task.variant.params["patience"] == 4 for task in searched_tasks)
 
     run = recipe.command.run
     assert "./venv/bin/emmy trace" in run
@@ -53,6 +62,7 @@ def test_common_kernel_corpus_is_small_and_identical(project_root) -> None:
         "requirements.txt",
         "Makefile",
         "experiments/golden-bench-2026/kernels/recipe.yaml",
+        "experiments/golden-bench-2026/kernels/golden",
     ]
     assert recipe.command.strict is True
     assert recipe.command.result_files == ["artifacts.tar.gz"]


### PR DESCRIPTION
Adds replay-only A100 common-corpus rows, the latest 18-target working goldens, the prior durable A100 snapshot, and the matching corpus contract test. Positive direct tuning evidence: PLACE@b=cut runs the sequence-512 score/statistics target at 299.69 us versus 745.47 us eager; PLACE@map=cut runs the sequence-1 norm/gate-up target at 66.97 us versus 154.62 us eager. Both pass strict Emmy-versus-eager correctness. The report explicitly labels that the archived replay predates these two pins and that two sequence-512 targets remain unpinned. Verification: make test (3072 passed, 560 skipped, 1 xfailed); make lint; archive row/LFS/secret checks.