### PR TITLE
Preserve predicate dtypes through tracing and lifting

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -299,6 +299,10 @@ How to comply:
 - **When generalizing an existing rule, normalize its incidental divergences** (one dtype rule, one index rule)
   and name the behavioral deltas explicitly in the commit — don't preserve two behaviors behind one entry point.
 
+Multi-source `IndexMapOp` lifting preserves predicate dtype: an explicit source predicate is substituted unchanged,
+and an unconditional fallback is a boolean `Literal(True, "bool")`. The rendered CUDA condition remains `1`, while
+Loop IR persistence and vectorized reference evaluation retain the boolean type required by `Select`.
+
 Loop fusion is greedy-maximal and algebra-only: every legal merge is taken. It never weighs shapes, hardware,
 downstream pattern knowledge, or whether one kernel will be faster than two — which form of a region deploys is the
 deploy evidence hierarchy's decision (measured evidence or pins for a deployed model, the prior for a cold compile).

--- a/emmy/compiler/pipeline/passes/loop/lifting/030_lift_indexmap.py
+++ b/emmy/compiler/pipeline/passes/loop/lifting/030_lift_indexmap.py
@@ -48,7 +48,7 @@ def rewrite(match: Match, root: Node) -> Graph | None:
             input_names.append(src_id)
             name = f"in{i}"
             body.append(Load(name=name, input=src_id, index=idx))
-            select_expr = src.select.substitute(mapping) if src.select is not None else Literal(1, "int")
+            select_expr = src.select.substitute(mapping) if src.select is not None else Literal(True, "bool")
             branches.append(SelectBranch(value=name, select=select_expr))
         body.append(Select(name="v", branches=tuple(branches)))
         body.append(Write(output=out_buf, index=write_index, value="v"))

--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -25,7 +25,9 @@ constant plus an explicit broadcast; the receiver's unrelated shape and values n
 chain rooted at a locally computed tensor additionally reassembles the updated base as a two-source `IndexMapOp`: the
 copied value supplies the written region and the previous base supplies the remainder. Rebinding the root's FX name
 versions sequential overlapping writes and later aliases built from that name; an empty write leaves that version
-unchanged. A write through an input/parameter, a dynamic or strided view, a used `copy_` return, or a view created
+unchanged. The written-region predicate starts from a boolean literal, so coordinate ternaries and the source select
+retain a boolean condition in vectorized reference evaluation and after Loop IR lifting. A write through an
+input/parameter, a dynamic or strided view, a used `copy_` return, or a view created
 before the write still fails closed; those forms need general alias versioning rather than this local functional
 update. `masked_fill` lowers to ternary `where(mask, fill, self)` so an unselected infinity is preserved
 instead of becoming NaN through arithmetic selection. `triu` and `tril` lower to two-source `IndexMapOp` regions over

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -1469,7 +1469,7 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
         if any(extent == 0 for extent in extents):
             return
 
-        select = Literal(1, "int")
+        select = Literal(True, "bool")
         for axis, (offset, extent) in enumerate(zip(offsets, extents, strict=True)):
             coord = placeholder(axis)
             in_axis = BinaryExpr(">=", coord, Literal(offset, "int"))
@@ -1551,7 +1551,7 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
                     f"aten.copy_ local view shape mismatch: base={base_shape}, destination={tuple(view_shape)}, copy={tuple(shape)}"
                 )
 
-            select = Literal(1, "int")
+            select = Literal(True, "bool")
             for axis, (offset, extent) in enumerate(zip(offsets, extents, strict=True)):
                 coord = placeholder(axis)
                 in_axis = BinaryExpr(">=", coord, Literal(offset, "int"))

--- a/tests/compiler/backend/test_torch_ref.py
+++ b/tests/compiler/backend/test_torch_ref.py
@@ -250,7 +250,8 @@ def test_indexmap_cat_with_select():
 def test_indexmap_recurrence_patch_uses_tensor_ternary_coordinates():
     # Insert a two-cell recurrence update into columns 1:3 of a larger carried state.
     column = placeholder(1)
