### PR TITLE
Round-trip composite dimensions in Graph JSON

### DIFF
--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -110,6 +110,8 @@ autotuning cache doesn't bust on cosmetic edits.
   size (default `DEFAULT_SEQ_HINT=512`, set automatically so reconstruction can't lose it; an explicit
   `Dim(name, hint=...)` overrides). The hint is pure metadata (excluded from `==`/`hash`/structural keys),
   read only by the tuner / partition planner to size tiles for a dynamic axis.
+  Graph JSON op fields use the same stable dimension wire mapping as Torch IR, so static, symbolic, and composite
+  `Dim` values round-trip instead of depending on the scalar-only `Dim.value` compatibility property.
 - **A symbolic free axis is tiled for its hint and emitted as a *masked* tile.** A symbolic M/N axis is treated as
   size `hint`, always-overhang: the block axis becomes a composite ceil-div over the symbolic extent
   (`(seq_len + bf - 1)//bf`), and a boundary `Cond(decoded_coord < seq_len)` wraps the body, so one cached kernel runs

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -165,6 +165,8 @@ def _serialize_field(v):
     Special cases:
 
     - ``ir.elementwise.ElementwiseImpl`` → its ``name`` string.
+    - ``Dim`` → the stable Torch-wire dimension mapping, tagged so atomic and
+      composite expressions round-trip through op fields.
     - ``ir.stmt.Body`` → the underlying ``stmts`` tuple. Body is an
       in-memory wrapper; on disk we keep the tuple-of-stmts form so
       ``_deserialize_field``'s list-of-Stmt-reprs path keeps working
@@ -198,7 +200,9 @@ def _serialize_field(v):
     if isinstance(v, ElementwiseImpl):
         return v.name
     if isinstance(v, Dim):
-        return v.value
+        from emmy.compiler.torch_wire import dim_to_wire
+
+        return {"__dim__": dim_to_wire(v)}
     if isinstance(v, Body):
         # Body is a ``tuple`` subclass; downcast to plain tuple so
         # JSON encodes element-by-element rather than via ``__repr__``
@@ -225,6 +229,11 @@ def _deserialize_field(k, v):
     the IR's ``__all__`` exports — same classes the Stmt reprs reference."""
     from emmy.compiler.ir.elementwise import ElementwiseImpl
 
+    if isinstance(v, dict) and set(v) == {"__dim__"}:
+        from emmy.compiler.torch_wire import dim_from_wire
+
+        return dim_from_wire(v["__dim__"])
+
     if k == "op" and isinstance(v, str):
         # A bare name (``"add"``) is an ``ElementwiseImpl``; a constructor repr
         # (``"Fold(...)"`` — the ``TileOp.op`` node tree) is eval'd back like a Stmt repr.
@@ -249,6 +258,8 @@ def _deserialize_field(k, v):
         fields = {fk: _deserialize_field(fk, fv) for fk, fv in v.get("fields", {}).items()}
         return op_cls(**fields) if fields else op_cls()
     if isinstance(v, list) and v and all(isinstance(e, dict) and "__op__" in e for e in v):
+        return tuple(_deserialize_field(k, e) for e in v)
+    if isinstance(v, list) and v and any(isinstance(e, dict) and "__dim__" in e for e in v):
         return tuple(_deserialize_field(k, e) for e in v)
     if isinstance(v, list):
         # Constructor-repr string *elements* rehydrate under the same known-class guard —

--- a/tests/compiler/ir/test_graph.py
+++ b/tests/compiler/ir/test_graph.py
@@ -4,7 +4,7 @@ import pytest
 
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
-from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp, ReduceOp
 
 # ---- helpers ----
 
@@ -248,6 +248,25 @@ def test_to_dict_serializes_composite_shape_dim():
     assert isinstance(shape[1], str) and "seq_len" in shape[1] and "64" in shape[1], (
         f"composite dim must serialize to its pretty expr string, got {shape[1]!r}"
     )
+
+
+def test_to_dict_roundtrips_composite_op_field_dim():
+    from emmy.compiler.dim import Dim
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (48,)), node_id="x")
+    groups = Dim(48) // Dim("num_tokens")
+    g.add_node(
+        op=IndexMapOp(out_shape=(groups,), sources=()),
+        inputs=["x"],
+        output=Tensor("y", (groups,)),
+        node_id="y",
+    )
+    g.inputs, g.outputs = ["x"], ["y"]
+
+    restored = Graph.from_dict(g.to_dict())
+
+    assert restored.nodes["y"].op.out_shape == (groups,)
 
 
 # ---- multi-output (MIMO) foundation ----


### PR DESCRIPTION
## Summary

- encode `Dim` op fields with the existing stable Torch-wire dimension mapping
- restore tagged dimensions recursively inside tuple-valued op fields
- cover a composite `IndexMapOp.out_shape` round trip and document the Graph JSON contract

## Exact failure provenance

The exact Laguna S-2.1 V100 source-classification matrix used clean commit
`552908fd8bd5bcb35eff3d198029fe5978bf76ef` (compiler tree byte-identical to the f326 trace).
Nine of 112 source attempts ended before JSON because `Graph.to_dict` called scalar-only `Dim.value` on
composite op fields such as `(48|72|1536|2304|49152|73728)//num_tokens`. The affected immutable logs are under
`/home/riftuser/.cache/emmy/onb-laguna-agentic.hj9sGn/artifacts/main-f3268e59/classify/cold-v2-20260824T025816Z`
on the 8xV100 host: gpu1-3 rows 004/005 and gpu5-7 row 004.

This draft contains the generic serialization fix only. Exact affected-row V100 reruns are still required before
marking it ready.

## Verification

- `tests/compiler/ir/test_graph.py`: 28 passed
- full suite: 3148 passed, 561 skipped, 1 xfailed
- `ruff check .` and `ruff format --check .`: passed
- `git diff --check`: passed