### PR TITLE
Preserve ordered scan writes across fusion

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -483,6 +483,11 @@ node must rename its body `Write.output` to match (`fusion/_helpers.py::rename_w
 Every `_NotSupported` carries a reason string, logged at DEBUG by `splice_loops`
 — `compile -vv` shows which pattern a rejected edge hit.
 
+A `Write` that observes an `Accum` inside that accumulator's own reduce scope is an ordered prefix output. The
+splicer refuses that shape whether it is the merged root or a producer edge: dependency reconstruction would freshen
+the reduce loop and move the `Write` after it, changing every prefix value into the final reduction. The standalone
+`LoopOp` remains the raw-loop escape, so the accumulator update and its `Write` stay in one serial loop.
+
 Each splice memoizes `Expr.free_vars()` by expression identity while placing dependencies. Sigma expressions remain
 live for the splice, and identity avoids both repeated coordinate-tree walks and the recursive structural hashing a
 global cache would require; the memo is discarded with the splicer.

--- a/emmy/compiler/ir/loop/splicer.py
+++ b/emmy/compiler/ir/loop/splicer.py
@@ -311,8 +311,18 @@ class _Splicer(LoopBuilder):
 
     # -- Seed: every root Write, with its value queued ----------------------
 
+    @staticmethod
+    def _write_observes_running_accumulator(meta: LoopMeta, write: Write, scope: Scope) -> bool:
+        """Whether ``write`` observes an accumulator before its reduce loop completes."""
+        defining = meta.defs.get(write.value)
+        reduce_axis = meta.reduce_axes.get(write.value)
+        return isinstance(defining, Accum) and reduce_axis is not None and reduce_axis in scope.enclosing
+
     def _seed(self) -> None:
-        for w, scope in self.loops[self.root].writes:
+        root = self.loops[self.root]
+        for w, scope in root.writes:
+            if self._write_observes_running_accumulator(root, w, scope):
+                raise _NotSupported(f"root Write to {w.output!r} observes running accumulator {w.value!r}; ordered loop cannot be spliced")
             v_bound = self._ensure_dep(w.value, self.root, Sigma(), scope)
             self.insert(Write(output=w.output, index=w.index, value=v_bound), scope)
 
@@ -405,11 +415,16 @@ class _Splicer(LoopBuilder):
         subsequent iterations. ``target_output_buf`` selects which ``Write``
         of the target is the splice source when the target has multiple outputs."""
         target = self.loops[target_tag]
-        target_write = next((w for w, _ in target.writes if w.output == target_output_buf), None)
-        if target_write is None:
+        found = next(((w, scope) for w, scope in target.writes if w.output == target_output_buf), None)
+        if found is None:
             raise _NotSupported(
                 f"splice edge into {target_tag!r}: no Write with output={target_output_buf!r} "
                 f"(target writes {[w.output for w, _ in target.writes]}) — usually a buf-name != node-id mismatch on the producer"
+            )
+        target_write, target_scope = found
+        if self._write_observes_running_accumulator(target, target_write, target_scope):
+            raise _NotSupported(
+                f"splice edge into {target_tag!r} observes running accumulator {target_write.value!r}; ordered loop cannot be spliced"
             )
         source_meta = self.loops[d.origin]
         index_rename = {

--- a/tests/compiler/ir/loop/test_splicer.py
+++ b/tests/compiler/ir/loop/test_splicer.py
@@ -231,6 +231,77 @@ def test_reduction_producer():
 
 
 # ---------------------------------------------------------------------------
+# Ordered prefix: a Write of the running accumulator cannot cross the splice
+# ---------------------------------------------------------------------------
+
+
+def _prefix_scan(*, source: str, output: str) -> LoopOp:
+    return LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=A1,
+                        body=(
+                            Load(name="x", input=source, index=(Var("a0"), Var("a1"))),
+                            Accum(name="prefix", value="x", op="add"),
+                            Write(output=output, index=(Var("a0"), Var("a1")), value="prefix"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_ordered_prefix_root_declines_splice():
+    """Rebuilding a root from its Writes must not move a prefix output after the reduce loop."""
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=A1,
+                        body=(
+                            Load(name="x", input="X", index=(Var("a0"), Var("a1"))),
+                            Assign(name="y", op="negative", args=("x",)),
+                            Write(output="P", index=(Var("a0"), Var("a1")), value="y"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert splice_loop_ops(producer, _prefix_scan(source="P", output="OUT"), source="P") is None
+
+
+def test_ordered_prefix_producer_declines_splice():
+    """Resolving a producer edge must not replace its prefix output with one final reduction."""
+    consumer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=A1,
+                        body=(
+                            Load(name="x", input="P", index=(Var("a0"), Var("a1"))),
+                            Assign(name="y", op="negative", args=("x",)),
+                            Write(output="OUT", index=(Var("a0"), Var("a1")), value="y"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert splice_loop_ops(_prefix_scan(source="X", output="P"), consumer, source="P") is None
+
+
+# ---------------------------------------------------------------------------
 # Consumer has extra input: source-remapping puts consumer inputs after producer's
 # ---------------------------------------------------------------------------
 

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -73,15 +73,14 @@ Lifting wraps each surviving tensor primitive (elementwise / reduce / scan /
 indexmap / gather) in a trivial single-op `LoopOp`. Fusion then splices
 adjacent `LoopOp` pairs by inlining the producer body at each consumer
 `Load` that reads it. `test_fusion_rules.py` runs lifting followed by
-fusion as a single pass; the splicer's behaviour is exercised
-end-to-end there (no separate unit-test file — the old
-`test_merge_core.py` was retired with `_merge_core.py`).
+fusion as a single pass; `tests/compiler/ir/loop/test_splicer.py` covers the worklist and scope rules directly, while
+the pass tests exercise the resulting graph end to end.
 
 | Rule file                              | Op                         | Tested via                                                                         |
 |----------------------------------------|----------------------------|------------------------------------------------------------------------------------|
 | `loop/lifting/010_lift_elementwise.py` | `ElementwiseOp` → `LoopOp` | `test_fusion_rules.py` (pass fixpoint)                                             |
 | `loop/lifting/020_lift_reduce.py`      | `ReduceOp` → `LoopOp`      | `test_fusion_rules.py::test_contraction_*`                                         |
-| `loop/lifting/025_lift_scan.py`        | `ScanOp` → `LoopOp`        | `test_pipeline_semantics.py::test_scan_sum_lifts_and_preserves_prefix_values`      |
+| `loop/lifting/025_lift_scan.py`        | `ScanOp` → `LoopOp`        | `test_pipeline_semantics.py::test_scan_*`                                          |
 | `loop/lifting/030_lift_indexmap.py`    | `IndexMapOp` → `LoopOp`    | `test_optimization_rules.py::test_matmul_with_transpose_fuses_to_one_kernel` (e2e) |
 | `loop/lifting/040_lift_gather.py`      | `GatherOp` → `LoopOp`      | `test_torch_ops.py::test_gather`                                                   |
 | `loop/fusion/010_merge_loop_ops.py`    | `LoopOp → LoopOp` (splice) | `test_fusion_rules.py` (fixpoint)                                                  |

--- a/tests/compiler/passes/test_pipeline_semantics.py
+++ b/tests/compiler/passes/test_pipeline_semantics.py
@@ -20,7 +20,8 @@ from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda import CudaOp
 from emmy.compiler.ir.loop import Accum, Assign, LoopOp, Write
 from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp, ScanOp
-from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pipeline
+from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Pipeline
 
 _backend = NumpyBackend()
 rng = np.random.default_rng(0)
@@ -134,6 +135,55 @@ def test_scan_sum_lifts_and_preserves_prefix_values():
     assert len(cuda_ops) == 1
     source = cuda_ops[0].kernel_source
     assert source.index("+=") < source.index("out[")
+
+
+def test_scan_after_pointwise_keeps_the_write_inside_its_reduce_loop():
+    """Fusion must not rebuild an ordered prefix as one full reduce plus an output sweep."""
+
+    def make_graph():
+        graph = Graph()
+        _input(graph, "x", (2, 4))
+        graph.add_node(op=ElementwiseOp("negative"), inputs=["x"], output=Tensor("neg", (2, 4)), node_id="neg")
+        graph.add_node(op=ScanOp(op="sum", axis=-1), inputs=["neg"], output=Tensor("out", (2, 4)), node_id="out")
+        graph.inputs = ["x"]
+        graph.outputs = ["out"]
+        return graph
+
+    result = _compile(make_graph())
+    launches = _loop_nodes(result)
+    assert len(launches) == 2, "the pointwise producer stays materialized across the ordered scan boundary"
+    scan = next(node.op for node in launches if node.id == "out")
+    reduce_loop = next(loop for loop in scan.body.iter() if getattr(loop, "axis", None) and loop.axis.name in scan.reduce_axis_names)
+    assert any(isinstance(stmt, Accum) for stmt in reduce_loop.body)
+    assert any(isinstance(stmt, Write) for stmt in reduce_loop.body)
+    _assert_pipeline_preserves_semantics(make_graph, {"x": np.arange(8, dtype=np.float32).reshape(2, 4)}, rtol=0, atol=0)
+
+    tiled = Pipeline.build(TILE_PASSES).run(make_graph(), ctx=Context.from_target((8, 9)))
+    scan_tile = next(node.op for node in tiled.nodes.values() if isinstance(node.op, TileOp) and node.id == "out")
+    assert scan_tile.schedule == {}
+    assert scan_tile.knobs["REDUCE"] == "" and scan_tile.knobs["WORK"] == ""
+
+    from emmy.compiler.pipeline.search.space import REDUCE, WORK
+
+    with WORK.pinned("t4"), REDUCE.pinned("coop"):
+        pinned = Pipeline.build(TILE_PASSES).run(make_graph(), ctx=Context.from_target((8, 9)))
+    pinned_scan = next(node.op for node in pinned.nodes.values() if isinstance(node.op, TileOp) and node.id == "out")
+    assert pinned_scan.schedule == {}
+    assert pinned_scan.knobs["REDUCE"] == "" and pinned_scan.knobs["WORK"] == ""
+
+    lowered = Pipeline.build(CUDA_PASSES).run(make_graph(), ctx=Context.from_target((8, 9)))
+    source = next(
+        node.op.kernel_source for node in lowered.nodes.values() if isinstance(node.op, CudaOp) and "out[" in node.op.kernel_source
+    )
+    lines = source.splitlines()
+    update = next(i for i, line in enumerate(lines) if "acc0 +=" in line)
+    write = next(i for i, line in enumerate(lines) if "out[a0 * 4 + a1] = acc0;" in line)
+    loop_open = max(i for i in range(update) if lines[i].lstrip().startswith("for ("))
+    loop_indent = len(lines[loop_open]) - len(lines[loop_open].lstrip())
+    loop_close = next(
+        i for i in range(update + 1, len(lines)) if lines[i].strip() == "}" and len(lines[i]) - len(lines[i].lstrip()) == loop_indent
+    )
+    assert update < write < loop_close, "the prefix store must execute after each accumulator update"
 
 
 def test_matmul():


### PR DESCRIPTION
## Summary

- refuse loop fusion when an output observes an accumulator inside that accumulator’s reduce loop
- preserve the standalone raw loop for ordered prefix outputs as either the fusion root or producer
- cover direct splice refusal, serial scheduling, pinned unsafe-row refusal, semantics, and CUDA statement order

## Correctness evidence

The exact Qwen3.8 layer-0 cumsum target previously fused into one full reduction followed by an output sweep. Strict O3 on the RTX 4090 differed in 24,153 of 24,576 values (max absolute error 30.4). With this change, exact-e8 CPU compilation keeps the pointwise producer materialized and lowers cumsum to a raw loop whose accumulator update and output Write share the same reduce loop; WORK and REDUCE are empty.

Fresh exact-e8 RTX 4090 retrace and strict O3 replay are still pending behind the immutable 194-target classifier. Keep this PR in draft until that proof is attached.

## Checks

- focused scan/splicer tests: 30 passed
- make test: 3,124 passed, 561 skipped, 1 xfailed
- make lint: passed
- documentation, terminology, plan, diff, and minimization audits: passed