### PR TITLE
Persist Conv1d in Torch IR programs

### DIFF
--- a/emmy/compiler/torch_wire.py
+++ b/emmy/compiler/torch_wire.py
@@ -17,6 +17,7 @@ from emmy.compiler.ir.base import ConstantOp, InputOp, Op
 from emmy.compiler.ir.expr import BinaryExpr, Builtin, CastExpr, FuncCallExpr, Literal, TernaryExpr, Var
 from emmy.compiler.ir.frontend.ir import (
     CatOp,
+    Conv1dOp,
     LayerNormOp,
     LinearOp,
     MatmulOp,
@@ -66,6 +67,7 @@ _OP_SPECS: dict[str, tuple[type[Op], tuple[str, ...]]] = {
     "torch.slice": (SliceOp, ("shape", "dim", "start")),
     "torch.cat": (CatOp, ()),
     "torch.unsqueeze": (UnsqueezeOp, ("dim",)),
+    "torch.conv1d": (Conv1dOp, ("stride", "padding", "dilation", "groups")),
     "torch.linear": (LinearOp, ("has_bias",)),
     "torch.matmul": (MatmulOp, ("has_bias",)),
     "torch.sdpa": (SdpaOp, ("is_causal", "sliding_window", "scale")),

--- a/tests/compiler/cli/test_trace.py
+++ b/tests/compiler/cli/test_trace.py
@@ -11,7 +11,7 @@ from emmy.compiler.backend import torch_ref
 from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
-from emmy.compiler.ir.frontend.ir import LinearOp
+from emmy.compiler.ir.frontend.ir import Conv1dOp, LinearOp
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.tensor.ir import CastOp, ElementwiseOp, GatherOp
 from emmy.compiler.pipeline.search.golden import load_golden_file, load_golden_records
@@ -206,6 +206,27 @@ def test_trace_writes_deterministic_self_contained_programs(tmp_path) -> None:
     assert all(set(entry) == {"program", "target", "realizations"} for entry in first_doc["configs"])
     assert all(set(entry["realizations"][0]) == {"name", "bindings", "pins"} for entry in first_doc["configs"])
     assert all(set(entry["target"]) == {"origins"} for entry in first_doc["configs"])
+
+
+def test_trace_inventory_replays_depthwise_conv1d_program(tmp_path) -> None:
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (1, 8, 16), "f16"), node_id="x")
+    graph.add_node(InputOp(), [], Tensor("weight", (8, 1, 4), "f16"), node_id="weight")
+    graph.add_node(
+        Conv1dOp(stride=1, padding=3, dilation=1, groups=8),
+        ["x", "weight"],
+        Tensor("conv", (1, 8, 19), "f16"),
+        node_id="conv",
+    )
+    graph.inputs, graph.outputs = ["x", "weight"], ["conv"]
+
+    path = tmp_path / "conv1d.yaml"
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
+    _document, targets = load_working_targets(path)
+
+    assert targets
+    expected = Conv1dOp(stride=1, padding=3, dilation=1, groups=8)
+    assert all(target.program.nodes["conv"].op == expected for target in targets)
 
 
 def test_trace_keeps_materialized_storage_outputs_and_quant_digest(tmp_path) -> None:

--- a/tests/compiler/ir/test_torch_wire.py
+++ b/tests/compiler/ir/test_torch_wire.py
@@ -13,6 +13,7 @@ from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.expr import BinaryExpr, Builtin, CastExpr, FuncCallExpr, Literal, TernaryExpr, Var
 from emmy.compiler.ir.frontend.ir import (
     CatOp,
+    Conv1dOp,
     LayerNormOp,
     LinearOp,
     MatmulOp,
@@ -117,6 +118,17 @@ def test_dimension_round_trip_preserves_composite_expression_and_hint():
 def test_operation_round_trip(op):
     restored = op_from_wire(json.loads(json.dumps(op_to_wire(op))))
     assert restored == op
+
+
+def test_conv1d_operation_wire_schema_round_trip():
+    op = Conv1dOp(stride=2, padding=3, dilation=4, groups=5)
+    wire = op_to_wire(op)
+
+    assert wire == {
+        "op": "torch.conv1d",
+        "attrs": {"stride": 2, "padding": 3, "dilation": 4, "groups": 5},
+    }
+    assert op_from_wire(json.loads(json.dumps(wire))) == op
 
 
 def _program() -> Graph:


### PR DESCRIPTION
## Summary

- Add the stable torch.conv1d Torch IR wire tag with the four semantic Conv1dOp fields: stride, padding, dilation, and groups.
- Cover the exact JSON schema and reconstruction of every field.
- Cover working-golden inventory serialization and load replay for a depthwise convolution target.

## Exact onboarding evidence

With #602 overlaid on the RTX 4090, the Qwen3.8 layer-0 trace completed compiler fusion in 14.53 seconds and the full command reached serialization in 31.52 seconds at 981,668 KiB peak RSS. The only failure was Torch IR wire does not support Conv1dOp. This change adds that missing persistence case without changing decomposition or lowering.

## Checks

- Focused Torch-wire and trace tests: 62 passed.
- make test: 3,097 passed, 560 skipped, 1 xfailed.
- make lint: green.
- git diff --check: green.
- Current working-golden and architecture documentation reviewed; no contract text changes required.
