### PR TITLE
Preserve BF16 carriers at runtime boundaries

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -129,7 +129,9 @@ and Emmy always rebuild the same module and example inputs. Inductor compiles wi
 `fullgraph=True, mode="max-autotune-no-cudagraphs"`; the harness supplies the shared outer CUDA graph so every backend
 has identical captured timing semantics. Inductor output must match eager on the same inputs at `rtol=atol=1e-3`
 before its latency is accepted. `run --strict` makes every requested backend, captured timing, exact pin, and direct
-Emmy-vs-eager proof authoritative. It records max/mean/relative error in `--json` and exits
+Emmy-vs-eager proof authoritative. BF16 inputs and constants bind through the compiler's raw `uint16` carrier, and
+backend output bits are decoded to numeric values before every command-layer correctness check. The command records
+max/mean/relative error in `--json` and exits
 nonzero on any missing or failed evidence. Dynamic-shape parsing, quantized architecture twins and
 their in-graph storage algebra, sliding-window stamps, and the guarded `trust_remote_code` fallback therefore behave
 identically for all four commands (see `compiler/ARCHITECTURE.md`, "Quantized checkpoints").

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -713,6 +713,25 @@ def _wrong_answer_flag(outputs: dict, ref_outputs: dict) -> str | None:
     return None
 
 
