### PR TITLE
Preserve grouped placement through fusion

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -737,7 +737,9 @@ so same-shaped computations over different values never alias; a class with more
 The one producer writes a common workspace, while each replacement `Load` retains its member's contextual index axes.
 This grouped inverse is also fusion's boundedness witness: a nested-reduce or multi-statistic merge it recognizes is
 counted as child-once + parent rather than by the duplicated raw-loop spelling, and placement keeps that materialized
-form beside the fused form for evidence to price. A piece is a RAW loop body: the tree's λ-local SSA names flatten
+form beside the fused form for evidence to price. A later merge must preserve that witness; destroying it would make
+the already-admissible materialized sibling disappear and leave evidence unable to recover the prior kernel boundary.
+A piece is a RAW loop body: the tree's λ-local SSA names flatten
 into one scope,
 so each piece is minted under canonical sequential names, and a second spelling of the same stmts — the fused
 reading's store-side prefix, which re-evaluates the tail's stat-free cone stmts beside the statistic prologue — is

--- a/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
@@ -23,7 +23,8 @@ one streaming loop) — other shapes fall to the raw-loop escape downstream (no 
 recognition may prove two alpha-equivalent computed edges reconstruct one producer through a
 grouped placement cut; the fused cell and that materialized form remain priced siblings. The same
 witness makes the work bound count the child once plus its parent instead of the raw duplicated
-spelling. Otherwise ``_total_work`` sums the enclosing free×reduce iteration count of every
+spelling. A later merge may preserve that witness, but never consume it and leave no placement
+inverse for evidence to price. Otherwise ``_total_work`` sums the enclosing free×reduce iteration count of every
 compute leaf, and a merge that grows it by more than ``_BLOWUP_FACTOR`` is refused. That bound is
 what keeps the downstream problem finite, not a
 performance preference: unbounded splicing folds a whole transformer layer into ONE loop nest

--- a/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
@@ -142,6 +142,8 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
     if merged is None:
         raise RuleSkipped("N-way Loop splicer rejected the region")
     reuse_pieces = _recognized_reuse_pieces(merged)
+    if reuse_pieces is None and any(_recognized_reuse_pieces(graph.nodes[node_id].op) is not None for node_id in region):
+        raise RuleSkipped("merge destroys a recognized grouped placement inverse")
     if _nests_reduce(merged) and not any(_nests_reduce(graph.nodes[node_id].op) for node_id in region) and reuse_pieces is None:
         raise RuleSkipped("merge nests a reduce loop inside a reduce loop — an unreadable seam (raw-loop escape only)")
     if (

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -303,6 +303,32 @@ def test_synthetic_decode_row_requires_a_literal_unit_coordinate(index) -> None:
     assert _unit_output_row((write,), "n") is None
 
 
+def test_followup_fusion_preserves_the_sdpa_grouped_inverse() -> None:
+    """A producer merge cannot consume an attention target's recovered placement sibling."""
+    from emmy.commands.trace import trace_inline_code
+    from emmy.compiler.ir.loop import LoopOp
+    from emmy.compiler.pipeline import LOOP_PASSES
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import reusable_cut_pieces
+
+    graph = trace_inline_code(
+        "F.scaled_dot_product_attention(torch.randn(1,2,8,128), torch.randn(1,2,8,128), torch.randn(1,2,8,128), is_causal=True)"
+    )["graph"]
+    graph = Pipeline.build(LOOP_PASSES).run(graph, ctx=Context.from_target((8, 0)))
+    attention = graph.nodes["scaled_dot_product_attention"]
+    assert isinstance(attention.op, LoopOp) and reusable_cut_pieces(attention.op) is not None
+
+    source = graph.nodes["x0"].output
+    graph.rename_node("x0", "q_src")
+    graph.add_node(ElementwiseOp("negative"), ["q_src"], replace(source, name="x0"), node_id="x0")
+    graph.replace_input(attention.id, "q_src", "x0")
+
+    fused = Pipeline.build(["loop/lifting", "loop/fusion"]).run(graph, ctx=Context.from_target((8, 0)))
+    loops = [node for node in fused.nodes.values() if isinstance(node.op, LoopOp)]
+    assert len(loops) == 2, "the producer must stay outside the reusable attention cell"
+    attention = fused.nodes["scaled_dot_product_attention"]
+    assert reusable_cut_pieces(attention.op) is not None
+
+
 # --- the realizer: pin-driven cuts, fuse-default, recursion ---------------------------------------
 
 


### PR DESCRIPTION
## Summary

- reject follow-up loop fusion that removes an already-recognized grouped placement inverse
- preserve the fused attention schedule and its materialized shared-score sibling for deploy evidence to price
- add a CPU structural regression with causal SDPA and a computed query producer

## A100 inventory evidence

Before this fix, the current Qwen3 seq512 trace collapsed attention into one scalar target with 10 rows and one
normalization seam. The fixed trace exposes 231,290 attention candidates, including tensor-core tiles, staging and
reduction families, plus the shallow and grouped shared-score placement seams.

## Validation

- `make test` (`3067 passed, 574 skipped, 1 xfailed`)
- `make lint`
- focused fusion, placement, attention, and trace tests (`95 passed, 29 skipped, 1 xfailed`)
