### PR TITLE
Expose Volta MMA schedules for unit-row contractions

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -173,8 +173,8 @@ single-home rule exists to prevent.
 **Derived VIEWS — the one mechanism ABOVE the product.** The stored `TileOp` is the ONE canonical tree per kernel; a
 VIEW is a pure, deterministic derivation of it, and the criterion that separates a view from a value is whether the
 derivation changes the SITE SET, because that is what a product cannot absorb. The register strip and split-K do not
-(`r` and `cta` are spelled TILE / REDUCE values, applied at materialization); two do, mutually exclusive by shape, so
-a term has at most TWO views (`_schedule._views`):
+(`r` and `cta` are spelled TILE / REDUCE values, applied at materialization); three do, mutually exclusive by shape,
+so a term has at most TWO views (`_schedule._views`):
 
 - the MONOID-producer composition (`_classify.fused_view`) — the fused norm→linear / gate⊗up edge, whose
   contraction reads its normalized row off a COMPUTED `a` edge. It ADDS the contraction and the cone's statistic to
@@ -182,6 +182,12 @@ a term has at most TWO views (`_schedule._views`):
   contraction's K fold, so the map view spells its statistic at `REDUCE@<axis>` too. The statistic's CARRIER is not
   part of the shape: a TWISTED `(m, d)` pair binds exactly like a `PLANAR` mean/rsqrt, which is what puts a fused
   `softmax(S)·V` region on the contraction catalog (cone `exp(S − m)·(1/d)`, B the value matrix);
+- the direct unit-row contraction (`_classify.unit_contraction_view`) — a matrix contraction whose M=1 loop was
+  elided keeps its stored one-axis form and derives the missing literal-zero output row. A split partial may carry
+  output-absent partition axes before that row only when both its workspace write and a sliced operand address prove
+  the partition receipt. Ordinary batch/head context, multiple output axes, and a nonliteral or nonzero row decline.
+  The derived contraction offers both scalar and warp schedules; split computed-edge forms retain their stored scalar
+  sibling, so adding the Volta catalog never removes the fallback;
 - the COLLAPSE (`Fold.demoted`) — a computed `a` edge spliced back INLINE, REMOVING its site. With no edges the
   bilinear reading declines, so the fold derives `PLANAR` and takes the reduce tiers; this is what carries a stat-free
   cone (`f(x) @ w`) on the per-cell tiers.
@@ -214,11 +220,12 @@ statistic into a materialized operand the mma tier streams. A seam standing in f
 the fused slab stored — the contraction's 16-bit output dtype, not the f32 its cone computed in — so the
 materialized B is a slab the warp atoms can copy.
 
