### PR TITLE
Version local affine copy updates

### DIFF
--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -21,13 +21,13 @@ stamp the output tensor.
 
 Tensor constructors whose receiver supplies only dtype/device metadata (`new_zeros`, `new_full`) lower from a scalar
 constant plus an explicit broadcast; the receiver's unrelated shape and values never become operands. Exported
-`copy_` is treated functionally as a destination-shaped broadcast/cast of its source. A static, unit-step slice chain
-rooted at a local `new_zeros` / `new_full` allocation additionally reassembles the updated base as a two-source
-`IndexMapOp`: the copied value supplies the written region and the previous base supplies the remainder. Rebinding
-the allocation's FX name versions sequential slice writes and later aliases built from that name; an empty slice write
-leaves that version unchanged. A write through an input/parameter, a dynamic or strided slice, a used `copy_` return,
-or a view created before the write still fails closed; those forms need general alias versioning rather than this local
-functional update. `masked_fill` lowers to ternary `where(mask, fill, self)` so an unselected infinity is preserved
+`copy_` is treated functionally as a destination-shaped broadcast/cast of its source. A static, unit-step slice/select
+chain rooted at a locally computed tensor additionally reassembles the updated base as a two-source `IndexMapOp`: the
+copied value supplies the written region and the previous base supplies the remainder. Rebinding the root's FX name
+versions sequential overlapping writes and later aliases built from that name; an empty write leaves that version
+unchanged. A write through an input/parameter, a dynamic or strided view, a used `copy_` return, or a view created
+before the write still fails closed; those forms need general alias versioning rather than this local functional
+update. `masked_fill` lowers to ternary `where(mask, fill, self)` so an unselected infinity is preserved
 instead of becoming NaN through arithmetic selection. `triu` and `tril` lower to two-source `IndexMapOp` regions over
 the last two axes: the selected triangular region reads the input and the complement reads a scalar zero. The
 diagonal must be a static integer; tensor-valued or symbolic diagonals fail closed instead of becoming broadcast

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -257,24 +257,6 @@ def _observable_alias_read_after_write(node) -> tuple[Any, Any] | None:
     return None
 
 
-def _static_local_slice_destination(node) -> tuple[Any, tuple[int, ...], tuple[int, ...]] | None:
-    """Describe a unit-step slice destination rooted at a local tensor constructor.
-
-    Returns ``(root, offsets, extents)`` in root coordinates. This deliberately accepts
-    only the allocation + static ``aten.slice`` form whose functional update is exactly
-    representable by a two-source ``IndexMapOp``. Other aliases stay fail-closed.
-    """
-    destination = _static_affine_view_destination(node)
-    if destination is None:
-        return None
-    root, offsets, extents, view_axes = destination
-    if any(axis is None for axis in view_axes):
-        return None
-    if root.op != "call_function" or _op_name(root.target) not in ("new_zeros", "new_full"):
-        return None
-    return root, offsets, extents
-
-
 def _static_affine_view_destination(
     node,
 ) -> tuple[Any, tuple[int, ...], tuple[int, ...], tuple[int | None, ...]] | None:
@@ -358,16 +340,20 @@ def _static_fx_shape(node) -> tuple[int, ...] | None:
     return tuple(shape)
 
 
-def _reassemblable_local_slice_copy(node) -> tuple[Any, tuple[int, ...], tuple[int, ...]] | None:
-    """Return a local slice-update description when every alias can be versioned safely."""
+def _reassemblable_local_affine_copy(
+    node,
+) -> tuple[Any, tuple[int, ...], tuple[int, ...], tuple[int | None, ...]] | None:
+    """Return a local affine-view update when every alias can be versioned safely."""
     # A used ``copy_`` return is itself an alias. Supporting both it and an updated base would
     # require versioning that returned view across later writes, outside this narrow local form.
     if node.users:
         return None
-    destination = _static_local_slice_destination(node)
+    destination = _static_affine_view_destination(node)
     if destination is None:
         return None
-    root, _, _ = destination
+    root, _, _, _ = destination
+    if root.op != "call_function":
+        return None
     if not _local_alias_version_is_rebindable(node, root):
         return None
     return destination
@@ -1411,14 +1397,14 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
         )
         return
 
-    # ``copy_(dest, src)`` returns destination-shaped source values. A static slice of a local
-    # constructor can also update its base functionally: one IndexMap source supplies the written
+    # ``copy_(dest, src)`` returns destination-shaped source values. A static slice/select of a
+    # local value can also update its base functionally: one IndexMap source supplies the written
     # region and the previous base supplies the rest. Broader alias mutation remains fail-closed.
     if op_name == "copy_":
         from emmy.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to
 
         observable = _observable_alias_read_after_write(fx_node)
