### PR TITLE
Exclude low-precision direct atomic reductions

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1521,9 +1521,11 @@ stored).
 per-thread remainder is derived, never spelled); the retired `b<n>` coop-width spelling raises. The
 cross-CTA split is the `g<n>` field (GRID stage), and the
 **finalize** is that field's trailing letter — `g<n>a` = in-place `atomicAdd` (one kernel, additive single-fold
-carriers only; both tiers — an mma partial's C fragment rides `RegStore.atomic`, the packed f16x2/bf16x2 red, at the
-cost of one output-dtype rounding per partition), `g<n>k` = deferred `__partial` workspace + a sibling combine kernel
-(any carrier; the only legal arm for a multi-component twisted carrier and for a multi-channel ⊗-combine). Pin
+carriers only, with no f16/bf16 destination; both tiers — an mma partial's C fragment rides `RegStore.atomic`),
+`g<n>k` = deferred f32 `__partial` workspace + a sibling combine kernel (any carrier; the only legal arm for a
+low-precision output, a multi-component twisted carrier, and a multi-channel ⊗-combine). A direct atomic low-precision
+destination would round once per partition and can cross the strict correctness boundary; the deferred arm combines
+carrier state in f32 and rounds once. Pin
 via `EMMY_REDUCE=g2k` (one flat knob — no per-axis `EMMY_REDUCE_<axis>`, no `EMMY_FINALIZE`). The split is realized by
 `lowering/tile/030_split_reduce` as a graph rewrite whose pieces are **brand-new kernels** — unmapped, knob-free,
 re-stamped, each scheduled at its own fork; a split node is priced as the Σ of its pieces' bests, and the split is

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -641,7 +641,9 @@ grammar it read).
 
 - **`030_split_reduce`** splits the **reduce axis** (the REDUCE codec's `g<w>` cross-CTA shard): the SAME
   computation, its K partitioned across CTAs into a partial + finalize (or, on the atomic arm, one kernel that
-  accumulates in place). It runs AFTER its decision — the `g` row was chosen FOR the split form.
+  accumulates in place). Direct atomic finalization is legal only when it does not write each partial into f16/bf16
+  output storage; low-precision output takes the deferred f32 workspace and rounds once after the combine. It runs
+  AFTER its decision — the `g` row was chosen FOR the split form.
 
 **Every piece is a BRAND-NEW kernel.** A rewrite that returns DIFFERENT NODES is a kernel-set change, and the
 minting rule states it by consuming the replaced kernel's row on the pieces it builds

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_split_reduce.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_split_reduce.py
@@ -19,7 +19,9 @@ the kernel's annotated reduce ``Loop`` (``loop.axis`` / position) and the ALGEBR
   - ``"atomic"`` — the partial ``atomicAdd``\\ s its (additive) state into the output (applying
     the kernel's projection epilogue per-partition first, when that epilogue *distributes* over
     the add — ``mean``'s ``×1/N``; a non-distributive one like ``l2``'s ``sqrt`` is refused, use
-    ``"kernel"``); the output is zero-init'd per launch. **1 node.** Additive carriers only.
+    ``"kernel"``); the output is zero-init'd per launch. **1 node.** Additive carriers with
+    non-f16/bf16 output storage only — schedule legality routes low-precision outputs through
+    the f32 deferred workspace so they round once rather than once per partition.
 
 **Every piece is a BRAND-NEW kernel, minted in the LOOP dialect.** Each leaves here as a plain
 ``LoopOp`` (:func:`_piece`) — the term lowered to per-cell stmts with its boundary stores put back,
