### PR TITLE
Preserve narrowing reduction boundaries through fusion

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -488,6 +488,14 @@ splicer refuses that shape whether it is the merged root or a producer edge: dep
 the reduce loop and move the `Write` after it, changing every prefix value into the final reduction. The standalone
 `LoopOp` remains the raw-loop escape, so the accumulator update and its `Write` stay in one serial loop.
 
+An `Accum` stores its value into the producing tensor before a distinct frontend operation loads that tensor. When the
+declared tensor dtype differs from the accumulator dtype (implicitly f32 until Kernel IR), `splice_graph` keeps that
+boundary as a typed `copy` alias. Nodes created by decomposing and rewriting one frontend operation share the ultimate
+`Op.source` object and may reconstruct their private edge directly. A private output stays recognizable even when its
+consumer fragment already mixes origins: it is absent from the ultimate frontend source's declared outputs. Missing
+or unrelated source chains preserve the conversion. Equal-dtype reductions and non-`Accum` producers keep the
+ordinary untyped alias, so fusion does not duplicate a conversion already carried by the defining statement.
+
 Each splice memoizes `Expr.free_vars()` by expression identity while placing dependencies. Sigma expressions remain
 live for the splice, and identity avoids both repeated coordinate-tree walks and the recursive structural hashing a
 global cache would require; the memo is discarded with the splicer.
@@ -498,9 +506,10 @@ reformats deep coordinate trees nor retains duplicate canonical strings.
 
 Fusion may give the splicer the ordinary work-growth ceiling before construction. The splicer accumulates the exact
 static-extent arithmetic-leaf work at each inserted scope (using 128 for a symbolic extent, as the final fusion metric
-does) and refuses as soon as the monotonic partial work exceeds that ceiling. Identity-copy aliases are excluded
-because normalization removes them from the finished body. An admitted bounded splice constructs the same body bytes
-as an unbounded splice; the bound only terminates a candidate whose final ordinary work limit is already impossible.
+does) and refuses as soon as the monotonic partial work exceeds that ceiling. Untyped identity-copy aliases are
+excluded because normalization removes them from the finished body; a typed copy is a real conversion and counts as
+work. An admitted bounded splice constructs the same body bytes as an unbounded splice; the bound only terminates a
+candidate whose final ordinary work limit is already impossible.
 
 ### `loop/runner.py` — C++ JIT executor
 

--- a/emmy/compiler/ir/loop/splicer.py
+++ b/emmy/compiler/ir/loop/splicer.py
@@ -18,7 +18,10 @@ Resolution dispatches on stmt kind:
 - **Load on a splice edge** — emit a copy alias at the demand scope;
   σ is solved by pairing target's ``Write.index`` against the reader's
   σ-substituted index, and the target's ``Write.value`` is queued under
-  the solved σ. The target's expression chain reconstructs piecemeal.
+  the solved σ. A narrowing reduction at a declared frontend output keeps its
+  tensor dtype when the consumer has a distinct origin; a decomposition-private
+  output may reconstruct within the frontend operation. The target's expression
+  chain reconstructs piecemeal.
 - **Accum** — freshen its reduce axis, place
   ``Loop(fresh_reduce_axis, Accum(...))`` at
   ``_scope_for_axes(ref_scope, required_c_axes)``, queue the Accum's
