### PR TITLE
Preserve semantic coordinates in register epilogues

### DIFF
--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1805,8 +1805,9 @@ class RegEpilogue:
     # Coord-predicated Selects (the causal attention mask), rendered before the
     # ``ops`` chain as per-element ternaries. Each is ``(name, branches)`` where
     # ``branches`` is ``((cond_expr | None, value_name), ...)`` — the predicate
-    # carries ``__M__`` / ``__N__`` placeholder Vars the store substitutes with
-    # the fragment element's own (row, col); the last branch is the else.
+    # carries its σ-applied cell bases plus ``__M__`` / ``__N__`` placeholder
+    # Vars the store substitutes with the fragment element's row/col offsets;
+    # the last branch is the else.
     selects: tuple[tuple[str, tuple[tuple[Expr | None, str], ...]], ...] = ()
     # Additional ``(acc_name, frag_name)`` accumulator bindings — a multi-fold contraction's
     # extra C fragments (the fused gate/up edge): each name substitutes to its fragment's
@@ -1973,20 +1974,12 @@ class RegStore(Stmt):
         coords = self._element_coords()
         if self.epilogue is None:
             return [[] for _ in coords], [f"{self.frag}[{i}]" for i in range(len(coords))]
-        from emmy.compiler.ir.expr import BinaryExpr, Var  # noqa: PLC0415
+        from emmy.compiler.ir.expr import Var  # noqa: PLC0415
         from emmy.compiler.ir.stmt import render_index  # noqa: PLC0415
         from emmy.compiler.ir.stmt.base import op_to_expr  # noqa: PLC0415
 
         epi = self.epilogue
         conv = {"f16": "__half2float({})", "bf16": "__bfloat162float({})"}
-        # Coord-predicated Selects (causal mask) need the cell-base M / N coords
-        # (the last two var-bearing output dims) — the element adds its own
-        # (row, col) to get the absolute coordinate the predicate compares.
-        sel_m_base = sel_n_base = None
-        if epi.selects:
-            dvd = [e for e in self.dst_index if e.free_vars()]
-            sel_m_base = dvd[-2] if len(dvd) >= 2 else None
-            sel_n_base = dvd[-1] if dvd else None
         per_elem: list[list[str]] = []
         vals: list[str] = []
         for i, (row, col, row_off, col_off) in enumerate(coords):
@@ -2011,11 +2004,9 @@ class RegStore(Stmt):
                 lines.append(f"const float {temp} = {conv.get(dt, '{}').format(f'{ld.buffer}[{addr}]')};")
                 env[ld.name] = temp
             # Coord-predicated Selects (the causal mask): a per-element ternary.
-            # ``__M__`` / ``__N__`` substitute to this element's absolute (row,
-            # col); branches fold right with the last branch as the else.
-            m_abs = BinaryExpr("+", sel_m_base, row_off) if sel_m_base is not None else row_off
-            n_abs = BinaryExpr("+", sel_n_base, col_off) if sel_n_base is not None else col_off
-            coord = {"__M__": m_abs, "__N__": n_abs}
+            # ``__M__`` / ``__N__`` substitute to this element's row/col offset;
+            # the captured predicate already carries its semantic cell base.
+            coord = {"__M__": row_off, "__N__": col_off}
             for sel_name, branches in epi.selects:
                 expr = env[branches[-1][1]]
                 for cond, value in reversed(branches[:-1]):
@@ -2631,10 +2622,15 @@ def _(s: RegStore, rename, sigma, axis_fn):
             ),
             ops=epilogue.ops,
             result=epilogue.result,
