### PR TITLE
Bind named frontend shape fields during specialization

### DIFF
--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -112,6 +112,8 @@ autotuning cache doesn't bust on cosmetic edits.
   read only by the tuner / partition planner to size tiles for a dynamic axis.
   Graph JSON op fields use the same stable dimension wire mapping as Torch IR, so static, symbolic, and composite
   `Dim` values round-trip instead of depending on the scalar-only `Dim.value` compatibility property.
+  Program specialization also binds the named string extents admitted by the `ReshapeOp.shape` and `SliceOp.shape`
+  frontend contracts; unrelated string-valued operation fields are never interpreted as dimensions.
 - **A symbolic free axis is tiled for its hint and emitted as a *masked* tile.** A symbolic M/N axis is treated as
   size `hint`, always-overhang: the block axis becomes a composite ceil-div over the symbolic extent
   (`(seq_len + bf - 1)//bf`), and a boundary `Cond(decoded_coord < seq_len)` wraps the body, so one cached kernel runs

--- a/emmy/compiler/specialize.py
+++ b/emmy/compiler/specialize.py
@@ -9,6 +9,7 @@ from emmy.compiler.loop_wire import loop_graph_from_wire, loop_graph_to_wire
 from emmy.compiler.torch_wire import expr_from_wire, expr_to_wire, graph_from_wire, graph_to_wire
 
 _EXPR_TAGS = {"var", "literal", "binary", "builtin", "call", "ternary", "cast"}
+_NAMED_SHAPE_OPS = {"torch.reshape", "torch.slice"}
 
 
 def _specialize_expr(value: Mapping, bindings: Mapping[str, int]) -> dict:
@@ -37,6 +38,16 @@ def _specialize_dim(value, bindings: Mapping[str, int]):
     return {key: _specialize_wire(item, bindings) for key, item in value.items()}
 
 
+def _specialize_named_shape(value, bindings: Mapping[str, int]):
+    if isinstance(value, str):
+        return bindings.get(value, value)
+    if isinstance(value, list):
+        return [_specialize_named_shape(item, bindings) for item in value]
+    if isinstance(value, Mapping) and set(value) == {"__tuple__"}:
+        return {"__tuple__": _specialize_named_shape(value["__tuple__"], bindings)}
+    return value
+
+
 def _specialize_wire(value, bindings: Mapping[str, int]):
     if isinstance(value, list):
         return [_specialize_wire(item, bindings) for item in value]
@@ -57,7 +68,13 @@ def _specialize_wire(value, bindings: Mapping[str, int]):
     if keys in ({"__expr__"}, {"expr"}):
         key = next(iter(keys))
         return {key: _specialize_expr(value[key], bindings)}
-    return {key: _specialize_wire(item, bindings) for key, item in value.items()}
+    specialized = {key: _specialize_wire(item, bindings) for key, item in value.items()}
+    attrs = specialized.get("attrs")
+    tag = specialized.get("op")
+    if isinstance(tag, str) and tag in _NAMED_SHAPE_OPS and isinstance(attrs, Mapping) and "shape" in attrs:
+        specialized["attrs"] = dict(attrs)
+        specialized["attrs"]["shape"] = _specialize_named_shape(attrs["shape"], bindings)
+    return specialized
 
 
 def specialize_program(graph, bindings: Mapping[str, int], *, loop: bool = False):

--- a/tests/compiler/test_specialize.py
+++ b/tests/compiler/test_specialize.py
@@ -1,7 +1,7 @@
 from emmy.compiler.dim import Dim
 from emmy.compiler.graph import Graph, Tensor
-from emmy.compiler.ir.base import InputOp
-from emmy.compiler.ir.frontend.ir import ReshapeOp
+from emmy.compiler.ir.base import ConstantOp, InputOp
+from emmy.compiler.ir.frontend.ir import ReshapeOp, SliceOp
 from emmy.compiler.specialize import specialize_program
 
 
@@ -18,6 +18,35 @@ def test_specialize_program_binds_tensor_and_semantic_dimensions():
     assert specialized.nodes["y"].op.shape == (32, 4)
     assert specialized.nodes["y"].outputs[0].shape == (32, 4)
     assert graph.nodes["x"].outputs[0].shape == (Dim("num_tokens"), 8)
+
+
+def test_specialize_program_binds_named_frontend_shape_fields_only():
+    rows = Dim("num_tokens", hint=32)
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (rows, 4)), node_id="x")
+    graph.add_node(ReshapeOp(shape=("num_tokens", 4)), ["x"], Tensor("y", (rows, 4)), node_id="y")
+    graph.add_node(
+        SliceOp(shape=("num_tokens", 2), dim=1, start=0),
+        ["y"],
+        Tensor("z", (rows, 2)),
+        node_id="z",
+    )
+    graph.add_node(
+        ConstantOp(name="num_tokens", value=1),
+        [],
+        Tensor("unrelated", (1,), "f32"),
+        node_id="unrelated",
+    )
+    graph.inputs, graph.outputs = ["x"], ["z"]
+
+    specialized = specialize_program(graph, {"num_tokens": 16})
+    missing = specialize_program(graph, {"other": 8})
+
+    assert specialized.nodes["y"].op.shape == (16, 4)
+    assert specialized.nodes["z"].op.shape == (16, 2)
+    assert specialized.nodes["unrelated"].op.name == "num_tokens"
+    assert missing.nodes["y"].op.shape == ("num_tokens", 4)
+    assert missing.nodes["z"].op.shape == ("num_tokens", 2)
 
 
 def test_specialize_program_rejects_invalid_binding_values():


### PR DESCRIPTION
## Summary

- bind named string extents in the established ReshapeOp.shape and SliceOp.shape contracts
- preserve missing names and unrelated string-valued operation fields
- document the specialization boundary and add focused regressions

## Evidence

- focused: 3 passed
- full: 3155 passed, 562 skipped, 1 xfailed
- make lint: green
- exact Laguna diagnostic inventory: all 288 records with num_tokens bindings specialize without remaining named reshape or slice extents

The exact six V100 source-row replay is pending on this PR head. This PR does not claim the remaining Laguna correctness or performance gaps are resolved.