### PR TITLE
Fix standalone Loop input boundaries

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -860,7 +860,8 @@ only (`tile → kernel → cuda`), and returns the Σ once ALL Loop kernels are 
 - The slice keeps the root kernel + its leaf-op closure and turns every other kernel-input into a synthetic `InputOp`.
   The root op is shared **by reference**, so its body — and thus `Op.cache_key` — is byte-for-byte the full-graph op's.
   It filters the graph's canonical topological order rather than iterating its set-backed ancestor closure, so slice
-  inputs and persisted Loop programs stay byte-identical across fresh Python processes.
+  inputs and persisted Loop programs stay byte-identical across fresh Python processes. Every retained `InputOp` is
+  registered as a slice input even when a minting fragment did not list the boundary in its own `Graph.inputs`.
 - Because the inner tree holds one op, MCTS explores only that op's forks with `patience` as the op's own budget —
   `Σ_k n_k` benches total, never the product.
 - **Leaves are deduped by `Op.cache_key`**: 24 RMSNorm LoopOps across 24 layers collapse to one work unit, and the

--- a/emmy/compiler/pipeline/search/slice.py
+++ b/emmy/compiler/pipeline/search/slice.py
@@ -10,8 +10,9 @@ Used in two places:
 
 The slice keeps the root kernel node plus its transitive ``ConstantOp`` /
 ``InputOp`` producers (so scalar-constant inlining and load-op replay behave
-identically) and replaces every *compute* ancestor — another kernel feeding
-this one — with a synthetic ``InputOp`` boundary, so the result is standalone.
+identically), declares every retained ``InputOp`` as an external boundary, and
+replaces every *compute* ancestor — another kernel feeding this one — with a
+synthetic ``InputOp`` boundary, so the result is standalone.
 The root op is shared **by reference**: its body (and therefore
 :meth:`~emmy.compiler.ir.base.Op.cache_key`) is byte-for-byte the full-graph op's, which is what lets
 inner-tuned ``perf`` / ``lowering`` rows transfer back to the assembled graph.
@@ -79,8 +80,8 @@ def single_node_graph(graph: Graph, node_id: str) -> Graph:
     """Slice ``graph`` to the single kernel node ``node_id`` plus its
     leaf-op closure, with every compute-op input turned into a synthetic
     ``InputOp``. Returns a standalone :class:`Graph` whose sole output is
-    ``node_id`` and whose ``inputs`` list its synthetic boundaries + real
-    graph inputs — sized identically to the full graph (partition
+    ``node_id`` and whose ``inputs`` list every retained or synthetic
+    ``InputOp`` boundary — sized identically to the full graph (partition
     enumeration depends on the producers' extents)."""
     from emmy.compiler.graph import Graph as _Graph  # noqa: PLC0415
     from emmy.compiler.ir.base import InputOp  # noqa: PLC0415
@@ -97,8 +98,8 @@ def single_node_graph(graph: Graph, node_id: str) -> Graph:
             sub.inputs.extend(src.buffer_names())
         else:
             sub.add_node(src.op, list(src.inputs), outputs=src.outputs, node_id=src.id)
-            if isinstance(src.op, InputOp) and kid in graph.inputs:
-                sub.inputs.append(kid)
+            if isinstance(src.op, InputOp):
+                sub.inputs.extend(src.buffer_names())
     # Every buffer of the sliced node is a slice output (a non-primary buffer
     # with no in-slice consumer must plan as an output, not dead scratch).
     sub.outputs.extend(graph.nodes[node_id].buffer_names())

--- a/emmy/compiler/pipeline/search/strategy/two_level.py
+++ b/emmy/compiler/pipeline/search/strategy/two_level.py
@@ -38,7 +38,6 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from emmy.compiler.context import Context
-from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pass, Pipeline, TuningSearch
 from emmy.compiler.pipeline.knob import stamp_schedule_families
