### PR TITLE
Keep split finalize external inputs

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/tile/030_split_reduce.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_split_reduce.py
@@ -152,6 +152,13 @@ def _frag(match: Match, root: Node) -> Graph:
     return frag
 
 
+def _piece_inputs(root: Node, op: Fold, *first: str) -> list[str]:
+    """Graph edges for a minted piece: fragment-created buffers first, followed by external
+    inputs the piece actually reads. Every rendered CUDA argument must remain a registered edge."""
+    reads = {load.input for load in op.body.loads}
+    return [*first, *(inp for inp in root.inputs if inp in reads)]
+
+
 def _one(frag: Graph, root: Node, piece: LoopOp) -> Graph:
     """The ATOMIC arm's one-kernel fragment. It replaces the split kernel with ONE kernel, but it
     is a SPLICE, never an op rebind: a rebind is how the engine says "the same kernel, decided
@@ -308,7 +315,7 @@ def _split_contraction(match: Match, root: Node, tile: TileOp, node, outer: Fold
     # features fold in its operands' dtypes, which only resolve once the buffer is a graph node.
     frag.add_node(op=partial_tile, inputs=list(root.inputs), output=Tensor(ws_name, ws_shape, F32), node_id=ws_name)
     fin_tile = _piece(fin_op, grid, stores=fin_stores)
-    frag.add_node(op=fin_tile, inputs=[ws_name], output=Tensor(out.name, out.shape, out.dtype), node_id=out.name)
+    frag.add_node(op=fin_tile, inputs=_piece_inputs(root, fin_op, ws_name), output=Tensor(out.name, out.shape, out.dtype), node_id=out.name)
     frag.outputs = [out.name]
     return frag
 
@@ -460,6 +467,6 @@ def rewrite(match: Match, root: Node) -> Graph:
     # kernel's structural features fold in its operands' dtypes.
     frag.add_node(op=partial_tile, inputs=list(root.inputs), output=Tensor(ws_name, ws_shape, F32), node_id=ws_name)
     fin_tile = _piece(fin_op, grid, stores=fin_stores)
-    frag.add_node(op=fin_tile, inputs=[ws_name], output=Tensor(out.name, out.shape, out.dtype), node_id=out.name)
+    frag.add_node(op=fin_tile, inputs=_piece_inputs(root, fin_op, ws_name), output=Tensor(out.name, out.shape, out.dtype), node_id=out.name)
     frag.outputs = [out.name]
     return frag

--- a/tests/compiler/passes/test_split_fresh_kernels.py
+++ b/tests/compiler/passes/test_split_fresh_kernels.py
@@ -25,6 +25,7 @@ from emmy.compiler.dtype import F16, F32
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp
 from emmy.compiler.ir.tile.ir import TileOp
 from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
@@ -62,6 +63,21 @@ def test_the_split_returns_two_kernels(monkeypatch) -> None:
     assert set(_kernels(_resolve(CUDA_PASSES)[0])) == {"o", "o__partial"}
     monkeypatch.setenv("EMMY_REDUCE", "g2a")
     assert set(_kernels(_resolve(CUDA_PASSES)[0])) == {"o"}
+
+
+def test_finalize_keeps_projection_input_edges(monkeypatch) -> None:
+    """A deferred finalize keeps every external buffer its projection reads. The CUDA op's
+    argument order cannot name a buffer absent from the graph node's inputs."""
+    graph = _matmul()
+    graph.add_node(InputOp(), [], Tensor("bias", (Dim(128),), dtype=F16), node_id="bias")
+    graph.add_node(ElementwiseOp("add"), ["o", "bias"], Tensor("biased", (Dim(128), Dim(128)), dtype=F16), node_id="biased")
+    graph.inputs, graph.outputs = ["a", "b", "bias"], ["biased"]
+    monkeypatch.setenv("EMMY_REDUCE", "g2k")
+
+    out, _ = _resolve(CUDA_PASSES, graph)
+    finalize = out.nodes["biased"]
+    assert finalize.inputs == ["biased__partial", "bias"]
+    assert finalize.op.arg_order == ("biased__partial", "bias", "biased")
 
 
 def test_no_piece_inherits_the_kernel_it_replaces(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- register every external buffer read by a deferred split-reduce finalize as a graph edge
- reuse the finalize body load inventory for both structural contraction and residual split paths
- cover fused projection operands through the full CUDA pass pipeline

## Reproducer

Before this change, a fused matmul+bias with `REDUCE=g2k` produced finalize inputs `[biased__partial]` but CUDA argument order `(biased__partial, bias, biased)`; launch then raised `KeyError(bias)`.

## Verification

- `make test`: 3076 passed, 574 skipped, 1 xfailed
- `make lint`
- `git diff --check`