### PR TITLE
Memoize splicer expression variable walks

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -483,6 +483,10 @@ node must rename its body `Write.output` to match (`fusion/_helpers.py::rename_w
 Every `_NotSupported` carries a reason string, logged at DEBUG by `splice_loops`
 — `compile -vv` shows which pattern a rejected edge hit.
 
+Each splice memoizes `Expr.free_vars()` by expression identity while placing dependencies. Sigma expressions remain
+live for the splice, and identity avoids both repeated coordinate-tree walks and the recursive structural hashing a
+global cache would require; the memo is discarded with the splicer.
+
 ### `loop/runner.py` — C++ JIT executor
 
 `execute_loop_op_cpp(loop, input_arrays, out_shape) → ndarray` renders the

--- a/emmy/compiler/ir/loop/splicer.py
+++ b/emmy/compiler/ir/loop/splicer.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import logging
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from emmy.compiler.ir.expr import Expr, Literal, Var
@@ -264,6 +265,10 @@ class _Splicer(LoopBuilder):
         # to its own enclosing — the only bindings that affect its rewrite.
         # Same key → share a single emission.
         self._binding: dict[_BindKey, str] = {}
+        # Sigma expressions stay live for one splice. Cache by object identity so repeated
+        # dependency placement does not recursively walk the same large coordinate tree, while
+        # avoiding structural hashing (which would perform another recursive tree walk).
+        self._free_vars_by_expr_id: dict[int, tuple[Expr, frozenset[str]]] = {}
 
     def run(self) -> LoopOp:
         self._seed()
@@ -293,7 +298,11 @@ class _Splicer(LoopBuilder):
         if name not in meta.defs:
             raise _NotSupported(f"_ensure_dep: {name!r} is not defined in loop {origin!r}")
 
-        required_axes = tuple(mapped for axis in meta.scopes[name].enclosing for mapped in _remap_axis_names(axis, sigma, ref_scope))
+        required_axes = tuple(
+            mapped
+            for axis in meta.scopes[name].enclosing
+            for mapped in _remap_axis_names(axis, sigma, ref_scope, free_vars=self._expr_free_vars)
+        )
         emit_scope = _scope_for_axes(ref_scope, required_axes)
 
         # σ restricted to axes transitively used in Expr subtrees reachable
@@ -309,6 +318,16 @@ class _Splicer(LoopBuilder):
         self._binding[key] = bound
         self._pending.append(_Demand(name=name, origin=origin, sigma=sigma, demand_scope=emit_scope, bound_as=bound))
         return bound
+
+    def _expr_free_vars(self, expr: Expr) -> frozenset[str]:
+        """Memoize one expression's variables for this splice by object identity."""
+        key = id(expr)
+        cached = self._free_vars_by_expr_id.get(key)
+        if cached is not None and cached[0] is expr:
+            return cached[1]
+        variables = expr.free_vars()
+        self._free_vars_by_expr_id[key] = (expr, variables)
+        return variables
 
     # -- Resolution dispatch -------------------------------------------------
 
@@ -416,7 +435,13 @@ def _scope_for_axes(ref_scope: Scope, required: tuple[str, ...]) -> Scope:
     return Scope(enclosing=ref_scope.enclosing[:k])
 
 
-def _remap_axis_names(axis: Axis, sigma: Sigma, ref_scope: Scope) -> tuple[str, ...]:
+def _remap_axis_names(
+    axis: Axis,
+    sigma: Sigma,
+    ref_scope: Scope,
+    *,
+    free_vars: Callable[[Expr], frozenset[str]] | None = None,
+) -> tuple[str, ...]:
     """Pick the merged-kernel axes that ``axis``'s σ target depends on.
 
     Every occurrence of the producer axis is substituted with the complete target expression by
@@ -432,7 +457,7 @@ def _remap_axis_names(axis: Axis, sigma: Sigma, ref_scope: Scope) -> tuple[str, 
     target = sigma.get(axis.name)
     if target is None:
         return (axis.name,)
-    variables = target.free_vars()
+    variables = free_vars(target) if free_vars is not None else target.free_vars()
     scope_axes = tuple(a.name for a in ref_scope.enclosing)
     if any(name not in scope_axes for name in variables):
         # A non-axis variable is an SSA gather index. Keep the producer at the reader's current

--- a/tests/compiler/ir/loop/test_splicer.py
+++ b/tests/compiler/ir/loop/test_splicer.py
@@ -570,3 +570,57 @@ def test_literal_producer_write_index():
     assert merged is not None
     assert "exp" in _elementwise_fns(merged)
     assert "negative" in _elementwise_fns(merged)
+
+
+def test_large_sigma_target_free_vars_walks_do_not_scale_with_producer_chain(monkeypatch):
+    """A long producer chain reuses one large coordinate target without re-walking its tree."""
+    from emmy.compiler.ir.expr import BinaryExpr
+
+    producer_axis = Axis("p", 4096)
+    producer_stmts = [Load(name="x", input="X", index=(Var("p"),))]
+    previous = "x"
+    for i in range(128):
+        name = f"v{i}"
+        producer_stmts.append(Assign(name=name, op="negative", args=(previous,)))
+        previous = name
+    producer_stmts.append(Write(output="P", index=(Var("p"),), value=previous))
+    producer = LoopOp(body=(Loop(axis=producer_axis, body=tuple(producer_stmts)),))
+
+    i_axis, j_axis = Axis("i", 8), Axis("j", 8)
+    target = Var("i")
+    for _ in range(128):
+        target = target * 2 + Var("j")
+    target = BinaryExpr("^", target, Literal(1, "int"))
+    consumer = LoopOp(
+        body=(
+            Loop(
+                axis=i_axis,
+                body=(
+                    Loop(
+                        axis=j_axis,
+                        body=(
+                            Load(name="pv", input="P", index=(target,)),
+                            Write(output="OUT", index=(Var("i"), Var("j")), value="pv"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+    )
+
+    root_walks = 0
+    original = BinaryExpr.free_vars
+
+    def counted_free_vars(expr):
+        nonlocal root_walks
+        if expr.op == "^":
+            root_walks += 1
+        return original(expr)
+
+    monkeypatch.setattr(BinaryExpr, "free_vars", counted_free_vars)
+    merged = splice_loops(loops={"producer": producer, "consumer": consumer}, splice_edges={("consumer", "P"): ("producer", "P")})
+
+    assert merged is not None
+    # Loop construction and normalization also inspect the coordinate expression, but the count
+    # must not grow with the 128 producer dependencies (without the per-splice memo it exceeds 128).
+    assert root_walks < 32


### PR DESCRIPTION
## Summary

- memoize expression free-variable discovery by object identity for the lifetime of one splice
- keep the memo local to the splicer so expression trees are neither structurally hashed nor retained globally
- add a counter-backed regression with 128 producer dependencies sharing one deep coordinate expression
- document the placement invariant in the loop IR architecture

## Evidence

- RTX 4090 Qwen3.8 layer-0 trace isolated repeated recursive Expr.free_vars walks during dependency placement after the fresh-name fix; the bounded trace reached 4.5 GB RSS before it was stopped
- synthetic large-expression splice (1,024 dependencies, expression depth 256): 0.202423 s on main, 0.147076 s with this change
- representative rendered CUDA source SHA-1 is byte-identical to main: 585f72e4ac36562a525f280e58548f0f2bd5662f
- representative working-inventory SHA-256 is byte-identical to main: 9d7897bfa7b98e1deb72761a9f8cf830fad6659d83c83b052ec0d24b92fab4ae

## Checks

- make test: 3,086 passed, 560 skipped, 1 xfailed
- make lint
- focused splicer, source-determinism, trace, and loop-wire tests: 36 passed
- git diff --check