@@ -220,11 +222,10 @@ def _split_contraction(match: Match, root: Node, tile: TileOp, node, outer: Fold
     atom, scalar otherwise. No ``_slice_loop`` (unlike the residual plain-sum path).
 
     Finalize matches the additive-carrier finalize: ``atomic`` (``g<w>a``) atomicAdds the partition's
-    ``acc`` into the zero-init'd output — ONE kernel, both tiers (an mma partial's C fragment rides
-    ``RegStore.atomic``: the packed f16x2/bf16x2 ``atomicAdd`` pair, per-element for f32) — at the
-    cost of one output-dtype rounding per partition (the deferred arm's f32 workspace rounds once);
-    ``kernel`` (``g<w>k``) writes each partition's ``acc`` to a ``ws[ksplit, *cell]`` workspace and a
-    sibling finalize kernel sums it + runs the projection epilogue."""
+    ``acc`` into the zero-init'd output — ONE kernel, both tiers, admitted only when the output
+    storage is not f16/bf16. Low-precision output takes ``kernel`` (``g<w>k``): each partition's
+    ``acc`` is written to a f32 ``ws[ksplit, *cell]`` workspace and a sibling finalize kernel sums
+    it + runs the projection epilogue, rounding the output once instead of once per partition."""
     out = root.output
     grid = tile.place.grid
     cell = tuple(Var(a.name) for a in grid)

--- a/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from emmy.compiler.dtype import BF16, F16
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import BinaryExpr
 from emmy.compiler.ir.pure.fold import Fold, operand_name
@@ -67,6 +68,21 @@ def enforce(reason: str | None, *, pinned: bool) -> bool:
     if pinned:
         raise ValueError(reason)
     return False
+
+
+def direct_atomic_output(outputs) -> str | None:
+    """Whether direct cross-CTA partials avoid another low-precision rounding step.
+
+    F16/BF16 destinations round once per CTA; the deferred finalize instead combines f32
+    carrier state and rounds once at the output boundary.
+    """
+    lowp = sorted({str(t.dtype) for t in outputs.values() if t.dtype in (F16, BF16)})
+    if not lowp:
+        return None
+    return (
+        f"direct atomic REDUCE writes each partial into {'/'.join(lowp)} output storage; "
+        "use the deferred f32 workspace finalize (REDUCE=g<n>k) so the output rounds once"
+    )
 
 
 # ---- thread budgets ---------------------------------------------------------------------------- #

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -810,6 +810,8 @@ def _reduce_specs(term: _Term, node) -> list[ReducePlan]:
     if pin is not None:
         plan = _consumed_split(term, node, ReducePlan.parse(pin, Workers.parse(WORK.raw())))
         band_legal(plan, pinned=True)
+        if plan.needs_split and plan.finalize == "atomic":
+            legal.enforce(legal.direct_atomic_output(term.tile.outputs), pinned=True)
         return [plan]
     extent = _hint_extent(node.axis)
     cands = [ReducePlan()]
@@ -817,6 +819,8 @@ def _reduce_specs(term: _Term, node) -> list[ReducePlan]:
         if p.needs_split and not _splittable_axis(term, node):
             continue  # the axis is already a slice — its cross-CTA partition was consumed
         if not band_legal(p, pinned=False):
+            continue
+        if p.finalize == "atomic" and not legal.enforce(legal.direct_atomic_output(term.tile.outputs), pinned=False):
             continue
         if p.coop <= extent and p.reg <= extent and p not in cands:
             cands.append(p)
@@ -994,6 +998,8 @@ def _contraction_reduces(term: _Term, node, plan: TilePlan) -> list[ReducePlan]:
         # A pin meets the transposed band's geometry as a refusal, not an emitter crash.
         legal.enforce(legal.coop_band_geometry(pinned, ext.as_static() if ext.is_static else None, _inner_free(term.place)), pinned=True)
         if pinned.needs_split:
+            if pinned.finalize == "atomic":
+                legal.enforce(legal.direct_atomic_output(term.tile.outputs), pinned=True)
             return [pinned]
         if pinned.coop > 1 or pinned.reg > 1:
             # A tiled candidate contracts K serially per register cell — the coop / ILP partition is
@@ -1021,10 +1027,14 @@ def _contraction_reduces(term: _Term, node, plan: TilePlan) -> list[ReducePlan]:
     if splittable and _splittable_axis(term, node) and len(term.place.free) >= 2:
         step = plan.atom.atom_k * plan.bk if plan.is_warp else 1
         tail = tuple(projection_tail(term.tile))
-        atomic_ok = len(node.channels) == 1 and (len(tail) == 0 or projection_distributes(tail, (node.acc,)))
+        atomic_ok = (
+            len(node.channels) == 1
+            and (len(tail) == 0 or projection_distributes(tail, (node.acc,)))
+            and legal.enforce(legal.direct_atomic_output(term.tile.outputs), pinned=False)
+        )
         for sp in splitk_moves():
             if sp.finalize == "atomic" and not atomic_ok:
-                continue  # a non-distributive projection would raise at 030_split_reduce
+                continue  # the carrier, projection, or destination cannot realize a direct atomic finalize
             if k % sp.cta == 0 and (k // sp.cta) % step == 0:
                 out.append(sp)
     return out

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -361,10 +361,10 @@ def test_fused_sdpa_split_partition_keeps_the_two_pass_pair(monkeypatch):
     axis (every partition divides by the whole denominator), so one pass cannot serve both — the
     single-pass sweep declines and the two-pass pair stands, bridging through the stat smem rows.
 
-    The decline is a correctness gate, not a preference: sweeping only the partition's keys would
+    The deferred split is a correctness gate, not a preference: sweeping only the partition's keys would
     normalize each partial by its own denominator and the atomic sum of those is not softmax."""
     monkeypatch.setenv("EMMY_PLACE", "fuse")
-    monkeypatch.setenv("EMMY_REDUCE", "g2a")  # two cross-CTA partitions of the KV axis, atomic-summed
+    monkeypatch.setenv("EMMY_REDUCE", "g2k")  # two cross-CTA partitions with an f32 deferred finalize
     torch.manual_seed(0)
     B, H, S, D = 1, 2, 64, 16
     q, k, v = (torch.randn(B, H, S, D, dtype=torch.float16) for _ in range(3))
@@ -391,7 +391,7 @@ def test_fused_causal_sdpa_split_partition_keeps_absolute_predicate_coordinates(
     coordinates; deriving them from that local write index admits future keys in every chunk after the first.
     """
     monkeypatch.setenv("EMMY_PLACE", "fuse")
-    monkeypatch.setenv("EMMY_REDUCE", "g2a")
+    monkeypatch.setenv("EMMY_REDUCE", "g2k")
     monkeypatch.setenv("EMMY_WORK", "w2x2")
     monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f2x2/k2")
     torch.manual_seed(0)

--- a/tests/compiler/e2e/test_matmul_coverage.py
+++ b/tests/compiler/e2e/test_matmul_coverage.py
@@ -1493,14 +1493,14 @@ def test_bf16_operands_stage_via_cp_async(monkeypatch):
 # (the split-K option): the inner bilinear ``Fold`` factorizes to mma exactly like a non-split
 # matmul. Deferred (``g2k``): ``030_split_reduce`` retargets each partition's C-fragment into a
 # ``ws[ksplit, M, N]`` workspace summed by a sibling additive finalize kernel — NO codegen
-# ``atomicAdd``. Atomic (``g2a``): ONE kernel — each partition's C-fragment ``atomicAdd``\\ s into the
-# per-launch zero-init'd output (``RegStore.atomic`` → the packed ``__half2`` red, ``zero_outputs``);
-# scalar-tier atomic split-K is covered by ``test_reduce_coverage``'s cross-CTA matrix.
-def _splitk_mma_graph(m: int, k: int, n: int) -> Graph:
+# ``atomicAdd``. Atomic (``g2a``): ONE kernel — each partition's C-fragment ``atomicAdd``\\ s into a
+# per-launch zero-init'd f32 output (``RegStore.atomic`` + ``zero_outputs``). Low-precision output
+# takes the deferred arm; scalar-tier f32 atomic split-K is covered by ``test_reduce_coverage``.
+def _splitk_mma_graph(m: int, k: int, n: int, *, out_dtype=F16) -> Graph:
     g = Graph()
     g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (m, k), dtype=F16), node_id="a")
     g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (k, n), dtype=F16), node_id="b")