-A row carries NO view ownership: the derived contraction view offers only warp tiles (a computed operand's scalar
-list is empty) and the per-cell view only scalar / per-cell ones, so the row's `WORK` tier decodes its view by
-construction — replay is a function of `(stored op, row)` and nothing else. The union carries two obligations:
-uniform key sets with `""` as a decided empty, and NO cross-view suppression (each gate is a local predicate on its
-own term — a 16-bit atom, a resolvable fill, an inventory a value can spell against).
+A row carries NO view ownership. In the MONOID-producer and COLLAPSE cases, the derived contraction view offers only
+warp tiles (a computed operand's scalar list is empty) and the per-cell view only scalar / per-cell ones, so the row's
+`WORK` tier decodes its view by construction. The direct unit-row contraction's scalar and warp schedules share its
+one derived tree. Replay remains a function of `(stored op, row)` and nothing else. A union carries two obligations:
+uniform key sets with `""` as a decided empty, and NO cross-view suppression (each gate is a local predicate on its own
+term — a 16-bit atom, a resolvable fill, an inventory a value can spell against).
 
 **Coverage, as it stands.** The recursion carries the single-site terms — the pointwise cell plus the register-strip
 term variant, the reduce partition, and the contraction's tile × stage × reduce × raster product over the scalar and

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -29,6 +29,7 @@ from emmy.compiler.ir.pure.fold import (
     _operand_result_names,
     deep_defines,
     deep_reads,
+    is_contraction,
     refs_axis,
     stmt_axis_names,
 )
@@ -421,6 +422,63 @@ def _unit_output_row(writes: tuple[Write, ...], n_name: str) -> Axis | None:
         if not (len(index) >= 2 and index[-1] == Var(n_name) and isinstance(index[-2], Literal) and index[-2].value == 0):
             return None
     return Axis(name="_um", extent=Dim(1))
+
+
+def unit_contraction_view(tile) -> tuple[Fold, tuple[Axis, ...]] | None:
+    """The bilinear view of an ``m1 x K x N`` term whose row loop was elided.
+
+    The canonical term keeps the visible output axes. Ordinarily N must be its only free axis.
+    A split partial may also carry leading cross-CTA partition coordinates; those are admitted
+    only when each coordinate is present in the workspace boundary and composes with the sliced
+    reduction coordinate in an operand address. That receipt cannot mistake an ordinary batch or
+    head coordinate for M. When every boundary write also proves the established literal-zero
+    unit row, reclassify a derived view with that row restored. The view must expose an actual
+    contraction at the root or through its projection; otherwise decline so a pointwise or
+    incompletely bound fold cannot acquire an MMA schedule.
+    """
+    if not tile.place.free:
+        return None
+    *prefix, n_axis = tile.place.free
+    writes = tuple(store.write for store in tile.stores if store.sweep is None)
+    unit_m = _unit_output_row(writes, n_axis.name)
+    if unit_m is None or (prefix and not _partitioned_output_prefix(tile, tuple(prefix), writes)):
+        return None
+    free = (*prefix, unit_m, n_axis)
+    node = classify(tile.op, free)
+    if not _contains_contraction(node):
+        return None
+    return node, free
+
+
+def _partitioned_output_prefix(tile, prefix: tuple[Axis, ...], writes: tuple[Write, ...]) -> bool:
+    """Whether every leading free axis is a realized reduction partition, not output context.
+
+    ``030_split_reduce`` leaves two independent receipts on a partial: the sliced reduce loop has
+    a partition ``Window``, and its operand address combines that loop coordinate with the new
+    leading grid coordinate. The workspace boundary carries that coordinate before the restored
+    literal-zero row. Require all three facts for every prefix axis; a batch/head axis that merely
+    indexes a separate tensor dimension therefore declines.
+    """
+    body = Body(tuple(tile.op.lower()))
+    sliced = {loop.axis.name for loop in body.loops if loop.is_reduce and loop.axis.window is not None and loop.axis.window.partition}
+    if not sliced:
+        return False
+    prefix_names = {axis.name for axis in prefix}
+    if any(not prefix_names <= {name for expr in write.index[:-2] for name in expr.free_vars()} for write in writes):
+        return False
+    return all(
+        any(
+            axis.name in variables and bool(variables & sliced)
+            for load in body.loads
+            for variables in (expr.free_vars() for expr in load.index)
+        )
+        for axis in prefix
+    )
+
+
+def _contains_contraction(node) -> bool:
+    """Whether ``node`` or one of its operand edges has the bilinear reading."""
+    return is_contraction(node) or (isinstance(node, Fold) and any(_contains_contraction(operand) for operand in node.operands))
 
 
 def fused_view(tile) -> tuple[Fold, tuple[Axis, ...], tuple] | None:

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -108,7 +108,7 @@ from emmy.compiler.ir.tile.path import Site, sites
 from emmy.compiler.pipeline.fork import Fork, Level, build_fork_tree
 from emmy.compiler.pipeline.knob import family_of, schedule_pin_fingerprint, values_equal
 from emmy.compiler.pipeline.passes.lowering.tile import _legality as legal
-from emmy.compiler.pipeline.passes.lowering.tile._classify import demoted_chain, fused_view
+from emmy.compiler.pipeline.passes.lowering.tile._classify import demoted_chain, fused_view, unit_contraction_view
 from emmy.compiler.pipeline.passes.lowering.tile._pool import Block, PoolSpace, Segment
 from emmy.compiler.pipeline.search.space import (
     RASTER,
@@ -472,6 +472,9 @@ def _views(tile: TileOp, ctx) -> tuple[list[_Term], int]:
     - the MONOID-producer composition (``_classify.fused_view``) — the stored map form plus
       the derived fused contraction. The contraction's tree is the REFERENCE namespace: bare
       ``REDUCE`` must mean its K fold, so the map view spells its statistic at ``REDUCE@<axis>``;
+    - the direct unit-row contraction (``_classify.unit_contraction_view``) — the stored one-axis
+      term reclassified with its proven synthetic M axis, exposing the ordinary contraction
+      schedule without changing the canonical tree;
     - the COLLAPSE (:meth:`Fold.demoted`) — a stored computed-A contraction plus the derived
       per-cell splice, which carries the cone on the reduce tiers.
 
@@ -490,6 +493,13 @@ def _views(tile: TileOp, ctx) -> tuple[list[_Term], int]:
     if pro is not None:
         fused = _view(tile, pro[0], ctx, free=(*tile.place.free, *pro[1]), stores=pro[2])
         return [_Term(cell, tile.place.on_grid(), ctx, ref=fused.sched), fused], 1
+    unit = unit_contraction_view(tile)
+    if unit is not None:
+        contraction = _view(tile, unit[0], ctx, free=unit[1])
+        unit_node = head(unit[0])
+        if unit_node is not None and _has_computed_operand(unit_node):
+            return [_Term(cell, tile.place.on_grid(), ctx, ref=contraction.sched), contraction], 1
+        return [contraction], 0
     node = head(tile.op)
     if node is None or not is_contraction(node):
         return [base], 0

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -224,6 +224,61 @@ def _m1_linear_graph() -> Graph:
     return g
 
 
+def _m1_contraction_tile(*, row: int | Var = 0, context: str | None = None) -> TileOp:
+    """A direct unit-row contraction, optionally nested under an ordinary output axis."""
+    n, k = Axis("n", Dim(16)), Axis("k", Dim(16))
+    row_index = Literal(row) if isinstance(row, int) else row
+    load_prefix = (Var(context),) if context is not None else ()
+    store_prefix = (Var(context),) if context is not None else ()
+    cell = Body(
+        (
+            Loop(
+                axis=n,
+                body=Body(
+                    (
+                        Loop(
+                            axis=k,
+                            body=Body(
+                                (
+                                    Load(name="a", input="x", index=(*load_prefix, Literal(0), Var("k"))),
+                                    Load(name="b", input="w", index=(Var("n"), Var("k"))),
+                                    Assign(name="p", op=ElementwiseImpl("multiply"), args=("a", "b")),
+                                    Accum(name="acc", value="p", op=ElementwiseImpl("add"), axes=("k",)),
+                                )
+                            ),
+                        ),
+                        Write(output="o", index=(*store_prefix, row_index, Var("n")), value="acc"),
+                    )
+                ),
+            ),
+        )
+    )
+    body = cell if context is None else Body((Loop(axis=Axis(context, Dim(8)), body=cell),))
+    node, free, stores = _lift_tree(body)
+    from emmy.compiler.ir.tile import Placement
+
+    return TileOp(op=node, place=Placement(free=tuple(free)), stores=stores)
+
+
+def test_unit_contraction_view_restores_only_the_literal_zero_output_row():
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import unit_contraction_view
+
+    view = unit_contraction_view(_m1_contraction_tile())
+    assert view is not None and [axis.name for axis in view[1]] == ["_um", "n"]
+    assert unit_contraction_view(_m1_contraction_tile(row=1)) is None
+    assert unit_contraction_view(_m1_contraction_tile(row=Var("m"))) is None
+
+
+@pytest.mark.parametrize("context", ["batch", "head"])
+def test_unit_contraction_view_does_not_reclassify_output_context(context):
+    """A second output axis is not M unless a realized split receipt proves otherwise."""
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import unit_contraction_view
+
+    tile = _m1_contraction_tile(context=context)
+    assert [axis.name for axis in tile.place.free] == [context, "n"]
+    assert unit_contraction_view(tile) is None
+
+
 def _resolve(g: Graph, pick=None, ctx: Context | None = None) -> tuple[list[dict], TileOp]:
     """Run the tile passes, capturing every fork leaf's knob row; ``pick`` selects the applied
     leaf (default: option-0, the emission-order head). Returns ``(rows, the one TileOp)``."""
@@ -278,6 +333,15 @@ def test_wide_m1_flinear_offers_the_warp_k_fold_and_a_pin_realizes_it(monkeypatc
     _, tile = _resolve(_m1_linear_graph(), ctx=ctx)
     assert [v for k, v in tile.knobs.items() if family_of(k) == "REDUCE"] == ["coop"]
     assert tile.knobs.get("WORK") == "t32"
+
+
+def test_direct_m1_contraction_offers_scalar_and_volta_mma_rows():
+    """Restoring the unit M axis adds the Volta tier without losing scalar schedules."""
+    ctx = Context.from_target((7, 0), gpu_name="NVIDIA Tesla V100 SXM3 32GB")
+    rows, _ = _resolve(_m1_linear_graph(), ctx=ctx)
+
+    assert any(str(row.get("WORK", "")).startswith("t") for row in rows)
+    assert any(str(row.get("WORK", "")).startswith("w") and "mma_m8n8k4_f16_f32" in str(row.get("TILE", "")) for row in rows)
 
 
 def test_norm_linear_offers_both_the_map_rows_and_the_warp_contraction_rows():

--- a/tests/compiler/passes/test_split_fresh_kernels.py
+++ b/tests/compiler/passes/test_split_fresh_kernels.py
@@ -120,6 +120,45 @@ def test_each_piece_decides_its_own_row(monkeypatch) -> None:
     assert scheduled >= {"o", "o__partial"}, f"each piece must be offered its own schedule fork, saw {scheduled}"
 
 
+def test_a_split_m1_partial_offers_scalar_and_volta_mma_rows() -> None:
+    """The split-group coordinate is not the missing M row.
+
+    The partial's workspace boundary carries ``(partition, 0, N)`` and its operand address
+    composes that partition with the sliced K coordinate. That realized split receipt restores a
+    synthetic unit M after the partition while preserving the scalar sibling rows.
+    """
+    ctx = Context.from_target((7, 0), gpu_name="NVIDIA Tesla V100 SXM3 32GB")
+    partial_rows: list[dict] = []
+    derived_free: tuple[str, ...] | None = None
+
+    def decide(fp):
+        nonlocal derived_free
+        from emmy.compiler.pipeline.passes.lowering.tile._classify import unit_contraction_view
+        from emmy.compiler.pipeline.pipeline import _is_structural_option
+
+        leaves = flatten_leaves(fp.options)
+        if any(_is_structural_option(leaf) for leaf in leaves):
+            return next(leaf for leaf in leaves if not _is_structural_option(leaf))
+        rows = [leaf for leaf in leaves if hasattr(leaf, "knobs")]
+        materialized = rows[0].expand()[0] if rows else None
+        if isinstance(materialized, TileOp) and any(store.write.output.endswith("__partial") for store in materialized.stores):
+            partial_rows.extend(dict(row.knobs) for row in rows)
+            view = unit_contraction_view(materialized)
+            assert view is not None
+            derived_free = tuple(axis.name for axis in view[1])
+            return rows[0]
+        split = next((row for row in rows if row.knobs.get("REDUCE") == "g2k"), None)
+        return split or (rows[0] if rows else leaves[0])
+
+    Run(pipeline=Pipeline.build(TILE_PASSES), ctx=ctx).resolve(_matmul(m=1, k=64, n=16), decide)
+
+    assert derived_free is not None and derived_free[1] == "_um" and len(derived_free) == 3
+    assert any(str(row.get("WORK", "")).startswith("t") for row in partial_rows), "the scalar sibling was lost"
+    assert any(str(row.get("WORK", "")).startswith("w") and "mma_m8n8k4_f16_f32" in str(row.get("TILE", "")) for row in partial_rows), (
+        "the sliced m1 partial offered no Volta MMA row"
+    )
+
+
 def test_each_piece_carries_its_own_structural_identity(monkeypatch) -> None:
     """A piece featurizes as ITSELF. Without this the partial joined the pre-split kernel's
     evidence — the same signature for a kernel doing half the reduction. Nothing in the rule stamps

--- a/tests/compiler/passes/test_volta_mma.py
+++ b/tests/compiler/passes/test_volta_mma.py
@@ -160,6 +160,16 @@ def test_sm70_sync_copy_composes_ring_and_register_pipelines(monkeypatch) -> Non
     assert "cp.async" not in src and "ldmatrix" not in src
 
 
+def test_sm70_m1_linear_synthesizes_a_masked_mma_row(monkeypatch) -> None:
+    """A literal unit output row is still the M side of a plain m1×K×N contraction."""
+    _pin(monkeypatch, VOLTA, tile="f1x1", stage="")
+    src, knobs = _source(_graph(m=1, n=16, k=16, trans=True), Context(compute_capability=(7, 0)))
+    assert knobs["TILE"] == f"{VOLTA}/f1x1"
+    assert knobs["WORK"] == "w1x1"
+    assert "emmy_mma_m8n8k4_f16_f32" in src
+    assert "_um_b" in src and "< (1)" in src
+
+
 def test_sm70_register_tile_keeps_the_volta_fragment_layout_through_the_reroll(monkeypatch) -> None:
     """A register tile wide enough to ROLL back into a loop still drains and stores as Volta.
 


### PR DESCRIPTION
## Summary

- derive the missing unit M axis for a contraction whose Loop IR boundary proves a literal-zero output row
- accept leading split partitions only when both the workspace write and a sliced operand address prove the partition
- retain scalar schedules while exposing the existing Volta `mma_m8n8k4_f16_f32` catalog
- fail closed for nonzero/nonliteral rows, ordinary batch/head output axes, and terms without a contraction

## Exact-source evidence

The final controls used base `037495fabef248910d6d5fc6e8117e4806668c42` (tree
`d77ef72de43053a1643d7651ebf4ec435f73ce30`) on one exact Tesla V100-SXM3-32GB,
`GPU-77102226-f726-90f2-15b4-dcbf3f8cace3`. The task checkout reported only this PR's `_classify.py` and
`_schedule.py` overlays; `emmy.__file__` and every relevant compiler module resolved under that checkout. The two
source hashes were byte-identical to the kenshin worktree.

A deterministic standalone 1x16x16 control realized both exact rows and strict-passed on identical inputs:

- scalar `WORK=t16,REDUCE=coop`: 1.696 us, strict pass
- Volta `WORK=w1x1,TILE=mma_m8n8k4_f16_f32/f1x1,STAGE=d1/smem`: 2.525 us, zero error, rendered source contains the
  requested Volta MMA instruction family

The tiny control proves admission and correctness, not a speedup; retaining the scalar row is intentional.

The full Laguna expert control depends on the already-merged SiLU opmath and narrowing-boundary fixes (#613 and #614)
for semantics. This PR contributes only the complete parent/split-partial Volta row. With those upstream fixes plus
this overlay, exact O3 replay strict-passed end to end (`max_abs_error=0.001953125`) at 181.974 us total: 100.250 us
partial, 2.089 us finalize, and 79.636 us downstream. The finalizer/downstream CUDA sources were byte-identical to the
prior accepted combined proof. This is not an attribution of all numerical or performance gains to this PR.

Raw evidence is preserved under:

- `/home/riftuser/.cache/emmy/onb-laguna-agentic.hj9sGn/artifacts/main-037495fa/volta-m1-mma/standalone-library-gpu4`
- `/home/riftuser/.cache/emmy/onb-laguna-agentic.hj9sGn/artifacts/main-037495fa/volta-m1-mma/laguna-combined-gpu4-v17`

## Validation

- focused compiler files: 66 passed
- `make test`: 3124 passed, 575 skipped, 1 xfailed
- `make lint`: passed
- exact V100 standalone scalar/Volta strict O3 control: passed
- exact V100 complete Laguna configuration strict O3 control: passed
