### PR TITLE
Support zero-width pad rendering

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -189,7 +189,7 @@ it replaces the frontend layout ops via `coord_map` expressions.
 
 | Symbol                               | Role                                                           |
 |--------------------------------------|----------------------------------------------------------------|
-| `ElementwiseOp`                      | Per-element scalar function (`add`/`mul`/`where`/`exp`/`sin`/`cos`/…). |
+| `ElementwiseOp`                      | Per-element scalar function (`add`/`mul`/`where`/`exp`/`sin`/`cos`/…); unary `pad` is the frontend's exact zero-width identity. |
 | `CastOp`, `BitcastOp`                | Numeric conversion and same-width bit reinterpretation.       |
 | `RangeOp`                            | Static one-dimensional integer sequence.                       |
 | `ReduceOp`                           | Collapse one axis via associative binary op.                   |

--- a/emmy/compiler/ir/elementwise.py
+++ b/emmy/compiler/ir/elementwise.py
@@ -61,6 +61,10 @@ _NAME_TO_FN: dict[str, object] = {
     "gelu": lambda x: 0.5 * x * (1.0 + _erf(x / np.sqrt(2.0))),
     "gelu_tanh": lambda x: 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (x + 0.044715 * x**3))),
     "copy": lambda x: x,
+    # ``aten.pad`` reaches the generic elementwise spelling only when every pad width is zero.
+    # The tracer rejects every non-empty pad before this point, so the stored unary op is an
+    # identity (kept distinct from ``copy`` for frontend provenance).
+    "pad": lambda x: x,
     "where": np.where,
     # Generic scalar same-width bit reinterpretation. The destination dtype lives on the
     # enclosing Assign/Tensor; source renderers spell the bitcast from both SSA dtypes.

--- a/emmy/compiler/ir/stmt/base.py
+++ b/emmy/compiler/ir/stmt/base.py
@@ -268,7 +268,7 @@ def op_to_expr(fn: str, inputs: list[Expr], *, dtype: str | None = None) -> Expr
         return FuncCallExpr("pow", tuple(inputs))
     if fn == "negative":
         return BinaryExpr("-", Literal(0.0, "float"), inputs[0])
-    if fn == "copy":
+    if fn in ("copy", "pad"):
         return inputs[0]
     if fn in ("from_f8e4m3", "from_f8e5m2"):
         # fp8 decode cast: the value semantics live in the dtype conversion the

--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -42,6 +42,10 @@ fail closed.
 Static integer `arange` lowers to the zero-input tensor `RangeOp`, so constant-source replay evaluates one sequence
 instead of applying NumPy `arange` elementwise to a broadcast stop. Dynamic and non-integer ranges fail closed.
 
+An explicit all-zero `aten.pad` width tuple stays as a unary `ElementwiseOp("pad")` identity so a working golden
+retains the frontend provenance and exact dtype. Any nonzero, symbolic, or otherwise unrepresented padding fails
+closed: the elementwise form has no coordinate, mode, or fill-value fields and cannot describe a changed tensor.
+
 `aten.chunk` is the deliberate exception to the otherwise single-output frontend: the walker materializes every
 FX-described static chunk as its own `SliceOp` and stores a transient tuple of node IDs only while walking FX.
 `operator.getitem` resolves an integer tuple index to the matching slice, so no multi-output Graph IR is introduced.

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -1592,6 +1592,26 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
         "maximum",
         "minimum",
     }
+    # Some chunked recurrent paths call ``F.pad`` even when the static sequence length
+    # already fills the chunk. Preserve that unary no-op in the graph for provenance, but
+    # reject every non-empty pad here: the generic elementwise spelling has no pad-width,
+    # mode, or fill-value fields and therefore cannot represent changed coordinates.
+    if op_name == "pad":
+        raw_pad = fx_node.args[1] if len(fx_node.args) > 1 else (fx_node.kwargs or {}).get("pad")
+        if not isinstance(raw_pad, (tuple, list)) or not raw_pad or any(type(width) is not int or width != 0 for width in raw_pad):
+            raise NotImplementedError(f"aten.pad supports only explicit zero-width padding, got {raw_pad!r}")
+        if len(input_ids) != 1:
+            raise ValueError(f"zero-width aten.pad requires one tensor input, got {len(input_ids)}")
+        input_shape = tuple(g.nodes[input_ids[0]].output.shape)
+        if input_shape != tuple(shape):
+            raise ValueError(f"zero-width aten.pad changed shape from {input_shape} to {tuple(shape)}")
+        node_map[name] = g.add_node(
+            op=ElementwiseOp(op="pad"),
+            inputs=input_ids,
+            output=Tensor(name, shape, dtype),
+            node_id=name,
+        )
+        return
     # --- Clamp ---
     # ``aten.clamp(x, min, max)`` / ``clamp_min`` / ``clamp_max`` decompose to the
     # elementwise ``maximum`` (lower bound) / ``minimum`` (upper bound) chain with the