-    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (m, n), dtype=F16), node_id="o")
+    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (m, n), dtype=out_dtype), node_id="o")
     g.inputs, g.outputs = ["a", "b"], ["o"]
     return g
 
@@ -1512,9 +1512,8 @@ def test_mma_splitk_finalize(monkeypatch, finalize):
     """fp16 MMA split-K through the structural fork (warp ``TILE`` atom + ``REDUCE=g2k``/``g2a``).
     Deferred (``g2k``) sums each partition's C-fragment through a workspace + additive finalize kernel
     on the tensor-core tier — mma present, NO ``atomicAdd``. Atomic (``g2a``) is ONE kernel: each
-    partition's C-fragment ``atomicAdd``\\ s into the zero-init'd output via ``RegStore.atomic`` (the
-    packed ``__half2`` red — no ``__partial`` workspace, no finalize node). Both are accurate (the
-    atomic arm adds one f16 rounding per partition — inside the shared 2e-2 tolerance)."""
+    partition's C-fragment ``atomicAdd``\\ s into a zero-init'd f32 output via ``RegStore.atomic``
+    (no ``__partial`` workspace or finalize node). Low-precision output takes the deferred arm."""
     from emmy.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
 
     monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16/f2x2/k2")
@@ -1525,14 +1524,14 @@ def test_mma_splitk_finalize(monkeypatch, finalize):
     rng = np.random.default_rng(4)
     a = (rng.standard_normal((m, k)) * 0.1).astype(np.float16)
     b = (rng.standard_normal((k, n)) * 0.1).astype(np.float16)
-    compiled = be.compile(_splitk_mma_graph(m, k, n))
+    compiled = be.compile(_splitk_mma_graph(m, k, n, out_dtype=F32 if finalize == "atomic" else F16))
     src = "\n".join(node.op.kernel_source for node in compiled.nodes.values() if getattr(node.op, "kernel_source", None))
     assert "mma.sync.aligned.m16n8k16" in src, "must be on the tensor-core tier"
     if finalize == "deferred":
         assert "atomicAdd" not in src, "atomic-free split-K must not emit atomicAdd"
         assert "__partial" in src, "the deferred finalize writes partials to a workspace"
     else:
-        assert "atomicAdd(reinterpret_cast<__half2*>" in src, "the atomic finalize rides the packed-pair red"
+        assert "atomicAdd(&" in src, "the f32 atomic finalize emits scalar atomic stores"
         assert "__partial" not in src, "the atomic finalize is single-kernel (no workspace)"
         zeroed = [n.op.zero_outputs for n in compiled.nodes.values() if getattr(n.op, "zero_outputs", ())]
         assert zeroed == [("o",)], f"the atomic output must be zero-init'd per launch, got {zeroed}"
@@ -2097,7 +2096,7 @@ def test_regstore_rewrite_preserves_atomic():
 @requires_cuda
 def test_mma_splitk_atomic_f16acc_staged_rolled(monkeypatch):
     """The f16acc atom's array-fragment (rolled-store) form threads ``RegStore.atomic`` through the
