### PR TITLE
Require repeated tuned A100 evidence

### DIFF
--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
@@ -15,11 +15,13 @@
 #   neptune  the pinned artifact's own tune + Nsight profile for one operator (10 operators)
 #   emmy     bench eager / torch.compile / Emmy, with Emmy replaying a pre-tuned golden (5 operators)
 #
-# The emmy lane runs two arms per setup: the golden replay times the committed tuned schedules, and
-# a `emmy run -c` reference arm supplies eager, torch.compile, and the strict Emmy-vs-eager
-# correctness proof. They are separate because `emmy trace --code` stores a single-op program's
-# post-fusion targets as Loop IR — every kernel of an SDPA snippet shares one provenance selector —
-# and a Loop IR target carries no torch twin to compare against.
+# The emmy lane runs two repeated arms per setup: golden replay times the committed tuned schedules
+# twice, and a `emmy run -c` reference arm supplies two eager, torch.compile, and strict whole-program
+# Emmy-vs-eager correctness observations. They are separate because `emmy trace --code` stores a
+# single-op program's post-fusion targets as Loop IR — every kernel of an SDPA snippet shares one
+# provenance selector — and a Loop IR target carries no torch twin for direct eager proof. Replay
+# instead checks each exact pin against same-input greedy Emmy; benchmark conclusions use its repeated
+# deployable-O3 timings.
 #
 # Tuning happens outside this recipe, through the tune-kernels skill: trace each setup from
 # operators.sh (`./operators.sh OPERATOR SEQUENCE_LENGTH` prints the exact module source this

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
@@ -2,15 +2,15 @@
 # Comparison lane: bench one common attention operator's sequence sweep as
 # eager PyTorch / torch.compile / Emmy. Two arms per setup:
 #
-#   replay     `emmy run --golden` re-measures the setup's committed tuned schedules at -O3.
+#   replay     `emmy run --golden` re-measures the setup's committed tuned schedules twice at -O3.
 #              `emmy trace --code` stores a single-op program's post-fusion targets as Loop IR
 #              (every kernel shares one provenance selector), and a Loop IR target has no torch
-#              twin, so this arm times Emmy only — the reference and the correctness gate are the
-#              second arm's job.
+#              twin, so each replay checks exact pins against same-input greedy Emmy. It is not a
+#              direct eager proof; the reference arm owns that separate correctness boundary.
 #   reference  `emmy run -c` re-traces the same snippet and benches eager, torch.compile, and the
-#              UNTUNED Emmy deploy under --strict, so every setup carries an eager reference, an
-#              Inductor reference, and a direct Emmy-vs-eager correctness proof. When that arm
-#              fails, run_pytorch.py still preserves the two PyTorch references on their own.
+#              UNTUNED Emmy deploy twice under --strict, so every successful setup carries repeated
+#              eager and Inductor references plus direct whole-program Emmy-vs-eager proofs. When
+#              an invocation fails, run_pytorch.py still preserves the two PyTorch references.
 #
 # The search happens outside the recipe, through the tune-kernels skill.
 set -euo pipefail
@@ -31,7 +31,7 @@ source "$here/operators.sh"
 
 mkdir -p "$results/json" "$results/dumps" "$results/logs"
 status_file=$results/setup-status.tsv
-printf "operator\tsequence_length\treplay\treference\n" > "$status_file"
+printf "operator\tsequence_length\treplay_1\treplay_2\treference_1\treference_2\n" > "$status_file"
 successful_setups=0
 missing_goldens=0
 
@@ -39,45 +39,58 @@ for sequence_length in "${SEQUENCE_LENGTHS[@]}"; do
   setup="${operator}-b1-s${sequence_length}"
   golden=$golden_dir/$setup.golden.yaml
   if [ ! -f "$golden" ]; then
-    printf "%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" "missing-golden" "skipped" >> "$status_file"
+    printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
+      "$operator" "$sequence_length" "missing-golden" "missing-golden" "skipped" "skipped" >> "$status_file"
     missing_goldens=$((missing_goldens + 1))
     continue
   fi
   source_code=$(operator_code "$operator" "$sequence_length")
 