-            # Select predicates carry ``__M__`` / ``__N__`` placeholders (not
-            # real partition vars), so they're cell-invariant — pass through; the
-            # per-cell M/N offset reaches them via ``dst_index`` at render.
-            selects=epilogue.selects,
+            # Captured predicates carry semantic cell-base expressions plus
+            # placeholders, so replicate the real coordinate vars like load indices.
+            selects=tuple(
+                (
+                    name,
+                    tuple((None if cond is None else sigma.apply(cond), value) for cond, value in branches),
+                )
+                for name, branches in epilogue.selects
+            ),
             # The extra channel accumulators rename with the store's own fragment (they are
             # per-cell C-fragment names too) — dropping them here left the multi-channel combine
             # (the gemma GeGLU ``acc2``) unbound at render.

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -222,6 +222,12 @@ the `ldmatrix` drain undoes (`RegStore.swizzle`, stamped through the fill's `Wri
 bank conflicts than the operands beside it. The nested score's own staged operands (its per-chunk keys, its
 loop-invariant query tile) carry their mode on the cp.async fill the same way.
 
+A `RegEpilogue` predicate carries the semantic cell origin captured from the producer's substitution plus
+per-fragment row/column placeholders. The destination index remains only an address: a chained fill may rebase that
+index to a tile-local slab, but it must not rebase a causal or other coordinate predicate. Later cell replication
+substitutes the predicate's real coordinate variables and the store fills only its element offsets. Inferring the
+predicate origin from `RegStore.dst_index` would make every nonzero chunk compare slab-local coordinates instead.
+
 The chained fill takes one of two forms, and the first is preferred wherever it reads:
 
 - **SINGLE-PASS** (`_atom.chain_stream_fill`) — the statistic and the weight come off ONE pass of the score. The two

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -183,11 +183,15 @@ def _warp_epilogue(
     an optional causal ``Select``. Each leaf ``Load`` becomes an :class:`EpilogueLoad` at the
     cell-base coordinate (σ-applied; the render adds the per-element row/col motion on the
     ``m``/``n`` dims); each ``Assign`` becomes an ``(name, op, args)`` op; a coord-predicated
-    ``Select`` (causal mask) rewrites its ``m``/``n`` coordinate vars to the ``__M__`` / ``__N__``
-    placeholders the store substitutes with the element's own (row, col)."""
+    ``Select`` (causal mask) captures its σ-applied cell bases plus ``__M__`` / ``__N__``
+    placeholders; the store substitutes only the element's row/col offsets. This keeps semantic
+    source coordinates independent of a later store to a tile-local shared-memory slab."""
     loads, ops, selects = [], [], []
     write = None
-    ph = {m_name: Var("__M__"), n_name: Var("__N__")}
+    ph = {
+        m_name: BinaryExpr("+", sigma.apply(Var(m_name)), Var("__M__")),
+        n_name: BinaryExpr("+", sigma.apply(Var(n_name)), Var("__N__")),
+    }
     for s in tail:
         if isinstance(s, Load):
             loads.append(

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -383,6 +383,36 @@ def test_fused_sdpa_split_partition_keeps_the_two_pass_pair(monkeypatch):
 
 
 @requires_cuda
+def test_fused_causal_sdpa_split_partition_keeps_absolute_predicate_coordinates(monkeypatch):
+    """A causal predicate in the two-pass computed fill keeps the absolute query/key coordinates.
+
+    Two cross-CTA partitions and two chunks per partition make both offsets nonzero. The fragment epilogue writes
+    weights to a tile-local shared-memory slab, but its predicate still compares the source program's absolute
+    coordinates; deriving them from that local write index admits future keys in every chunk after the first.
+    """
+    monkeypatch.setenv("EMMY_PLACE", "fuse")
+    monkeypatch.setenv("EMMY_REDUCE", "g2a")
+    monkeypatch.setenv("EMMY_WORK", "w2x2")
+    monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f2x2/k2")
+    torch.manual_seed(0)
+    B, H, S, D = 1, 2, 128, 32
+    q, k, v = (torch.randn(B, H, S, D, dtype=torch.float16) for _ in range(3))
+    feed = {"q": q.numpy(), "k": k.numpy(), "v": v.numpy()}
+    cuda = {name: torch.from_numpy(array).cuda() for name, array in feed.items()}
+
+    def ref():
+        with torch.no_grad():
+            return F.scaled_dot_product_attention(cuda["q"], cuda["k"], cuda["v"], is_causal=True).cpu().flatten().float().numpy()
+
+    backend, compiled, _graph, kernels = _trace(_Causal(), (q, k, v))
+    src = "".join(compiled.nodes[nid].op.kernel_source for nid in kernels)
+    assert "_a_stat_" in src, "the split partition must use the two-pass computed fill"
+    assert "_ks - _ks" not in src, "the causal predicate lost the absolute key-chunk base"
+    md = _max_diff(backend, compiled, feed, ref)
+    assert md < 4e-3, f"split-K causal fused sdpa vs torch max_diff={md:.6e}"
+
+
+@requires_cuda
 @pytest.mark.parametrize("variant", ["plain", "gqa", "mask"])
 def test_scalar_flash_dynamic_matches_torch(monkeypatch, variant):
     """Symbolic ``seq_len`` (Q/K/V dim -2): ONE cached kernel carrying ``int seq_len`` serves every

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -157,6 +157,7 @@
  "tests/compiler/e2e/test_attention_coverage.py::test_flash_form_fork_offers_geometry_grid": 0.16,
  "tests/compiler/e2e/test_attention_coverage.py::test_full_self_attn_tinyllama@cuda": 6.0,
  "tests/compiler/e2e/test_attention_coverage.py::test_full_self_attn_tinyllama_seq512@cuda": 5.8,
+ "tests/compiler/e2e/test_attention_coverage.py::test_fused_causal_sdpa_split_partition_keeps_absolute_predicate_coordinates": 10.8,
  "tests/compiler/e2e/test_block.py::test_qwen_block_accuracy@cuda": 9.1,
  "tests/compiler/e2e/test_block.py::test_tinyllama_block_accuracy[cpu]": 4.96,
  "tests/compiler/e2e/test_block.py::test_tinyllama_block_accuracy[cuda]@cuda": 7.3,


### PR DESCRIPTION
## Summary

- capture a register epilogue predicate's semantic cell origin when lowering the producer
- use the fragment row/column only as element offsets when the epilogue writes a tile-local slab
- substitute captured predicate coordinates during later cell replication
- cover a causal two-pass computed fill with nonzero split partitions and chunks

## Cause

The chained attention fill rebases its fragment store index to a tile-local shared-memory slab. `RegStore` previously
derived a predicate's cell origin from that destination index, so a causal predicate in every nonzero key chunk
compared slab-local coordinates instead of the source program's absolute query/key coordinates.

## Verification

- exact RTX 4090 base `758fc740d61dc073f0d1e99ae968df943878a70c`: the new regression failed before the fix because
  the rendered causal predicate contained `_ks - _ks`
- exact RTX 4090 patched tree: the regression passed strict eager comparison and the source assertion in 4.14 seconds
- exact RTX 4090 rebased commit `9a4b2c58e23194a4d805ee5b725a501ff4f36fa6` replay of frozen full-model target
  `k_sdpa_reduce_fd92e2.e496506297b2`: 0 / 3,145,728 strict mismatches, maximum absolute error 0.001953125
- the replay used the original frozen input SHA-256 `f8c0f7ffa4e835d77eddaad9fdbad4b82e342595e1747f0a60e3c23dca19947b`
  and eager-output SHA-256 `f732a01f8181e18b2edd9719af8bea0468cbd1cce358df3f4624ccf4b6df1ac6`
- corrected kernel source SHA-256 `5078e8ad10461017014cd34833ef7eb5041161f238ee9665751dddb0c1ad312d`
- `make test`: 3154 passed, 562 skipped, 1 xfailed
- `make lint`

## Follow-up

The corrected greedy row is still a performance blocker: 21,141.5 µs versus 79.872 µs for eager PyTorch on the same
RTX 4090. This PR restores strict correctness without changing that schedule; tuning remains separate work.