-    stmt rewrite: the staged ``d2/smem-tma`` + ``g2a`` pin on a deep-K matmul must emit ``atomicAdd``
+    stmt rewrite: the staged ``d2/smem-tma`` + ``g2a`` pin on a deep-K matmul with f32 output must emit ``atomicAdd``
     (the pre-fix render emitted racing plain stores here — the accuracy assert below fails ~4x-low
     values loudly if the flag is ever dropped again)."""
     from emmy.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
@@ -2111,7 +2110,7 @@ def test_mma_splitk_atomic_f16acc_staged_rolled(monkeypatch):
     rng = np.random.default_rng(7)
     a = (rng.standard_normal((m, k)) * 0.1).astype(np.float16)
     b = (rng.standard_normal((k, n)) * 0.1).astype(np.float16)
-    compiled = be.compile(_splitk_mma_graph(m, k, n))
+    compiled = be.compile(_splitk_mma_graph(m, k, n, out_dtype=F32))
     src = "\n".join(node.op.kernel_source for node in compiled.nodes.values() if getattr(node.op, "kernel_source", None))
     assert "atomicAdd" in src, "the rolled f16acc atomic split-K must emit atomicAdd stores"
     out = np.asarray(be.run(compiled, input_data={"a": a, "b": b})[0].outputs["o"]).reshape(m, n)

--- a/tests/compiler/passes/test_delegate_zero_init.py
+++ b/tests/compiler/passes/test_delegate_zero_init.py
@@ -16,16 +16,14 @@ from emmy.compiler.pipeline import CUDA_PASSES, Pipeline
 
 
 def _compile_chain(n: int):
-    """``(x @ w1) @ w2`` fp16 with the matmul seam cut and ``REDUCE=g4a`` pinned on each
+    """``(x @ w1) @ w2`` f32 with the matmul seam cut and ``REDUCE=g4a`` pinned on each
     piece — two atomic kernels whose outputs are ``32×n`` (the delegation-cap lever:
-    512 → 32 KB per accumulator; 3840 → 240 KB,
+    512 → 64 KB per accumulator; 3840 → 480 KB,
     past it)."""
     mp = pytest.MonkeyPatch()
     # Per-knob vars, NOT EMMY_KNOBS: the aggregate splat runs at knob-module IMPORT time, long
     # before this fixture — and calling apply_knobs_env here would write env keys monkeypatch
     # never cleans up.