@@ -57,6 +60,7 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from emmy.compiler.dtype import F32, DataType
 from emmy.compiler.ir.expr import Expr, Literal, Var
 from emmy.compiler.ir.loop.builder import LoopBuilder
 from emmy.compiler.ir.loop.ir import (
@@ -139,6 +143,7 @@ def splice_loops(
     loops: dict[str, LoopOp],
     splice_edges: dict[tuple[str, str], tuple[str, str]],
     *,
+    splice_dtypes: dict[tuple[str, str], DataType] | None = None,
     max_work: int | None = None,
 ) -> LoopOp | None:
     """Splice a DAG of ``LoopOp``s into one merged kernel.
@@ -149,6 +154,9 @@ def splice_loops(
     ``(target_tag, target_output_buf)`` meaning "this loop's Load whose
     ``source`` is ``source_buf`` reads ``target_tag``'s Write whose
     ``output`` is ``target_output_buf`` and should be inlined."
+    ``splice_dtypes`` optionally gives an edge's required dtype conversion.
+    The emitted copy alias retains that dtype so reconstructing a reduction
+    cannot bypass its tensor boundary.
 
     Non-splice Loads keep their original ``source`` buf names — buf
     identity is global, no remap needed. The sink — the loop whose Writes
@@ -169,6 +177,7 @@ def splice_loops(
         return _Splicer(
             loops={tag: op.analyze() for tag, op in loops.items()},
             splice_edges=splice_edges,
+            splice_dtypes=splice_dtypes or {},
             root=root,
             max_work=max_work,
         ).run()
@@ -203,6 +212,7 @@ def splice_graph(graph, *, max_work: int | None = None) -> tuple[LoopOp, list[st
 
     loop_nodes = {n.id: n for n in graph.nodes.values() if isinstance(n.op, LoopOp)}
     splice_edges: dict[tuple[str, str], tuple[str, str]] = {}
+    splice_dtypes: dict[tuple[str, str], DataType] = {}
     external_order: list[str] = []
     seen_external: set[str] = set()
 
@@ -216,6 +226,22 @@ def splice_graph(graph, *, max_work: int | None = None) -> tuple[LoopOp, list[st
             # same producer.
             if inp in loop_nodes:
                 splice_edges[(node.id, inp)] = (inp, inp)  # producer's Write.output is its node id
+                producer = graph.buffer(inp)
+                producer_meta = loop_nodes[inp].op.analyze()
+                producer_write = next((write for write, _ in producer_meta.writes if write.output == inp), None)
+                producer_value = producer_meta.defs.get(producer_write.value) if producer_write is not None else None
+                producer_origin = _ultimate_source(loop_nodes[inp].op)
+                same_origin = producer_origin is _ultimate_source(node.op)
+                origin_outputs = getattr(producer_origin, "outputs", {})
+                private_output = producer_origin is not loop_nodes[inp].op and bool(origin_outputs) and inp not in origin_outputs
+                if (
+                    not same_origin
+                    and not private_output
+                    and isinstance(producer_value, Accum)
+                    and producer is not None
+                    and producer.dtype != (producer_value.dtype or F32)
+                ):
+                    splice_dtypes[(node.id, inp)] = producer.dtype
             elif inp not in seen_external:
                 seen_external.add(inp)
                 external_order.append(inp)
@@ -223,11 +249,20 @@ def splice_graph(graph, *, max_work: int | None = None) -> tuple[LoopOp, list[st
     merged = splice_loops(
         loops={nid: n.op for nid, n in loop_nodes.items()},
         splice_edges=splice_edges,
+        splice_dtypes=splice_dtypes,
         max_work=max_work,
     )
     if merged is None:
         return None
     return merged, external_order
+
+
+def _ultimate_source(op):
+    """The frontend-origin object at the end of an op rewrite chain."""
+    root = op
+    for source in op.source_chain():
+        root = source
+    return root
 
 
 # ---------------------------------------------------------------------------
@@ -257,6 +292,7 @@ class _Splicer(LoopBuilder):
         *,
         loops: dict[str, LoopMeta],
         splice_edges: dict[tuple[str, str], tuple[str, str]],
+        splice_dtypes: dict[tuple[str, str], DataType],
         root: str,
         max_work: int | None,
     ) -> None:
@@ -266,6 +302,7 @@ class _Splicer(LoopBuilder):
         super().__init__(used_names=used)
         self.loops = loops
         self.splice_edges = splice_edges
+        self.splice_dtypes = splice_dtypes
         self.root = root
         self._max_work = max_work
         self._partial_work = 0
@@ -435,7 +472,8 @@ class _Splicer(LoopBuilder):
         if sigma is None:
             raise _NotSupported(f"σ-solve failed pairing target write index {target_write.index} against reader index {effective_index}")
         v_bound = self._ensure_dep(target_write.value, target_tag, sigma, d.demand_scope)
-        self.insert(Assign(name=d.bound_as, op="copy", args=(v_bound,)), d.demand_scope)
+        dtype = self.splice_dtypes.get((d.origin, stmt.input))
+        self.insert(Assign(name=d.bound_as, op="copy", args=(v_bound,), dtype=dtype), d.demand_scope)
 
     def _resolve_accum(self, stmt: Accum, d: _Demand) -> None:
         """Emit ``Loop(fresh_reduce_axis, [Accum(bound, value_bound, op)])`` at

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -244,7 +244,12 @@ Two binding scopes share the protocol:
 
 The two discovered strategies: **`ProvenanceStrategy`** owns op provenance end to end (`seed` at run start,
 `propagate` from the splice receipt, mint for `frontend/decomposition`'s fragments, aggregate for everything else)
-— a pipeline built without it has no provenance anywhere, and `graph.py` imports none of it.
+and keeps the replaced result's ultimate `Op.source` object on its rewrite fragments. The pattern root may be an
+upstream producer while `Match.output` names the consumer result that the fragment replaces. A fragment may consume
+inputs from other origins without losing that result identity; those producer edges retain their own sources. The
+source identity lets semantic rewrites distinguish a frontend operation's private decomposition edges from tensor
+boundaries between operations. A pipeline built without the strategy has no provenance anywhere, and `graph.py`
+imports none of it.
 **`IdentityStrategy`** owns the `S_*` structural identity: computed (`structure_features`) and materialized into
 `op.knobs` exactly once per kernel, at birth — fusion-born kernels at the loop dialect's end (`PassEndEvent` of
 `loop/stamp`), minted pieces (a cut's fragments, a split's pieces) at the splice event, before the fragment even

--- a/emmy/compiler/pipeline/passes/provenance.py
+++ b/emmy/compiler/pipeline/passes/provenance.py
@@ -12,7 +12,7 @@ seed gives every unseeded node a fresh self-origin.
 from __future__ import annotations
 
 from emmy.compiler import provenance
-from emmy.compiler.pipeline.strategy import PipelineStrategy, RunStartEvent, SplicedEvent
+from emmy.compiler.pipeline.strategy import PipelineStrategy, RunStartEvent, SplicedEvent, SpliceEvent
 
 
 class ProvenanceStrategy(PipelineStrategy):
@@ -26,6 +26,32 @@ class ProvenanceStrategy(PipelineStrategy):
 
     def on_run_start(self, e: RunStartEvent) -> None:
         provenance.seed(e.graph)
+
+    def on_splice(self, e: SpliceEvent) -> None:
+        """Keep the replaced result's frontend origin object on its rewrite fragments.
+
+        ``Op.source`` is the executable identity used while a rewrite is still in flight;
+        hints remain reporting metadata. A decomposition and later rewrites therefore share
+        the result operation's ultimate source even when the pattern root is an upstream producer
+        and the fragment consumes inputs from other origins; those producer edges retain their own
+        sources and remain distinct at semantic boundary checks.
+        """
+        results = tuple(e.match.output) if isinstance(e.match.output, dict) else (e.match.output or e.match.root_node_id,)
+        origins: dict[int, object] = {}
+        for result in results:
+            result_node = e.graph.producer(result)
+            origin = result_node.op if result_node is not None else e.root_op
+            for source in origin.source_chain():
+                origin = source
+            origins[id(origin)] = origin
+        if len(origins) != 1:
+            return  # one fragment replacing several unrelated results has no single executable source
+        origin = next(iter(origins.values()))
+        for node in e.fragment.nodes.values():
+            op = node.op
+            if provenance.is_boundary(op) or op is origin or op.source is not None:
+                continue
+            op.source = origin
 
     def on_spliced(self, e: SplicedEvent) -> None:
         r = e.receipt

--- a/tests/compiler/ir/loop/test_splicer.py
+++ b/tests/compiler/ir/loop/test_splicer.py
@@ -8,7 +8,13 @@ itself rather than some upstream lowering quirk.
 
 from __future__ import annotations
 
+import pytest
+
+from emmy.compiler.dtype import F16, F32, DataType
+from emmy.compiler.graph import Graph
+from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Literal, Var
+from emmy.compiler.ir.frontend.ir import MatmulOp
 from emmy.compiler.ir.loop import (
     Accum,
     Assign,
@@ -17,9 +23,11 @@ from emmy.compiler.ir.loop import (
     Loop,
     LoopOp,
     Write,
+    splice_graph,
     splice_loop_ops,
     splice_loops,
 )
+from emmy.compiler.tensor import Tensor
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,6 +50,47 @@ def _elementwise_fns(op: LoopOp) -> list[str]:
 A0 = Axis("a0", 4)
 A1 = Axis("a1", 8)
 K = Axis("k", 16)
+
+
+def _splice_graph_producer(
+    producer: LoopOp,
+    *,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    edge_dtype: DataType,
+    shared_origin: bool = False,
+    private_origin_output: bool = False,
+) -> LoopOp:
+    consumer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Load(name="value", input="producer", index=(Var("a0"),)),
+                    Assign(name="activated", op="silu", args=("value",)),
+                    Write(output="consumer", index=(Var("a0"),), value="activated"),
+                ),
+            ),
+        ),
+    )
+    if shared_origin:
+        origin = MatmulOp()
+        producer.source = origin
+        consumer.source = origin
+    elif private_origin_output:
+        origin = MatmulOp()
+        origin.outputs["frontend_output"] = Tensor("frontend_output", output_shape, edge_dtype)
+        producer.source = origin
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", input_shape, F16), node_id="x")
+    graph.add_node(producer, ["x"], Tensor("producer", output_shape, edge_dtype), node_id="producer")
+    graph.add_node(consumer, ["producer"], Tensor("consumer", output_shape, edge_dtype), node_id="consumer")
+    graph.outputs = ["consumer"]
+    result = splice_graph(graph)
+    assert result is not None
+    merged, external = result
+    assert external == ["x"]
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +277,216 @@ def test_reduction_producer():
     assert _count_kind(merged, Accum) == 1
     # Elementwise chain includes the producer-load copy + the consumer's exp.
     assert "exp" in _elementwise_fns(merged)
