### PR TITLE
Preserve boolean dtype in TorchRef

### DIFF
--- a/emmy/compiler/backend/torch_ref.py
+++ b/emmy/compiler/backend/torch_ref.py
@@ -64,6 +64,7 @@ def torch_dtype(dtype) -> torch.dtype | None:
         # numeric torch float8 value.
         "f8e4m3": torch.uint8,
         "f8e5m2": torch.uint8,
+        "bool": torch.bool,
         "i32": torch.int32,
         "i64": torch.int64,
     }.get(str(dtype))

--- a/tests/compiler/backend/test_torch_ref.py
+++ b/tests/compiler/backend/test_torch_ref.py
@@ -8,7 +8,7 @@ import pytest
 from emmy.compiler.backend import torch_ref
 from emmy.compiler.backend.numpy import NumpyBackend
 from emmy.compiler.graph import Graph, Tensor
-from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.expr import BinaryExpr, Literal, TernaryExpr, placeholder
 from emmy.compiler.ir.frontend.ir import LinearOp, MatmulOp, RmsNormOp, SoftmaxOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, IndexMapOp, IndexSource, ReduceOp, ScanOp
@@ -108,6 +108,61 @@ def test_where_preserves_bool_condition_dtype_and_broadcasts():
     assert actual.dtype == torch.float32
     assert actual.shape == (2, 3)
     np.testing.assert_array_equal(actual.numpy(), expected)
+
+
+@pytest.mark.parametrize(("dtype_name", "value", "expected_dtype"), [("bool", 1.0, torch.bool), ("i64", 7.0, torch.int64)])
+def test_indexmap_scalar_preserves_declared_dtype(dtype_name, value, expected_dtype):
+    g = Graph()
+    g.add_node(ConstantOp(name="scalar", value=value), [], Tensor("scalar", (1,), dtype_name), node_id="scalar")
+    g.add_node(
+        IndexMapOp(out_shape=(2, 2), sources=(IndexSource(input_idx=0, coord_map=(Literal(0, "int"),)),)),
+        ["scalar"],
+        Tensor("out", (2, 2), dtype_name),
+        node_id="out",
+    )
+    g.outputs = ["out"]
+
+    fn, inputs = torch_ref.build_callable(g, {})
+    actual = fn(*inputs)
+
+    assert torch_ref.is_runnable(g)
+    assert actual.dtype == expected_dtype
+    assert actual.tolist() == [[int(value), int(value)], [int(value), int(value)]]
+
+
+def test_where_accepts_bool_scalar_broadcast_through_triangular_indexmap():
+    g = Graph()
+    g.add_node(ConstantOp(name="one", value=1.0), [], Tensor("one", (1,), "bool"), node_id="one")
+    g.add_node(ConstantOp(name="zero", value=0.0), [], Tensor("zero", (1,), "bool"), node_id="zero")
+    g.add_node(
+        IndexMapOp(
+            out_shape=(2, 2),
+            sources=(
+                IndexSource(
+                    input_idx=0,
+                    coord_map=(Literal(0, "int"),),
+                    select=BinaryExpr(">=", placeholder(1), placeholder(0)),
+                ),
+                IndexSource(input_idx=1, coord_map=(Literal(0, "int"),)),
+            ),
+        ),
+        ["one", "zero"],
+        Tensor("condition", (2, 2), "bool"),
+        node_id="condition",
+    )
+    g.add_node(InputOp(), [], Tensor("left", (2, 2)), node_id="left")
+    g.add_node(InputOp(), [], Tensor("right", (2, 2)), node_id="right")
+    g.add_node(ElementwiseOp(op="where"), ["condition", "left", "right"], Tensor("out", (2, 2)), node_id="out")
+    g.inputs, g.outputs = ["left", "right"], ["out"]
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    left = torch.full((2, 2), 1.0, device=device)
+    right = torch.full((2, 2), -1.0, device=device)
+
+    fn, inputs = torch_ref.build_callable(g, {"left": left, "right": right})
+    actual = fn(*inputs)
+
+    assert torch_ref.is_runnable(g)
+    torch.testing.assert_close(actual, torch.tensor([[1.0, 1.0], [-1.0, 1.0]], device=device), rtol=0, atol=0)
 
 
 def test_declared_dtype_cast_is_enforced():


### PR DESCRIPTION
## Summary
- materialize declared boolean graph outputs as torch.bool in TorchRef
- cover scalar IndexMap dtype preservation for boolean and integer outputs
- reproduce the triangular boolean broadcast feeding elementwise where

## Evidence
- focused TorchRef suite: 25 passed
- make test: 3150 passed, 561 skipped, 1 xfailed
- make lint: clean
- exact RTX 4090 row-026 strict replay: pending classifier completion

The frontend graph already declares the predicate boolean; this restores that declared dtype and does not make TorchRef accept invalid Float predicates.
