### PR TITLE
Return every Torch reference output

### DIFF
--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -36,7 +36,9 @@ FP8 tensors remain exact `uint8` bit carriers; `to_f8*` casts to torch float8 an
 `from_f8*` performs the inverse reinterpretation before widening. `is_runnable(graph)` is `True` only when every
 compute op and every elementwise operation name has a mapping. Data-dependent `GatherOp` / `ScatterOp` remain
 unsupported, so `run --ir` falls back to emmy-only benchmarking for those graphs. `build_callable(graph,
-input_tensors)` returns a pure `fn(*tensors)` (scalar constants read inline) so `torch.compile` can trace it. Symbolic
+input_tensors)` returns a pure `fn(*tensors)` (scalar constants read inline) so `torch.compile` can trace it. A
+single-output graph returns its tensor directly; a multi-output graph returns an ordered tuple following
+`graph.outputs`, matching the backend result boundary. Symbolic
 graphs work too: `build_callable` binds every symbolic axis name to its concrete extent read off the supplied tensors
 (the CUDA launch convention) and bakes the env into the per-node callables — shape-resolving sites (`ReshapeOp` target
 shape, `IndexMapOp` out-shape and coord/select exprs) eval through it, so a dynamic frontend provenance slice

--- a/emmy/compiler/backend/torch_ref.py
+++ b/emmy/compiler/backend/torch_ref.py
@@ -381,8 +381,9 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
     """Build a torch callable for ``graph`` plus its positional input list.
 
     The returned ``fn(*tensors)`` runs the frontend ops in topological order and
-    returns the graph's first output; the input list is the ``tensors`` to call
-    it with (drawn from ``input_tensors`` in boundary topo order). Scalar
+    returns a tensor for a single-output graph or a tuple following
+    ``graph.outputs`` order for a multi-output graph; the input list is the
+    ``tensors`` to call it with (drawn from ``input_tensors`` in boundary topo order). Scalar
     constants are read inline from the graph (so ``fn`` is a pure function of
     its tensor inputs and ``torch.compile`` can trace it).
 
@@ -430,7 +431,7 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
         else:
             op_callable = (lambda n: lambda ins: _eval(n, ins, sym_env))(node)
         compute_steps.append((nid, op_callable, list(node.inputs), torch_dtype(node.output.dtype)))
-    out_id = graph.outputs[0]
+    out_ids = tuple(graph.outputs)
 
     def fn(*tensors):
         env = dict(scalars)
@@ -438,6 +439,8 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
         for nid, op_callable, in_ids, out_dtype in compute_steps:
             v = op_callable([env[i] for i in in_ids])
             env[nid] = v if out_dtype is None else v.to(out_dtype)
-        return env[out_id]
+        if len(out_ids) == 1:
+            return env[out_ids[0]]
+        return tuple(env[out_id] for out_id in out_ids)
 
     return fn, [input_tensors[i] for i in tensor_ids]

--- a/tests/compiler/backend/test_torch_ref.py
+++ b/tests/compiler/backend/test_torch_ref.py
@@ -56,6 +56,35 @@ def test_linear_and_elementwise():
     _assert_matches_numpy(g, {"x": r.standard_normal((4, 8)), "w": r.standard_normal((16, 8))})
 
 
+def test_multi_output_preserves_declared_order_and_single_output_tensor_contract():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (2, 3)), node_id="x")
+    g.add_node(ElementwiseOp(op="multiply"), ["x", "x"], Tensor("intermediate", (2, 3)), node_id="intermediate")
+    g.add_node(ElementwiseOp(op="silu"), ["intermediate"], Tensor("hidden", (2, 3)), node_id="hidden")
+    g.add_node(ElementwiseOp(op="add"), ["hidden", "x"], Tensor("final", (2, 3)), node_id="final")
+    g.inputs = ["x"]
+    # A working golden may expose a live intermediate after the semantic final
+    # output so exact target replay can validate both buffers.
+    g.outputs = ["final", "intermediate"]
+    x = np.arange(6, dtype=np.float32).reshape(2, 3) - 2
+    expected = NumpyBackend().run(g, input_data={"x": x})[0].outputs
+    fn, inputs = torch_ref.build_callable(g, {"x": torch.from_numpy(x)})
+
+    actual = fn(*inputs)
+
+    assert isinstance(actual, tuple)
+    assert len(actual) == 2
+    for value, output_name in zip(actual, g.outputs, strict=True):
+        np.testing.assert_allclose(value.numpy(), expected[output_name], rtol=1e-4, atol=1e-4)
+
+    g.outputs = ["final"]
+    single_fn, single_inputs = torch_ref.build_callable(g, {"x": torch.from_numpy(x)})
+    single = single_fn(*single_inputs)
+
+    assert torch.is_tensor(single)
+    np.testing.assert_allclose(single.numpy(), expected["final"], rtol=1e-4, atol=1e-4)
+
+
 @pytest.mark.parametrize(("dtype_name", "torch_dtype"), [("f16", torch.float16), ("f32", torch.float32)])
 def test_zero_width_pad_is_runnable_identity(dtype_name, torch_dtype):
     g = Graph()


### PR DESCRIPTION
## Summary
- return graph outputs in declared order from the Torch reference evaluator
- preserve the existing tensor return for single-output graphs
- cover a semantic final plus live intermediate output

## Motivation
Laguna exact-source qualification found 52 output-count mismatches: CUDA returned every declared Graph output while the Torch reference returned only the first.

## Verification
- make test: 3129 passed, 575 skipped, 1 xfailed
- make lint: green
- exact affected V100 replay pending before ready/merge