+def _comparison_outputs(outputs: dict, graph) -> dict:
+    """Decode physical carriers before command-layer correctness checks."""
+    import numpy as np  # noqa: PLC0415
+
+    from emmy.compiler.dtype import decode_bf16  # noqa: PLC0415
+
+    if not hasattr(graph, "buffer"):
+        return outputs
+    decoded = outputs
+    for name, value in outputs.items():
+        arr = np.asarray(value)
+        dtype = graph.buffer(name).dtype
+        if dtype.name == "bf16" and arr.dtype == np.uint16:
+            if decoded is outputs:
+                decoded = dict(outputs)
+            decoded[name] = decode_bf16(arr)
+    return decoded
+
+
 def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, atol: float = 1e-3) -> dict:
     """Return a direct Emmy-vs-eager tolerance verdict with reproducible error statistics.
 
@@ -925,6 +944,7 @@ async def _bench_golden_variants(backend, source, golden_configs, *, warmup, ite
             logger.warning("[golden] %s: bench of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
             out.append(_GoldenBench(sample, g_compiled, None, [f"bench_fail: {exc}"], "bench_fail"))
             continue
+        run_outputs = _comparison_outputs(run_outputs, g_compiled) if run_outputs is not None else None
         correctness = None
         if run_outputs is not None and ref_outputs is not None:
             if strict_correctness:
@@ -1874,11 +1894,12 @@ async def bench_lowered_vs_torch(
             input_data[nid] = arr.flatten().tolist()
 
     result, _ = backend.run(lowered, input_data=input_data)
+    result_outputs = _comparison_outputs(result.outputs, lowered)
     if frontend is None and ref_out is not None:
-        ref_out.append((input_data, result.outputs))
+        ref_out.append((input_data, result_outputs))
     if ref_us_out is not None:
         ref_us_out.append(result.time_ms * 1000)
-    for nid, arr in result.outputs.items():
+    for nid, arr in result_outputs.items():
         finite = np.isfinite(arr).all()
         logger.info("Output %s: shape=%s finite=%s mean=%.4f", nid, arr.shape, bool(finite), float(arr.mean()))
 
@@ -1890,12 +1911,12 @@ async def bench_lowered_vs_torch(
             with torch.no_grad():
                 eager_out = torch_fn(*torch_inputs)
             if strict_accuracy:
-                correctness = _strict_correctness_proof(result.outputs, eager_out)
+                correctness = _strict_correctness_proof(result_outputs, eager_out)
                 if correctness["status"] != "pass":
                     accuracy_error = f"strict eager correctness failed: {correctness.get('error', 'tolerance exceeded')}"
             else:
-                accuracy_error = _check_accuracy(result.outputs, eager_out)
-            reference = (input_data, _eager_outputs_by_name(result.outputs, eager_out))
+                accuracy_error = _check_accuracy(result_outputs, eager_out)
+            reference = (input_data, _eager_outputs_by_name(result_outputs, eager_out))
             if ref_out is not None:
                 ref_out.append(reference)
             if accuracy_error is not None:
@@ -2337,14 +2358,25 @@ def _bind_inputs(compiled, module, example_args, example_kwargs, checkpoint=None
     input_data: dict[str, np.ndarray] = {}
     torch_f8 = (torch.float8_e4m3fn, torch.float8_e5m2)
     for nid, tensor in zip(input_ids, flat_inputs, strict=True):
-        np_dtype = compiled.nodes[nid].output.dtype.np
+        dtype = compiled.nodes[nid].output.dtype
+        np_dtype = dtype.np
         tensor = tensor.detach().cpu()
         # An fp8 activation/weight INPUT binds the raw bit pattern on its uint8 carrier —
         # numpy has no fp8 scalar type, and a value cast would decode the bits (the same
         # rule the constant side and the serving expert feed already follow).
         if tensor.dtype in torch_f8:
             tensor = tensor.view(torch.uint8)
-        input_data[nid] = tensor.numpy().astype(np_dtype, copy=False)
+        if dtype.name == "bf16":
+            from emmy.compiler.dtype import encode_bf16  # noqa: PLC0415
+
+            if tensor.dtype == torch.bfloat16:
+                input_data[nid] = tensor.contiguous().view(torch.uint16).numpy()
+            else:
+                input_data[nid] = encode_bf16(tensor.numpy())
+        else:
+            if tensor.dtype == torch.bfloat16:
+                tensor = tensor.float()
+            input_data[nid] = tensor.numpy().astype(np_dtype, copy=False)
 
     # ``remove_duplicate=False`` so tied weights (e.g. a model whose lm_head
     # shares the embedding matrix) are surfaced under *every* name, including
@@ -2352,9 +2384,19 @@ def _bind_inputs(compiled, module, example_args, example_kwargs, checkpoint=None
     # picked may be the one torch dedups away and the constant won't bind.
     sources: dict[str, np.ndarray] = {}
     for path, tensor in module.named_parameters(remove_duplicate=False):
-        sources[path] = tensor.detach().cpu().numpy().astype(np.float32, copy=False)
+        tensor = tensor.detach().cpu()
+        sources[path] = (
+            tensor.contiguous().view(torch.uint16).numpy()
+            if tensor.dtype == torch.bfloat16
+            else tensor.numpy().astype(np.float32, copy=False)
+        )
     for path, tensor in module.named_buffers(remove_duplicate=False):
-        sources[path] = tensor.detach().cpu().numpy().astype(np.float32, copy=False)
+        tensor = tensor.detach().cpu()
+        sources[path] = (
+            tensor.contiguous().view(torch.uint16).numpy()
+            if tensor.dtype == torch.bfloat16
+            else tensor.numpy().astype(np.float32, copy=False)
+        )
 
     input_data.update(bind_constants(compiled, sources))
 

--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -126,6 +126,9 @@ autotuning cache doesn't bust on cosmetic edits.
 - **One `LoopOp` = one kernel.** Fusion produces `LoopOp` nodes;
   lowering turns each into `KernelOp` (AST) then `CudaOp` (rendered
   source).
+- **BF16 uses raw `uint16` bits at NumPy boundaries.** `dtype.encode_bf16` and `decode_bf16` are the shared
+  round-to-nearest-even conversion. Numeric values must never be value-cast to the carrier: live PyTorch tensors,
+  standalone random inputs, CUDA uploads, and command-layer comparisons preserve or decode the physical bits.
 - **`LoopOp.forward()` executes.** `ir/loop/runner.py` renders the body
   to C++ and JIT-compiles it via cppyy / Cling, letting the default
   `Backend.run` topo-walk (`backend/base.py`) run post-fusion graphs on

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -76,10 +76,12 @@ codegen, no nvcc), and both paths share every line downstream. The projection:
    constant overrides come from `input_data`; scalar `ConstantOp`s
    materialize as single-element arrays; scratch buffers zero-init.
    Inputs without supplied data get a deterministic pseudo-random fill
-   (useful for standalone compile-and-benchmark scripts).
+   (useful for standalone compile-and-benchmark scripts). BF16 buffers use NumPy's `uint16` carrier as raw bits:
+   numeric inputs are round-to-nearest-even encoded before upload, while an already-`uint16` source is preserved.
 2. Launch each kernel in topological order; `zero_outputs` fills run
    before the launch.
-3. Copy `graph.outputs` buffers back to numpy.
+3. Copy `graph.outputs` buffers back to numpy. BF16 outputs remain raw `uint16` bits at this backend boundary;
+   command-layer correctness checks decode them.
 
 **Scratch-buffer reuse (`_planner.py`).** Step 1 does *not* give every node its
 own permanently-live buffer — that holds all 28 layers' `[heads, S, S]` attention scratch resident at once (~29 GB for

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -192,17 +192,24 @@ async def _run_job(req: dict) -> dict:
                 # benching a miscompiling program would be wasted GPU time. ``want_ref``
                 # ships this run's (inputs, outputs) back as the pinned rows' wrong-answer
                 # reference (bounded: pinned rows only exist for --code inputs).
-                from emmy.commands.run import _bind_inputs, _check_accuracy, _eager_output, _strict_correctness_proof
+                from emmy.commands.run import (
+                    _bind_inputs,
+                    _check_accuracy,
+                    _comparison_outputs,
+                    _eager_output,
+                    _strict_correctness_proof,
+                )
 
                 input_data = _bind_inputs(req["graph"], module, args_t, kwargs, checkpoint=payload.get("input"))
                 run_result, _ = backend.run(req["graph"], input_data=input_data)
+                run_outputs = _comparison_outputs(run_result.outputs, req["graph"])
                 eager_out = _eager_output(module, args_t, kwargs)
                 if req.get("strict_accuracy"):
-                    correctness = _strict_correctness_proof(run_result.outputs, eager_out)
+                    correctness = _strict_correctness_proof(run_outputs, eager_out)
                     if correctness["status"] != "pass":
                         accuracy_error = f"strict eager correctness failed: {correctness.get('error', 'tolerance exceeded')}"
                 else:
-                    accuracy_error = _check_accuracy(run_result.outputs, eager_out)
+                    accuracy_error = _check_accuracy(run_outputs, eager_out)
                 if accuracy_error is not None:
                     return {
                         "result": None,
@@ -213,7 +220,7 @@ async def _run_job(req: dict) -> dict:
                         "run_io": None,
                     }
                 if req.get("want_ref"):
-                    run_io = (input_data, run_result.outputs)
+                    run_io = (input_data, run_outputs)
             results, bench, captured = await bench_full_model_real(
                 module,
                 args_t,

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -34,6 +34,7 @@ from emmy.compiler.backend.cuda.dtype import cupy_dtype
 from emmy.compiler.backend.plan import BufferSpec as _Buffer
 from emmy.compiler.backend.plan import ExecutionPlan, KernelSpec, apply_weight_loads, plan_from_graph
 from emmy.compiler.backend.plan import LaunchSpec as _Launch
+from emmy.compiler.dtype import encode_bf16
 from emmy.compiler.graph import Graph
 
 if TYPE_CHECKING:
@@ -166,6 +167,14 @@ def _nvrtc_options(*, uses_tma: bool) -> tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
+def _numpy_storage(src, dtype) -> np.ndarray:
+    """Return a contiguous host array in one buffer's physical storage dtype."""
+    arr = np.asarray(src)
+    if getattr(dtype, "name", dtype) == "bf16":
+        return np.ascontiguousarray(arr) if arr.dtype == np.uint16 else encode_bf16(arr)
+    return np.ascontiguousarray(arr, dtype=dtype.np)
+
+
 def _materialize(buf: _Buffer, shape: tuple[int, ...], src: np.ndarray | cp.ndarray | None, constants: dict[str, float]) -> cp.ndarray:
     """Build one device array for ``buf`` at ``shape`` — the single fill
     policy shared by :func:`_allocate` and :meth:`CompiledProgram.rebind`.
@@ -177,15 +186,20 @@ def _materialize(buf: _Buffer, shape: tuple[int, ...], src: np.ndarray | cp.ndar
 
     cp_dtype = cupy_dtype(buf.dtype)
     np_dtype = buf.dtype.np
+    is_bf16 = getattr(buf.dtype, "name", buf.dtype) == "bf16"
     if src is not None:
         if isinstance(src, cp.ndarray):
+            if is_bf16 and src.dtype != np.dtype(np.uint16):
+                values = src.astype(cp.float32, copy=False).view(cp.uint32)
+                values = values + cp.uint32(0x7FFF) + ((values >> cp.uint32(16)) & cp.uint32(1))
+                src = (values >> cp.uint32(16)).astype(cp.uint16)
             if src.dtype != np.dtype(np_dtype):
                 src = src.astype(np_dtype)
             return src.reshape(shape) if tuple(src.shape) != tuple(shape) else src
-        return cp.asarray(np.ascontiguousarray(src, dtype=np_dtype).reshape(shape))
+        return cp.asarray(_numpy_storage(src, buf.dtype).reshape(shape))
     if buf.role == "constant" and buf.name in constants:
         v = float(constants[buf.name])
-        if getattr(buf.dtype, "name", buf.dtype) == "bf16":
+        if is_bf16:
             # bf16 buffers ride as uint16 BITS (``BF16.np``) — casting the float would zero it;
             # encode the value to bf16 bits (round-to-nearest-even on the dropped mantissa half).
             bits = int(np.float32(v).view(np.uint32))
@@ -201,7 +215,8 @@ def _materialize(buf: _Buffer, shape: tuple[int, ...], src: np.ndarray | cp.ndar
         # → ``nan``). Compute in fp32 and cast the final values — always in
         # ``[-0.5, 0.5]``, so fp16-safe.
         idx = np.arange(n, dtype=np.int64)
-        vals = (0.01 * ((idx.astype(np.float32) * 7 + 13) % 101 - 50)).astype(np_dtype)
+        vals = 0.01 * ((idx.astype(np.float32) * 7 + 13) % 101 - 50)
+        vals = encode_bf16(vals) if is_bf16 else vals.astype(np_dtype)
         return cp.asarray(vals.reshape(shape))
     return cp.zeros(shape, dtype=cp_dtype)
 

--- a/emmy/compiler/dtype.py
+++ b/emmy/compiler/dtype.py
@@ -104,6 +104,25 @@ U64 = DataType("u64", np.dtype(np.uint64), 8)
 BOOL = DataType("bool", np.dtype(np.bool_), 1)
 
 
+def encode_bf16(values) -> np.ndarray:
+    """Encode numeric values as NumPy's raw ``uint16`` BF16 carrier.
+
+    NumPy has no first-class BF16 scalar. Runtime boundaries therefore carry
+    the round-to-nearest-even BF16 bit pattern, not a numeric ``uint16`` cast.
+    """
+    f32 = np.asarray(values, dtype=np.float32)
+    bits = f32.view(np.uint32)
+    rounded = bits + np.uint32(0x7FFF) + ((bits >> np.uint32(16)) & np.uint32(1))
+    return np.ascontiguousarray((rounded >> np.uint32(16)).astype(np.uint16))
+
+
+def decode_bf16(bits) -> np.ndarray:
+    """Decode NumPy's raw ``uint16`` BF16 carrier to float32 values."""
+    carrier = np.asarray(bits, dtype=np.uint16)
+    expanded = carrier.astype(np.uint32) << np.uint32(16)
+    return np.ascontiguousarray(expanded.view(np.float32))
+
+
 _BY_NAME: dict[str, DataType] = {dt.name: dt for dt in (F32, F16, F64, BF16, F8E4M3, F8E5M2, F16x2, I16, I32, I64, U16, U32, U64, BOOL)}
 
 # Aliases let callers feed PyTorch/numpy-style names without re-canonicalizing

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -3,7 +3,15 @@
 import numpy as np
 import pytest
 
