### PR TITLE
Support zero-width pad in Torch reference

### DIFF
--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -29,6 +29,8 @@ Not a `Backend` — a small Graph→torch evaluator that runs a frontend-dialect
 `torch.compile` baseline for `emmy run --ir`. Each frontend / tensor op is mapped to its torch twin
 (`RmsNormOp`→`F.rms_norm`, `LayerNormOp`→`F.layer_norm`, `SdpaOp`→`F.scaled_dot_product_attention`,
 `LinearOp`→`F.linear`, `ElementwiseOp`/`ReduceOp`→the torch elementwise/reduce, layout ops→view/transpose/cat).
+The stored unary `pad` form is an identity because tracing admits it only when every explicit pad width is zero and
+fails closed otherwise.
 FP8 tensors remain exact `uint8` bit carriers; `to_f8*` casts to torch float8 and reinterprets its storage, while
 `from_f8*` performs the inverse reinterpretation before widening. `is_runnable(graph)` is `True` only when every
 compute op and every elementwise operation name has a mapping. Data-dependent `GatherOp` / `ScatterOp` remain

--- a/emmy/compiler/backend/torch_ref.py
+++ b/emmy/compiler/backend/torch_ref.py
@@ -136,6 +136,7 @@ def _build_elementwise_table() -> dict[str, Callable]:
         "from_f8e4m3": from_f8(torch.float8_e4m3fn),
         "from_f8e5m2": from_f8(torch.float8_e5m2),
         "copy": lambda a: a[0],
+        "pad": lambda a: a[0],
     }
 
 

--- a/tests/compiler/backend/test_torch_ref.py
+++ b/tests/compiler/backend/test_torch_ref.py
@@ -56,6 +56,22 @@ def test_linear_and_elementwise():
     _assert_matches_numpy(g, {"x": r.standard_normal((4, 8)), "w": r.standard_normal((16, 8))})
 
 
+@pytest.mark.parametrize(("dtype_name", "torch_dtype"), [("f16", torch.float16), ("f32", torch.float32)])
+def test_zero_width_pad_is_runnable_identity(dtype_name, torch_dtype):
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (2, 3), dtype_name), node_id="x")
+    g.add_node(ElementwiseOp(op="pad"), ["x"], Tensor("out", (2, 3), dtype_name), node_id="out")
+    g.inputs, g.outputs = ["x"], ["out"]
+    expected = torch.arange(6, dtype=torch_dtype).reshape(2, 3)
+
+    assert torch_ref.is_runnable(g)
+    fn, inputs = torch_ref.build_callable(g, {"x": expected})
+    actual = fn(*inputs)
+
+    assert actual.dtype == torch_dtype
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
 def test_where_preserves_bool_condition_dtype_and_broadcasts():
     g = Graph()
     g.add_node(InputOp(), [], Tensor("condition", (2, 1), "bool"), node_id="condition")


### PR DESCRIPTION
## Summary

- replay the stored unary `pad` operation as identity in the Torch reference
- document that tracing stores this form only for explicit all-zero pad widths and rejects other widths
- cover exact value/dtype preservation and `is_runnable` for `f16` and `f32`

## Evidence

- regression before the implementation: 2 failures because `is_runnable` rejected `pad`
- focused regression after the implementation: 2 passed
- `tests/compiler/backend/test_torch_ref.py`: 21 passed
- `make test`: 3116 passed, 561 skipped, 1 xfailed
- `make lint`: passed

This intentionally does not add `cumsum` support or change tracing semantics.
