### PR TITLE
Fix staged command provenance and replay gate

### DIFF
--- a/emmy/benchmark/ARCHITECTURE.md
+++ b/emmy/benchmark/ARCHITECTURE.md
@@ -50,9 +50,11 @@ The orchestrator MUST NOT:
 - reject a filtered matrix for scientific reasons; or
 - generate `RESULTS.md` or invoke result-validation or report-generation scripts.
 
-Command records preserve timing, status, errors, and system information. `command.strict` requires a clean Git
-worktree, every declared result file, GPU identity, NVCC, and cuBLAS. A failed command still attempts to retrieve
-declared results.
+Command records preserve timing, status, errors, and system information. For a staged command, Git provenance names
+the invoking worktree revision and the dirty state of the exact declared stage paths; neither the installed package
+nor a reused remote source tree supplies that provenance. `command.strict` requires those staged paths to be clean,
+every declared result file, GPU identity, NVCC, and cuBLAS. A failed command still attempts to retrieve declared
+results.
 
 The repository `run-experiment` skill validates row coverage, keeps the latest records inside the archived raw-run
 tree, writes a thoughtful interpretation grounded in the raw evidence, replaces the exact GPU platform's named Git

--- a/emmy/benchmark/execution.py
+++ b/emmy/benchmark/execution.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from emmy.benchmark.bench_logging import _get_group_logger, active_run_dir, add_group_file_handler
 from emmy.benchmark.command_workload import run_command_workload
-from emmy.benchmark.experiment_record import ExperimentRecord, Infrastructure
+from emmy.benchmark.experiment_record import ExperimentRecord, Infrastructure, Provenance
 from emmy.benchmark.workload import capture_server_log, run_benchmark_workload
 from emmy.deploy import DeployParams
 from emmy.deploy import deploy as deploy_entry
