### PR TITLE
Preserve declared CUDA output order

### DIFF
--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -123,6 +123,8 @@ grammar (`int` literal, `"name"` var, `[op, lhs, rhs]`), deliberately not the co
 on-disk format survives compiler changes; only runtime-contract changes bump `PLAN_FORMAT_VERSION`.
 CUDA-specific launch fields (TMA descriptors) nest under a `"cuda"` key so another backend can add its own
 namespace and its own `build_from_plan` equivalent.
+The declared output list is also the runtime return order; allocation planning may reorder buffers, but cannot reorder
+observable program results.
 
 `plan_cache.py` is the process-local reuse seam for repeated compiled structure within one immutable compile session.
 It keys the exact graph wire form after loader spelling and ABI hints, erasing only external tensor addresses while

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -80,7 +80,8 @@ codegen, no nvcc), and both paths share every line downstream. The projection:
    numeric inputs are round-to-nearest-even encoded before upload, while an already-`uint16` source is preserved.
 2. Launch each kernel in topological order; `zero_outputs` fills run
    before the launch.
-3. Copy `graph.outputs` buffers back to numpy. BF16 outputs remain raw `uint16` bits at this backend boundary;
+3. Copy `graph.outputs` buffers back to numpy in their declared order, independently of buffer allocation order. BF16
+   outputs remain raw `uint16` bits at this backend boundary;
    command-layer correctness checks decode them.
 
 **Scratch-buffer reuse (`_planner.py`).** Step 1 does *not* give every node its

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -86,6 +86,7 @@ class _Compiled:
     constants: dict[str, float]
     kernels: dict[str, cp.RawKernel]  # kernel_name → RawKernel
     launches: list[_Launch]
+    outputs: list[str]
     # Symbolic axis name → (input_buf_name, dim_index). Resolved from input
     # array shapes at run-time; empty when the graph has no symbolic dims.
     symbolic_bindings: dict[str, tuple[str, int]] = field(default_factory=dict)
@@ -142,6 +143,7 @@ def _load_plan(plan: ExecutionPlan) -> _Compiled:
         constants=dict(plan.constants),
         kernels=kernels,
         launches=list(plan.launches),
+        outputs=list(plan.outputs),
         symbolic_bindings=dict(plan.symbolic_bindings),
         symbolic_hints=dict(plan.symbolic_hints),
         symbolic_caps=dict(plan.symbolic_caps),
@@ -1198,16 +1200,15 @@ class CompiledProgram:
         default) the whole buffer is returned (the uncaptured rebind path already
         sizes buffers to the request)."""
         out: dict[str, np.ndarray] = {}
-        for b in self.compiled.bufs:
-            if b.role != "output":
-                continue
-            arr = self.arrays[b.name]
+        for name in self.compiled.outputs:
+            b = self.compiled.buf_by_name[name]
+            arr = self.arrays[name]
             if sym_values is not None:
                 shape = b.resolve_shape({**self.sym_values, **sym_values})
                 n = math.prod(shape) if shape else 1
-                out[b.name] = arr.ravel()[:n].get().reshape(shape)
+                out[name] = arr.ravel()[:n].get().reshape(shape)
             else:
-                out[b.name] = arr.get()
+                out[name] = arr.get()
         return out
 
     def output_prefix_device(self, sym_values: dict[str, int] | None = None) -> dict[str, cp.ndarray]:
@@ -1220,16 +1221,15 @@ class CompiledProgram:
         is returned. Caller must hold ``gpu_lock()`` (and read on the replay
         stream — see :meth:`upload_prefix_device`)."""
         out: dict[str, cp.ndarray] = {}
-        for b in self.compiled.bufs:
-            if b.role != "output":
-                continue
-            arr = self.arrays[b.name]
+        for name in self.compiled.outputs:
+            b = self.compiled.buf_by_name[name]
+            arr = self.arrays[name]
             if sym_values is not None:
                 shape = b.resolve_shape({**self.sym_values, **sym_values})
                 n = math.prod(shape) if shape else 1
-                out[b.name] = arr.ravel()[:n].reshape(shape)
+                out[name] = arr.ravel()[:n].reshape(shape)
             else:
-                out[b.name] = arr
+                out[name] = arr
         return out
 
     def snapshot(self) -> dict[str, np.ndarray]:

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -4,14 +4,18 @@ import numpy as np
 import pytest
 
 from emmy.compiler.backend.cuda.program import (
+    CompiledProgram,
     _collapse_inert_dims,
     _Compiled,
+    _load_plan,
     _numpy_storage,
     _resolve_symbolic,
     benchmark_program,
     run_program,
 )
-from emmy.compiler.dtype import BF16, decode_bf16
+from emmy.compiler.backend.plan import BufferSpec, ExecutionPlan
+from emmy.compiler.dim import Dim
+from emmy.compiler.dtype import BF16, F32, decode_bf16
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda import CudaOp
@@ -21,7 +25,7 @@ from tests.compiler.helpers import requires_cuda
 def _minimal_compiled(**kw) -> _Compiled:
     """A ``_Compiled`` with no kernels — enough to exercise ``_resolve_symbolic``
     (which only reads the symbolic_* maps). No CUDA needed."""
-    return _Compiled(bufs=[], buf_by_name={}, constants={}, kernels={}, launches=[], **kw)
+    return _Compiled(bufs=[], buf_by_name={}, constants={}, kernels={}, launches=[], outputs=[], **kw)
 
 
 def test_bf16_host_values_materialize_as_bits():
@@ -31,6 +35,54 @@ def test_bf16_host_values_materialize_as_bits():
     assert storage.dtype == np.uint16
     np.testing.assert_array_equal(decode_bf16(storage), np.array([1.0, -2.0, 3.140625], dtype=np.float32))
     np.testing.assert_array_equal(_numpy_storage(storage, BF16), storage)
+
+
+def test_compiled_program_outputs_follow_declared_order_not_allocation_order():
+    class HostArray:
+        def __init__(self, value):
+            self.value = np.atleast_1d(np.asarray(value, dtype=np.float32))
+
+        def get(self):
+            return self.value.copy()
+
+        def ravel(self):
+            return HostArray(self.value.ravel())
+
+        def __getitem__(self, item):
+            return HostArray(self.value[item])
+
+        def reshape(self, shape):
+            return self.value.reshape(shape)
+
+    plan = ExecutionPlan(
+        backend="cuda",
+        inputs=[],
+        outputs=["first", "second"],
+        buffers=[
+            BufferSpec("second", (Dim(1),), F32, "output"),
+            BufferSpec("scratch", (Dim(1),), F32, "scratch"),
+            BufferSpec("first", (Dim(1),), F32, "output"),
+        ],
+        constants={},
+        runtime_constants={},
+        launches=[],
+        kernels={},
+    )
+    program = CompiledProgram(
+        compiled=_load_plan(plan),
+        arrays={"second": HostArray(2), "scratch": HostArray(3), "first": HostArray(1)},
+        descs={},
+    )
+
+    outputs = program.outputs(sym_values={})
+    device_outputs = program.output_prefix_device(sym_values={})
+
+    assert list(outputs) == ["first", "second"]
+    np.testing.assert_array_equal(outputs["first"], [1])
+    np.testing.assert_array_equal(outputs["second"], [2])
+    assert list(device_outputs) == ["first", "second"]
+    np.testing.assert_array_equal(device_outputs["first"], [1])
+    np.testing.assert_array_equal(device_outputs["second"], [2])
 
 
 class TestSymbolicCapacityGuard:


### PR DESCRIPTION
## Summary

- carry the declared ExecutionPlan output list into the CUDA runtime
- return host and device outputs in declared graph order instead of allocation order
- document and test the observable output-order contract

The execution-plan wire format already serializes this list, so this changes no stored format.

## Verification

- focused backend tests: 33 passed, 5 skipped
- full suite: 3155 passed, 562 skipped, 1 xfailed
- make lint
- git diff --check
- exact latest-main V100 gate: 4/4 formerly failing Laguna program 20/21 M32/M1024 rows passed strict eager correctness on four distinct V100-SXM3-32GB GPUs, with cold task-owned DB, online, and cubin state

The V100 gate is a correctness/output-contract result only; greedy timings are not a tuned performance claim.