@@ -473,12 +472,6 @@ class TwoLevelStrategy(SearchStrategy):
                 await asyncio.gather(*tasks)
                 # Enrollment wave: everything the inventory reported while this wave ran. Waves
                 # terminate because cut/split trees strictly shrink and the seen-set dedups.
-                # A minting fragment carries InputOp boundary nodes but no ``Graph.inputs``
-                # registration (the splice never needed one) — declare them so the slice cut
-                # from it feeds them bench data instead of treating them as unproduced scratch.
-                for _nid, _op, frag in minted:
-                    if not frag.inputs:
-                        frag.inputs = [i for i, n in frag.nodes.items() if isinstance(n.op, InputOp)]
                 wave = [
                     _Work(key=key, nid=nid, op=op, src_graph=frag, count=0, enrolled=True)
                     for nid, op, frag in minted

--- a/tests/compiler/pipeline/search/test_two_level_strategy.py
+++ b/tests/compiler/pipeline/search/test_two_level_strategy.py
@@ -18,13 +18,17 @@ import zlib
 import pytest
 
 from emmy.compiler.backend.base import BenchmarkResult, LaunchTime
+from emmy.compiler.backend.cuda._planner import compute_live_intervals
+from emmy.compiler.backend.plan import plan_from_graph
 from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda.ir import CudaOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
-from emmy.compiler.pipeline import LOOP_PASSES, Pipeline
+from emmy.compiler.ir.loop import LoopOp
+from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pipeline
 from emmy.compiler.pipeline.search.db import SearchDB
+from emmy.compiler.pipeline.search.slice import single_node_graph
 from emmy.compiler.pipeline.search.strategy.two_level import InnerReward, OpResult, _KernelInventory
 from tests.compiler.helpers import run_inner_reward, run_two_level
 
@@ -120,6 +124,24 @@ def test_identical_kernels_dedup_with_multiplicity() -> None:
     assert len(reward.per_op) == 1, "structurally identical kernels share one inner search"
     assert reward.per_op[0].multiplicity == 2
     assert reward.total_us == pytest.approx(2 * reward.per_op[0].best_us)
+
+
+def test_single_node_slice_declares_unregistered_input_boundaries_in_the_runtime_plan() -> None:
+    fused = _fuse(_graph(("x", 64, 128, 48)))
+    fused.inputs.remove("xb")
+    root = next(node.id for node in fused.nodes.values() if isinstance(node.op, LoopOp))
+
+    sliced = single_node_graph(fused, root)
+    lowered = Pipeline.build(CUDA_PASSES).run(sliced, ctx=Context.from_target((8, 0)))
+    plan = plan_from_graph(lowered)
+
+    assert set(sliced.inputs) == {"xa", "xb"}
+    roles = {buffer.name: buffer.role for buffer in plan.buffers}
+    assert roles == {"xa": "input", "xb": "input", "xc": "output"}
+    scratch = [buffer.name for buffer in plan.buffers if buffer.role == "scratch"]
+    # Exercise the allocator's exact liveness seam: an undeclared InputOp would
+    # be scratch here and fail because no CUDA launch produces it.
+    assert compute_live_intervals(scratch, plan.launches) == {}
 
 
 def test_run_drives_outer_scores_separably_and_assembles() -> None:


### PR DESCRIPTION
## Summary

- register every retained `InputOp` as an external input when slicing one Loop kernel
- remove the narrower two-level workaround that only repaired fragments with no registered inputs
- document and regress the standalone slice contract for partially registered minting fragments

## Why

A heterogeneous placement cut can mint a fragment whose `Graph.inputs` contains one external edge but omits another
retained `InputOp`. The old workaround only ran when the list was empty, so a standalone route-child replay planned the
omitted boundary as scratch and failed because it had no producing launch.

## Verification

- `./venv/bin/pytest tests/compiler/pipeline/search/ -p no:randomly -n auto --dist=loadgroup -q` — 125 passed
- `make test` — 3135 passed, 576 skipped, 1 xfailed
- `make lint`
- `git diff --check`