+
+
+@pytest.mark.parametrize(("edge_dtype", "expected_alias_dtype"), [(F16, F16), (F32, None)])
+def test_graph_splice_preserves_distinct_origin_reduction_dtype(edge_dtype: DataType, expected_alias_dtype: DataType | None):
+    """A reduction entering a distinct frontend operation crosses its tensor boundary."""
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=K,
+                        body=(
+                            Load(name="x", input="x", index=(Var("a0"), Var("k"))),
+                            Accum(name="sum", value="x", op="add"),
+                        ),
+                    ),
+                    Write(output="producer", index=(Var("a0"),), value="sum"),
+                ),
+            ),
+        ),
+    )
+    merged = _splice_graph_producer(producer, input_shape=(4, 16), output_shape=(4,), edge_dtype=edge_dtype)
+    aliases = [stmt for stmt in merged.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    if expected_alias_dtype is None:
+        assert aliases == []
+    else:
+        assert len(aliases) == 1
+        assert aliases[0].dtype == expected_alias_dtype
+
+
+def test_graph_splice_same_origin_reduction_is_private():
+    """Nodes decomposed from one frontend operation may reconstruct their private edge directly."""
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=K,
+                        body=(
+                            Load(name="x", input="x", index=(Var("a0"), Var("k"))),
+                            Accum(name="sum", value="x", op="add"),
+                        ),
+                    ),
+                    Write(output="producer", index=(Var("a0"),), value="sum"),
+                ),
+            ),
+        ),
+    )
+    merged = _splice_graph_producer(
+        producer,
+        input_shape=(4, 16),
+        output_shape=(4,),
+        edge_dtype=F16,
+        shared_origin=True,
+    )
+    aliases = [stmt for stmt in merged.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert aliases == []
+
+
+def test_graph_splice_private_origin_output_is_private_in_mixed_fragment():
+    """An internal decomposition output reconstructs after its consumer has mixed origins."""
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=K,
+                        body=(
+                            Load(name="x", input="x", index=(Var("a0"), Var("k"))),
+                            Accum(name="sum", value="x", op="add"),
+                        ),
+                    ),
+                    Write(output="producer", index=(Var("a0"),), value="sum"),
+                ),
+            ),
+        ),
+    )
+    merged = _splice_graph_producer(
+        producer,
+        input_shape=(4, 16),
+        output_shape=(4,),
+        edge_dtype=F16,
+        private_origin_output=True,
+    )
+    aliases = [stmt for stmt in merged.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert aliases == []
+
+
+def test_graph_splice_load_output_needs_no_conversion():
+    """A pass-through value is already represented at the loaded input dtype."""
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Load(name="x", input="x", index=(Var("a0"),)),
+                    Write(output="producer", index=(Var("a0"),), value="x"),
+                ),
+            ),
+        ),
+    )
+    merged = _splice_graph_producer(producer, input_shape=(4,), output_shape=(4,), edge_dtype=F16)
+    aliases = [stmt for stmt in merged.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert aliases == []
+
+
+@pytest.mark.parametrize(("edge_dtype", "expected_aliases"), [(F16, 2), (F32, 0)])
+def test_graph_splice_preserves_multi_reduction_output_dtypes(edge_dtype: DataType, expected_aliases: int):
+    """Sibling reductions cross their tensor boundaries before their shared projection."""
+
+    def producer(input_name: str, output_name: str) -> LoopOp:
+        return LoopOp(
+            body=(
+                Loop(
+                    axis=A0,
+                    body=(
+                        Loop(
+                            axis=K,
+                            body=(
+                                Load(name=f"{input_name}_value", input=input_name, index=(Var("a0"), Var("k"))),
+                                Accum(name=f"{output_name}_sum", value=f"{input_name}_value", op="add"),
+                            ),
+                        ),
+                        Write(output=output_name, index=(Var("a0"),), value=f"{output_name}_sum"),
+                    ),
+                ),
+            ),
+        )
+
+    consumer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Load(name="left_value", input="left", index=(Var("a0"),)),
+                    Load(name="right_value", input="right", index=(Var("a0"),)),
+                    Load(name="aux_value", input="aux", index=(Var("a0"),)),
+                    Assign(name="activated", op="silu", args=("left_value",)),
+                    Assign(name="product", op="multiply", args=("activated", "right_value")),
+                    Assign(name="result", op="add", args=("product", "aux_value")),
+                    Write(output="consumer", index=(Var("a0"),), value="result"),
+                ),
+            ),
+        ),
+    )
+    pointwise = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Load(name="z_value", input="z", index=(Var("a0"),)),
+                    Assign(name="exp_value", op="exp", args=("z_value",), dtype=F16),
+                    Write(output="aux", index=(Var("a0"),), value="exp_value"),
+                ),
+            ),
+        ),
+    )
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (4, 16), F16), node_id="x")
+    graph.add_node(InputOp(), [], Tensor("y", (4, 16), F16), node_id="y")
+    graph.add_node(InputOp(), [], Tensor("z", (4,), F16), node_id="z")
+    graph.add_node(producer("x", "left"), ["x"], Tensor("left", (4,), edge_dtype), node_id="left")
+    graph.add_node(producer("y", "right"), ["y"], Tensor("right", (4,), edge_dtype), node_id="right")
+    graph.add_node(pointwise, ["z"], Tensor("aux", (4,), F16), node_id="aux")
+    graph.add_node(consumer, ["left", "right", "aux"], Tensor("consumer", (4,), F16), node_id="consumer")
+    graph.outputs = ["consumer"]
+
+    result = splice_graph(graph)
+    assert result is not None
+    merged, external = result
+    assert external == ["x", "y", "z"]
+    aliases = [stmt for stmt in merged.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert len(aliases) == expected_aliases
+    assert {alias.dtype for alias in aliases} <= {F16}
+    pointwise_result = next(stmt for stmt in merged.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "exp")
+    assert pointwise_result.dtype == F16
+
+
+def test_graph_splice_typed_boundary_roundtrips():
+    """Serialized Loop IR retains the conversion when source-chain metadata is absent."""
+    producer = LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Loop(
+                        axis=K,
+                        body=(
+                            Load(name="x", input="x", index=(Var("a0"), Var("k"))),
+                            Accum(name="sum", value="x", op="add"),
+                        ),
+                    ),
+                    Write(output="producer", index=(Var("a0"),), value="sum"),
+                ),
+            ),
+        ),
+    )
+    merged = _splice_graph_producer(producer, input_shape=(4, 16), output_shape=(4,), edge_dtype=F16)
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (4, 16), F16), node_id="x")
+    graph.add_node(merged, ["x"], Tensor("consumer", (4,), F16), node_id="consumer")
+    graph.outputs = ["consumer"]
+
+    restored = Graph.from_dict(graph.to_dict()).nodes["consumer"].op
+    aliases = [stmt for stmt in restored.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert len(aliases) == 1
+    assert aliases[0].dtype == F16
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/test_strategies.py
+++ b/tests/compiler/pipeline/test_strategies.py
@@ -91,6 +91,27 @@ def test_decomposition_mints_fresh_pieces_and_fusion_aggregates() -> None:
     assert covered == totals["o"], "the kernels together cover every piece of the origin"
 
 
+def test_one_origin_rewrites_keep_the_frontend_source_object() -> None:
+    """Decomposition and lifting fragments retain one ultimate object for private-edge checks."""
+    graph = _matmul()
+    origin = graph.nodes["o"].op
+    out, _ = _resolve(["frontend/decomposition", "frontend/optimization", "loop/lifting"], graph)
+    loops = [node.op for node in out.nodes.values() if isinstance(node.op, LoopOp)]
+    assert loops
+    assert all(list(op.source_chain())[-1] is origin for op in loops)
+
+
+def test_mixed_origin_rewrite_keeps_the_result_frontend_source_object() -> None:
+    """A fused result retains its consumer origin while its input keeps a distinct origin."""
+    graph = _norm_linear()
+    origin = graph.nodes["y"].op
+    input_origins = {name: graph.nodes[name].op for name in graph.inputs}
+    out, _ = _resolve(LOOP_PASSES, graph)
+    result = out.nodes["y"].op
+    assert list(result.source_chain())[-1] is origin
+    assert all(list(out.nodes[name].op.source_chain())[-1] is input_origin for name, input_origin in input_origins.items())
+
+
 def test_a_pipeline_without_the_provenance_strategy_has_no_provenance() -> None:
     """PipelineStrategy-scoped concern: strip ProvenanceStrategy from the pipeline and NO node carries
     provenance — the graph and engine hold none of it. (Identity is kept so kernels still stamp.)"""


### PR DESCRIPTION
## Summary

- retain a typed copy when loop fusion crosses a distinct frontend operation's narrowing `Accum` tensor boundary
- reconstruct decomposition-private reductions directly when producer and consumer share the same ultimate source
- propagate a rewrite fragment's replaced-result source without relabeling its external producer inputs
- preserve the ordered-prefix refusal merged in #611

The rule fails closed when source metadata is absent or unrelated. Equal-dtype reductions and non-`Accum` values keep
the existing untyped alias path.

## Verification

- focused source/provenance/fusion/decomposition suite: 155 passed, 1 xfailed
- `make test`: 3,117 passed, 575 skipped, 1 xfailed
- `make lint`
- exact Tesla V100-SXM3-32GB (CC 7.0) seeded Laguna expert replay on merged main `f508156c`: strict whole-program
  pass, max absolute error 0.001953125; source commit/tree/status/module paths and overlay hashes recorded

## Evidence boundary

The exact GPU replay combines this PR with the still-unmerged generic Volta m=1 structural overlay and exact schedule
pins. It proves the pieces interoperate and the full expert can be strict-correct, but does not attribute the complete
result or the selected schedule to this PR alone.

The preserved Accum boundary was previously isolated on the same seeded expert: it reduced whole-program strict
mismatches from 61 to 44 before the separately merged SiLU fix. With the SiLU fix now on main and the exact existing
downstream MMA row selected, the combined replay is strict-pass and improves the three-launch stage from about
308.2 us to 183.0 us. Cold equal-budget tuning across the complete Laguna inventory remains follow-up work.
