### PR TITLE
Recognize unit-row decode attention

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -515,11 +515,12 @@ failing several passes later:
   It is offered as a fork SIBLING of the
   cooperative reduce form (the warp mma rows ride the mandatory `sync` compute-fill;
   dtype / geometry legality stays schedule-side). This retired the pin-only
-  `_prologue_warp_option` rescue. The **degenerate M=1** composition (per-token decode: the unit row axis elided,
-  `free = ()`) binds too — a synthesized unit free axis keeps the column grid; without it the fused kernel
-  schedules at grid 1, ~300× off the memory floor. SSA renames track the stored algebra through the `Fold`
-  rewrite handler (`rename_combine` — a verbatim combine left the cooperative combine reading a state name the
-  renamed body no longer defined).
+  `_prologue_warp_option` rescue. The **degenerate M=1** composition (per-token decode: the unit row axis elided)
+  binds too — when the output row is the literal-zero coordinate, a synthesized unit free axis precedes the column
+  grid even if batch or head axes remain contextual; without it the fused kernel schedules at grid 1, ~300× off the
+  memory floor. A non-unit or structurally missing row declines this reading. SSA renames track the stored algebra
+  through the `Fold` rewrite handler (`rename_combine` — a verbatim combine left the cooperative combine reading a
+  state name the renamed body no longer defined).
 - a cooperative / ILP reduce (`PLANAR` / `TWISTED`, or a non-output-tiled `CONTRACTION`) needs **no** binding here — its
   accumulator dtype + the shuffle/tree fold mechanism are **derived** at materialize time (`emit_combine` off the fold
   node's `Reduction` view + `ReduceStage.combine`), never stored. Its one schedule-time staging decision follows the same

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -44,7 +44,7 @@ def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | list | None:
     # the reference tree when it binds; its seams are the ones a ``PLACE`` key spells.
     pro = fused_view(map_tile)
     route_tree, route_free, route_stores = (
-        (pro[0], (*map_tile.place.free, pro[1]), pro[2]) if pro is not None else (map_tile.op, map_tile.place.free, map_tile.stores)
+        (pro[0], (*map_tile.place.free, *pro[1]), pro[2]) if pro is not None else (map_tile.op, map_tile.place.free, map_tile.stores)
     )
     verdict, seam = route_cut(ctx, dict(loop.knobs or {}), route_tree, route_stores, route_free)
     if verdict == "cut":

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from emmy.compiler.ir.axis import AxisRole
-from emmy.compiler.ir.expr import Var
+from emmy.compiler.dim import Dim
+from emmy.compiler.ir.axis import Axis, AxisRole
+from emmy.compiler.ir.expr import Literal, Var
 from emmy.compiler.ir.pure import Lambda, component_ops
 from emmy.compiler.ir.pure.fold import (
     Channel,
@@ -406,7 +407,23 @@ def _unchain(col: Fold) -> tuple[Fold, Fold | None]:
     return bare, edge
 
 
-def fused_view(tile) -> tuple[Fold, object, tuple] | None:
+def _unit_output_row(writes: tuple[Write, ...], n_name: str) -> Axis | None:
+    """The established synthetic row for a matrix output whose M=1 loop was elided.
+
+    Loop IR spells that exact case as a literal-zero penultimate output coordinate followed by
+    the column sweep. Every boundary write must prove the same shape; a non-unit or missing row
+    coordinate declines rather than reclassifying a contextual batch / head axis as M.
+    """
+    if not writes:
+        return None
+    for write in writes:
+        index = write.index
+        if not (len(index) >= 2 and index[-1] == Var(n_name) and isinstance(index[-2], Literal) and index[-2].value == 0):
+            return None
+    return Axis(name="_um", extent=Dim(1))
+
+
+def fused_view(tile) -> tuple[Fold, tuple[Axis, ...], tuple] | None:
     """B3 — the MONOID-PRODUCER composition, read off the lifted tree: a root projection whose one
     operand is a per-row statistic fold (PLANAR Σx² — RMSNorm; TWISTED ``(m, l)`` — softmax·V) and
     whose body is the statistic's scalar epilogue + ONE raw column contraction loop (restored by
@@ -415,12 +432,13 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     on the ``a`` edge with the statistic as its SOURCE (``make_cone`` — the K seam on the node),
     one :class:`Channel` per ⊗-fold, the column axis joining the grid.
 
-    Returns the same ``(Fold, column Axis, stores)`` the old recognize-time binder returned — or
-    ``None`` (not this shape). The returned contraction keeps a wrapping projection only when its
-    body has real work; an empty identity projection carries no information. A VIEW, not a rewrite:
-    ``classify`` stores the canonical projection tree; this derivation runs on demand at the
-    schedule (``_views``) and the golden decode, because which of the two readings a fork row
-    realizes is a decision about the SCHEDULE.
+    Returns ``(Fold, added grid Axes, stores)`` — or ``None`` (not this shape). The added axes are
+    normally just the column axis; a provably unit output row that Loop IR elided adds the existing
+    synthetic ``_um`` row before it. The returned contraction keeps a wrapping projection only
+    when its body has real work; an empty identity projection carries no information. A VIEW, not
+    a rewrite: ``classify`` stores the canonical projection tree; this derivation runs on demand
+    at the schedule (``_views``) and the golden decode, because which of the two readings a fork
+    row realizes is a decision about the SCHEDULE.
 
     The statistic's OWN composed score binds too (the old ``bound_producer``): a single fold edge
     on the statistic re-binds through :func:`bind_bilinear` — tried against each free axis as the
@@ -452,16 +470,20 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
         # A chained column over TWO statistics (normalized Q against normalized K): the bilinear
         # binder reads it with the sweep as the column axis and each side's statistic on its cone.
         folds = [s for s in body if isinstance(s, Fold)]
-        if len(folds) == 1 and folds[0].axis is not None and free:
+        if len(folds) == 1 and folds[0].axis is not None:
             n_ax = stores[0].sweep
-            r = bind_bilinear(folds[0], free[-1].name, n_ax.name, frozenset(a.name for a in free) | {n_ax.name})
+            unit_m = _unit_output_row((stores[0].write,), n_ax.name)
+            view_free = (*free, unit_m) if unit_m is not None else free
+            axes = frozenset(a.name for a in view_free) | {n_ax.name}
+            r = bind_bilinear(folds[0], view_free[-1].name, n_ax.name, axes, unit_m=unit_m is not None) if view_free else None
+            added = (unit_m, n_ax) if unit_m is not None else (n_ax,)
             if r is not None:
                 con, epi = r
                 at = body.index(folds[0])
                 tail = [*body[:at], *epi, *body[at + 1 :]]
                 from emmy.compiler.ir.tile.ir import Store  # noqa: PLC0415
 
-                return Fold.projection(body=Body(tuple(tail)), operands=(con,)), n_ax, (Store(write=stores[0].write),)
+                return Fold.projection(body=Body(tuple(tail)), operands=(con,)), added, (Store(write=stores[0].write),)
     if chain is None:
         if len(node.operands) != 1:
             return None
@@ -502,10 +524,13 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
         return None
     if not all(isinstance(s, (Load, Assign)) for s in stat_epi) or not all(isinstance(s, Assign) for s in tail):
         return None
+    unit_m = _unit_output_row(tuple(writes), n_ax.name)
+    view_free = (*free, unit_m) if unit_m is not None else free
+    added = (unit_m, n_ax) if unit_m is not None else (n_ax,)
     if stat.operands:
         if len(stat.operands) != 1 or not isinstance(stat.operands[0], Fold) or stat.operands[0].axis is None:
             return None
-        score = _bound_producer(stat.operands[0], free, stat.axis.name)
+        score = _bound_producer(stat.operands[0], view_free, stat.axis.name)
         if score is None:
             return None  # a composed score the binder cannot read — the base rows stand
         stat = replace(stat, operands=(score,))
@@ -522,7 +547,7 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     for e in fcol.operands:
         if not (isinstance(e, Fold) and e.axis is not None):
             return None
-        b = _bound_producer(e, free, k_name)
+        b = _bound_producer(e, view_free, k_name)
         if b is None:
             return None
         edges.append(b)
@@ -534,7 +559,12 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     stat_defs = set(_operand_result_names(stat)) | {nm for s in stat_epi for nm in s.defines()}
     edge_names = frozenset(nm for e in edges for nm in _operand_result_names(e))
     bound = _bind_stat_channels(
-        fcol, n_ax.name, stat_defs, frozenset(a.name for a in free) | {n_ax.name}, edge_names, m_name=free[-1].name if free else None
+        fcol,
+        n_ax.name,
+        stat_defs,
+        frozenset(a.name for a in view_free) | {n_ax.name},
+        edge_names,
+        m_name=view_free[-1].name if view_free else None,
     )
     if bound is None:
         return None
@@ -590,7 +620,7 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
 
     projection = Body((*prefix, *tail))
     root = Fold.projection(body=projection, operands=(con,)) if projection else con
-    return root, n_ax, tuple(Store(write=w) for w in writes)
+    return root, added, tuple(Store(write=w) for w in writes)
 
 
 def _cone_value_key(name: str, defs: dict) -> tuple:
@@ -623,7 +653,7 @@ def _bound_producer(e: Fold, free: tuple, n_name: str) -> Fold | None:
     for ax in free:
         if ax.name == n_name:
             continue
-        b = bind_bilinear(e, ax.name, n_name, axes, producer=True)
+        b = bind_bilinear(e, ax.name, n_name, axes, producer=True, unit_m=ax.name == "_um" and ax.extent == Dim(1))
         if b is not None and not b[1] and isinstance(b[0].a, Load) and isinstance(b[0].b, Load):
             return b[0]  # an edge carries no projection epilogue — a hoisted producer declines
     return None
@@ -809,7 +839,14 @@ def _cone(body: list, arg: str, avoid_name: str, k_name: str, axes: frozenset, b
     return stmts
 
 
-def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset(), producer: bool = False) -> tuple[Fold, tuple] | None:
+def bind_bilinear(
+    f: Fold,
+    m_name: str,
+    n_name: str,
+    axes: frozenset = frozenset(),
+    producer: bool = False,
+    unit_m: bool = False,
+) -> tuple[Fold, tuple] | None:
     """Rebind a lifted fold as the bilinear contraction — the ONE contraction reading, off the λ
     spelling and stated on the ALGEBRAIC TRAITS, never op names: the carrier must be a product of
     ONE commutative-monoid ⊕ (associative + commutative + identity — the reassociation license
@@ -818,6 +855,8 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
     registered-semiring table; ``(multiply, add)`` is the matmul). The ⊗ args classify by their
     loads' grid-axis indexing — B is the ``(n, k)``-indexed side and never reads ``m``, A the
     mirror (role-exclusive: a load carrying both axes is neither, and the fold stays PLANAR).
+    ``unit_m`` admits an A load with no M coordinate only for the synthetic unit row proven by
+    :func:`_unit_output_row`; it must still read K and remain N-free.
     Role purity is per index EXPR (:func:`_role_pure`): another free axis may ride a separate
     dim (a batch offset), never the same expr as the role axis — the DIRECT slab loaders
     template an operand address over the bare role Var and cannot spell a composite, so it
@@ -868,8 +907,10 @@ def bind_bilinear(f: Fold, m_name: str, n_name: str, axes: frozenset = frozenset
 
     def role_load(name: str, on: str, off: str) -> Load | None:
         ld = loads.get(name)
-        if ld is None or on not in _idx_vars(ld) or off in _idx_vars(ld):
+        if ld is None or off in _idx_vars(ld):
             return None
+        if on not in _idx_vars(ld):
+            return ld if unit_m and on == m_name and k_name in _idx_vars(ld) else None
         return ld if producer or _role_pure(ld, on, axes) else None
 
     # The per-channel ⊗ reads: each result's two-arg multiply, its directly-named B load (or

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -413,7 +413,7 @@ def reusable_cut_pieces(loop_op: LoopOp) -> tuple[LoopOp, LoopOp] | None:
         return None
     if pro is None:
         return None
-    tree, free, stores = pro[0], (*tile.place.free, pro[1]), pro[2]
+    tree, free, stores = pro[0], (*tile.place.free, *pro[1]), pro[2]
     groups = [cut for cut in cuttable_seams(tree, stores, free) if len(cut.members) == 2]
     if len(groups) != 1:
         return None

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -488,7 +488,7 @@ def _views(tile: TileOp, ctx) -> tuple[list[_Term], int]:
     base = _Term(cell, tile.place.on_grid(), ctx)
     pro = fused_view(tile)
     if pro is not None:
-        fused = _view(tile, pro[0], ctx, free=(*tile.place.free, pro[1]), stores=pro[2])
+        fused = _view(tile, pro[0], ctx, free=(*tile.place.free, *pro[1]), stores=pro[2])
         return [_Term(cell, tile.place.on_grid(), ctx, ref=fused.sched), fused], 1
     node = head(tile.op)
     if node is None or not is_contraction(node):

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -701,7 +701,7 @@ def decode_record(record: GoldenRecord) -> str | None:
             return verdicts[verdict_key]
         pro = fused_view(tile)
         route_tree, route_free, route_stores = (
-            (pro[0], (*tile.place.free, pro[1]), pro[2]) if pro is not None else (tile.op, tile.place.free, tile.stores)
+            (pro[0], (*tile.place.free, *pro[1]), pro[2]) if pro is not None else (tile.op, tile.place.free, tile.stores)
         )
         seams = cuttable_seams(route_tree, route_stores, route_free)
         all_sites = sites(route_tree)

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -223,7 +223,8 @@ def test_twisted_statistic_binds_the_sweep_as_one_contraction() -> None:
 
     bound = fused_view(tile)
     assert bound is not None, "the sweep must bind as a computed-A contraction over the twisted statistic"
-    node, n_axis, _stores = bound
+    node, added_axes, _stores = bound
+    (n_axis,) = added_axes
     con = node
     assert is_contraction(con) and con.axis.extent == Dim(128), "one contraction over the whole reduce axis"
     assert n_axis.extent == Dim(32), "the output column axis joins the grid"
@@ -244,10 +245,11 @@ def test_twisted_statistic_survives_the_loop_dialect_round_trip() -> None:
     tile = recognized_tile(LoopOp(body=_wrap_rows(_sweep_body()), inputs={}))
     bound = fused_view(tile)
     assert bound is not None
-    node, n_axis, stores = bound
+    node, added_axes, stores = bound
+    (n_axis,) = added_axes
 
     stmts = tuple(effect_tail(node.lower(), stores))
-    for axis in reversed((*tile.place.free, n_axis)):
+    for axis in reversed((*tile.place.free, *added_axes)):
         stmts = (Loop(axis=axis, body=Body.coerce(stmts)),)
     relifted = recognized_tile(LoopOp(body=Body.coerce(stmts)))
     again = fused_view(relifted)

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -20,6 +20,7 @@ from emmy.compiler.dim import Dim
 from emmy.compiler.dtype import F16
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.frontend.ir import MatmulOp, RmsNormOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
 from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Pipeline
@@ -120,7 +121,7 @@ def test_place_sites_are_the_non_root_nodes() -> None:
     tile = recognized_tile(node.op, name=node.op.name)
     pro = fused_view(tile)
     assert pro is not None, "the norm→linear tile must derive its fused computed-A view"
-    c_map, _n_ax, _stores = pro
+    c_map, _added_axes, _stores = pro
     all_sites = sites(c_map)
     seams = family_sites("PLACE", all_sites)
     assert seams and all(s.depth > 1 for s in seams)
@@ -238,6 +239,68 @@ def test_sdpa_offers_fused_and_one_shared_score_cut_without_overrides() -> None:
     loads = [load for load in parent.body.loads if load.input == ws]
     assert len(loads) == 2, "both reconstructed uses must read the one workspace"
     assert loads[0].index != loads[1].index, "each use must keep its contextual free-axis mapping"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "torch.manual_seed(0);"
+            "q=torch.randn(1,2,1,128,dtype=torch.float16);"
+            "k=torch.randn(1,2,8,128,dtype=torch.float16);"
+            "v=torch.randn(1,2,8,128,dtype=torch.float16);"
+            "F.scaled_dot_product_attention(q,k,v,is_causal=False)"
+        ),
+        (
+            "torch.manual_seed(0);"
+            "q=torch.randn(1,4,1,128,dtype=torch.float16);"
+            "k=torch.randn(1,2,8,128,dtype=torch.float16);"
+            "v=torch.randn(1,2,8,128,dtype=torch.float16);"
+            "F.scaled_dot_product_attention("
+            "q.reshape(1,2,2,1,128),k.reshape(1,2,1,8,128),v.reshape(1,2,1,8,128),"
+            "is_causal=False).reshape(1,4,1,128)"
+        ),
+    ],
+    ids=["mha", "gqa"],
+)
+def test_decode_sdpa_offers_grouped_fused_target(source) -> None:
+    """A unit-elided query row keeps the same fused/grouped placement alternatives."""
+    from emmy.commands.trace import trace_inline_code
+    from emmy.compiler.ir.loop import LoopOp
+    from emmy.compiler.ir.tile import TileOp
+    from emmy.compiler.pipeline import LOOP_PASSES
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import fused_view
+    from emmy.compiler.pipeline.passes.lowering.tile._lift import recognized_tile
+
+    graph = trace_inline_code(source)["graph"]
+    fused = Pipeline.build(LOOP_PASSES).run(graph)
+    (node,) = [node for node in fused.nodes.values() if isinstance(node.op, LoopOp)]
+    node.op.populate_io(fused, node)
+    view = fused_view(recognized_tile(node.op, name=node.id))
+    assert view is not None
+    assert [(axis.name, axis.extent) for axis in view[1][:-1]] == [("_um", Dim(1))]
+
+    captured: list = []
+
+    def decide(fork):
+        leaves = flatten_leaves(fork.options)
+        captured.extend(leaves)
+        return leaves[0]
+
+    Run(pipeline=Pipeline.build(["lowering/tile"], select=["recognize"]), ctx=Context.from_target((8, 0))).resolve(fused, decide)
+    assert any(isinstance(option, TileOp) for option in captured)
+    grouped = [option for option in captured if isinstance(option, Graph) and any("__cut_acc" in node_id for node_id in option.nodes)]
+    assert len(grouped) == 1
+
+
+@pytest.mark.parametrize("index", [(Var("m"), Var("n")), (Var("n"),)], ids=["nonunit", "missing-row"])
+def test_synthetic_decode_row_requires_a_literal_unit_coordinate(index) -> None:
+    """A real or absent row coordinate cannot opt into the M=1 contraction reading."""
+    from emmy.compiler.ir.stmt import Write
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import _unit_output_row
+
+    write = Write(output="out", index=index, value="acc")
+    assert _unit_output_row((write,), "n") is None
 
 
 # --- the realizer: pin-driven cuts, fuse-default, recursion ---------------------------------------

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -883,7 +883,7 @@ def test_normed_q_k_scores_bind_both_computed_cones_with_a_cuttable_b_seam():
     assert pro is not None, "the chained score column binds through the fused view"
     node = pro[0].operands[0]
     assert is_contraction(node) and isinstance(node.a, Fold) and isinstance(node.channels[0].b, Fold), "both operands computed"
