### PR TITLE
Trace triangular tensor filters as index maps

### DIFF
--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -28,7 +28,10 @@ the allocation's FX name versions sequential slice writes and later aliases buil
 leaves that version unchanged. A write through an input/parameter, a dynamic or strided slice, a used `copy_` return,
 or a view created before the write still fails closed; those forms need general alias versioning rather than this local
 functional update. `masked_fill` lowers to ternary `where(mask, fill, self)` so an unselected infinity is preserved
-instead of becoming NaN through arithmetic selection.
+instead of becoming NaN through arithmetic selection. `triu` and `tril` lower to two-source `IndexMapOp` regions over
+the last two axes: the selected triangular region reads the input and the complement reads a scalar zero. The
+diagonal must be a static integer; tensor-valued or symbolic diagonals fail closed instead of becoming broadcast
+elementwise operands.
 
 A static one-dimension `roll` and rank-reducing `select` lower directly to affine `IndexMapOp` regions. An exported
 `fill_` is functional through its returned value. If a later live read observes the written storage, a static unit-step

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -1508,6 +1508,44 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
         node_map[name] = nid
         return
 
+    # ``triu`` / ``tril`` keep one triangular region of the last two dimensions and
+    # fill the other with zero. They are coordinate maps, not scalar elementwise
+    # functions: the diagonal selects output coordinates and is not a tensor operand.
+    if op_name in ("triu", "tril"):
+        if not input_ids:
+            raise ValueError(f"aten.{op_name} requires a resolved tensor input")
+        if len(shape) < 2:
+            raise ValueError(f"aten.{op_name} requires a tensor with at least two dimensions, got shape {shape}")
+        diagonal = fx_node.args[1] if len(fx_node.args) > 1 else (fx_node.kwargs or {}).get("diagonal", 0)
+        if not isinstance(diagonal, int) or isinstance(diagonal, bool):
+            raise NotImplementedError(f"aten.{op_name} requires a static integer diagonal, got {diagonal!r}")
+
+        row = placeholder(len(shape) - 2)
+        column = placeholder(len(shape) - 1)
+        boundary = row if diagonal == 0 else BinaryExpr("+", row, Literal(diagonal, "int"))
+        keep = BinaryExpr(">=", column, boundary) if op_name == "triu" else BinaryExpr("<=", column, boundary)
+        identity = tuple(placeholder(axis) for axis in range(len(shape)))
+        zero_name = f"{name}_zero"
+        zero_id = g.add_node(
+            op=ConstantOp(name=zero_name, value=False if dtype == "bool" else 0.0),
+            inputs=[],
+            output=Tensor(zero_name, (1,), dtype),
+            node_id=zero_name,
+        )
+        node_map[name] = g.add_node(
+            op=IndexMapOp(
+                out_shape=shape,
+                sources=(
+                    IndexSource(input_idx=0, coord_map=identity, select=keep),
+                    IndexSource(input_idx=1, coord_map=(Literal(0, "int"),)),
+                ),
+            ),
+            inputs=[input_ids[0], zero_id],
+            output=Tensor(name, shape, dtype),
+            node_id=name,
+        )
+        return
+
     # --- Elementwise ops ---
     # Torch's aten-level short names (``sub`` / ``mul`` / ``div`` / ``neg``)
     # get translated to numpy-style long names here so the rest of the

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -690,6 +690,33 @@ def test_trace_masked_fill_lowers_to_ternary_where_and_matches_eager():
     np.testing.assert_array_equal(got, MaskedFill()(x, mask).numpy())
 
 
+def test_trace_triangular_filters_lower_to_index_maps_and_match_eager():
+    """Function and tensor triangular APIs select the last two axes and zero the rest."""
+    import numpy as np
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.backend.numpy import NumpyBackend
+    from emmy.compiler.ir.tensor.ir import IndexMapOp
+    from emmy.compiler.trace.torch import trace_module
+
+    class TriangularFilters(nn.Module):
+        def forward(self, x):
+            return torch.triu(x, diagonal=1), x.tril(diagonal=-1)
+
+    x = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    graph = trace_module(TriangularFilters(), (x,))
+    triangular_maps = [node for node in graph.nodes.values() if isinstance(node.op, IndexMapOp) and len(node.op.sources) == 2]
+    assert len(triangular_maps) == 2
+
+    backend = NumpyBackend()
+    result, _ = backend.run(backend.compile(graph), input_data={graph.inputs[0]: x.numpy()})
+    with torch.no_grad():
+        expected = TriangularFilters()(x)
+    for got, want in zip(result.outputs.values(), expected, strict=True):
+        np.testing.assert_array_equal(got, want.numpy())
+
+
 def test_trace_transpose():
     """aten.transpose traces to TransposeOp."""
     import torch


### PR DESCRIPTION
## Summary

- lower `aten.triu` and `aten.tril` as coordinate-selected index maps
- keep the diagonal as a static operator argument instead of broadcasting it as a tensor operand
- cover the function and tensor APIs against eager PyTorch on batched inputs

This is the first focused compiler-coverage increment for the Qwen3.8 Gated DeltaNet path. It fixes the triangular mask operation, but does not claim complete model coverage; the sequential overlapping-slice recurrence remains separate work, and no partial model golden is included.

## Verification

- `make test` (3,073 passed, 560 skipped, 1 xfailed)
- `make lint`
- exact pre-fix reproducer failed in NumPy with a broadcast diagonal; the new focused test passes
