### PR TITLE
Bound fusion construction work

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -491,6 +491,12 @@ global cache would require; the memo is discarded with the splicer.
 `extend` and `restrict` retain the applicable canonical entries from their parent, so dependency placement neither
 reformats deep coordinate trees nor retains duplicate canonical strings.
 
+Fusion may give the splicer the ordinary work-growth ceiling before construction. The splicer accumulates the exact
+static-extent arithmetic-leaf work at each inserted scope (using 128 for a symbolic extent, as the final fusion metric
+does) and refuses as soon as the monotonic partial work exceeds that ceiling. Identity-copy aliases are excluded
+because normalization removes them from the finished body. An admitted bounded splice constructs the same body bytes
+as an unbounded splice; the bound only terminates a candidate whose final ordinary work limit is already impossible.
+
 ### `loop/runner.py` — C++ JIT executor
 
 `execute_loop_op_cpp(loop, input_arrays, out_shape) → ndarray` renders the

--- a/emmy/compiler/ir/loop/splicer.py
+++ b/emmy/compiler/ir/loop/splicer.py
@@ -138,6 +138,8 @@ def splice_loop_ops(producer: LoopOp, consumer: LoopOp, source: str) -> LoopOp |
 def splice_loops(
     loops: dict[str, LoopOp],
     splice_edges: dict[tuple[str, str], tuple[str, str]],
+    *,
+    max_work: int | None = None,
 ) -> LoopOp | None:
     """Splice a DAG of ``LoopOp``s into one merged kernel.
 
@@ -153,7 +155,10 @@ def splice_loops(
     seed the traversal — is derived from ``splice_edges``: it's the
     unique tag in ``loops`` that never appears as a splice target.
     Returns ``None`` if the sink is ambiguous (cycle or multiple sinks)
-    or if any splice edge hits an unsupported pattern.
+    or if any splice edge hits an unsupported pattern. ``max_work`` bounds
+    the arithmetic work accumulated while constructing the body; fusion uses
+    it to reject a merge as soon as its existing work-growth limit cannot be
+    met.
     """
     target_tags = {tag for tag, _out in splice_edges.values()}
     candidates = [tag for tag in loops if tag not in target_tags]
@@ -165,6 +170,7 @@ def splice_loops(
             loops={tag: op.analyze() for tag, op in loops.items()},
             splice_edges=splice_edges,
             root=root,
+            max_work=max_work,
         ).run()
     except (_NotSupported, ValueError) as exc:
         # _NotSupported = splicer hit an unsupported pattern (σ-solve, scope).
