### PR TITLE
Trace static eye as a coordinate map

### DIFF
--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -42,6 +42,11 @@ fail closed.
 Static integer `arange` lowers to the zero-input tensor `RangeOp`, so constant-source replay evaluates one sequence
 instead of applying NumPy `arange` elementwise to a broadcast stop. Dynamic and non-integer ranges fail closed.
 
+Static rank-two `eye` lowers to a two-source `IndexMapOp`: output coordinates select a typed scalar one on the
+diagonal and a typed scalar zero everywhere else. Square and rectangular dimensions must be static integers and match
+the exported tensor metadata. Dynamic dimensions, non-strided layouts, pinned memory, and unsupported overloads or
+constructor options fail closed rather than being stored as an elementwise operation without coordinate semantics.
+
 An explicit all-zero `aten.pad` width tuple stays as a unary `ElementwiseOp("pad")` identity so a working golden
 retains the frontend provenance and exact dtype. Any nonzero, symbolic, or otherwise unrepresented padding fails
 closed: the elementwise form has no coordinate, mode, or fill-value fields and cannot describe a changed tensor.

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -1180,6 +1180,68 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
     name = fx_node.name
     shape = _get_shape(fx_node, sym_rename)
     dtype = _get_dtype(fx_node)
+
+    # ``eye`` constructs values from output coordinates; its dimensions are not tensor
+    # operands. Preserve that coordinate meaning directly and reject forms whose constructor
+    # semantics cannot be represented by the static tensor dialect.
+    if op_name == "eye":
+        import torch
+
+        overload = str(fx_node.target)
+        if overload not in ("aten.eye.default", "aten.eye.m"):
+            raise NotImplementedError(f"unsupported aten.eye overload {overload}")
+        if len(fx_node.args) not in (1, 2):
+            raise NotImplementedError(f"aten.eye requires one or two static integer dimensions, got {len(fx_node.args)}")
+        if not all(isinstance(value, int) and not isinstance(value, bool) for value in fx_node.args):
+            raise NotImplementedError("aten.eye requires static integer dimensions")
+        rows = fx_node.args[0]
+        columns = fx_node.args[1] if len(fx_node.args) == 2 else rows
+        expected_shape = (rows, columns)
+        if _static_fx_shape(fx_node) != expected_shape:
+            raise ValueError(f"aten.eye output shape mismatch: expected {expected_shape}, got {_static_fx_shape(fx_node)}")
+
+        kwargs = fx_node.kwargs or {}
+        unexpected = set(kwargs) - {"dtype", "layout", "device", "pin_memory"}
+        if unexpected:
+            raise NotImplementedError(f"aten.eye unsupported keyword arguments: {sorted(unexpected)}")
+        if kwargs.get("layout") not in (None, torch.strided):
+            raise NotImplementedError(f"aten.eye requires strided layout, got {kwargs['layout']}")
+        if kwargs.get("pin_memory") not in (None, False):
+            raise NotImplementedError("aten.eye does not support pinned-memory construction")
+        resolve_dtype(dtype)
+
+        one_name = f"{name}_one"
+        one_id = g.add_node(
+            op=ConstantOp(name=one_name, value=True if dtype == "bool" else 1.0),
+            inputs=[],
+            output=Tensor(one_name, (1,), dtype),
+            node_id=one_name,
+        )
+        zero_name = f"{name}_zero"
+        zero_id = g.add_node(
+            op=ConstantOp(name=zero_name, value=False if dtype == "bool" else 0.0),
+            inputs=[],
+            output=Tensor(zero_name, (1,), dtype),
+            node_id=zero_name,
+        )
+        node_map[name] = g.add_node(
+            op=IndexMapOp(
+                out_shape=shape,
+                sources=(
+                    IndexSource(
+                        input_idx=0,
+                        coord_map=(Literal(0, "int"),),
+                        select=BinaryExpr("==", placeholder(0), placeholder(1)),
+                    ),
+                    IndexSource(input_idx=1, coord_map=(Literal(0, "int"),)),
+                ),
+            ),
+            inputs=[one_id, zero_id],
+            output=Tensor(name, shape, dtype),
+            node_id=name,
+        )
+        return
+
     input_ids = _resolve_inputs(fx_node, node_map, g)
 
     if op_name is None:

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -611,6 +611,91 @@ def test_trace_rejects_noninteger_arange():
         trace_module(FloatRange(), (torch.randn(4),))
 
 
