### PR TITLE
Reuse canonical Sigma entries

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -487,6 +487,10 @@ Each splice memoizes `Expr.free_vars()` by expression identity while placing dep
 live for the splice, and identity avoids both repeated coordinate-tree walks and the recursive structural hashing a
 global cache would require; the memo is discarded with the splicer.
 
+`Sigma` computes canonical expression text once for each initial substitution. Derived substitutions created by
+`extend` and `restrict` retain the applicable canonical entries from their parent, so dependency placement neither
+reformats deep coordinate trees nor retains duplicate canonical strings.
+
 ### `loop/runner.py` — C++ JIT executor
 
 `execute_loop_op_cpp(loop, input_arrays, out_shape) → ndarray` renders the

--- a/emmy/compiler/ir/sigma.py
+++ b/emmy/compiler/ir/sigma.py
@@ -37,6 +37,14 @@ class Sigma:
         key = tuple(sorted((k, v.pretty()) for k, v in self.mapping.items()))
         object.__setattr__(self, "_key", key)
 
+    @classmethod
+    def _from_key(cls, mapping: dict[str, Expr], key: tuple[tuple[str, str], ...]) -> Sigma:
+        """Construct a derived substitution whose canonical entries are already known."""
+        sigma = object.__new__(cls)
+        object.__setattr__(sigma, "mapping", mapping)
+        object.__setattr__(sigma, "_key", key)
+        return sigma
+
     def apply(self, e: Expr) -> Expr:
         return e.substitute(self.mapping)
 
@@ -48,11 +56,16 @@ class Sigma:
         return e.substitute(self.mapping).simplify(ctx)
 
     def extend(self, name: str, expr: Expr) -> Sigma:
-        return Sigma({**self.mapping, name: expr})
+        mapping = {**self.mapping, name: expr}
+        existing = ((axis, canonical) for axis, canonical in self._key if axis != name)
+        key = tuple(sorted((*existing, (name, expr.pretty()))))
+        return self._from_key(mapping, key)
 
     def restrict(self, names: set[str]) -> Sigma:
         """Return a new Sigma keeping only bindings whose axis name is in ``names``."""
-        return Sigma({k: v for k, v in self.mapping.items() if k in names})
+        mapping = {k: v for k, v in self.mapping.items() if k in names}
+        key = tuple(entry for entry in self._key if entry[0] in names)
+        return self._from_key(mapping, key)
 
     def get(self, name: str) -> Expr | None:
         return self.mapping.get(name)

--- a/tests/compiler/ir/test_sigma.py
+++ b/tests/compiler/ir/test_sigma.py
@@ -1,0 +1,50 @@
+from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
+from emmy.compiler.ir.sigma import Sigma
+
+
+def _deep_expr(depth: int) -> BinaryExpr:
+    expr = Var("i")
+    for _ in range(depth):
+        expr = expr * 2 + Var("j")
+    return BinaryExpr("^", expr, Literal(1, "int"))
+
+
+def test_restrict_reuses_parent_canonical_entries(monkeypatch):
+    target = _deep_expr(128)
+    sigma = Sigma({"b": Var("b"), "a": target})
+    root_walks = 0
+    original = BinaryExpr.pretty
+
+    def counted_pretty(expr):
+        nonlocal root_walks
+        if expr.op == "^":
+            root_walks += 1
+        return original(expr)
+
+    monkeypatch.setattr(BinaryExpr, "pretty", counted_pretty)
+    restricted = [sigma.restrict({"a"}) for _ in range(1_000)]
+
+    assert root_walks == 0
+    assert all(item == restricted[0] and hash(item) == hash(restricted[0]) for item in restricted)
+    assert all(item._key[0][1] is sigma._key[0][1] for item in restricted)
+
+
+def test_extend_reuses_unchanged_canonical_entries(monkeypatch):
+    target = _deep_expr(128)
+    sigma = Sigma({"a": target})
+    root_walks = 0
+    original = BinaryExpr.pretty
+
+    def counted_pretty(expr):
+        nonlocal root_walks
+        if expr.op == "^":
+            root_walks += 1
+        return original(expr)
+
+    monkeypatch.setattr(BinaryExpr, "pretty", counted_pretty)
+    extended = sigma.extend("b", Var("j"))
+
+    assert root_walks == 0
+    assert extended == Sigma({"a": target, "b": Var("j")})
+    assert hash(extended) == hash(Sigma({"a": target, "b": Var("j")}))
+    assert extended._key[0][1] is sigma._key[0][1]


### PR DESCRIPTION
## Summary

- derive canonical keys for restricted and extended substitutions from their parent entries
- retain shared canonical strings rather than reformatting deep coordinate expressions
- preserve initial canonical construction, equality, hashing, mapping, and serialized compiler output
- document the substitution-key lifetime and add counter-backed equality/hash regressions

## Evidence

The RTX 4090 Qwen3.8 layer-0 trace reached 5,092,352 KiB RSS at the bounded 4m17s stop. Its guaranteed traceback ended in Sigma canonical-key construction while the splicer was solving a coordinate substitution.

For 10,000 retained restrictions of one depth-256 expression:

- main: 10.335742 s, 33.210 MiB retained, 10,000 distinct canonical strings
- this change: 0.038789 s, 3.051 MiB retained, one shared canonical string

Representative rendered CUDA source SHA-1 remains byte-identical to main: 585f72e4ac36562a525f280e58548f0f2bd5662f. Representative working-inventory SHA-256 remains byte-identical: 9d7897bfa7b98e1deb72761a9f8cf830fad6659d83c83b052ec0d24b92fab4ae.

## Checks

- make test: 3,088 passed, 560 skipped, 1 xfailed
- make lint
- focused Sigma, splicer, source-determinism, and trace tests: 37 passed
- git diff --check