@@ -175,7 +181,7 @@ def splice_loops(
         return None
 
 
-def splice_graph(graph) -> tuple[LoopOp, list[str]] | None:
+def splice_graph(graph, *, max_work: int | None = None) -> tuple[LoopOp, list[str]] | None:
     """Splice a subgraph of ``LoopOp`` nodes into one merged kernel.
 
     Each ``LoopOp`` node in ``graph`` becomes a registered loop tagged
@@ -217,6 +223,7 @@ def splice_graph(graph) -> tuple[LoopOp, list[str]] | None:
     merged = splice_loops(
         loops={nid: n.op for nid, n in loop_nodes.items()},
         splice_edges=splice_edges,
+        max_work=max_work,
     )
     if merged is None:
         return None
@@ -251,6 +258,7 @@ class _Splicer(LoopBuilder):
         loops: dict[str, LoopMeta],
         splice_edges: dict[tuple[str, str], tuple[str, str]],
         root: str,
+        max_work: int | None,
     ) -> None:
         used: set[str] = set()
         for meta in loops.values():
@@ -259,6 +267,8 @@ class _Splicer(LoopBuilder):
         self.loops = loops
         self.splice_edges = splice_edges
         self.root = root
+        self._max_work = max_work
+        self._partial_work = 0
         self._pending: deque[_Demand] = deque()
         # Dedup: a stmt is uniquely identified by its (origin, name), the
         # emit scope it lands at in the merged body, and the σ restricted
@@ -269,6 +279,25 @@ class _Splicer(LoopBuilder):
         # dependency placement does not recursively walk the same large coordinate tree, while
         # avoiding structural hashing (which would perform another recursive tree walk).
         self._free_vars_by_expr_id: dict[int, tuple[Expr, frozenset[str]]] = {}
+
+    def insert(self, stmt: Stmt, enclosure: Scope) -> None:
+        """Insert one statement while maintaining fusion's work lower bound.
+
+        Source LoopOps are normalized before splicing, so their arithmetic leaves already sit at
+        the shallowest valid scope. Coordinate substitution may only remove axes, which
+        ``_scope_for_axes`` does before insertion. Identity copies are omitted because
+        ``LoopOp`` normalization removes them from the final body. Every other inserted Assign
+        or Accum therefore contributes permanently to the final ``_total_work`` metric.
+        """
+        extent = 1
+        for axis in enclosure.enclosing:
+            extent *= axis.extent.as_static() if axis.extent.is_static else 128
+        is_copy = isinstance(stmt, Assign) and stmt.op.name == "copy" and stmt.dtype is None
+        added = extent if isinstance(stmt, (Assign, Accum)) and not is_copy else 0
+        if self._max_work is not None and self._partial_work + added > self._max_work:
+            raise _NotSupported(f"partial work exceeds construction limit: {self._partial_work + added} > {self._max_work}")
+        self._partial_work += added
+        super().insert(stmt, enclosure)
 
     def run(self) -> LoopOp:
         self._seed()

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -310,7 +310,12 @@ sweep of flat same-extent additive folds — the value folds of a fused softmax�
 contraction over the pair; other shapes fall to the raw-loop
 escape with no schedule tier and no `PLACE` seam, so evidence could never price the split back) plus one
 boundedness cap on aggregate work growth: without it a whole transformer layer splices into a single loop
-nest that no schedule can run and recognition cannot certify.
+nest that no schedule can run and recognition cannot certify. Ordinary merges enforce that same cap during splicer
+construction, stopping once their monotonic partial arithmetic work already exceeds the final 8× limit. The only
+uncapped construction shapes are structural candidates for the existing grouped-placement exception: one additive
+contraction at exactly two coordinate demands along otherwise linear paths, or a linear extension of an already
+recognized grouped inverse. The post-build recognizer and final work check remain authoritative; the preflight never
+admits a new exception.
 
 **Merge ORDER is a decision, and `loop/prefusion` makes it.** A merge is directional — it makes the SINK the
 region's output, so the sink's width must then be written. Splice a compute producer into a still-open

--- a/emmy/compiler/pipeline/passes/loop/fusion/_helpers.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_helpers.py
@@ -128,7 +128,7 @@ def closed_loop_consumer_region(graph: Graph, producer: Node) -> tuple[set[str],
     return region, graph.nodes[sink_id]
 
 
-def build_merged_region(graph: Graph, region: set[str], sink: Node) -> LoopOp | None:
+def build_merged_region(graph: Graph, region: set[str], sink: Node, *, max_work: int | None = None) -> LoopOp | None:
     """Splice an owned DAG of ``LoopOp`` nodes into ``sink``.
 
     ``region`` may be the ordinary two-node case or fan out and reconverge.
@@ -175,7 +175,7 @@ def build_merged_region(graph: Graph, region: set[str], sink: Node) -> LoopOp | 
         sub.add_node(node.op, list(node.inputs), outputs=node.outputs, node_id=nid)
     sub.outputs = [sink.id]
 
-    result = splice_graph(sub)
+    result = splice_graph(sub, max_work=max_work)
     if result is None:
         return None
     merged, _ = result

--- a/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
@@ -129,6 +129,53 @@ def _recognized_reuse_pieces(loop_op: LoopOp) -> tuple[LoopOp, LoopOp] | None:
     return reusable_cut_pieces(loop_op)
 
 
+def _may_need_grouped_reuse(graph: Graph, region: set[str], sink: Node) -> bool:
+    """Whether construction may expose or preserve a grouped placement inverse.
+
+    A new grouped placement shares one additive contraction at exactly two distinct coordinate
+    demands. Everything between that producer and the sink is linear: only the producer fans out,
+    only the sink joins, and every intermediate has one coordinate demand. A merge that extends
+    one already-recognized inverse is eligible only along a single linear path. The post-build
+    recognizer remains the authoritative witness in both cases.
+    """
+    parents = {node_id: set() for node_id in region}
+    users = {node_id: set() for node_id in region}
+    demands: dict[str, list[tuple]] = {node_id: [] for node_id in region}
+    for consumer_id in region:
+        for load in graph.nodes[consumer_id].op.body.loads:
+            if load.input in region:
+                parents[consumer_id].add(load.input)
+                users[load.input].add(consumer_id)
+                if not any(load.index == existing for existing in demands[load.input]):
+                    demands[load.input].append(load.index)
+
+    sources = [node_id for node_id in region if not parents[node_id]]
+    if len(sources) != 1:
+        return False
+    source = sources[0]
+
+    linear = all(
+        (not parents[node_id] and len(users[node_id]) == 1 and len(demands[node_id]) == 1)
+        if node_id == source
+        else (len(parents[node_id]) == 1 and not users[node_id])
+        if node_id == sink.id
+        else (len(parents[node_id]) == 1 and len(users[node_id]) == 1 and len(demands[node_id]) == 1)
+        for node_id in region
+    )
+    if linear and any(_recognized_reuse_pieces(graph.nodes[node_id].op) is not None for node_id in region):
+        return True
+
+    accums = [stmt for stmt in graph.nodes[source].op.body.iter() if isinstance(stmt, Accum)]
+    if len(accums) != 1 or accums[0].op.reduce_canon != "add" or _nests_reduce(graph.nodes[source].op):
+        return False
+    if len(demands[source]) != 2:
+        return False
+    for node_id in region - {source, sink.id}:
+        if len(parents[node_id]) != 1 or len(users[node_id]) != 1 or len(demands[node_id]) != 1:
+            return False
+    return not users[sink.id]
+
+
 def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
     """Splice an owned one- or multi-consumer region, capped only by compute growth.
 
@@ -138,7 +185,9 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
     if any("__cut_" in node_id for node_id in region - {sink.id}):
         raise RuleSkipped("region crosses a decided placement cut")
 
-    merged = _build_merged_region(graph, region, sink)
+    pre_work = sum(_total_work(graph.nodes[node_id].op) for node_id in region)
+    construction_limit = None if _may_need_grouped_reuse(graph, region, sink) else _BLOWUP_FACTOR * pre_work
+    merged = _build_merged_region(graph, region, sink, max_work=construction_limit)
     if merged is None:
         raise RuleSkipped("N-way Loop splicer rejected the region")
     reuse_pieces = _recognized_reuse_pieces(merged)
@@ -157,7 +206,6 @@ def merge_region(match: Match, region: set[str], sink: Node) -> Graph:
         # expectation channels the pairing joins). A merge that entangles the pair with any
         # other tail produces a cell recognition keeps as the raw-loop escape.
         raise RuleSkipped("merge entangles a multi-statistic compound — an unreadable seam")
-    pre_work = sum(_total_work(graph.nodes[node_id].op) for node_id in region)
     post_work = _total_work(merged)
     if reuse_pieces is not None:
         # Raw Loop IR spells the equal producer once at each demand site and may nest one copy

--- a/tests/compiler/ir/loop/test_splicer.py
+++ b/tests/compiler/ir/loop/test_splicer.py
@@ -624,3 +624,103 @@ def test_large_sigma_target_free_vars_walks_do_not_scale_with_producer_chain(mon
     # Loop construction and normalization also inspect the coordinate expression, but the count
     # must not grow with the 128 producer dependencies (without the per-splice memo it exceeds 128).
     assert root_walks < 32
+
+
+# ---------------------------------------------------------------------------
+# Construction work bound
+# ---------------------------------------------------------------------------
+
+
+def test_construction_work_bound_preserves_body_at_the_exact_limit():
+    """The bound changes only rejection; an admitted splice stays byte-identical."""
+    axis = Axis("i", 4)
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=axis,
+                body=(
+                    Load(name="x", input="X", index=(Var("i"),)),
+                    Assign(name="y", op="exp", args=("x",)),
+                    Write(output="P", index=(Var("i"),), value="y"),
+                ),
+            ),
+        )
+    )
+    consumer = LoopOp(
+        body=(
+            Loop(
+                axis=axis,
+                body=(
+                    Load(name="p", input="P", index=(Var("i"),)),
+                    Assign(name="z", op="negative", args=("p",)),
+                    Write(output="O", index=(Var("i"),), value="z"),
+                ),
+            ),
+        )
+    )
+    loops = {"producer": producer, "consumer": consumer}
+    edges = {("consumer", "P"): ("producer", "P")}
+
+    unbounded = splice_loops(loops, edges)
+    at_limit = splice_loops(loops, edges, max_work=8)
+
+    assert unbounded is not None and at_limit is not None
+    assert at_limit.body == unbounded.body
+    assert splice_loops(loops, edges, max_work=7) is None
+
+
+def test_construction_work_bound_stops_repeated_affine_recurrence(monkeypatch):
+    """A minimized recurrence/mask shape terminates before its coordinate paths expand.
+
+    Each update reads the preceding value at two affine coordinates. Composing 32 updates is the
+    same repeated-coordinate structure as the 169-node onboarding region, but the ordinary 8×
+    input-work ceiling must stop construction without a wall-clock assertion.
+    """
+    from emmy.compiler.ir.loop import splicer as splicer_module
+
+    depth = 32
+    axis = Axis("i", 4)
+    loops: dict[str, LoopOp] = {
+        "n0": LoopOp(
+            body=(
+                Loop(
+                    axis=axis,
+                    body=(
+                        Load(name="x", input="X", index=(Var("i"),)),
+                        Assign(name="y", op="negative", args=("x",)),
+                        Write(output="n0", index=(Var("i"),), value="y"),
+                    ),
+                ),
+            )
+        )
+    }
+    edges: dict[tuple[str, str], tuple[str, str]] = {}
+    for i in range(1, depth):
+        previous, current = f"n{i - 1}", f"n{i}"
+        loops[current] = LoopOp(
+            body=(
+                Loop(
+                    axis=axis,
+                    body=(
+                        Load(name="left", input=previous, index=(Var("i"),)),
+                        Load(name="right", input=previous, index=(Var("i") + Literal(1, "int"),)),
+                        Assign(name="y", op="add", args=("left", "right")),
+                        Write(output=current, index=(Var("i"),), value="y"),
+                    ),
+                ),
+            )
+        )
+        edges[(current, previous)] = (previous, previous)
+
+    resolutions = 0
+    original = splicer_module._Splicer._resolve
+
+    def counted(self, demand):
+        nonlocal resolutions
+        resolutions += 1
+        return original(self, demand)
+
+    monkeypatch.setattr(splicer_module._Splicer, "_resolve", counted)
+    input_work = depth * axis.extent.as_static()
+    assert splice_loops(loops, edges, max_work=8 * input_work) is None
+    assert resolutions < 1000

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -203,7 +203,7 @@ def test_grouped_cut_rejects_more_than_two_equivalent_uses() -> None:
     assert not [cut for cut in cuts if len(cut.members) > 1]
 
 
-def test_sdpa_offers_fused_and_one_shared_score_cut_without_overrides() -> None:
+def test_sdpa_offers_fused_and_one_shared_score_cut_without_overrides(monkeypatch) -> None:
     """The fused cell and its two-kernel inverse are structural siblings.
 
     The inverse materializes one score producer. Its two contextual uses retain distinct
@@ -213,13 +213,28 @@ def test_sdpa_offers_fused_and_one_shared_score_cut_without_overrides() -> None:
     from emmy.compiler.ir.loop import LoopOp
     from emmy.compiler.ir.tile import TileOp
     from emmy.compiler.pipeline import LOOP_PASSES
+    from emmy.compiler.pipeline.passes.loop.fusion import _merge
 
+    grouped_over_limit: list[tuple[int, int]] = []
+    original = _merge._build_merged_region
+
+    def tracked(graph, region, sink, *, max_work=None):
+        merged = original(graph, region, sink, max_work=max_work)
+        if merged is not None and max_work is None and _merge._recognized_reuse_pieces(merged) is not None:
+            pre_work = sum(_merge._total_work(graph.nodes[node_id].op) for node_id in region)
+            raw_work = _merge._total_work(merged)
+            if raw_work > 8 * pre_work:
+                grouped_over_limit.append((pre_work, raw_work))
+        return merged
+
+    monkeypatch.setattr(_merge, "_build_merged_region", tracked)
     graph = trace_inline_code(
         "F.scaled_dot_product_attention(torch.randn(1,2,8,128), torch.randn(1,2,8,128), torch.randn(1,2,8,128), is_causal=True)"
     )["graph"]
     fused = Pipeline.build(LOOP_PASSES).run(graph)
     loop_nodes = [node for node in fused.nodes.values() if isinstance(node.op, LoopOp)]
     assert len(loop_nodes) == 1, "recognized reuse must admit the whole fused Loop-IR cell"
+    assert grouped_over_limit, "the grouped score inverse must bypass the ordinary raw-work limit"
 
     captured: list = []
 


### PR DESCRIPTION
## Summary

- enforce fusion's existing 8x aggregate-work ceiling while the Loop splicer constructs ordinary merge candidates
- preserve the existing grouped placement exception through a structural preflight for two score-coordinate demands and linear extensions of an already-recognized grouped inverse
- keep admitted Loop IR deterministic and byte-identical; the post-build grouped-reuse witness and final work check remain authoritative

## Scaling evidence

The Qwen3.8 Gated DeltaNet layer-0 trace exposed one speculative 169-node recurrence/mask region ending at `to_14_cast`:

- input work: `38,109,277,455`
- ordinary final ceiling: `304,874,219,640` (8x)
- after only 10,000 dependency resolutions: 13,054 bindings, 11,134 body statements, and `1,454,992,819,006,795,063,298` partial arithmetic work
- that monotonic partial work was already about 4.77 billion times the ordinary final ceiling; previous construction continued past 150,000 bindings and multi-GiB RSS even though the completed merge could only be rejected

The minimized 32-stage affine recurrence regression now rejects in 763 dependency resolutions, with no wall-clock threshold. A separate exact-bound test proves the admitted body equals the unbounded body and rejects only one work unit below the threshold.

## Grouped-attention boundary

The causal SDPA regression proves the grouped score inverse still admits its fused Loop IR when raw spelling exceeds the ordinary 8x ceiling. Decode MHA/GQA creation and the existing follow-up grouped-inverse preservation regression also remain green. Representative rendered CUDA digests for warp, masked, head-dim-256, and scalar SDPA are identical to exact `fefd605a` main.

## Validation

- `make test`: 3,095 passed, 560 skipped, 1 xfailed
- `make lint`: green
- focused splicer/fusion/placement/recognition: 118 passed, 1 xfailed
- `git diff --check`: green

## Evidence boundary

This PR establishes generic compiler termination and preserves current attention structure. The exact RTX 4090 Qwen3.8 layer-0 retrace will run from this commit and be reported separately; no model golden or performance claim is included here.