-from emmy.compiler.backend.cuda.program import _collapse_inert_dims, _Compiled, _resolve_symbolic, benchmark_program, run_program
+from emmy.compiler.backend.cuda.program import (
+    _collapse_inert_dims,
+    _Compiled,
+    _numpy_storage,
+    _resolve_symbolic,
+    benchmark_program,
+    run_program,
+)
+from emmy.compiler.dtype import BF16, decode_bf16
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda import CudaOp
@@ -14,6 +22,15 @@ def _minimal_compiled(**kw) -> _Compiled:
     """A ``_Compiled`` with no kernels — enough to exercise ``_resolve_symbolic``
     (which only reads the symbolic_* maps). No CUDA needed."""
     return _Compiled(bufs=[], buf_by_name={}, constants={}, kernels={}, launches=[], **kw)
+
+
+def test_bf16_host_values_materialize_as_bits():
+    values = np.array([1.0, -2.0, np.pi], dtype=np.float32)
+    storage = _numpy_storage(values, BF16)
+
+    assert storage.dtype == np.uint16
+    np.testing.assert_array_equal(decode_bf16(storage), np.array([1.0, -2.0, 3.140625], dtype=np.float32))
+    np.testing.assert_array_equal(_numpy_storage(storage, BF16), storage)
 
 
 class TestSymbolicCapacityGuard:

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -1075,6 +1075,42 @@ def test_bind_inputs_preserves_int_dtype():
     np.testing.assert_array_equal(bound["position_ids"], np.arange(8, dtype=np.int32)[None, :])
 
 