-    in_patch = BinaryExpr("&&", BinaryExpr(">=", column, Literal(1, "int")), column.lt(Literal(3, "int")))
+    bounds = BinaryExpr("&&", BinaryExpr(">=", column, Literal(1, "int")), column.lt(Literal(3, "int")))
+    in_patch = BinaryExpr("&&", Literal(True, "bool"), bounds)
     patch_column = TernaryExpr(in_patch, column - Literal(1, "int"), Literal(0, "int"))
     sources = (
         IndexSource(input_idx=0, coord_map=(placeholder(0), patch_column), select=in_patch),

--- a/tests/compiler/passes/test_fusion_rules.py
+++ b/tests/compiler/passes/test_fusion_rules.py
@@ -17,7 +17,7 @@ from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.expr import Literal, placeholder
 from emmy.compiler.ir.frontend.ir import LinearOp, RmsNormOp
-from emmy.compiler.ir.loop import Accum, Assign, Load, LoopOp, Write
+from emmy.compiler.ir.loop import Accum, Assign, Load, LoopOp, Select, Write
 from emmy.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, IndexMapOp, IndexSource, ReduceOp
 from emmy.compiler.pipeline import Pipeline
 
@@ -75,6 +75,47 @@ def _has_update(body) -> bool:
 
 def _local_combine_fns(locals_) -> set[str]:
     return {lb.op.name for lb in locals_ if lb.op is not None}
+
+
+def test_multisource_indexmap_lifts_unconditional_branch_as_bool():
+    """The fallback predicate remains boolean through rendering and Loop IR persistence."""
+    import json
+
+    from emmy.compiler.loop_wire import loop_graph_from_wire, loop_graph_to_wire
+
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("left", (2, 2)), node_id="left")
+    graph.add_node(InputOp(), [], Tensor("right", (2, 2)), node_id="right")
+    graph.add_node(
+        IndexMapOp(
+            out_shape=(2, 2),
+            sources=(
+                IndexSource(
+                    input_idx=0,
+                    coord_map=(placeholder(0), placeholder(1)),
+                    select=placeholder(1).lt(Literal(1, "int")),
+                ),
+                IndexSource(input_idx=1, coord_map=(placeholder(0), placeholder(1))),
+            ),
+        ),
+        ["left", "right"],
+        Tensor("out", (2, 2)),
+        node_id="out",
+    )
+    graph.inputs, graph.outputs = ["left", "right"], ["out"]
+    inputs = {
+        "left": np.array([[1, 2], [3, 4]], dtype=np.float32),
+        "right": np.array([[5, 6], [7, 8]], dtype=np.float32),
+    }
+    lifted = Pipeline.build(["loop/lifting"]).run(graph)
+    select = next(stmt for stmt in _kernel_nodes(lifted)[0].op.body.iter() if isinstance(stmt, Select))
+    assert select.branches[-1].select == Literal(True, "bool")
+    assert select.branches[-1].select.render(None) == "1"
+    _assert_close(_run(graph, inputs), _run(lifted, inputs))
+
+    restored = loop_graph_from_wire(json.loads(json.dumps(loop_graph_to_wire(lifted))))
+    restored_select = next(stmt for stmt in _kernel_nodes(restored)[0].op.body.iter() if isinstance(stmt, Select))
+    assert restored_select.branches[-1].select == Literal(True, "bool")
 
 
 # ===================================================================

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -421,6 +421,7 @@ def test_trace_reassembles_static_local_slice_copies_observed_through_base():
 
     from emmy.compiler.backend.numpy import NumpyBackend
     from emmy.compiler.ir.base import ConstantOp, InputOp
+    from emmy.compiler.ir.expr import BinaryExpr, Literal
     from emmy.compiler.ir.loop import LoopOp
     from emmy.compiler.ir.tensor.ir import IndexMapOp
     from emmy.compiler.pipeline import LOOP_PASSES, Pipeline
@@ -447,6 +448,11 @@ def test_trace_reassembles_static_local_slice_copies_observed_through_base():
         node for node in graph.nodes.values() if isinstance(node.op, IndexMapOp) and len(node.op.sources) == 2 and node.id.endswith("_base")
     ]
     assert len(updates) == 4
+    for update in updates:
+        select = update.op.sources[0].select
+        while isinstance(select, BinaryExpr) and select.op == "&&":
+            select = select.left
+        assert select == Literal(True, "bool")
 
     backend = NumpyBackend()
     result, _ = backend.run(


### PR DESCRIPTION
## Summary

- seed static local copy and fill reassembly predicates with boolean literals
- keep an unconditional multi-source IndexMap branch boolean through Loop IR lifting
- cover trace structure, vectorized Torch reference parity, NumPy parity, CUDA rendering, and Loop IR persistence

## Correctness evidence

The exact Qwen3.8 layer-0 source serializes copy-base coordinate ternaries whose predicates previously began with an integer literal. Vectorized reference evaluation promoted the integer-and-boolean expression to Long, so torch.where rejected the condition and strict eager correctness was unavailable. The boolean seed preserves the predicate dtype without adding a Torch reference coercion; CUDA rendering remains the same literal one.

Fresh exact-e8 RTX 4090 retrace and strict O3 replay of the affected copy-base and eye-containing targets are pending behind the immutable classifier. Keep this PR in draft until that proof is attached.

## Checks

- focused predicate controls: 3 passed
- make test: 3,122 passed, 561 skipped, 1 xfailed
- make lint: passed
- documentation, terminology, plan, diff, and minimization audits: passed