--- a/tests/compiler/ir/stmt/test_op_to_expr.py
+++ b/tests/compiler/ir/stmt/test_op_to_expr.py
@@ -1,6 +1,10 @@
 """Unit tests for ``op_to_expr`` — elementwise op-name → Expr translation."""
 
+import numpy as np
+import pytest
+
 from emmy.compiler.dtype import F32
+from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, FuncCallExpr, Literal, TernaryExpr
 from emmy.compiler.ir.stmt import Assign, Body
 from emmy.compiler.ir.stmt.base import dtype_promote, op_to_expr
@@ -24,6 +28,18 @@ def test_copy_is_identity_passthrough():
     """``copy`` returns its input unchanged (dropout lowers through this path)."""
     x = Literal(1.0, "float")
     assert op_to_expr("copy", [x]) is x
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32])
+def test_zero_width_pad_is_an_exact_typed_identity(dtype):
+    """Stored unary ``pad`` nodes represent only the zero-width frontend case."""
+    x = Literal(1.0, "float")
+    assert op_to_expr("pad", [x]) is x
+
+    values = np.array([-1.5, 0.0, 2.25], dtype=dtype)
+    actual = ElementwiseImpl("pad")(values)
+    assert actual.dtype == values.dtype
+    np.testing.assert_array_equal(actual, values)
 
 
 def test_typed_copy_is_a_cast_not_an_alias():

--- a/tests/compiler/passes/test_conv1d_einsum_rules.py
+++ b/tests/compiler/passes/test_conv1d_einsum_rules.py
@@ -65,6 +65,36 @@ def test_depthwise_conv1d_matches_eager(run_graph, conv_module) -> None:
     _assert_matches_eager(run_graph, conv_module(groups=8, padding=3), (x, w))
 
 
+def test_causal_conv1d_with_zero_width_chunk_pad_matches_eager(run_graph) -> None:
+    """The Qwen3.8 causal Conv1d target retains its empty chunk-alignment pad."""
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F  # noqa: N812
+
+    class CausalConv(nn.Module):
+        def forward(self, x, w):
+            return F.pad(F.conv1d(x, w, padding=3, groups=8), (0, 0))
+
+    torch.manual_seed(0)
+    x, w = torch.randn(2, 8, 16), torch.randn(8, 1, 4)
+    _assert_matches_eager(run_graph, CausalConv(), (x, w))
+
+
+def test_causal_conv1d_rejects_nonzero_generic_pad() -> None:
+    """A coordinate-changing pad fails before the attribute-free elementwise fallback."""
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F  # noqa: N812
+
+    class CausalConv(nn.Module):
+        def forward(self, x, w):
+            return F.pad(F.conv1d(x, w, padding=3, groups=8), (1, 0))
+
+    x, w = torch.randn(1, 8, 16), torch.randn(8, 1, 4)
+    with pytest.raises(NotImplementedError, match="only explicit zero-width padding"):
+        _decompose(CausalConv(), (x, w))
+
+
 def test_dense_conv1d_im2col_matches_eager(run_graph, conv_module) -> None:
     """The im2col form, with the stride and dilation that make the window map non-trivial."""
     import torch


### PR DESCRIPTION
## Summary

- define the persisted unary `ElementwiseOp("pad")` as the exact typed identity emitted for an all-zero `aten.pad` width tuple
- render that stored operation through the existing identity expression path
- reject nonzero or unrepresented padding during tracing, before the attribute-free elementwise fallback can misrepresent coordinates
- document the trace and Tensor IR contract

## 4090 evidence

Exact-main Qwen3.8 classification on RTX 4090 reached four independent saved targets that fail before launch with
`NotImplementedError: render: elementwise fn='pad' not supported`:

- `linear-layer0.k_linear_a73165.b434ea70d5cd`
- `linear-layer0.k_linear_c3b3b5.98f9398e0507`
- `linear-layer0.k_reshape_slice_transpose_reduce_185fb5.7330265bfc5b`
- `linear-layer0.k_reshape_slice_transpose_reduce_2b6c25.dedb4559e899`

Their embedded frontend program records same-shape unary pad nodes at the chunk boundary. The change supports exactly
that zero-width case; coordinate-changing padding remains unsupported and fails closed.

## Verification

- focused: 29 passed, 6 CUDA-skipped
- `make test`: 3,102 passed, 561 skipped, 1 xfailed
- `make lint`: green
