### PR TITLE
Avoid repeated fresh-name suffix scans

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -493,8 +493,10 @@ default `Backend.run` topo-walk like any pre-fusion graph.
 
 ### `loop/builder.py` — fluent construction
 
-`LoopBuilder` helper used by decomposition/fusion tests to construct
-LoopOp bodies without spelling out every `Loop(Axis(…))` nest.
+`LoopBuilder` constructs merged `LoopOp` bodies for the fusion splicer without spelling out every `Loop(Axis(…))`
+nest. Fresh SSA names retain the lowest available deterministic suffix while a per-hint monotonic cursor ensures each
+occupied suffix is tested at most once; the used-name set remains authoritative when another hint claims a future
+suffix.
 
 ## `tile/`
 

--- a/emmy/compiler/ir/loop/builder.py
+++ b/emmy/compiler/ir/loop/builder.py
@@ -26,17 +26,20 @@ class LoopBuilder:
     def __init__(self, used_names: set[str]) -> None:
         self._body: Body = ()
         self._used: set[str] = set(used_names)
+        self._next_suffix: dict[str, int] = {}
 
     def fresh(self, hint: str) -> str:
         """Return an unused name derived from ``hint`` and reserve it."""
         if hint not in self._used:
             self._used.add(hint)
+            self._next_suffix[hint] = 1
             return hint
-        i = 1
+        i = self._next_suffix.get(hint, 1)
         while f"{hint}_s{i}" in self._used:
             i += 1
         name = f"{hint}_s{i}"
         self._used.add(name)
+        self._next_suffix[hint] = i + 1
         return name
 
     def insert(self, stmt: Stmt, enclosure: Scope) -> None:

--- a/tests/compiler/ir/loop/test_builder.py
+++ b/tests/compiler/ir/loop/test_builder.py
@@ -1,0 +1,40 @@
+"""Loop body construction and fresh-name allocation."""
+
+from emmy.compiler.ir.loop.builder import LoopBuilder
+
+
+class _LookupBudget(set):
+    """Set whose deterministic probe budget catches suffix rescans without wall-clock assertions."""
+
+    def __init__(self, budget: int):
+        super().__init__()
+        self.budget = budget
+        self.lookups = 0
+
+    def __contains__(self, value):
+        self.lookups += 1
+        if self.lookups > self.budget:
+            raise AssertionError(f"fresh-name allocation exceeded {self.budget} membership probes")
+        return super().__contains__(value)
+
+
+def test_many_same_hint_allocations_stay_within_a_linear_probe_budget():
+    count = 50_000
+    builder = LoopBuilder(set())
+    used = _LookupBudget(3 * count)
+    builder._used = used
+
+    last = None
+    for _ in range(count):
+        last = builder.fresh("v")
+
+    assert last == f"v_s{count - 1}"
+    assert used.lookups < 2 * count
+
+
+def test_fresh_names_keep_lowest_available_suffix_across_hint_collisions():
+    builder = LoopBuilder({"v", "v_s1", "v_s3"})
+
+    assert builder.fresh("v") == "v_s2"
+    assert builder.fresh("v_s4") == "v_s4"
+    assert builder.fresh("v") == "v_s5"


### PR DESCRIPTION
## Summary

- retain a per-hint next-suffix cursor in LoopBuilder
- preserve the lowest available deterministic SSA name when existing or cross-hint names occupy suffixes
- cover 50,000 repeated allocations with a deterministic linear membership-probe budget
- document the fusion splicer naming contract

## Motivation

An exact Qwen3.8 linear-recurrence layer reached 2,737 frontend IR nodes, then remained CPU-bound in loop fusion for more than 31 minutes. The captured stack stopped in LoopBuilder.fresh while it rescanned suffixes from 1 for every dependency name.

## Verification

- make test on latest origin/main: 3084 passed, 560 skipped, 1 xfailed
- make lint: passed
- focused splicer, trace, loop-wire, and source-determinism tests: 37 passed
- representative generated CUDA source is byte-identical to origin/main: sha1 585f72e4ac36562a525f280e58548f0f2bd5662f
- representative working inventory is byte-identical to origin/main: sha256 eae7455be57f5aaef2e4ce9a5898787755bdfc85b60318de02df81fed2946a4f
- 100,000 same-hint allocations complete in 21 ms on the verification host; 10,000 took 3.27 s before the fix