-    seams = [spell(pro[0], "PLACE", s.node) for s in cuttable_seams(pro[0], pro[2], (*tile.place.free, pro[1]))]
+    seams = [spell(pro[0], "PLACE", s.node) for s in cuttable_seams(pro[0], pro[2], (*tile.place.free, *pro[1]))]
     assert "PLACE@b" in seams, seams
 
 
@@ -967,7 +967,7 @@ def test_fused_view_tail_prefix_is_alpha_renamed_from_the_statistic_prologue():
     tile = recognized_tile(LoopOp(body=_m1_norm_gate_up_body()))
     pro = fused_view(TileOp(op=tile.op, place=Placement(free=tuple(tile.place.free)), stores=tuple(tile.stores)))
     assert pro is not None, "the one-row norm→gate/up must bind the fused (computed-A) reading"
-    tree, n_ax, stores = pro
+    tree, added_axes, stores = pro
     assert any(s.name.endswith("__p") for s in tree.body if isinstance(s, Load)), [s for s in tree.body]
     # The parent piece of any cut is this flattening; it must be a valid single-scope program.
-    LoopOp(body=Body(tuple(_nest(effect_tail(tree.lower(), stores), [*tile.place.free, n_ax]))))
+    LoopOp(body=Body(tuple(_nest(effect_tail(tree.lower(), stores), [*tile.place.free, *added_axes]))))


### PR DESCRIPTION
## Summary

- restore the established synthetic unit row when Loop IR proves an elided M=1 output coordinate
- keep batch and head axes contextual while binding the chained score producer and final softmax-times-V contraction
- preserve fail-closed behavior for non-unit or missing row coordinates and carry the added grid axes through placement, scheduling, and golden replay

## CPU and structural proof

- plain MHA decode and reshaped GQA decode each fuse to one LoopOp
- both expose the fused TileOp and exactly one grouped score-materialization sibling
- non-unit and missing-row counterexamples cannot synthesize the unit row
- make test: 3070 passed, 574 skipped, 1 xfailed
- make lint: green

## Evidence boundary

This PR proves compiler structure and CPU regressions only. Exact A100 O3 correctness, full hybrid-vs-MCTS retuning, and Emmy-vs-Neptune/torch.compile performance validation remain pending and are not claimed here.