### PR TITLE
Use the execution symbolic environment for kernel stats

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -135,6 +135,8 @@ max/mean/relative error in `--json` and exits
 nonzero on any missing or failed evidence. Dynamic-shape parsing, quantized architecture twins and
 their in-graph storage algebra, sliding-window stamps, and the guarded `trust_remote_code` fallback therefore behave
 identically for all four commands (see `compiler/ARCHITECTURE.md`, "Quantized checkpoints").
+For isolated frontend-graph runs, the worker returns the symbolic environment used for execution with its benchmark
+result; `run` uses that same binding when rendering dynamic per-kernel grid statistics.
 For a single-layer trace, the loader derives a missing attention `layer_type` from
 `config.layer_types[self_attn.layer_idx]`. Rotary modules keyed by that attention label supply one `(cos, sin)` tuple;
 modules with independent rotary keys (for example DeepSeek V4's `main` / `compress`) supply the complete mapping.

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -998,7 +998,7 @@ def _launch_order_cuda_nodes(graph):
     return [graph.nodes[nid] for nid in graph.topological_order() if isinstance(graph.nodes[nid].op, CudaOp)]
 
 
-def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, greedy_iso=None):
+def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, greedy_iso=None, sym_env=None):
     """Per-kernel breakdown. Pulls structural stats off each ``CudaOp``
     (block / grid / smem), per-launch timings from ``bench.per_launch``,
     and per-kernel hardware attributes from the compiled cupy RawKernels
@@ -1051,11 +1051,12 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, gre
     # Symbolic grids (ceil-div over a dynamic axis) need a concrete env to
     # resolve for display — use each symbolic input dim's hint, so the printed
     # geometry reflects the hint-sized tile the kernel was tuned for.
-    sym_env: dict[str, int] = {}
-    for nid in graph.inputs:
-        for dim in graph.buffer(nid).shape:
-            if isinstance(dim.expr, Var) and dim.hint is not None:
-                sym_env.setdefault(dim.expr.name, dim.hint)
+    if sym_env is None:
+        sym_env = {}
+        for nid in graph.inputs:
+            for dim in graph.buffer(nid).shape:
+                if isinstance(dim.expr, Var) and dim.hint is not None:
+                    sym_env.setdefault(dim.expr.name, dim.hint)
 
     def _geom(op, attrs: dict):
         block_dims = [resolve_dim(d, sym_env) for d in op.block]
@@ -1786,6 +1787,7 @@ async def bench_lowered_vs_torch(
     capture_graphs=True,
     ref_out=None,
     ref_us_out=None,
+    sym_env_out=None,
     strict_accuracy=False,
     return_reference=False,
 ):
@@ -1840,6 +1842,8 @@ async def bench_lowered_vs_torch(
     from emmy.compiler.dim import Dim
 
     sym_env = _collect_sym_env(([frontend] if frontend is not None else []) + [lowered])
+    if sym_env_out is not None:
+        sym_env_out.append(dict(sym_env))
 
     def _static(shape):
         return tuple((d.as_static() if d.is_static else int(d.expr.eval(sym_env))) if isinstance(d, Dim) else int(d) for d in shape)
@@ -2145,6 +2149,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     async def _bench_session():
         greedy_fail = results = bench = accuracy_error = correctness = ab_ref = reference_error = ab_benches = greedy_iso = None
         greedy_reference_us = None
+        stats_sym_env = _collect_sym_env(([frontend] if frontend is not None else []) + [graph])
         torch_available = captured = False
         pinned = _pinned_samples_for_ir(args, embedded)
         try:
@@ -2167,6 +2172,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                 torch_available, accuracy_error = resp["torch_available"], resp["accuracy_error"]
                 ab_ref = resp["run_io"]
                 greedy_reference_us = resp.get("reference_run_us")
+                stats_sym_env = resp.get("sym_env")
                 correctness = resp.get("correctness")
                 if resp.get("greedy_error"):
                     greedy_fail = f"greedy timing failed after reference execution: {resp['greedy_error']}"
@@ -2207,6 +2213,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
             ab_benches,
             greedy_iso,
             greedy_reference_us,
+            stats_sym_env,
             correctness,
         )
 
@@ -2221,6 +2228,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         ab_benches,
         greedy_iso,
         greedy_reference_us,
+        stats_sym_env,
         correctness,
     ) = asyncio.run(_bench_session())
 
@@ -2247,7 +2255,14 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         print()
         for line in render_table([Col("Backend"), Col("Latency (us)", "r")], [["Emmy", f"{bench.time_ms * 1000:.0f}"]], rule=True):
             print(line)
-    _print_kernel_stats(graph, bench, golden_benches=ab_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
+    _print_kernel_stats(
+        graph,
+        bench,
+        golden_benches=ab_benches,
+        greedy_fail=greedy_fail,
+        greedy_iso=greedy_iso,
+        sym_env=stats_sym_env,
+    )
     strict_errors = _strict_benchmark_errors(args, results, bench, captured, correctness, ab_benches) if strict_correctness else None
     if getattr(args, "json", None):
         _write_ab_json(

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -213,6 +213,9 @@ flags: `accuracy` (bind the rebuilt module's real inputs, run the emmy program o
 eager — the verdict rides back as `accuracy_error` and a numeric failure skips the bench) and
 `want_ref` (return that run's `(inputs, outputs)` as `run_io`). A frontend-graph job may also request
 `strict_accuracy`; it returns the direct eager proof and same-input eager outputs used to check exact-pinned rows.
+The frontend-graph response also returns the exact symbolic environment used to specialize its hint-sized inputs, so
+the parent resolves dynamic launch geometry from the execution binding instead of reconstructing it from lowered
+graph inputs that may no longer carry the symbol.
 Embedded Loop replay has no Torch twin, so its Emmy-only greedy execution returns that same-input reference too. If
 this execution completes but later repeated timing crosses the watchdog, the worker returns the reference, single-run
 timing, and exact timing error. The command marks greedy ineligible while still reference-checking pinned rows; the

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -137,13 +137,13 @@ async def _run_job(req: dict) -> dict:
         # In-process within this child — the parent's SIGKILL is the wall-timeout backstop.
         backend = CudaBackend(bench_compile_timeout_s=60.0, bench_run_timeout_s=60.0)
         kind, payload = spec
-        accuracy_error = run_io = correctness = greedy_error = reference_run_us = None
+        accuracy_error = run_io = correctness = greedy_error = reference_run_us = stats_sym_env = None
         retire_worker = False
         if kind == "frontend_graph":
             from emmy.commands.run import bench_lowered_vs_torch
 
             want_reference = req.get("want_ref", False) or req.get("strict_accuracy", False)
-            refs, ref_times = [], []
+            refs, ref_times, sym_envs = [], [], []
             try:
                 response = await bench_lowered_vs_torch(
                     payload,
@@ -156,6 +156,7 @@ async def _run_job(req: dict) -> dict:
                     bench_backends=req["bench_backends"],
                     ref_out=refs if want_reference else None,
                     ref_us_out=ref_times if want_reference else None,
+                    sym_env_out=sym_envs,
                     strict_accuracy=req.get("strict_accuracy", False),
                     return_reference=want_reference,
                 )
@@ -175,6 +176,7 @@ async def _run_job(req: dict) -> dict:
             if run_io is None:
                 run_io = refs[0] if refs else None
             reference_run_us = ref_times[0] if ref_times else None
+            stats_sym_env = sym_envs[0] if sym_envs else None
         elif kind == "trace_args":
             import types
 
@@ -243,6 +245,7 @@ async def _run_job(req: dict) -> dict:
             "run_io": run_io,
             "greedy_error": greedy_error,
             "reference_run_us": reference_run_us,
+            "sym_env": stats_sym_env,
             "_retire_worker": retire_worker,
             "correctness": correctness,
         }

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -1924,6 +1924,7 @@ async def benchmark_compare_worker_async(
         "run_io": resp.get("run_io"),
         "greedy_error": resp.get("greedy_error"),
         "reference_run_us": resp.get("reference_run_us"),
+        "sym_env": resp.get("sym_env"),
         "correctness": resp.get("correctness"),
     }
 

--- a/tests/compiler/backend/test_bench_worker_compare.py
+++ b/tests/compiler/backend/test_bench_worker_compare.py
@@ -571,6 +571,40 @@ def test_embedded_reference_survives_later_greedy_timing_failure(monkeypatch) ->
     assert response["result"] is None and response["results"] is None
 
 
+def test_frontend_graph_worker_returns_execution_symbolic_environment(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from emmy.commands import run as run_mod
+    from emmy.compiler.backend.cuda import _bench_worker
+    from emmy.compiler.backend.cuda import backend as backend_mod
+
+    class _FakeBackend:
+        def __init__(self, **_kwargs):
+            pass
+
+    async def _fake_compare(*_args, sym_env_out, **_kwargs):
+        sym_env_out.append({"num_tokens": 32})
+        return {"Emmy": 1.0}, SimpleNamespace(captured=True), False, True, None
+
+    monkeypatch.setattr(backend_mod, "CudaBackend", _FakeBackend)
+    monkeypatch.setattr(run_mod, "bench_lowered_vs_torch", _fake_compare)
+
+    response = asyncio.run(
+        _bench_worker._run_job(
+            {
+                "graph": "LOWERED",
+                "torch_spec": ("frontend_graph", "FRONTEND"),
+                "bench_backends": "emmy",
+                "warmup": 1,
+                "iters": 1,
+                "seed": 0,
+            }
+        )
+    )
+
+    assert response["sym_env"] == {"num_tokens": 32}
+
+
 @requires_cuda
 def test_worker_hang_is_sigkilled_not_wedged() -> None:
     import asyncio

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -1416,6 +1416,34 @@ def test_print_kernel_stats_greedy_bench_fail_row(capsys):
     assert "k_greedy" in outp and "ab TILE=w4x2/f2x4" in outp
 
 
+def test_print_kernel_stats_uses_execution_symbolic_environment(capsys):
+    from types import SimpleNamespace
+
+    from emmy.commands.run import _print_kernel_stats
+    from emmy.compiler.graph import Graph, Tensor
+    from emmy.compiler.ir.cuda.ir import CudaOp
+    from emmy.compiler.ir.expr import Var
+
+    graph = Graph()
+    graph.add_node(
+        op=CudaOp(kernel_name="k_dynamic", grid=((Var("num_tokens"),), (1,), (1,))),
+        inputs=[],
+        output=Tensor("out", (1,)),
+        node_id="out",
+    )
+    graph.outputs = ["out"]
+    bench = SimpleNamespace(
+        min_ms=0.5,
+        time_ms=0.5,
+        per_launch=[SimpleNamespace(idx=0, samples=[0.5], time_ms=0.5)],
+        e2e_min_ms=None,
+    )
+
+    _print_kernel_stats(graph, bench, sym_env={"num_tokens": 32})
+
+    assert "k_dynamic" in capsys.readouterr().out
+
+
 def _iso_bench_fixtures():
     """One-kernel greedy graph + interleaved bench (500 µs) + isolated re-bench (400 µs)
     ``_GoldenBench`` — the ``greedy_iso`` display/json inputs."""


### PR DESCRIPTION
## Summary

- return the frontend comparison's concrete symbolic environment through the isolated benchmark worker
- use that same binding when resolving dynamic launch geometry for per-kernel statistics
- retain input-hint reconstruction as the fallback when no execution environment is available
- cover both worker transport and dynamic grid rendering

## Exact failure provenance

The exact Laguna S-2.1 V100 source-classification matrix used clean commit
`552908fd8bd5bcb35eff3d198029fe5978bf76ef` (compiler tree byte-identical to the f326 trace).
Six of 112 source attempts completed execution but ended before JSON when `_print_kernel_stats` rebuilt its
symbolic environment only from lowered graph inputs and then failed to resolve `num_tokens`. The affected immutable
logs are under
`/home/riftuser/.cache/emmy/onb-laguna-agentic.hj9sGn/artifacts/main-f3268e59/classify/cold-v2-20260824T025816Z`
on the 8xV100 host: gpu1-3 and gpu5-7 row 010 (programs 20/21 bindings).

This draft contains the generic transport fix only. Exact affected-row V100 reruns are still required before marking
it ready.

## Verification

- focused CLI/worker suite: 65 passed, 42 skipped
- full suite: 3149 passed, 561 skipped, 1 xfailed
- `ruff check .` and `ruff format --check .`: passed
- `git diff --check`: passed