-    mp.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f2x2/k4")
-    mp.setenv("EMMY_WORK", "w1x8")
     mp.setenv("EMMY_REDUCE", "g4a")
     # Gate-free loop fusion composes the two matmuls. This test is about CUDA zero-init
     # delegation between kernels, so route the recognized contraction seam back to two pieces.
@@ -34,12 +32,7 @@ def _compile_chain(n: int):
     try:
         from emmy.commands.trace import graph_from_code
 
-        code = (
-            "x = torch.randn(32,3840,dtype=torch.float16)\n"
-            f"w1 = torch.randn(3840,{n},dtype=torch.float16)\n"
-            f"w2 = torch.randn({n},{n},dtype=torch.float16)\n"
-            "(x @ w1) @ w2"
-        )
+        code = f"x = torch.randn(32,3840)\nw1 = torch.randn(3840,{n})\nw2 = torch.randn({n},{n})\n(x @ w1) @ w2"
         graph, _slug, _bundle = graph_from_code(code)
         ctx = Context.from_target((12, 0), gpu_name="NVIDIA GeForce RTX 5090")
         return Pipeline.build(CUDA_PASSES).run(graph, ctx=ctx)
@@ -84,7 +77,7 @@ def test_first_atomic_keeps_its_memset(chained_atomic):
 
 
 def test_oversized_accumulator_is_delegated_too():
-    """A 240 KB accumulator (32×3840 fp16) delegates like any other static accumulator: whether
+    """A 480 KB accumulator (32×3840 f32) delegates like any other static accumulator: whether
     delegation's saved MEMSET node beats CTA-0's serial zeroing is a size- and card-dependent
     measurement, so it is tuned evidence's decision, never a compile-time size threshold."""
     ops = _cuda_ops(_compile_chain(3840))

--- a/tests/compiler/passes/test_pool_space.py
+++ b/tests/compiler/passes/test_pool_space.py
@@ -88,7 +88,7 @@ FIXTURES = {
 #: enumeration order. Recorded against the pre-space recursion — see the module docstring.
 EXPECTED: dict[str, list[tuple[tuple[str, ...], int, str]]] = {
     "scalar_matmul": [(("TILE", "STAGE", "REDUCE"), 17988, "b30d5d0f9070cd89d130ff8fad132a84")],
-    "warp_matmul": [(("TILE", "STAGE", "REDUCE"), 122308, "38eb4fdc94a7be1bb8cc889f3dd01462")],
+    "warp_matmul": [(("TILE", "STAGE", "REDUCE"), 74926, "67b94c73a84918b48aa104e1575f2399")],
     "reduce_matvec": [(("TILE", "STAGE", "REDUCE"), 20, "bc42c1d8f8640471f226c25327e6d792")],
     "fused_norm_linear": [(("TILE", "STAGE@a1", "STAGE", "REDUCE@a1", "REDUCE"), 21495, "3931bd58b58a61f03789de5e68ea4747")],
     "flash_pair": [(("TILE", "STAGE", "REDUCE"), 3541, "4d3f19fcca6a294d9651ea9bc7ddba4b")],

--- a/tests/compiler/passes/test_split_fresh_kernels.py
+++ b/tests/compiler/passes/test_split_fresh_kernels.py
@@ -21,11 +21,11 @@ import pytest
 
 from emmy.compiler.context import Context
 from emmy.compiler.dim import Dim
-from emmy.compiler.dtype import F16, F32
+from emmy.compiler.dtype import BF16, F16, F32
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
-from emmy.compiler.ir.tensor.ir import ElementwiseOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
 from emmy.compiler.ir.tile.ir import TileOp
 from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
@@ -35,12 +35,20 @@ from emmy.compiler.pipeline.pipeline import Run
 _CTX = Context.from_target((12, 0))
 
 
-def _matmul(m: int = 128, k: int = 512, n: int = 128) -> Graph:
+def _matmul(m: int = 128, k: int = 512, n: int = 128, *, out_dtype=F16) -> Graph:
     g = Graph()
     g.add_node(InputOp(), [], Tensor("a", (Dim(m), Dim(k)), dtype=F16), node_id="a")
     g.add_node(InputOp(), [], Tensor("b", (Dim(k), Dim(n)), dtype=F16), node_id="b")
-    g.add_node(MatmulOp(), ["a", "b"], Tensor("o", (Dim(m), Dim(n)), dtype=F16), node_id="o")
+    g.add_node(MatmulOp(), ["a", "b"], Tensor("o", (Dim(m), Dim(n)), dtype=out_dtype), node_id="o")
     g.inputs, g.outputs = ["a", "b"], ["o"]
+    return g
+
+
+def _sum(*, dtype=F16) -> Graph:
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (Dim(4), Dim(512)), dtype=dtype), node_id="x")
+    g.add_node(ReduceOp(axis=1), ["x"], Tensor("s", (Dim(4), Dim(1)), dtype=dtype), node_id="s")
+    g.inputs, g.outputs = ["x"], ["s"]
     return g
 
 
