### PR TITLE
Preserve computed contraction cone sources

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -1042,7 +1042,8 @@ def bind_bilinear(
             if cone is None:
                 return None  # a computed A that does not read cleanly — the fold stays PLANAR
             consumed.update(id(s) for s in cone)
-            a_edge = make_cone(cone, k_name, stat=stat, sweep=tuple(sweep)) if stat is not None else make_cone(cone, k_name)
+            source = stat if stat is not None else edge
+            a_edge = make_cone(cone, k_name, stat=source, sweep=tuple(sweep) if sweep is not None else ())
         b_edges: list = [b for _, b, _ in reads]
     elif stat is None and len(reads) == 1 and (a_edge := role_load(a_arg, m_name, n_name)) is not None:
         # B rides a computed value (A is the direct load). A storage decode × k-invariant factors

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -832,6 +832,8 @@ def _prologue_shape(*, b_layouts, cone_per_channel=False):
 
 
 def test_channels_with_agreeing_b_layouts_form_one_product_node():
+    from emmy.compiler.ir.tile.ops import cone_seam
+
     node, free = _prologue_shape(b_layouts=(False, False))
     bound = _fused(node, free)
     assert bound is not None
@@ -840,6 +842,9 @@ def test_channels_with_agreeing_b_layouts_form_one_product_node():
     assert product.role is AxisRole.CONTRACTION
     assert len(product.channels) == 2, "two channels over ONE shared edge — sharing is the node's arity"
     assert product.a is not None
+    prologue, _cell, stats = cone_seam(product.a, product.axis.name)
+    assert stats == ("rs",)
+    assert sum(isinstance(s, Load) and s.input == "x" for s in Body(prologue).iter()) == 1
 
 
 def test_channels_with_disagreeing_b_layouts_never_group():

--- a/tests/compiler/passes/test_total_lift.py
+++ b/tests/compiler/passes/test_total_lift.py
@@ -74,6 +74,49 @@ def test_epilogue_stays_in_the_projection_body():
     assert {getattr(s, "input", None) for s in node.body if isinstance(s, Load)} == {"b"}
 
 
+def test_shared_row_value_stays_attached_to_a_computed_contraction_operand():
+    """A row value used by both a reduction cone and its output epilogue is duplicated by root
+    closure. The contraction binder must keep the duplicated edge as the computed A cone's
+    source; otherwise the cone reads its renamed value without a defining Load."""
+    m, n, k = Axis("m", Dim(8)), Axis("n", Dim(16)), Axis("k", Dim(32))
+    reduction = Loop(
+        axis=k,
+        body=Body(
+            (
+                Load(name="xk", input="x", index=(Var("m"), Var("k"))),
+                Assign(name="center", op=ElementwiseImpl("subtract"), args=("shared", "xk")),
+                Load(name="weight", input="weight", index=(Var("n"), Var("k"))),
+                Assign(name="product", op=ElementwiseImpl("multiply"), args=("center", "weight")),
+                Accum(name="acc", value="product", op=ElementwiseImpl("add"), axes=("k",)),
+            )
+        ),
+    )
+    column = Loop(
+        axis=n,
+        body=Body(
+            (
+                reduction,
+                Assign(name="outv", op=ElementwiseImpl("add"), args=("acc", "shared")),
+                Write(output="out", index=(Var("m"), Var("n")), value="outv"),
+            )
+        ),
+    )
+    tile = _tile(Body((Loop(axis=m, body=Body((Load(name="shared", input="row", index=(Var("m"),)), column))),)))
+    node = tile.op.operands[0]
+    assert isinstance(node, Fold) and node.role is AxisRole.CONTRACTION and isinstance(node.a, Fold)
+
+    cone_body = Body(node.a.lower())
+    row_loads = [s for s in cone_body.iter() if isinstance(s, Load) and s.input == "row"]
+    assert len(row_loads) == 1, "the detached edge defines its renamed value once inside the computed A cone"
+    defined: set[str] = set()
+    unbound: set[str] = set()
+    axes = {a.name for a in tile.place.free} | {node.axis.name}
+    for stmt in cone_body.iter():
+        unbound.update(set(stmt.deps()) - defined - axes)
+        defined.update(stmt.defines())
+    assert not unbound, f"the computed A cone must be closed, found free SSA reads: {sorted(unbound)}"
+
+
 def test_two_pass_softmax_lifts_both_folds_with_cross_operand_read():
     """The second pass's λ reads the first pass's carried state as a free name — the shape the
     online-softmax pairing will classify."""

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -251,6 +251,7 @@
  "tests/compiler/passes/test_split_fresh_kernels.py::test_a_pin_hands_its_remaining_row_to_the_pieces": 0.01,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_each_piece_carries_its_own_structural_identity": 0.16,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_each_piece_decides_its_own_row": 0.22,
+ "tests/compiler/passes/test_split_fresh_kernels.py::test_finalize_keeps_projection_input_edges": 1.4,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_no_piece_inherits_the_kernel_it_replaces": 0.16,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_the_split_is_consumed_by_the_kernel_that_realizes_it[g2a]": 0.22,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_the_split_is_consumed_by_the_kernel_that_realizes_it[g2k]": 0.21,


### PR DESCRIPTION
## Summary

- keep a detached zero-axis projection edge as the source of a stat-free computed contraction operand
- preserve the existing statistic-backed chained-column path
- cover closed SSA, one defining source load, and the ordinary chained-column control

## Cause

Total lift correctly closes a shared row-invariant value through a projection edge. During contraction classification,
`bind_bilinear` detached that edge to inspect the bare fold, admitted its result while finding the computed-A cone, and
then rebuilt the cone without supplying the edge to `make_cone`. The resulting Tile IR read the renamed edge value with
no defining `Load`, which later produced an undefined identifier in CUDA.

This reuses the existing `make_cone(..., stat=source)` boundary; it does not repair generated names or add a
model-specific path.

## Verification

- focused red/green regression for a shared row value used by both the reduction cone and output epilogue
- focused ordinary statistic-backed chained-column control
- latest `make test`: 3147 passed, 561 skipped, 1 xfailed
- latest `make lint`: clean
- documentation, terminology, plan-cap, and final-diff audits: clean; no durable docs changed because they already
  specify that operand edges are closed by construction

Exact RTX 4090 proof used clean commit `1fcdfd108d32dd943e528515be2055c2a1605985`, tree
`ea26e84d5e4e11413c86d79e8e39ef3ea82ce617`, a fresh trace, and fresh compile state. The trace completed in 36.44 s
with 196 targets; its golden SHA-256 was
`4bd3e5bfe476aa43304de335886101e114e7344ebb6436aa0e018117bacde0d4`. All seven previously failing Qwen targets
compiled at strict O3 and passed direct eager correctness. Their maximum absolute errors were 3.052e-4, 1.831e-4,
6.104e-4, 2.747e-4, 7.324e-4, 3.662e-4, and 1.221e-3. Generated CUDA was byte-identical to the pre-rebase proof.

Performance remains open: these seven kernels measured about 499.2-505.3 us versus 177.7-194.0 us eager
(0.352-0.389x).

The final head `edf860c967dd91b72b8e2c28530d4391aa2bcf51` (tree
`31fdd727766aa66d155a88c2a88ec90fcff8688b`) adds only the measured `tests/durations.json` entry required by the
merged split-finalization test. Relative to the exact GPU-proven commit, all three changed compiler/regression files
remain byte-identical:

- `_classify.py`: `37e684d31afb50da92b51c53373d9a7ded48eba1fb49e21047c7fd83f3d77022`
- `test_total_lift.py`: `4e036ac6b662553edd0ef31d0c9901ce5a536f6f97bee92e3ed18e40c5613f3b`
- `test_recognize_boundary_rules.py`: `3aa889dc7e88c0e085f93c228b78d05b9761f31c92b84fe71d865d67867ee8d2`

The exact missing duration test measured 1.40 s in three consecutive serial O1 runs (CI measured 5.2 s). This keeps
the duration-only head tied to the exact compiler source that produced the 4090 evidence.