@@ -166,7 +166,7 @@ async def run_execution_group(
             strict_stage = any(
                 task.recipe.command.strict for task in group.tasks if task.recipe.kind == "command" and task.recipe.command is not None
             )
-            await stage_to_remote(
+            staged_provenance = await stage_to_remote(
                 Path.cwd(),
                 stage_paths,
                 conn.address,
@@ -176,6 +176,14 @@ async def run_execution_group(
                 dry_run=dry_run,
                 require_clean=strict_stage,
             )
+            if staged_provenance is not None:
+                for task in group.tasks:
+                    if task.recipe.kind == "command" and task.recipe.command and task.recipe.command.stage:
+                        task.record.provenance = Provenance(
+                            git_revision=staged_provenance.git_revision,
+                            git_dirty=staged_provenance.git_dirty,
+                        )
+                        _persist(task, dry_run)
         for task in group.tasks:
             active_run_dir.set(task.run_dir)
             recipe = task.recipe

--- a/emmy/benchmark/experiment_record.py
+++ b/emmy/benchmark/experiment_record.py
@@ -174,7 +174,7 @@ class ExperimentRecord:
         if not self.provenance.git_revision or self.provenance.git_dirty is None:
             missing.append("Git provenance")
         elif self.provenance.git_dirty:
-            missing.append("clean Git worktree")
+            missing.append("clean staged source")
         gpus = self.system.gpus if self.system else []
         if not gpus or not all(item.uuid or item.pci_bus_id for item in gpus):
             missing.append("GPU provenance")

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -87,9 +87,9 @@ The benchmark library is an experiment-agnostic runner: it retains complete clie
 generic system information, and partial raw results after failure. It treats execution and result-collection
 failures as authoritative, but does not parse or record experiment measurements and does not judge model output,
 backend selection, or scientific claims. Recipes cannot run post-processing or report generation. Command recipes
-may opt into the single `command.strict` integrity contract for a clean Git worktree, required declared results, and
-Git/GPU/NVCC/cuBLAS provenance. The complete boundary lives in
-`emmy/benchmark/ARCHITECTURE.md`.
+may opt into the single `command.strict` integrity contract for clean declared stage paths, required declared results,
+and Git/GPU/NVCC/cuBLAS provenance. Staged Git provenance comes from the invoking worktree, not a shared virtual
+environment or reused remote source tree. The complete boundary lives in `emmy/benchmark/ARCHITECTURE.md`.
 
 `run_benchmark_workload()` drives `vllm bench serve`. Embedding recipes (`model.task: embed`) bench with
 `--backend openai-embeddings --endpoint /v1/embeddings` and drop `--random-output-len` because nothing is generated.

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -101,9 +101,9 @@ so every task's result reflects its host's stand-up cost. `vm_provision` is omit
 ## Command source staging
 
 Command recipes stage only the Git-visible files under their declared paths: tracked and untracked files are included,
-while ignored files are excluded. `command.strict` rejects dirty selected paths before any transfer. Staging sends the
-selected files without computing or returning a manifest or content digest; the experiment record separately captures
-the repository revision and dirty flag.
+while ignored files are excluded. `command.strict` rejects dirty selected paths before any transfer. Staging returns
+the invoking worktree's revision and path-scoped dirty flag to the benchmark runner, which records that source instead
+of deriving provenance from the installed package or a reused remote source tree.
 
 ## Error contract
 

--- a/emmy/provisioning/staging.py
+++ b/emmy/provisioning/staging.py
@@ -11,11 +11,20 @@ import asyncio
 import io
 import logging
 import tarfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from emmy.provisioning.ssh_transport import ssh_base_args
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StagedSourceProvenance:
+    """Git provenance for the exact local paths sent to a remote host."""
+
+    git_revision: str
+    git_dirty: bool
 
 
 async def enumerate_staged_files(repo_root: Path, stage_paths: list[str]) -> list[str]:
@@ -89,7 +98,7 @@ async def stage_to_remote(
     remote_dir: str,
     dry_run: bool = False,
     require_clean: bool = False,
-) -> None:
+) -> StagedSourceProvenance | None:
     """Stream a tar of staged files into `remote_dir` on the remote VM.
 
     No-op when `stage_paths` is empty.
@@ -101,12 +110,17 @@ async def stage_to_remote(
     if not files:
         logger.warning(f"stage_to_remote: no files matched {stage_paths}")
         return None
-    if require_clean and (dirty := await staged_paths_dirty(repo_root, stage_paths)):
-        raise RuntimeError(f"command staging requires a clean source tree: {dirty}")
+    dirty = await staged_paths_dirty(repo_root, stage_paths)
+    if require_clean and dirty:
+        raise RuntimeError(f"command staging requires clean declared paths: {dirty}")
+    provenance = StagedSourceProvenance(
+        git_revision=await _git_output(repo_root, "rev-parse", "HEAD"),
+        git_dirty=bool(dirty),
+    )
 
     if dry_run:
         logger.info(f"[dry-run] stage {len(files)} files to {server}:{remote_dir}")
-        return None
+        return provenance
 
     tar_bytes = build_stage_tar(repo_root, files)
 
@@ -129,3 +143,4 @@ async def stage_to_remote(
     if proc.returncode != 0:
         raise RuntimeError(f"stage_to_remote failed (rc={proc.returncode}): {stderr.decode().strip()}")
     logger.info(f"Staged {len(files)} files to {server}:{remote_dir}")
+    return provenance

--- a/experiments/golden-bench-2026/kernels/recipe.yaml
+++ b/experiments/golden-bench-2026/kernels/recipe.yaml
@@ -4,7 +4,9 @@
 # A row that names a `golden` replays `golden/<golden>.golden.yaml` instead of tracing and searching: those
 # schedules were tuned by the tune-kernels skill and committed beside this recipe, and the row only re-measures them
 # at deployable -O3. Rows with `golden: ""` keep the original trace + in-recipe search. Both paths end in the same
-# five fresh-process `emmy run --golden ... --bench --strict` repeats, so the two lanes produce the same evidence.
+# fresh-process `emmy run --golden ... --bench --strict` repeats against eager and Emmy, so the two lanes produce
+# the same terminal correctness evidence. A separate torch.compile replay is diagnostic because a reference backend
+# can be unavailable for a valid target; its absence must not fail an otherwise-correct Emmy replay.
 command:
   stage:
     - emmy
@@ -66,15 +68,26 @@ command:
       fi
     fi
 
-    # Every repeat runs even when one target fails its correctness/backend gate, so a single hard
-    # target cannot discard the other four fresh-process replays. The per-repeat exit status is
-    # preserved and the task still fails, so the failure is reported rather than hidden.
+    mkdir -p $task_dir/torch-compile
+    if EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
+      --golden $task_dir/working.yaml --bench \
+      --json $task_dir/torch-compile --warmup 10 --iters 100 \
+      --bench-backends eager,tcompile 2>&1 | tee $task_dir/torch-compile.log; then
+      torch_compile_status=0
+    else
+      torch_compile_status=$$?
+    fi
+    printf '%s\n' "$$torch_compile_status" > $task_dir/torch-compile.status
+
+    # Every strict repeat runs even when one target fails its eager/Emmy correctness gate, so a single hard target
+    # cannot discard the other four fresh-process replays. The per-repeat exit status is preserved and the task still
+    # fails, so an Emmy failure is reported rather than hidden. torch.compile availability is non-gating above.
     verification_status=0
     for repeat in 0 1 2 3 4; do
       if EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
         --golden $task_dir/working.yaml --bench --strict \
         --json $task_dir/verification/repeat-$$repeat --warmup 10 --iters 100 \
-        --bench-backends eager,tcompile,emmy 2>&1 | tee $task_dir/verification-$$repeat.log; then
+        --bench-backends eager,emmy 2>&1 | tee $task_dir/verification-$$repeat.log; then
         repeat_status=0
       else
         repeat_status=$$?

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -55,6 +55,10 @@ def test_common_kernel_corpus_is_small_and_identical(project_root) -> None:
     assert "./venv/bin/emmy run" in run
     assert "for repeat in 0 1 2 3 4" in run
     assert "--golden $task_dir/working.yaml --bench --strict" in run
+    assert "--bench-backends eager,tcompile" in run
+    assert "--bench-backends eager,emmy" in run
+    assert "--bench-backends eager,tcompile,emmy" not in run
+    assert "torch-compile.status" in run
     assert "scripts/" not in run
     assert recipe.command.stage == [
         "emmy",
@@ -221,7 +225,8 @@ def test_large_layer_corpus_is_bounded_and_not_labeled_tp8(project_root) -> None
         )
         assert "--loop-targets" not in command
         assert "--golden /task/working.yaml --bench --strict" in command
-        assert "--bench-backends eager,tcompile,emmy" in command
+        assert "--bench-backends eager,tcompile" in command
+        assert "--bench-backends eager,emmy" in command
 
 
 def test_convergence_check_is_one_shape_and_three_seeds(project_root) -> None:

--- a/tests/benchmark/test_experiment_record.py
+++ b/tests/benchmark/test_experiment_record.py
@@ -1,6 +1,7 @@
 """Tests for the typed, system-only YAML experiment record."""
 
 import re
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -9,6 +10,7 @@ from emmy.benchmark.execution import run_execution_group
 from emmy.benchmark.experiment_record import ExperimentRecord, Infrastructure, Provenance
 from emmy.planner import BenchmarkTask, ExecutionGroup
 from emmy.planner.variant import Variant
+from emmy.provisioning.types import VMConnectionInfo
 from emmy.recipe.types import Recipe
 from emmy.redact import register_secret
 from emmy.system_info import SystemInformation
@@ -171,6 +173,54 @@ def test_record_lifecycle_serialization_and_round_trip(tmp_path):
     assert not task.record_path().with_suffix(".yaml.tmp").exists()
 
 
+async def test_staged_command_provenance_ignores_shared_venv_checkout_and_unrelated_dirty_path(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=source, check=True)
+    (source / "staged.txt").write_text("staged\n")
+    (source / "unrelated.txt").write_text("clean\n")
+    subprocess.run(["git", "add", "staged.txt", "unrelated.txt"], cwd=source, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "source",
+        ],
+        cwd=source,
+        check=True,
+    )
+    revision = subprocess.run(["git", "rev-parse", "HEAD"], cwd=source, check=True, capture_output=True, text=True).stdout.strip()
+    (source / "unrelated.txt").write_text("local edit\n")
+    monkeypatch.chdir(source)
+    monkeypatch.setattr(ExperimentRecord, "_git_provenance", staticmethod(lambda: ("shared-venv-revision", True)))
+
+    recipe = Recipe.from_dict(
+        {
+            "command": {"stage": ["staged.txt"], "run": "true", "strict": True},
+            "deploy": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
+        }
+    )
+    variant = Variant(params={"deploy.gpu": recipe.deploy.gpu, "deploy.gpu_count": 1})
+    task = BenchmarkTask(recipe_dir=str(source), variant=variant, recipe=recipe, run_dir=tmp_path / "results")
+    group = ExecutionGroup(gpu_name=task.gpu_name, gpu_count=task.gpu_count, tasks=[task])
+
+    await run_execution_group(
+        group,
+        {"benchmark": {}},
+        "/missing/ssh-key",
+        dry_run=True,
+        preallocated_conn=VMConnectionInfo(host="example.test", username="riftuser"),
+    )
+
+    assert task.record.provenance == Provenance(git_revision=revision, git_dirty=False)
+
+
 def test_record_rejects_other_schema_versions(tmp_path):
     path = tmp_path / "old.experiment.yaml"
     path.write_text("schema_version: 1\n", encoding="utf-8")
@@ -213,6 +263,9 @@ def test_strict_command_provenance_uses_typed_system_information(tmp_path):
         "NVCC provenance",
         "cuBLAS provenance",
     ]
+
+    record.provenance = Provenance(git_revision="revision", git_dirty=True)
+    assert record.missing_command_provenance()[0] == "clean staged source"
 
 
 def test_create_run_dir_uses_run_timestamp_without_replacing_prior_runs(tmp_path):

--- a/tests/provisioning/test_staging.py
+++ b/tests/provisioning/test_staging.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from emmy.provisioning.staging import (
+    StagedSourceProvenance,
     build_stage_tar,
     enumerate_staged_files,
     stage_to_remote,
@@ -94,9 +95,11 @@ def test_staged_paths_dirty_reports_untracked_and_deleted_files(repo):
 
 
 def test_stage_to_remote_clean_gate_runs_before_dry_run_transfer(repo):
-    with pytest.raises(RuntimeError, match="requires a clean source tree"):
+    with pytest.raises(RuntimeError, match="requires clean declared paths"):
         asyncio.run(stage_to_remote(repo, ["scripts"], "host", "key", 22, "/remote", dry_run=True, require_clean=True))
 
     (repo / "scripts" / "untracked.py").unlink()
+    (repo / "other.txt").write_text("unrelated local edit\n")
     result = asyncio.run(stage_to_remote(repo, ["scripts"], "host", "key", 22, "/remote", dry_run=True, require_clean=True))
-    assert result is None
+    revision = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True).stdout.strip()
+    assert result == StagedSourceProvenance(git_revision=revision, git_dirty=False)


### PR DESCRIPTION
## Summary
- record command Git provenance from the exact invoking worktree and declared staged paths
- keep unrelated dirty paths and shared virtual environments from contaminating strict experiment records
- measure torch.compile separately so an unavailable reference backend does not fail strict eager/Emmy replay

## Verification
- focused provenance and golden-bench tests: 33 passed
- make lint: passed
- make test: 3054 passed, 574 skipped, 1 xfailed; the post-run duration audit remains nonzero on latest main because varying serving tests exceed 5s without entries in tests/durations.json (5 tests on the first run, 10 different tests on the clean rerun)
- git diff --check: passed

The duration baseline is intentionally unchanged because the repeated variation is host-load drift outside this diff.