@@ -62,7 +70,16 @@ def test_the_split_returns_two_kernels(monkeypatch) -> None:
     monkeypatch.setenv("EMMY_REDUCE", "g2k")
     assert set(_kernels(_resolve(CUDA_PASSES)[0])) == {"o", "o__partial"}
     monkeypatch.setenv("EMMY_REDUCE", "g2a")
-    assert set(_kernels(_resolve(CUDA_PASSES)[0])) == {"o"}
+    assert set(_kernels(_resolve(CUDA_PASSES, _matmul(out_dtype=F32))[0])) == {"o"}
+
+
+@pytest.mark.parametrize("dtype", [F16, BF16])
+def test_low_precision_output_refuses_direct_atomic_split(monkeypatch, dtype) -> None:
+    """F16/BF16 outputs would round every CTA partial; contraction and plain reduce fail closed."""
+    monkeypatch.setenv("EMMY_REDUCE", "g2a")
+    for graph in (_matmul(out_dtype=dtype), _sum(dtype=dtype)):
+        with pytest.raises(ValueError, match="direct atomic REDUCE.*output storage"):
+            _resolve(TILE_PASSES, graph)
 
 
 def test_finalize_keeps_projection_input_edges(monkeypatch) -> None:
@@ -205,7 +222,8 @@ def test_the_split_is_consumed_by_the_kernel_that_realizes_it(monkeypatch, pin) 
     records the partition already happened. Without that reading the partial re-splits its own
     slice on every sweep: K=512 → 256 → … → 1, ending in a raise."""
     monkeypatch.setenv("EMMY_REDUCE", pin)
-    kernels = _kernels(_resolve(CUDA_PASSES)[0])
+    graph = _matmul(out_dtype=F32) if pin.endswith("a") else _matmul()
+    kernels = _kernels(_resolve(CUDA_PASSES, graph)[0])
     assert len(kernels) <= 2, f"{pin}: the split must not cascade — {sorted(kernels)}"
     assert not [v for row in kernels.values() for k, v in row.items() if family_of(k) == "REDUCE" and str(v).startswith("g")]
 


### PR DESCRIPTION
## Summary

- exclude direct cross-CTA atomic finalization for FP16/BF16 outputs
- retain deferred f32 workspace finalization for low-precision outputs
- retain direct atomic finalization for FP32 outputs
- document and regress the schedule-legality boundary

## Why

Direct atomic finalization rounds every CTA partial in the output storage dtype. On the Qwen projection target,
FP16/BF16 atomic rows crossed strict correctness, while the deferred finalize combines f32 carrier state and rounds
once. Pinned illegal rows now fail before compilation with an actionable diagnostic.

## Verification

- exact rebased head `ea2f5aa` / tree `58a43aa2` on RTX 4090, isolated O3:
  - FP16 `g4k`: strict pass with f32 `__partial` workspace and finalize, 0 strict errors
  - FP16 `g2a`: failed closed before compile with the low-precision direct-atomic diagnostic
  - FP32 `g2a`: strict pass with float `atomicAdd`, 0 strict errors
- no performance claim: legal Emmy rows remained slower than eager in this gate
- focused tests: 67 passed, 199 skipped
- hosted test, lint, package dry run, and Vercel checks passed
- lint, format, and diff checks passed locally