+@pytest.mark.parametrize(("shape", "dtype"), [((4, 4), "float32"), ((3, 5), "float16")])
+def test_trace_static_eye_uses_index_map_and_matches_eager(shape, dtype):
+    """Eye is a diagonal coordinate map with typed scalar sources, not an elementwise function."""
+    import numpy as np
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.backend.numpy import NumpyBackend
+    from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp
+    from emmy.compiler.trace.torch import trace_module
+
+    class Eye(nn.Module):
+        def forward(self, x):
+            if x.shape[0] == x.shape[1]:
+                return x + torch.eye(x.shape[0], dtype=x.dtype, device=x.device)
+            return x + torch.eye(x.shape[0], x.shape[1], dtype=x.dtype, device=x.device)
+
+    x = torch.zeros(shape, dtype=getattr(torch, dtype))
+    graph = trace_module(Eye(), (x,))
+    eye_maps = [node for node in graph.nodes.values() if isinstance(node.op, IndexMapOp) and len(node.op.sources) == 2]
+    assert len(eye_maps) == 1
+    assert not any(isinstance(node.op, ElementwiseOp) and node.op.fn == "eye" for node in graph.nodes.values())
+
+    backend = NumpyBackend()
+    result, _ = backend.run(backend.compile(graph), input_data={graph.inputs[0]: x.numpy()})
+    got = next(iter(result.outputs.values()))
+    expected = Eye()(x)
+    assert got.dtype == expected.numpy().dtype
+    np.testing.assert_array_equal(got, expected.numpy())
+
+
+def test_trace_eye_rejects_symbolic_dimensions():
+    """Dynamic eye extents cannot be serialized as static IndexMap output dimensions."""
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.trace.torch import trace_module
+
+    class DynamicEye(nn.Module):
+        def forward(self, x):
+            return torch.eye(x.shape[0], x.shape[1], dtype=x.dtype, device=x.device)
+
+    rows = torch.export.Dim("rows", min=2, max=8)
+    columns = torch.export.Dim("columns", min=2, max=8)
+    with pytest.raises(NotImplementedError, match="static integer dimensions"):
+        trace_module(
+            DynamicEye(),
+            (torch.randn(3, 5),),
+            dynamic_shapes={"x": {0: rows, 1: columns}},
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_name", "kwargs", "message"),
+    [
+        ("default", {"layout": "sparse"}, "strided layout"),
+        ("default", {"pin_memory": True}, "pinned-memory"),
+        ("default", {"requires_grad": True}, "unsupported keyword arguments"),
+        ("out", {}, "unsupported aten.eye overload"),
+    ],
+)
+def test_trace_eye_rejects_unrepresented_constructor_semantics(target_name, kwargs, message):
+    """Eye options without stable tensor-IR fields fail before any invalid node is added."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from emmy.compiler.graph import Graph
+    from emmy.compiler.trace.torch import _handle_call_function
+
+    if kwargs.get("layout") == "sparse":
+        kwargs = {"layout": torch.sparse_coo}
+    fx_node = SimpleNamespace(
+        target=getattr(torch.ops.aten.eye, target_name),
+        args=(3,),
+        kwargs=kwargs,
+        meta={"val": torch.empty((3, 3))},
+        name="eye",
+    )
+    graph = Graph()
+    with pytest.raises(NotImplementedError, match=message):
+        _handle_call_function(graph, fx_node, {})
+    assert not graph.nodes
+
+
 def test_trace_reassembles_ling_mtp_roll_select_fill_observed_through_base():
     """Ling's exact MTP token shift versions the rolled base through its selected view."""
     import numpy as np


### PR DESCRIPTION
## Summary

- lower static square and rectangular `aten.eye` as a two-source `IndexMapOp`
- preserve the exported output dtype with typed scalar one and zero sources
- fail closed for symbolic dimensions, unsupported overloads, non-strided layout, pinned memory, and unrepresented
  options
- document the constructor contract in the trace architecture

## Evidence

Qwen3.8 classification row 149, `linear-layer0.k_add_68_pointwise.57748b432ccc`, exposed the invalid stored form:
`torch.eye(64)` had become a broadcast scalar `64` followed by `ElementwiseOp("eye")`. The renderer correctly has no
support for that coordinate-dependent form.

On the pre-fix tree, the new focused tests failed for both static forms and the symbolic form. On this commit, square
FP32 and rectangular FP16 traces replay exactly against eager through the NumPy backend, while dynamic and unsupported
constructor forms fail before adding a graph node.

## Checks

- focused eye tests: 7 passed
- full trace tests: 77 passed
- `make test`: 3114 passed, 561 skipped, 1 xfailed
- `make lint`: passed
- diff, documentation, terminology, and plan-cap audits: passed

Based on exact latest main `ef3ddd483aeceb6d583c231fc2e811b606c157c5`.