-  # --json takes a path per target: a file for a single-target golden, a directory when the
-  # traced program lowered to several post-fusion kernels.
-  if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
-    "$emmy" run --golden "$golden" --bench --bench-backends emmy \
-    --warmup 1 --iters 15 --no-record-nodes \
-    --json "$results/json/$setup" --dump-dir "$results/dumps/$setup" \
-    2>&1 | tee "$results/logs/$setup.log"; then
-    replay=ok
+  replay_statuses=()
+  reference_statuses=()
+  for repetition in 1 2; do
+    # --json takes a path per target: a file for a single-target golden, a directory when the
+    # traced program lowered to several post-fusion kernels.
+    if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
+      "$emmy" run --golden "$golden" --bench --bench-backends emmy \
+      --warmup 1 --iters 15 --no-record-nodes \
+      --json "$results/json/$setup.replay-$repetition" --dump-dir "$results/dumps/$setup.replay-$repetition" \
+      2>&1 | tee "$results/logs/$setup.replay-$repetition.log"; then
+      replay_statuses+=(ok)
+    else
+      replay_statuses+=("failed:$?")
+    fi
+  done
+  for repetition in 1 2; do
+    if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
+      "$emmy" run -c "$source_code" --bench --strict --bench-backends eager,tcompile,emmy \
+      --warmup 1 --iters 15 --no-record-nodes --json "$results/json/$setup.reference-$repetition.json" \
+      2>&1 | tee "$results/logs/$setup.reference-$repetition.log"; then
+      reference_statuses+=(ok)
+    else
+      reference_status=$?
+      if timeout --signal=TERM --kill-after=30s 600s \
+        "$python" "$pytorch_runner" "$operator" "$sequence_length" \
+        --warmup 1 --iters 15 --json "$results/json/$setup.pytorch-$repetition.json" \
+        2>&1 | tee "$results/logs/$setup.pytorch-$repetition.log"; then
+        reference_statuses+=("pytorch-only:emmy-failed:$reference_status")
+      else
+        reference_statuses+=("failed:emmy=$reference_status,pytorch=$?")
+      fi
+    fi
+  done
+  if [ "${replay_statuses[0]}" = ok ] && [ "${replay_statuses[1]}" = ok ] && \
+    [ "${reference_statuses[0]}" = ok ] && [ "${reference_statuses[1]}" = ok ]; then
     successful_setups=$((successful_setups + 1))
-  else
-    replay="failed:$?"
   fi
 
-  if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
-    "$emmy" run -c "$source_code" --bench --strict --bench-backends eager,tcompile,emmy \
-    --warmup 1 --iters 15 --no-record-nodes --json "$results/json/$setup.reference.json" \
-    2>&1 | tee "$results/logs/$setup.reference.log"; then
-    reference=ok
-  else
-    reference_status=$?
-    if timeout --signal=TERM --kill-after=30s 600s \
-      "$python" "$pytorch_runner" "$operator" "$sequence_length" \
-      --warmup 1 --iters 15 --json "$results/json/$setup.pytorch.json" \
-      2>&1 | tee "$results/logs/$setup.pytorch.log"; then
-      reference="pytorch-only:emmy-failed:$reference_status"
-    else
-      reference="failed:emmy=$reference_status,pytorch=$?"
-    fi
-  fi
-  printf "%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" "$replay" "$reference" >> "$status_file"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" \
+    "${replay_statuses[0]}" "${replay_statuses[1]}" \
+    "${reference_statuses[0]}" "${reference_statuses[1]}" >> "$status_file"
 done
 
 # A missing golden is a broken lane input, not a measurement: fail rather than silently
 # reporting a shorter sweep.
 test "$missing_goldens" -eq 0
+# Only setups with both O3 replays and both strict reference proofs support a performance conclusion.
 test "$successful_setups" -gt 0

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -389,10 +389,18 @@ def test_neptune_emmy_pytorch_a100_share_one_experiment(project_root) -> None:
     assert "emmy tune" not in emmy_runner
     assert "timeout --signal=TERM --kill-after=30s 600s" in emmy_runner
     assert "setup-status.tsv" in emmy_runner
+    assert "replay_1\\treplay_2\\treference_1\\treference_2" in emmy_runner
+    assert emmy_runner.count("for repetition in 1 2") == 2
+    assert '"$results/json/$setup.replay-$repetition"' in emmy_runner
+    assert '"$results/json/$setup.reference-$repetition.json"' in emmy_runner
+    assert '"${replay_statuses[0]}" = ok' in emmy_runner
+    assert '"${replay_statuses[1]}" = ok' in emmy_runner
+    assert '"${reference_statuses[0]}" = ok' in emmy_runner
+    assert '"${reference_statuses[1]}" = ok' in emmy_runner
     assert 'test "$missing_goldens" -eq 0' in emmy_runner
     assert 'test "$successful_setups" -gt 0' in emmy_runner
     assert "run_pytorch.py" in emmy_runner
-    assert 'reference="pytorch-only:emmy-failed:$reference_status"' in emmy_runner
+    assert 'reference_statuses+=("pytorch-only:emmy-failed:$reference_status")' in emmy_runner
 
     pytorch_runner = (Path(directory) / "run_pytorch.py").read_text()
     assert 'mode="max-autotune-no-cudagraphs"' in pytorch_runner


### PR DESCRIPTION
## Summary

- replay each committed tuned A100 golden twice at deployable O3
- run the whole-program eager / torch.compile / Emmy strict reference arm twice
- require all four observations before a setup contributes to benchmark conclusions
- preserve separate JSON, dump, log, and status fields for every repetition

The evidence boundary is deliberate: Loop-IR golden replay verifies exact pins against same-input greedy Emmy and supplies the tuned O3 timing; the runnable source arm supplies whole-program Emmy-vs-eager correctness and the eager / torch.compile references. This PR does not imply per-pin eager correctness.

## Validation

- exact base: `f3268e592b386df6fb19c50ee5bffefb65ab755d`
- branch: `7a270582457f6565f3691c5c7f4f817e21825ba5`
- `./venv/bin/pytest tests/benchmark/models/test_golden_bench_2026.py -k neptune -v` — 1 passed
- `bash -n experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh`
- `make lint` — green
- `git diff --check origin/main...HEAD` — green

Exact-A100 refreshed tuning and repeated benchmark evidence are intentionally pending. No Neptune parity or performance result is claimed by this harness-only increment.