+def test_bind_inputs_preserves_bf16_bits_for_inputs_and_constants():
+    import numpy as np
+
+    from emmy.commands.run import _bind_inputs, _comparison_outputs
+    from emmy.compiler import dtype as dt
+    from emmy.compiler.graph import Graph, Tensor
+    from emmy.compiler.ir.base import ConstantOp, InputOp
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (2,), dt.BF16), node_id="x")
+    g.add_node(
+        op=ConstantOp(name="weight", source_path="weight"),
+        inputs=[],
+        output=Tensor("weight", (2,), dt.BF16),
+        node_id="weight",
+    )
+    g.inputs = ["x"]
+    g.outputs = ["x"]
+
+    class _Module(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor([3.0, -4.0], dtype=torch.bfloat16))
+
+    x = torch.tensor([1.0, -2.0], dtype=torch.bfloat16)
+    bound = _bind_inputs(g, _Module(), (x,), {})
+
+    assert bound["x"].dtype == np.uint16
+    assert bound["weight"].dtype == np.uint16
+    np.testing.assert_array_equal(bound["x"], x.view(torch.uint16).numpy())
+    np.testing.assert_array_equal(
+        _comparison_outputs({"x": bound["x"]}, g)["x"],
+        np.array([1.0, -2.0], dtype=np.float32),
+    )
+
+
 def test_bind_inputs_arity_mismatch_raises():
     """Binding failures RAISE (with the real cause) instead of ``sys.exit`` — the function
     also runs inside the bench worker child, where an exit(1) reached the parent as an

--- a/tests/compiler/test_dtype.py
+++ b/tests/compiler/test_dtype.py
@@ -4,7 +4,20 @@ from __future__ import annotations
 
 import numpy as np
 
-from emmy.compiler.dtype import BF16, F8E4M3, F8E5M2, F16, F32, I16, DataType, F16x2, StructuredType, get
+from emmy.compiler.dtype import (
+    BF16,
+    F8E4M3,
+    F8E5M2,
+    F16,
+    F32,
+    I16,
+    DataType,
+    F16x2,
+    StructuredType,
+    decode_bf16,
+    encode_bf16,
+    get,
+)
 
 
 def test_scalars_are_not_structured():
@@ -29,6 +42,14 @@ def test_f8_bits_carriers():
         assert dt.nbytes == 1
         assert get(dt.name) is dt
         assert get(alias) is dt
+
+
+def test_bf16_bits_carrier_round_trips_values():
+    values = np.array([0.0, 1.0, -2.0, np.pi], dtype=np.float32)
+    bits = encode_bf16(values)
+
+    np.testing.assert_array_equal(bits, np.array([0x0000, 0x3F80, 0xC000, 0x4049], dtype=np.uint16))
+    np.testing.assert_array_equal(decode_bf16(bits), np.array([0.0, 1.0, -2.0, 3.140625], dtype=np.float32))
 
 
 def test_i16_packed_code_carrier():


### PR DESCRIPTION
## Summary

- encode numeric BF16 values into the raw uint16 carrier before CUDA upload
- preserve live PyTorch BF16 input, parameter, and buffer bits
- decode BF16 output carriers before command-layer accuracy and strict correctness checks
- document the BF16 boundary contract and cover conversion, binding, materialization, and comparison

## Verification

- make test: 3078 passed, 560 skipped, 1 xfailed
- make lint: passed
- exact NVIDIA GeForce RTX 4090: strict O3 Qwen3.8 BF16 RMSNorm reproducer passes; Emmy 7 us vs eager 20 us (2.86x)

No correctness tolerance was changed. The exact seq512 final-norm inventory separately exposes a reduction-order blocker: greedy WORK=t128, REDUCE=coop fails 14 / 2,621,440 values by one BF16 ULP at rtol=atol=1e-3, while measuring 7.8 us vs eager 561 us. That compiler correctness issue is intentionally outside this carrier-boundary fix.