-        reassembly = _reassemblable_local_slice_copy(fx_node) if observable is not None else None
+        reassembly = _reassemblable_local_affine_copy(fx_node) if observable is not None else None
         if observable is not None and reassembly is None:
             later, source = observable
             raise NotImplementedError(
@@ -1442,7 +1428,7 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
         node_map[name] = copied_id
 
         if reassembly is not None:
-            root, offsets, extents = reassembly
+            root, offsets, extents, view_axes = reassembly
             previous_base = node_map.get(root.name)
             if not isinstance(previous_base, str):
                 raise ValueError(f"aten.copy_ local destination root {root.name!r} did not resolve to a tensor")
@@ -1453,20 +1439,29 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
                 return
             base = g.nodes[previous_base].output
             base_shape = tuple(base.shape)
-            if len(base_shape) != len(offsets) or tuple(shape) != tuple(extents):
+            view_shape = [0] * sum(axis is not None for axis in view_axes)
+            for root_axis, view_axis in enumerate(view_axes):
+                if view_axis is not None:
+                    view_shape[view_axis] = extents[root_axis]
+            if len(base_shape) != len(offsets) or tuple(shape) != tuple(view_shape):
                 raise ValueError(
-                    f"aten.copy_ local slice shape mismatch: base={base_shape}, destination={tuple(extents)}, copy={tuple(shape)}"
+                    f"aten.copy_ local view shape mismatch: base={base_shape}, destination={tuple(view_shape)}, copy={tuple(shape)}"
                 )
 
             select = Literal(1, "int")
-            source_coords = []
             for axis, (offset, extent) in enumerate(zip(offsets, extents, strict=True)):
                 coord = placeholder(axis)
                 in_axis = BinaryExpr(">=", coord, Literal(offset, "int"))
                 in_axis = BinaryExpr("&&", in_axis, coord.lt(Literal(offset + extent, "int")))
                 select = BinaryExpr("&&", select, in_axis)
+            source_coords: list[Any] = [Literal(0, "int")] * len(view_shape)
+            for root_axis, view_axis in enumerate(view_axes):
+                if view_axis is None:
+                    continue
+                coord = placeholder(root_axis)
+                offset = offsets[root_axis]
                 source_coord = coord - Literal(offset, "int") if offset else coord
-                source_coords.append(TernaryExpr(select, source_coord, Literal(0, "int")))
+                source_coords[view_axis] = TernaryExpr(select, source_coord, Literal(0, "int"))
 
             identity = tuple(placeholder(axis) for axis in range(len(base_shape)))
             update_name = f"{name}_base"

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -397,6 +397,37 @@ def test_trace_reassembles_static_local_slice_copies_observed_through_base():
     assert all(isinstance(node.op, (InputOp, ConstantOp, LoopOp)) for node in lowered.nodes.values())
 
 
+def test_trace_reassembles_qwen_chunk_recurrence_on_computed_local_base():
+    """Sequential select/slice writes version Qwen's computed attention matrix and local output."""
+    import numpy as np
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.backend.numpy import NumpyBackend
+    from emmy.compiler.trace.torch import trace_module
+
+    class ChunkRecurrence(nn.Module):
+        def forward(self, x):
+            attn = -(x @ x.transpose(-1, -2))
+            for i in range(1, 4):
+                row = attn[..., i, :i].clone()
+                sub = attn[..., :i, :i].clone()
+                attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+            output = torch.zeros_like(attn)
+            output[..., 0, :].copy_(attn[..., 0, :])
+            return attn, output
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 4, 4)
+    graph = trace_module(ChunkRecurrence(), (x,))
+    backend = NumpyBackend()
+    result, _ = backend.run(backend.compile(graph), input_data={graph.inputs[0]: x.numpy()})
+    with torch.no_grad():
+        expected = ChunkRecurrence()(x)
+    for got, want in zip(result.outputs.values(), expected, strict=True):
+        np.testing.assert_allclose(got, want.numpy(), rtol=1e-5, atol=1e-5)
+
+
 def test_trace_treats_empty_static_local_slice_copy_as_noop():
     """An empty local write preserves its base without loading a zero-sized source."""
     import numpy as np


### PR DESCRIPTION
## Summary

- functionally version static slice/select writes into locally computed tensors
- preserve overlapping sequential writes by rebinding the local FX root to each reconstructed `IndexMapOp`
- keep writes through inputs, stale aliases, dynamic/strided views, and used mutation returns fail-closed
- cover the exact computed-attention and local-output update pattern from Qwen3.8 Gated DeltaNet

This follows #591. It removes the next frontend blocker for the pure-PyTorch Qwen3.8 chunked delta-rule recurrence; full model coverage and tuning are still being qualified separately, so this PR contains no partial golden.

## Verification

- focused tracer suite: 70 passed
- `make test`: 3,074 passed, 560 skipped, 1 xfailed
- `make lint`
