### PR TITLE
Preserve structural tune winners

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -183,8 +183,16 @@ realizations are measured in file order before MCTS and written back as working-
 `--max-candidates N`
 is a per-tuned-kernel budget: every supplied proposal reserves one slot, while an MCTS DB cache hit does not spend a
 remaining live-measurement slot. A traced target normally maps to one post-fusion kernel, but lowering may materialize
-several CudaOps; conflicting multi-CudaOp knob rows are reported as ambiguous instead of being assigned an invented
-winner. Proposal feedback is written immediately after measurement, before MCTS, so an interruption preserves it.
+several CudaOps. A conflicting multi-CudaOp proposal is replayable only when search retains the original exact
+structural row that minted the pieces; otherwise it is reported as ambiguous instead of being assigned an invented
+winner. The measured CUDA pipeline captures the finalized single Loop identity even when the working target starts
+from stable Torch IR, then captures the consumed parent at the kernel-set-changing splice. An authoritative structural
+proposal whose realized-pin check passes therefore persists one captured whole-slice perf row under that exact
+route-specific parent cache key and context, carrying the complete scheduler feature row and route. The unpinned Loop
+key remains two-level cost bookkeeping. The measured DB index consumes the route row after a cold reload;
+parent-linked node rows remain diagnostic and training evidence. Proposal feedback is written immediately after
+measurement, before MCTS, so an interruption
+preserves it.
 The final winner annotation is emitted only when one directly searched observation supplies both the knobs and cost;
 the later greedy deploy replay cannot be paired with the search reward. The ranking pass stays at tune's fast compile
 flags and never writes the trusted

--- a/emmy/commands/tune.py
+++ b/emmy/commands/tune.py
@@ -359,6 +359,7 @@ def _tune_one(
             ctx=ctx,
             max_candidates=getattr(args, "max_candidates", None),
             prior=prior,
+            run_id=run_id,
         )
         # Working-file feedback is durable as soon as its measurements finish;
         # an interrupted/failed MCTS must not discard already-paid proposal data.
@@ -509,6 +510,7 @@ def _tune_working_multi(args, targets, document, *, backends, db, ctx, run_id) -
                 ctx=ctx,
                 max_candidates=getattr(args, "max_candidates", None),
                 prior=prior,
+                run_id=run_id,
             )
             if target.proposals:
                 persist_proposal_rankings(args.golden_file, document, target, rankings)

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -79,7 +79,7 @@ lifetimes, and telling them apart is the single most useful thing to learn early
 |-------|----------------|------------|--------------|
 | **Golden configs** | model YAML under `recipes/<model>/golden/`; model-agnostic YAML under `search/goldens/` | promoted from deployable `run --bench` golden / `--ab` rows (Part 7) | greedy compile (tier 1, the verified tier); pinned replay (`run --golden NAME`); `emmy fit` trains the offline prior on them; `emmy eval` datasets |
 | **Reservoir** | inside the online prior checkpoint (`~/.cache/emmy/online.json`) — the sample of past measurements the model trains on | `emmy tune` — every training row, including the `-O3` re-benches | greedy compile (tier 2, its `H_opt=3` rows); the online prior's own refits |
-| **`perf` table** | the tune DB (`~/.cache/emmy/autotune.db`) | `emmy tune` — one row per benched kernel, at whatever flags the sweep ran | greedy compile (tier 3); the per-variant replay cache |
+| **`perf` table** | the tune DB (`~/.cache/emmy/autotune.db`) | `emmy tune` — terminal kernel measurements plus validated whole-slice structural routes, at the sweep's flags | greedy compile (tier 3); the per-variant replay cache |
 | **`node` table** | the same tune DB | `emmy tune` (every search-tree node) and `run --bench` (rows benched with hand-forced knob values) | `emmy eval` diagnostics — **never** consulted at deploy |
 
 Of the four, only the goldens travel with a clone: they are the only *measured* data a fresh machine has. The
@@ -933,9 +933,18 @@ for a forkless anchor) is compiled with scoped authoritative pins and measured t
 the normal isolated benchmark and DB persistence path before MCTS continues in the same input pin regime. A
 realized-vs-requested check marks an
 unoffered proposal `pin_unmatched` instead of attributing the planner's fallback to the proposed row. Successful seed
-rows feed the shared prior immediately, so the following MCTS can use their evidence. Ranking feedback is flushed to
-the working file as soon as proposal measurement finishes, before MCTS. A multi-CudaOp result records realized knobs
-only when their union is conflict-free; otherwise the ranking is explicitly ambiguous.
+rows feed the shared prior immediately, so the following MCTS can use their evidence. The measured pipeline captures
+the exact finalized single Loop's stamped structural identity, even when the working file starts from stable Torch IR.
+At the kernel-set-changing splice it also captures the consumed parent carrying the complete scheduler feature row and
+exact structural route. The proposal's measured whole-slice latency persists under that route-specific parent cache
+key and context. This captured perf row is deploy evidence: the measured DB index can select the route again after a
+cold reload while the unpinned Loop key remains the two-level search's cost bookkeeping and the split kernels retain
+their independent terminal measurements. Parent-linked node rows preserve the same proposal for diagnostics and
+training; they do not drive deploy selection. The direct row is written only when the authoritative pins pass
+realized-pin validation, search retains the exact structural route, one consumed parent realizes it, and the terminal
+measurement succeeds. Ranking feedback is flushed to the working file as soon as proposal measurement finishes,
+before MCTS. A multi-CudaOp result records realized knobs only when their union is conflict-free, or when search
+retained that exact structural replay row; otherwise the ranking is explicitly ambiguous.
 
 Each of those per-target persists rewrites the whole file, so its cost is the size of the inventory rather than of
 the entry that changed, and a whole-model sweep pays it once per target. They are written **incrementally**: the
@@ -950,8 +959,11 @@ already cached, which makes hybrid-vs-MCTS comparisons charge LLM proposals cons
 slots and counts only terminals that reached a live backend; cached replay observations update the tree without
 spending the live-measurement budget. Ranking feedback is written under the entry's working-only `ranking` mapping,
 and the final tune winner is annotated or appended as another proposal only when one directly searched observation
-provides both its knob row and cost. A later greedy deploy replay can select different golden/DB evidence and is never
-paired with that search reward. These `-O1` ranking numbers never populate
+provides both its knob row and cost. When the fastest searched terminal changes the kernel set, the winner is its first
+exact structural replay row: a `PLACE`-only routing row for a placement cut, or the complete pre-split schedule row for
+a cross-CTA reduction. The pieces remain independent tuning targets; promotion never fabricates their heterogeneous
+schedules into one row or falls back to a slower monolithic sibling. A later greedy deploy replay can select different
+golden/DB evidence and is never paired with that search reward. These `-O1` ranking numbers never populate
 `emmy_us` / `cublas_us`; promotion still requires the separate repeated, correct, deployable `-O3` A/B gate.
 
 Hybrid-vs-MCTS baselines start from identical inventory-only working files: verified rows are not copied into either

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -538,7 +538,10 @@ Three definitions the list leans on:
 - **What "agrees with" means** (`evidence_row_vouches` in the code; the same rule serves the reservoir and DB
   tiers): a measured row counts as evidence for a candidate when every tuning knob the candidate has decided so far
   has the same value in that row. Knobs the candidate has not decided yet are free — a later pass will decide them.
-  That is what lets one fully-decided measured row settle a fork whose candidates are still only partly decided.
+  That is what lets one fully-decided measured row settle a fork whose candidates are still only partly decided. At
+  a placement fork, `PLACE` is the exception: each candidate's complete `PLACE` subset must exactly equal the measured
+  row's subset, including the fused candidate's empty subset. A cut measurement therefore vouches only for that cut,
+  while the same prefix rule continues to apply to every non-`PLACE` knob.
 - **The reservoir** is the online prior's own training dataset: a bounded uniform sample (Algorithm R, capped at
   `MAX_ROWS` = 100k) of every training row ever streamed in across runs, stored INSIDE the online checkpoint
   (`online.json`, Part 5). Its `H_opt=3` rows — the deployable re-benches of Part 5 — double as deploy evidence, so

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -593,11 +593,13 @@ the fused form plus one cut fragment per legal seam, so `tune` discovers cuts an
 prices them through the same kernel-set costing as any structural option (Part 4) — measurements first, then
 whichever prior is loaded. That costing exists because a `Graph` leaf carries no knob row the ordinary ranking
 could score, not to defend the fused side: when some leaf cannot be priced the pricing decides nothing and every
-leaf, cuts included, goes on to the ordinary ranking. Exactly two computed seams whose runnable normalized Loop
-bodies are alpha-equivalent collapse to one cut fragment: one workspace producer replaces both contextual uses.
-Different external buffers or operations, and equivalence classes larger than two, remain independent seams. A
-chosen cut's
-parent piece carries `PLACE@<seam>: cut` in its op knobs, so a measured cut records and replays as the exact pin. A
+leaf, cuts included, goes on to the ordinary ranking. A measured whole-route row is direct evidence for the complete
+fused or cut candidate, so the reservoir and DB tiers consult it before estimating a route from its child kernels;
+only a placement fork without exact aggregate evidence reaches that structural cost estimate. Exactly two computed
+seams whose runnable normalized Loop bodies are alpha-equivalent collapse to one cut fragment: one workspace producer
+replaces both contextual uses. Different external buffers or operations, and equivalence classes larger than two,
+remain independent seams. A chosen cut's parent piece carries `PLACE@<seam>: cut` in its op knobs, so a measured cut
+records and replays as the exact pin. A
 **routing** golden entry (knobs that are only `PLACE@<label>` values; the loader rejects a mix of `PLACE` with
 schedule knobs) is the recorded form of that pin — replayed like any other pinned row, never consulted by an
 unpinned compile.

--- a/emmy/compiler/pipeline/knob.py
+++ b/emmy/compiler/pipeline/knob.py
@@ -630,11 +630,18 @@ def schedule_row_key(knobs: dict) -> tuple[tuple[str, str], ...]:
     return canonical_row_key({k: v for k, v in stamped.items() if family_of(k) in SCHEDULE_FAMILIES})
 
 
-def evidence_row_vouches(cand_tun: dict, row_tun: dict) -> bool:
+def evidence_row_vouches(cand_tun: dict, row_tun: dict, *, exact_families: frozenset[str] = frozenset()) -> bool:
     """Whether a measured evidence row can vouch for a candidate under value-of-position
     semantics: every tunable knob the candidate specifies must match the row, a key absent
-    from the ROW reading as free (a later pass decides it)."""
-    return not any(k in row_tun and row_tun[k] != v for k, v in cand_tun.items())
+    from the ROW reading as free (a later pass decides it). Families in
+    ``exact_families`` instead require the candidate and row to carry the same
+    complete family subset."""
+    if exact_families:
+        candidate_exact = {k: v for k, v in cand_tun.items() if family_of(k) in exact_families}
+        row_exact = {k: v for k, v in row_tun.items() if family_of(k) in exact_families}
+        if candidate_exact != row_exact:
+            return False
+    return not any(k in row_tun and row_tun[k] != v for k, v in cand_tun.items() if family_of(k) not in exact_families)
 
 
 def drop_uninformative_scopes(knobs: dict) -> dict[str, str]:

--- a/emmy/compiler/pipeline/search/db.py
+++ b/emmy/compiler/pipeline/search/db.py
@@ -18,9 +18,9 @@ Pure persistence layer — no MCTS state, no propagation walks. Tables:
   known-good row. Deterministic rewrites (single option) trivially
   win their own slot via the same path.
 - ``perf`` — backend-agnostic measurement store. ``op_key`` is whichever
-  terminal op the backend measured (today: a CudaOp; tomorrow whatever
-  other backends lower to). ``backend`` partitions the table so the
-  loop interpreter and the CUDA backend can coexist in the same DB.
+  terminal op the backend measured, or the finalized Loop cache key for a
+  directly measured whole-slice structural route. ``backend`` partitions the
+  table so the loop interpreter and the CUDA backend can coexist in the same DB.
 - ``node`` — one row per search-tree node (every partial branch + leaf of a
   per-kernel autotune search), keyed by ``digest(context_key, op_sig,
   tunable-knob set)``. Each row carries the full feature dict passed to the

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -857,6 +857,22 @@ def greedy_decide(
         # The pick equals scoring the flat candidate set, invariant to how
         # the lazy tree's levels are arranged.
         leaves = flatten_leaves(fp.options)
+        base = {**fp.ctx.features(), **dict(fp.root_op.knobs)}
+        placement_rows = _placement_candidate_rows(leaves)
+        picker = getattr(the_prior, "pick", None)
+        if price_structural and placement_rows and picker is not None:
+            from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
+
+            placement_base = {key: value for key, value in base.items() if family_of(key) != "PLACE"}
+            evidence_rows = [{**placement_base, **row} for row in placement_rows]
+            exact_families = frozenset({"PLACE"})
+            ev = getattr(the_prior, "evidence_pick", None)
+            got = ev(evidence_rows, exact_families=exact_families) if ev is not None else None
+            if got is None and db_index():
+                got = _db_measured_pick(db_index(), evidence_rows, exact_families=exact_families)
+            if got is not None:
+                best_i, fp.score = got
+                return leaves[best_i]
         # Structural options (Graph splices that change the kernel set): the
         # per-op prior prices ONE kernel's knob row, so its score for a
         # multi-kernel Graph option is meaningless. :func:`_priced_pick` asks
@@ -885,7 +901,6 @@ def greedy_decide(
         # The constant base under this fork's deltas: the offer op's knobs
         # (its ``S_*`` structural identity) plus the ``H_*`` host/hardware
         # regime — the feature base tune trained on (``two_level.inner_reward``).
-        base = {**fp.ctx.features(), **dict(fp.root_op.knobs)}
         # Tiles this node already failed to lower on an earlier attempt — skip
         # the matching leaf so greedy falls back to the next prior-ranked one.
         node_blocked = blocked.get(fp.node_id) if blocked else None
@@ -895,7 +910,6 @@ def greedy_decide(
         if not live:  # every leaf blocklisted → no valid alternative left
             return leaves[0]
         rows = [{**base, **k} for _, k in live]
-        placement_rows = _placement_candidate_rows([option for option, _knobs in live])
         # The deploy evidence hierarchy, top first: (1) measured -O3 reservoir
         # evidence (``Prior.evidence_pick`` — deployable-regime truth); (2) the
         # tune DB's measured best on an exact ``S_*`` match (a config the tune
@@ -903,33 +917,15 @@ def greedy_decide(
         # eighth-sweep finding 2); (3) the model argmin only when no candidate
         # has evidence at all. An env pin overrides everything upstream of the
         # fork (a pinned family never reaches a decide).
-        picker = getattr(the_prior, "pick", None)
-        if picker is not None:
-            evidence_rows = rows
-            exact_families = frozenset()
-            if placement_rows:
-                from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
-
-                placement_base = {key: value for key, value in base.items() if family_of(key) != "PLACE"}
-                evidence_rows = [{**placement_base, **row} for row in placement_rows]
-                exact_families = frozenset({"PLACE"})
+        if picker is not None and placement_rows is None:
             ev = getattr(the_prior, "evidence_pick", None)
-            if ev is None or placement_rows == []:
-                got = None
-            elif placement_rows is None:
-                got = ev(rows)
-            else:
-                got = ev(evidence_rows, exact_families=exact_families)
-            if got is None and db_index() and placement_rows != []:
-                got = (
-                    _db_measured_pick(db_index(), rows)
-                    if placement_rows is None
-                    else _db_measured_pick(db_index(), evidence_rows, exact_families=exact_families)
-                )
+            got = ev(rows) if ev is not None else None
+            if got is None and db_index():
+                got = _db_measured_pick(db_index(), rows)
                 if got is None:
-                    _warn_disjoint_evidence(db_index(), evidence_rows, fp.node_id)
+                    _warn_disjoint_evidence(db_index(), rows, fp.node_id)
             best_i, price = got if got is not None else picker(rows)
-        else:  # bare-mean_scores prior object (tests / custom callers)
+        else:  # bare-mean_scores prior, or placement with no whole-route evidence
             from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
 
             s = the_prior.mean_scores(rows)

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -423,7 +423,12 @@ def _sig_groups(index: dict[frozenset, list[tuple[dict, float, bool]]], sig: fro
     return Prior.sig_groups(index, sig)
 
 
-def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], rows: list[dict]) -> tuple[int, float] | None:
+def _db_measured_pick(
+    index: dict[frozenset, list[tuple[dict, float, bool]]],
+    rows: list[dict],
+    *,
+    exact_families: frozenset[str] = frozenset(),
+) -> tuple[int, float] | None:
     """Measured-evidence argmin over candidate knob rows against the DB index —
     the same prefix-consistency contract as ``Prior.evidence_pick`` (every
     tunable knob the candidate specifies must match the measured row; undecided
@@ -473,7 +478,7 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
             for row_tun, us, deployable in measured:
                 # A row counts as evidence when it matches every knob the candidate
                 # has decided; undecided knobs are free (``evidence_row_vouches``).
-                if not evidence_row_vouches(cand_tun, row_tun):
+                if not evidence_row_vouches(cand_tun, row_tun, exact_families=exact_families):
                     continue
                 if deployable:
                     if better(us, i, best):
@@ -481,6 +486,49 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
                 elif better(us, i, best_rank):
                     best_rank = (i, us)
     return best if best is not None else best_rank
+
+
+def _placement_candidate_rows(leaves: list[object]) -> list[dict] | None:
+    """Exact PLACE identities for one placement fork, aligned with ``leaves``.
+
+    A Graph has no ordinary knob row because its kernels may carry conflicting
+    schedules. Its placement route is different: every fragment stamps the one
+    exact PLACE subset that identifies it, while the fused Op has an empty
+    subset. ``None`` means this is not a placement fork; an empty list means the
+    offered routes are ambiguous and measured evidence must not decide them.
+    """
+    from emmy.compiler.pipeline.knob import canonical_row_key, family_of  # noqa: PLC0415
+    from emmy.compiler.pipeline.pipeline import _is_structural_option  # noqa: PLC0415
+
+    rows: list[dict] = []
+    saw_place = False
+    ambiguous = False
+    for leaf in leaves:
+        ordinary = {
+            key: value for key, value in _leaf_knobs(leaf).items() if not key.startswith(("S_", "H_")) and family_of(key) != "PLACE"
+        }
+        if not _is_structural_option(leaf):
+            rows.append(ordinary)
+            continue
+        route = {}
+        for node in _leaf_graph(leaf).nodes.values():
+            for key, value in (getattr(node.op, "knobs", None) or {}).items():
+                if family_of(key) != "PLACE":
+                    continue
+                value = str(value)
+                if key in route and route[key] != value:
+                    ambiguous = True
+                route[key] = value
+        if route:
+            saw_place = True
+            rows.append({**ordinary, **route})
+        else:
+            ambiguous = True
+            rows.append(ordinary)
+    if not saw_place:
+        return None
+    keys = [canonical_row_key(row) for row in rows]
+    return [] if ambiguous or len(set(keys)) != len(keys) else rows
 
 
 def _warn_disjoint_evidence(index: dict[frozenset, list[tuple[dict, float, bool]]], rows: list[dict], node_id: str) -> None:
@@ -847,6 +895,7 @@ def greedy_decide(
         if not live:  # every leaf blocklisted → no valid alternative left
             return leaves[0]
         rows = [{**base, **k} for _, k in live]
+        placement_rows = _placement_candidate_rows([option for option, _knobs in live])
         # The deploy evidence hierarchy, top first: (1) measured -O3 reservoir
         # evidence (``Prior.evidence_pick`` — deployable-regime truth); (2) the
         # tune DB's measured best on an exact ``S_*`` match (a config the tune
@@ -856,12 +905,29 @@ def greedy_decide(
         # fork (a pinned family never reaches a decide).
         picker = getattr(the_prior, "pick", None)
         if picker is not None:
+            evidence_rows = rows
+            exact_families = frozenset()
+            if placement_rows:
+                from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
+
+                placement_base = {key: value for key, value in base.items() if family_of(key) != "PLACE"}
+                evidence_rows = [{**placement_base, **row} for row in placement_rows]
+                exact_families = frozenset({"PLACE"})
             ev = getattr(the_prior, "evidence_pick", None)
-            got = ev(rows) if ev is not None else None
-            if got is None and db_index():
-                got = _db_measured_pick(db_index(), rows)
+            if ev is None or placement_rows == []:
+                got = None
+            elif placement_rows is None:
+                got = ev(rows)
+            else:
+                got = ev(evidence_rows, exact_families=exact_families)
+            if got is None and db_index() and placement_rows != []:
+                got = (
+                    _db_measured_pick(db_index(), rows)
+                    if placement_rows is None
+                    else _db_measured_pick(db_index(), evidence_rows, exact_families=exact_families)
+                )
                 if got is None:
-                    _warn_disjoint_evidence(db_index(), rows, fp.node_id)
+                    _warn_disjoint_evidence(db_index(), evidence_rows, fp.node_id)
             best_i, price = got if got is not None else picker(rows)
         else:  # bare-mean_scores prior object (tests / custom callers)
             from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -422,6 +422,10 @@ class TuningSearch(Search):
         if node is None:
             return None
         structural = self._structural_replay_row(node)
+        # A compatible multi-CUDA terminal has one exact merged row even though
+        # its kernel-set-changing choice never appeared as a search-tree fork.
+        if structural is None and (node.realized_cuda_ops or 0) > 1:
+            structural = self._structural_row(node.realized_knobs)
         if structural is None and node.realized_knobs is None and (node.realized_cuda_ops or 0) > 1:
             structural = self._structural_row(validated_input_route)
         if structural is not None:

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -35,7 +35,15 @@ from typing import TYPE_CHECKING
 
 from emmy import config
 from emmy.compiler.ir.cuda.ir import CudaOp
-from emmy.compiler.pipeline.knob import canonical_row_key, context_view, decision_view
+from emmy.compiler.ir.schedule import ReducePlan, Workers
+from emmy.compiler.pipeline.knob import (
+    canonical_row_key,
+    context_view,
+    decision_view,
+    family_of,
+    stamp_schedule_families,
+    tuning_knob_items,
+)
 from emmy.compiler.pipeline.search.candidate import LazyCandidate
 from emmy.compiler.pipeline.search.db import NodeRow, PerfStats
 from emmy.compiler.pipeline.search.policy.base import Search
@@ -350,27 +358,77 @@ class TuningSearch(Search):
             return None
         return sum(isinstance(node.op, CudaOp) for node in graph.nodes.values())
 
-    def best_realized(self) -> tuple[dict, float, int | None] | None:
-        """Return the fastest directly observed successful terminal.
+    @staticmethod
+    def _structural_row(knobs: dict | None) -> dict[str, str] | None:
+        """The exact kernel-set-changing replay row in ``knobs``, if any."""
+        if not knobs:
+            return None
+        row = dict(tuning_knob_items(knobs))
+        cuts = {key: value for key, value in row.items() if family_of(key) == "PLACE" and value == "cut"}
+        if cuts:
+            return cuts
+        work = Workers.parse(row.get("WORK"))
+        if any(ReducePlan.parse(value, work).needs_split for key, value in row.items() if family_of(key) == "REDUCE"):
+            return stamp_schedule_families(row)
+        return None
 
-        Unlike ``tree.best_reward``, this preserves the knobs and direct cost as
-        one indivisible observation. Callers must not reconstruct the knobs from
-        a later greedy/deploy replay, whose evidence hierarchy can select a
-        different configuration. Equal medians break deterministically by the
-        canonical knob row.
-        """
-        best: tuple[dict, float, int | None] | None = None
+    def _structural_replay_row(self, node: SearchNode) -> dict[str, str] | None:
+        """The first exact kernel-set-changing row on ``node``'s path."""
+        path: list[SearchNode] = []
+        cur: SearchNode | None = node
+        while cur is not None:
+            path.append(cur)
+            cur = cur.parent
+        for cur in reversed(path):
+            knobs = getattr(cur.candidate, "resolved_knobs", None)
+            structural = self._structural_row(knobs)
+            if structural is not None:
+                return structural
+        return None
+
+    def _best_terminal_node(self) -> SearchNode | None:
+        """The fastest directly observed successful terminal node."""
+        best: tuple[float, bool, tuple, SearchNode] | None = None
         stack = list(self.tree.root.children)
         while stack:
             node = stack.pop()
             stack.extend(node.children)
             stats = node.bench_stats
-            if node.bench_status != "ok" or node.realized_knobs is None or stats is None or stats.median <= 0:
+            if node.bench_status != "ok" or stats is None or stats.median <= 0:
                 continue
-            candidate = (dict(node.realized_knobs), float(stats.median), node.realized_cuda_ops)
-            if best is None or (candidate[1], canonical_row_key(candidate[0])) < (best[1], canonical_row_key(best[0])):
+            key = canonical_row_key(node.realized_knobs) if node.realized_knobs is not None else ()
+            candidate = (float(stats.median), node.realized_knobs is None, key, node)
+            if best is None or candidate[:3] < best[:3]:
                 best = candidate
-        return best
+        return best[3] if best is not None else None
+
+    def best_realized(self, *, validated_input_route: dict | None = None) -> tuple[dict, float, int | None, bool] | None:
+        """Return an exact replay row for the fastest directly observed successful terminal.
+
+        Unlike ``tree.best_reward``, this preserves the knobs and direct cost as
+        one indivisible observation. Callers must not reconstruct the knobs from
+        a later greedy/deploy replay, whose evidence hierarchy can select a
+        different configuration. When the winner changes the kernel set, its
+        first structural row is the replay contract and the independently
+        scheduled pieces remain separate targets. If neither that row nor one
+        terminal knob row exists, never fall back to a slower representable
+        sibling. An authoritative ``validated_input_route`` may supply the row
+        when pinning made the structural choice deterministic rather than a tree
+        node, but only for a conflicting multi-CUDA terminal. Equal medians
+        prefer a representable row and then break deterministically by its
+        canonical key.
+        """
+        node = self._best_terminal_node()
+        if node is None:
+            return None
+        structural = self._structural_replay_row(node)
+        if structural is None and node.realized_knobs is None and (node.realized_cuda_ops or 0) > 1:
+            structural = self._structural_row(validated_input_route)
+        if structural is not None:
+            return structural, float(node.bench_stats.median), node.realized_cuda_ops, True
+        if node.realized_knobs is None:
+            return None
+        return dict(node.realized_knobs), float(node.bench_stats.median), node.realized_cuda_ops, False
 
     def push(self, *cands: LazyCandidate, parent: object | None = None, structural: bool = False) -> None:
         # ``parent`` is the token the spawning candidate was popped with;
@@ -534,12 +592,27 @@ class TuningSearch(Search):
         return digest(context_key, gpu, op_sig, tun)
 
     def _collect_node_records(
-        self, *, context_key: str, op_sig: str, gpu: str = "", run_id: str = "", o3_context_key: str | None = None
+        self,
+        *,
+        context_key: str,
+        op_sig: str,
+        gpu: str = "",
+        run_id: str = "",
+        o3_context_key: str | None = None,
+        validated_input_route: dict | None = None,
     ) -> list[NodeRow]:
         """Post-search tree walk producing keyed, parent-linked :class:`NodeRow`
         records for :meth:`SearchDB.record_nodes` — the persistent/keyed/deduped
         sibling of :meth:`_collect_rows` (which feeds the prior's in-memory
         reservoir).
+
+        ``validated_input_route`` is an authoritative proposal row whose
+        realized-pin check already passed. When that row is structural and the
+        directly measured winner is a conflicting multi-CUDA terminal with no
+        structural node on its path, the walk records the original Loop parent
+        and its measured structural child. This is the pinned full-fork case:
+        the input route was applied deterministically instead of becoming an
+        ordinary search-tree node.
 
         Pre-order descent from the top forks (the sentinel root is skipped); each
         node passing the same ``visits > 0 and best_reward > 0`` guard as
@@ -583,6 +656,15 @@ class TuningSearch(Search):
         taking the max (not sum) of the duplicates' ``visits`` so
         ``record_nodes``'s SUM accumulation never double-counts within one run."""
         out: dict[str, NodeRow] = {}
+        structural_leaf = self._best_terminal_node()
+        structural_input = self._structural_row(validated_input_route)
+        if (
+            structural_leaf is None
+            or structural_leaf.realized_knobs is not None
+            or (structural_leaf.realized_cuda_ops or 0) <= 1
+            or self._structural_replay_row(structural_leaf) is not None
+        ):
+            structural_input = None
 
         def emit(row: NodeRow) -> None:
             prev = out.get(row.node_key)
@@ -611,7 +693,51 @@ class TuningSearch(Search):
                 # A benched leaf with no single row (several kernels with different
                 # decisions) has nothing to key a node record on — see :meth:`_collect_rows`.
                 skip = is_leaf and node.realized_knobs is None
-                if node.visits > 0 and node.best_reward > 0 and not skip:
+                if node is structural_leaf and structural_input is not None and node.visits > 0 and node.best_reward > 0:
+                    value_us = 1.0 / node.best_reward
+                    route_parent = parent_key
+                    route_depth = depth
+                    if route_parent is None:
+                        base_features = dict(self._base_knobs)
+                        route_parent = self._node_key(base_features, op_sig, context_key, gpu)
+                        emit(
+                            NodeRow(
+                                node_key=route_parent,
+                                parent_key=None,
+                                context_key=context_key,
+                                op_sig=op_sig,
+                                features=base_features,
+                                value_us=value_us,
+                                depth=depth,
+                                gpu=gpu,
+                                visits=node.visits,
+                                is_leaf=False,
+                                status="ok",
+                                run_id=run_id,
+                            )
+                        )
+                        route_depth += 1
+                    route_features = {**self._base_knobs, **structural_input}
+                    nk = self._node_key(route_features, op_sig, context_key, gpu)
+                    emit(
+                        NodeRow(
+                            node_key=nk,
+                            parent_key=route_parent,
+                            context_key=context_key,
+                            op_sig=op_sig,
+                            features=route_features,
+                            value_us=value_us,
+                            depth=route_depth,
+                            gpu=gpu,
+                            visits=node.visits,
+                            is_leaf=True,
+                            variance=stats.variance if stats is not None else None,
+                            n_samples=stats.n_samples if stats is not None else None,
+                            status="ok",
+                            run_id=run_id,
+                        )
+                    )
+                elif node.visits > 0 and node.best_reward > 0 and not skip:
                     feats = node.realized_knobs if is_leaf else self._node_knobs(node)
                     value_us = 1.0 / node.best_reward
                     assert parent_value is None or value_us >= parent_value - 1e-9, "value-of-position not monotone up the tree"

--- a/emmy/compiler/pipeline/search/prior/base.py
+++ b/emmy/compiler/pipeline/search/prior/base.py
@@ -302,13 +302,15 @@ class Prior(ABC):
             self._ev_fp = fp
         return self._ev_index
 
-    def evidence_pick(self, rows: list[dict]) -> tuple[int, float] | None:
+    def evidence_pick(self, rows: list[dict], *, exact_families: frozenset[str] = frozenset()) -> tuple[int, float] | None:
         """Measured-evidence argmin over candidate knob rows: the candidate whose
         knob prefix is consistent with the **fastest -O3 reservoir row** of the
         same op (``S_*`` signature). A candidate is consistent with a measured row
         when every tunable knob the candidate specifies matches the row (knobs the
         candidate hasn't decided yet are free, so a partial fork prefix inherits
-        the best measured outcome among its completions).
+        the best measured outcome among its completions). Families named by
+        ``exact_families`` instead require exact subset equality; placement forks
+        use that to distinguish a fused leaf from each cut fragment.
 
         Returns ``(index, measured_µs)`` or ``None`` when no candidate has
         evidence. This is what keeps the greedy deploy from preferring an
@@ -331,7 +333,7 @@ class Prior(ABC):
                 for row_tun, us in measured:
                     # A row counts as evidence when it matches every knob the candidate
                     # has decided; undecided knobs are free (``evidence_row_vouches``).
-                    if not evidence_row_vouches(cand_tun, row_tun):
+                    if not evidence_row_vouches(cand_tun, row_tun, exact_families=exact_families):
                         continue
                     # Tie on µs (one measured row matching several candidates) breaks by
                     # the candidates' canonical content, never their enumeration order.

--- a/emmy/compiler/pipeline/search/strategy/two_level.py
+++ b/emmy/compiler/pipeline/search/strategy/two_level.py
@@ -103,6 +103,7 @@ class OpResult:
     searched_knobs: dict[str, str] | None = None
     searched_us: float | None = None
     searched_cuda_ops: int | None = None
+    searched_structural: bool = False
 
 
 @dataclass
@@ -117,17 +118,22 @@ class InnerReward:
     prior_summaries: list[str] = field(default_factory=list)
 
     def searched_winner(self) -> tuple[dict[str, str], float] | None:
-        """The actual searched winner when it maps to exactly one CUDA kernel.
+        """The actual searched winner when it has one exact replay row.
 
-        A target can contain repeated/heterogeneous post-fusion kernels, and one
-        post-fusion kernel can lower to several CudaOps. In either case there is
-        no single golden-format knob row whose latency represents the target, so
-        callers must omit a winner annotation instead of inventing one.
+        A target can contain repeated/heterogeneous post-fusion kernels. One
+        post-fusion kernel can also lower to several CudaOps; that winner is
+        replayable only when search retained the exact structural row that
+        minted its independently scheduled pieces.
         """
         if len(self.per_op) != 1:
             return None
         op = self.per_op[0]
-        if op.multiplicity != 1 or op.searched_cuda_ops != 1 or op.searched_knobs is None or op.searched_us is None:
+        if (
+            op.multiplicity != 1
+            or (op.searched_cuda_ops != 1 and not op.searched_structural)
+            or op.searched_knobs is None
+            or op.searched_us is None
+        ):
             return None
         return dict(op.searched_knobs), op.searched_us
 
@@ -440,8 +446,10 @@ class TwoLevelStrategy(SearchStrategy):
                     return
                 best = db.best_per_op_time(ctx_key, work.key, backend=backend_name)
                 searched_knobs = searched_us = searched_cuda_ops = None
+                searched_structural = False
                 if searched is not None:
-                    searched_knobs = stamp_schedule_families(searched[0])
+                    searched_structural = searched[3]
+                    searched_knobs = dict(searched[0]) if searched_structural else stamp_schedule_families(searched[0])
                     searched_us = searched[1]
                     searched_cuda_ops = searched[2]
                 results[op_idx] = OpResult(
@@ -452,6 +460,7 @@ class TwoLevelStrategy(SearchStrategy):
                     searched_knobs=searched_knobs,
                     searched_us=searched_us,
                     searched_cuda_ops=searched_cuda_ops,
+                    searched_structural=searched_structural,
                 )
                 if progress is not None:
                     progress.op_done(name, slot=op_idx)

--- a/emmy/compiler/pipeline/search/working_golden.py
+++ b/emmy/compiler/pipeline/search/working_golden.py
@@ -384,14 +384,22 @@ class _ProposalLoopIdentity(PipelineStrategy):
         copy of the consumed parent before computing its route-specific cache key.
         """
         from emmy.compiler.pipeline import TuningSearch  # noqa: PLC0415
+        from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
 
         root = event.root_op
-        route = TuningSearch._structural_row(getattr(root, "knobs", None))
-        if route is None:
-            fragment_knobs: dict = {}
-            for node in event.fragment.nodes.values():
-                fragment_knobs.update(getattr(node.op, "knobs", None) or {})
-            route = TuningSearch._structural_row(fragment_knobs)
+        root_route = TuningSearch._structural_row(getattr(root, "knobs", None))
+        fragment_knobs: dict = {}
+        for node in event.fragment.nodes.values():
+            fragment_knobs.update(getattr(node.op, "knobs", None) or {})
+        fragment_route = TuningSearch._structural_row(fragment_knobs)
+        fragment_cut = fragment_route is not None and any(family_of(key) == "PLACE" for key in fragment_route)
+        root_cut = root_route is not None and any(family_of(key) == "PLACE" for key in root_route)
+        if fragment_cut:
+            route = fragment_route
+        elif root_route is not None and not root_cut:
+            route = root_route
+        else:
+            route = None
         if route is None:
             return
         parent = copy.copy(root)

--- a/emmy/compiler/pipeline/search/working_golden.py
+++ b/emmy/compiler/pipeline/search/working_golden.py
@@ -20,6 +20,7 @@ from emmy.compiler.pipeline.search.golden import (
     is_repository_golden_path,
     load_golden_file,
 )
+from emmy.compiler.pipeline.strategy import PipelineStrategy
 
 
 @dataclass
@@ -345,7 +346,80 @@ def realized_tuning_knobs(graph) -> dict[str, str] | None:
     return merged
 
 
-async def measure_proposals(graph, proposals, *, backend, db, ctx, max_candidates: int | None, prior=None) -> list[dict]:
+class _ProposalLoopIdentity(PipelineStrategy):
+    """Capture the finalized Loop target and any measured structural parent."""
+
+    def __init__(self) -> None:
+        self.value: tuple[str, str, dict] | None = None
+        self.structural_parents: list[tuple[dict[str, str], str, dict]] = []
+
+    def _capture(self, graph) -> None:
+        if self.value is not None:
+            return
+        from emmy.compiler.ir.loop import LoopOp  # noqa: PLC0415
+        from emmy.compiler.pipeline.knob import STRUCT_PREFIX  # noqa: PLC0415
+        from emmy.compiler.pipeline.passes.identity import IdentityStrategy  # noqa: PLC0415
+        from emmy.compiler.pipeline.strategy import discovered_strategies  # noqa: PLC0415
+
+        loops = [node.op for node in graph.nodes.values() if isinstance(node.op, LoopOp)]
+        if len(loops) != 1:
+            return
+        identity = next(strategy for strategy in discovered_strategies() if isinstance(strategy, IdentityStrategy))
+        stamped = {key: float(value) for key, value in loops[0].knobs.items() if key.startswith(STRUCT_PREFIX)}
+        cache_key = loops[0].cache_key()
+        if stamped and cache_key is not None:
+            self.value = identity.op_sig(loops[0], graph), cache_key, stamped
+
+    def on_run_start(self, event) -> None:
+        self._capture(event.graph)
+
+    def on_pass_end(self, event) -> None:
+        self._capture(event.graph)
+
+    def on_splice(self, event) -> None:
+        """Capture the consumed parent whose route changes the kernel set.
+
+        A cross-CTA split carries its route on ``root_op``. A placement cut carries
+        it on the fresh fragment instead, so fold that decision back onto an exact
+        copy of the consumed parent before computing its route-specific cache key.
+        """
+        from emmy.compiler.pipeline import TuningSearch  # noqa: PLC0415
+
+        root = event.root_op
+        route = TuningSearch._structural_row(getattr(root, "knobs", None))
+        if route is None:
+            fragment_knobs: dict = {}
+            for node in event.fragment.nodes.values():
+                fragment_knobs.update(getattr(node.op, "knobs", None) or {})
+            route = TuningSearch._structural_row(fragment_knobs)
+        if route is None:
+            return
+        parent = copy.copy(root)
+        parent.knobs = {**(getattr(root, "knobs", None) or {}), **route}
+        if not any(key.startswith("S_") for key in parent.knobs):
+            return
+        key = parent.cache_key()
+        if key is None:
+            return
+        receipt = (dict(route), key, dict(parent.knobs))
+        if receipt not in self.structural_parents:
+            self.structural_parents.append(receipt)
+
+    def structural_parent(self, route: dict) -> tuple[str, dict] | None:
+        """The one consumed parent that realized ``route``, or ``None`` if ambiguous."""
+        from emmy.compiler.pipeline import TuningSearch  # noqa: PLC0415
+
+        wanted = TuningSearch._structural_row(route)
+        matches = {(key, tuple(sorted(knobs.items()))) for got, key, knobs in self.structural_parents if got == wanted}
+        if len(matches) != 1:
+            return None
+        key, knob_items = matches.pop()
+        return key, dict(knob_items)
+
+
+async def measure_proposals(
+    graph, proposals, *, backend, db, ctx, max_candidates: int | None, prior=None, run_id: str | None = None
+) -> list[dict]:
     """Measure working-file candidates exactly, in file order, before MCTS."""
     from emmy.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
     from emmy.compiler.pipeline import CUDA_PASSES, Pipeline, TuningSearch  # noqa: PLC0415
@@ -371,16 +445,53 @@ async def measure_proposals(graph, proposals, *, backend, db, ctx, max_candidate
             prior_model=prior,
             base_knobs=ctx.features(),
         )
+        loop_identity = _ProposalLoopIdentity()
         terminal = None
         with pinned_knobs(pins):
-            async for candidate in Pipeline.build(CUDA_PASSES).tune_async(graph.copy(), search=search, ctx=ctx, backend=backend, db=db):
+            pipeline = Pipeline.build(CUDA_PASSES).with_strategies(loop_identity)
+            async for candidate in pipeline.tune_async(graph.copy(), search=search, ctx=ctx, backend=backend, db=db):
                 terminal = candidate
+        if loop_identity.value is not None:
+            search._base_knobs.update(loop_identity.value[2])
+        raw_rows = [node.op.knobs for node in terminal.graph.nodes.values() if isinstance(node.op, CudaOp)] if terminal else []
+        pin_error = unreproducible_pin_flag(pins, raw_rows) if raw_rows else "proposal produced no CUDA kernel"
+        validated_route = pins if pin_error is None and loop_identity.value is not None else None
+        searched = search.best_realized(validated_input_route=validated_route)
+        structural = searched if searched is not None and searched[3] else None
+        structural_parent = loop_identity.structural_parent(structural[0]) if structural is not None else None
+        if structural_parent is not None:
+            search._base_knobs.update({key: value for key, value in structural_parent[1].items() if key.startswith("S_")})
+        if (
+            pin_error is None
+            and structural_parent is not None
+            and (structural[2] or 0) > 1
+            and search.last_status == "ok"
+            and search.last_stats is not None
+        ):
+            structural_key, structural_knobs = structural_parent
+            db.record_perf(
+                ctx.structural_key(),
+                structural_key,
+                backend=ctx.backend_name or "cuda",
+                status="ok",
+                stats=search.last_stats,
+                knobs={**ctx.features(), **structural_knobs},
+                captured=True,
+            )
         if prior is not None:
             prior.add_rows(search._collect_rows() + search.o3_rows)
             prior.maybe_refit()
-        raw_rows = [node.op.knobs for node in terminal.graph.nodes.values() if isinstance(node.op, CudaOp)] if terminal else []
-        measured_knobs = realized_tuning_knobs(terminal.graph) if terminal is not None else None
-        pin_error = unreproducible_pin_flag(pins, raw_rows) if raw_rows else "proposal produced no CUDA kernel"
+        if loop_identity.value is not None:
+            db.record_nodes(
+                search._collect_node_records(
+                    context_key=ctx.structural_key(),
+                    op_sig=loop_identity.value[0],
+                    gpu=ctx.hardware_id(),
+                    run_id=run_id or "",
+                    validated_input_route=validated_route,
+                )
+            )
+        measured_knobs = dict(structural[0]) if structural is not None else (realized_tuning_knobs(terminal.graph) if terminal else None)
         knob_error = None
         if raw_rows and measured_knobs is None:
             knob_error = f"proposal lowered to {len(raw_rows)} CUDA kernels with conflicting tuning knobs"

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -469,7 +469,7 @@ def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(
     assert proposal["ranking"]["status"] == "ok"
     assert reloaded_targets[0].proposals == [((0, 1), route)]
 
-    place = {"PLACE@a7": "cut"}
+    place = {"PLACE@map": "cut"}
     active_route = place
     place_db = SearchDB(tmp_path / "place.db")
     [place_ranking] = asyncio.run(
@@ -492,6 +492,114 @@ def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(
     assert place_perf.knobs == {**ctx.features(), **live_features, **place}
     assert place_db.lookup_perf(ctx.structural_key(), original_loop.cache_key(), backend="cuda") is None
     place_db.close()
+
+    from emmy.compiler.pipeline.search.policy.greedy import (
+        _db_measured_index,
+        _db_measured_pick,
+        _placement_candidate_rows,
+    )
+    from emmy.compiler.pipeline.search.prior.online import OnlinePrior
+
+    fused = TileOp()
+
+    def cut(route):
+        graph = Graph()
+        graph.add_node(TileOp(knobs=route), [], Tensor("cut", (1,)), node_id="cut")
+        return graph
+
+    leaves = [fused, cut({"PLACE@a": "cut"}), cut({"PLACE@map": "cut"}), cut({"PLACE@a0": "cut"})]
+    placement_rows = _placement_candidate_rows(leaves)
+    assert placement_rows == [{}, {"PLACE@a": "cut"}, {"PLACE@map": "cut"}, {"PLACE@a0": "cut"}]
+    evidence_rows = [{**ctx.features(), **live_features, **row} for row in placement_rows]
+
+    reloaded_db = SearchDB.open_readonly(tmp_path / "place.db")
+    index = _db_measured_index(reloaded_db, ctx)
+    assert _db_measured_pick(index, evidence_rows, exact_families=frozenset({"PLACE"})) == (2, 59.61)
+    reloaded_db.close()
+
+    from emmy.compiler.pipeline.search.policy.greedy import greedy_decide
+
+    class NoEvidencePrior:
+        def evidence_pick(self, _rows, **_kwargs):
+            return None
+
+        def mean_scores(self, rows):
+            return [1_000_000.0] * len(rows)
+
+        def pick(self, _rows):
+            raise AssertionError("exact measured placement evidence was not selected")
+
+    reloaded_db = SearchDB.open_readonly(tmp_path / "place.db")
+    root = LoopOp(body=original_loop.body, knobs=live_features)
+    fork = SimpleNamespace(ctx=ctx, root_op=root, options=leaves, node_id="root", score=None)
+    monkeypatch.setattr("emmy.compiler.pipeline.search.policy.greedy._verified_index", lambda _ctx: ({}, {}))
+    monkeypatch.setattr("emmy.compiler.pipeline.search.policy.greedy._priced_pick", lambda *_args: None)
+    selected = greedy_decide(prior=NoEvidencePrior(), db=reloaded_db)(fork)
+    assert selected is leaves[2]
+    assert fork.score == pytest.approx(59.61)
+    reloaded_db.close()
+
+    def stats(us):
+        return PerfStats(median=us, min=us, max=us, mean=us, variance=0.0, n_samples=1)
+
+    place_db = SearchDB(tmp_path / "place.db")
+    place_db.record_perf(
+        ctx.structural_key(),
+        "fused",
+        backend="cuda",
+        status="ok",
+        stats=stats(40.0),
+        knobs={**ctx.features(), **live_features},
+        captured=True,
+    )
+    place_db.close()
+    reloaded_db = SearchDB.open_readonly(tmp_path / "place.db")
+    index = _db_measured_index(reloaded_db, ctx)
+    assert _db_measured_pick(index, evidence_rows, exact_families=frozenset({"PLACE"})) == (0, 40.0)
+    reloaded_db.close()
+
+    place_db = SearchDB(tmp_path / "place.db")
+    place_db.record_perf(
+        ctx.structural_key(),
+        "other-cut",
+        backend="cuda",
+        status="ok",
+        stats=stats(30.0),
+        knobs={**ctx.features(), **live_features, "PLACE@a": "cut"},
+        captured=True,
+    )
+    place_db.close()
+    reloaded_db = SearchDB.open_readonly(tmp_path / "place.db")
+    index = _db_measured_index(reloaded_db, ctx)
+    assert _db_measured_pick(index, evidence_rows, exact_families=frozenset({"PLACE"})) == (1, 30.0)
+    reloaded_db.close()
+
+    unmatched_db = SearchDB(tmp_path / "unmatched-place.db")
+    unmatched_db.record_perf(
+        ctx.structural_key(),
+        "unmatched-cut",
+        backend="cuda",
+        status="ok",
+        stats=stats(1.0),
+        knobs={**ctx.features(), **live_features, "PLACE@foreign": "cut"},
+        captured=True,
+    )
+    unmatched_db.close()
+    reloaded_db = SearchDB.open_readonly(tmp_path / "unmatched-place.db")
+    assert _db_measured_pick(_db_measured_index(reloaded_db, ctx), evidence_rows, exact_families=frozenset({"PLACE"})) is None
+    reloaded_db.close()
+
+    reservoir = OnlinePrior()
+    reservoir.add_rows(
+        [
+            ({**ctx.features(), **live_features, **place}, 59.61),
+            ({**ctx.features(), **live_features}, 40.0),
+            ({**ctx.features(), **live_features, "PLACE@foreign": "cut"}, 1.0),
+        ]
+    )
+    assert reservoir.evidence_pick(evidence_rows, exact_families=frozenset({"PLACE"})) == (0, 40.0)
+    reservoir.add_rows([({**ctx.features(), **live_features, "PLACE@a": "cut"}, 30.0)])
+    assert reservoir.evidence_pick(evidence_rows, exact_families=frozenset({"PLACE"})) == (1, 30.0)
 
     nonstructural = {**route, "REDUCE": ""}
     active_route = nonstructural

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -23,6 +23,7 @@ from emmy.compiler.pipeline.search.policy.mcts import SearchNode, SearchTree, Tu
 from emmy.compiler.pipeline.search.strategy.two_level import InnerReward, OpResult
 from emmy.compiler.pipeline.search.working_golden import (
     WorkingGoldenTarget,
+    _ProposalLoopIdentity,
     load_working_targets,
     measure_proposals,
     persist_proposal_rankings,
@@ -263,6 +264,37 @@ def test_structural_multi_cuda_winner_persists_its_exact_replay_row(tmp_path):
         "source": "tune",
         "tune_winner": True,
     }
+
+
+def test_place_proposal_records_only_the_fresh_fragment_cut(tmp_path):
+    path = tmp_path / "working.yaml"
+    dump_golden_file(_document(_matmul("mm")), path)
+    _, targets = load_working_targets(path)
+    loop_graph = Pipeline.build(LOOP_PASSES).run(targets[0].program.copy(), ctx=Context((8, 9)))
+    [original_loop] = [node.op for node in loop_graph.nodes.values() if isinstance(node.op, LoopOp)]
+
+    identity = _ProposalLoopIdentity()
+    original = TileOp(knobs={"S_n_loop": 2.0})
+    cut_fragment = Graph()
+    cut_fragment.add_node(
+        LoopOp(body=original_loop.body, knobs={"PLACE@map": "cut"}),
+        [],
+        Tensor("cut", (1,)),
+        node_id="cut",
+    )
+    identity.on_splice(SimpleNamespace(root_op=original, fragment=cut_fragment))
+
+    propagated = TileOp(knobs={"S_n_loop": 1.0, "PLACE@map": "cut"})
+    later_fragment = Graph()
+    later_fragment.add_node(LoopOp(body=original_loop.body), [], Tensor("later", (1,)), node_id="later")
+    identity.on_splice(SimpleNamespace(root_op=propagated, fragment=later_fragment))
+
+    assert len(identity.structural_parents) == 1
+    route, key, knobs = identity.structural_parents[0]
+    assert route == {"PLACE@map": "cut"}
+    assert knobs == {"S_n_loop": 2.0, "PLACE@map": "cut"}
+    assert key == TileOp(knobs=knobs).cache_key()
+    assert identity.structural_parent(route) == (key, knobs)
 
 
 def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(tmp_path, monkeypatch):

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -8,19 +8,29 @@ from types import SimpleNamespace
 import pytest
 
 from emmy.commands import tune
+from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda.ir import CudaOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
+from emmy.compiler.ir.loop import LoopOp
+from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.pipeline import LOOP_PASSES, Pipeline
+from emmy.compiler.pipeline.passes.identity import IdentityStrategy
+from emmy.compiler.pipeline.search.db import PerfStats, SearchDB
 from emmy.compiler.pipeline.search.golden import dump_golden_file, load_golden_file
+from emmy.compiler.pipeline.search.policy.mcts import SearchNode, SearchTree, TuningSearch
+from emmy.compiler.pipeline.search.strategy.two_level import InnerReward, OpResult
 from emmy.compiler.pipeline.search.working_golden import (
     WorkingGoldenTarget,
     load_working_targets,
+    measure_proposals,
     persist_proposal_rankings,
     persist_tune_winner,
     realized_tuning_knobs,
     validate_working_gpu,
 )
+from emmy.compiler.pipeline.strategy import discovered_strategies
 from emmy.compiler.torch_wire import intern_program
 
 
@@ -212,6 +222,263 @@ def test_ambiguous_multi_cuda_winner_is_not_annotated(tmp_path):
     assert len(got["configs"]) == 1
     assert got["configs"][0]["realizations"][0]["name"] == "mm"
     assert got["configs"][0]["target"] == {"origins": ["matmul"]}
+
+
+def test_structural_multi_cuda_winner_persists_its_exact_replay_row(tmp_path):
+    path = tmp_path / "working.yaml"
+    dump_golden_file(_document(_matmul("mm")), path)
+    document, targets = load_working_targets(path)
+    route = {
+        "WORK": "w1x1",
+        "TILE": "mma_m16n8k16_f16_f32/f1x4/k8",
+        "REDUCE": "g8k",
+        "STAGE": "d1/smem",
+        "RASTER": "",
+    }
+    reward = InnerReward(
+        total_us=6.0,
+        ok=True,
+        per_op=[
+            OpResult(
+                name="mm",
+                op_key="key",
+                best_us=6.0,
+                searched_knobs=route,
+                searched_us=6.0,
+                searched_cuda_ops=2,
+                searched_structural=True,
+            )
+        ],
+    )
+
+    persist_tune_winner(path, document, targets[0], reward.searched_winner(), compile_flags="-O1")
+
+    realizations = load_golden_file(path)["configs"][0]["realizations"]
+    assert realizations[1]["knobs"] == route
+    assert realizations[1]["ranking"] == {
+        "status": "ok",
+        "latency_us": 6.0,
+        "compile_flags": "-O1",
+        "measured_knobs": route,
+        "source": "tune",
+        "tune_winner": True,
+    }
+
+
+def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(tmp_path, monkeypatch):
+    from emmy.compiler.pipeline.search.policy.greedy import _db_measured_index, _db_measured_pick
+
+    route = {
+        "WORK": "w2x1",
+        "TILE": "mma_m16n8k16_f16_f32/f4x8/k8",
+        "REDUCE": "g4k",
+        "STAGE": "d1/smem-async",
+        "RASTER": "",
+    }
+    terminal = Graph()
+    terminal.add_node(
+        CudaOp(kernel_name="partial", knobs={**route, "REDUCE": ""}),
+        [],
+        Tensor("partial", (1,)),
+        node_id="partial",
+    )
+    terminal.add_node(
+        CudaOp(kernel_name="finalize", knobs={key: "" for key in route}),
+        [],
+        Tensor("finalize", (1,)),
+        node_id="finalize",
+    )
+    path = tmp_path / "working.yaml"
+    dump_golden_file(_document(_matmul("mm"), _matmul("mm", knobs=route)), path)
+    document, targets = load_working_targets(path)
+    stable_graph = targets[0].program
+    loop_graph = Pipeline.build(LOOP_PASSES).run(stable_graph.copy(), ctx=Context((8, 9)))
+    [original_loop] = [node.op for node in loop_graph.nodes.values() if isinstance(node.op, LoopOp)]
+    identity = next(strategy for strategy in discovered_strategies() if isinstance(strategy, IdentityStrategy))
+    original_op_sig = identity.op_sig(original_loop, loop_graph)
+    structural_features = {key: float(value) for key, value in original_loop.knobs.items() if key.startswith("S_")}
+    live_features = {**structural_features, "S_warp_eligible": 1.0}
+    active_route = route
+
+    class FakeSearch(TuningSearch):
+        def __init__(self, **kwargs):
+            assert kwargs["base_knobs"] == ctx.features()
+            self._base_knobs = dict(kwargs["base_knobs"])
+            self.tree = SearchTree()
+            self.last_status = "ok"
+            self.last_stats = PerfStats(median=59.61, min=59.61, max=59.61, mean=59.61, variance=0.0, n_samples=1)
+            self.o3_rows = []
+
+    class FakePipeline:
+        def __init__(self):
+            self.strategies = ()
+
+        @classmethod
+        def build(cls, _passes):
+            return cls()
+
+        def with_strategies(self, *strategies):
+            self.strategies = strategies
+            return self
+
+        async def tune_async(self, graph, **kwargs):
+            assert isinstance(graph.nodes["matmul"].op, MatmulOp)
+            event = SimpleNamespace(graph=loop_graph)
+            for strategy in self.strategies:
+                strategy.on_pass_end(event)
+            route_parent = TileOp(knobs=dict(live_features))
+            fragment = Graph()
+            if any(key.startswith("PLACE") for key in active_route):
+                piece = LoopOp(body=original_loop.body, knobs={**structural_features, **active_route})
+                fragment.add_node(piece, [], Tensor("piece", (1,)), node_id="piece")
+            else:
+                route_parent.knobs.update(active_route)
+            splice = SimpleNamespace(root_op=route_parent, fragment=fragment)
+            for strategy in self.strategies:
+                strategy.on_splice(splice)
+            search = kwargs["search"]
+            leaf = SearchNode(candidate=SimpleNamespace(resolved_knobs=None))
+            leaf.visits = 1
+            leaf.best_reward = 1.0 / 59.61
+            leaf.realized_knobs = None
+            leaf.realized_cuda_ops = 2
+            leaf.bench_status = "ok"
+            leaf.bench_stats = search.last_stats
+            search.tree.root.children = [leaf]
+            search.tree.root.visits = 1
+            search.tree.root.best_reward = leaf.best_reward
+            yield SimpleNamespace(graph=terminal)
+
+    monkeypatch.setattr("emmy.compiler.pipeline.TuningSearch", FakeSearch)
+    monkeypatch.setattr("emmy.compiler.pipeline.Pipeline", FakePipeline)
+    ctx = Context(
+        (8, 9),
+        compile_flags="-O3",
+        gpu_name="NVIDIA GeForce RTX 4090",
+        device_props={"sm_count": 128},
+    )
+    db_path = tmp_path / "proposal.db"
+    db = SearchDB(db_path)
+    proposals = [((0, 1), route)]
+    rankings = asyncio.run(
+        measure_proposals(stable_graph, proposals, backend=object(), db=db, ctx=ctx, max_candidates=1, run_id="proposal-run")
+    )
+    assert rankings == [
+        {
+            "status": "ok",
+            "latency_us": 59.61,
+            "compile_flags": "-O3",
+            "measured_knobs": route,
+        }
+    ]
+    db.close()
+    reloaded_db = SearchDB.open_readonly(db_path)
+    measured_nodes = list(reloaded_db.iter_nodes(context_key=ctx.structural_key(), op_sig=original_op_sig))
+    assert len(measured_nodes) == 2
+    parent = next(row for row in measured_nodes if row.parent_key is None)
+    branch = next(row for row in measured_nodes if row.parent_key is not None)
+    assert branch.parent_key == parent.node_key
+    assert parent.op_sig == branch.op_sig == original_op_sig
+    assert branch.features["REDUCE"] == "g4k"
+    assert branch.value_us == pytest.approx(59.61)
+    route_parent = TileOp(knobs={**live_features, **route})
+    assert route_parent.cache_key() != original_loop.cache_key()
+    perf = reloaded_db.lookup_perf(ctx.structural_key(), route_parent.cache_key(), backend="cuda")
+    assert perf is not None
+    assert perf.status == "ok"
+    assert perf.stats == PerfStats(median=59.61, min=59.61, max=59.61, mean=59.61, variance=0.0, n_samples=1)
+    assert perf.captured is True
+    assert perf.knobs == {**ctx.features(), **live_features, **route}
+    assert reloaded_db.lookup_perf(ctx.structural_key(), original_loop.cache_key(), backend="cuda") is None
+    reloaded_db.close()
+
+    # A later ordinary search keeps its own whole-slice bookkeeping and lowering
+    # evidence under the unpinned Loop key. Neither may replace or hide the exact
+    # structural parent measured by the proposal.
+    db = SearchDB(db_path)
+    bookkeeping = PerfStats(median=106.95, min=106.95, max=106.95, mean=106.95, variance=0.0, n_samples=1)
+    monolithic = PerfStats(median=153.45, min=153.45, max=153.45, mean=153.45, variance=0.0, n_samples=1)
+    fallback = {**route, "REDUCE": ""}
+    fallback_key = "monolithic-cuda"
+    db.record_perf(ctx.structural_key(), original_loop.cache_key(), backend="cuda", status="ok", stats=bookkeeping, captured=True)
+    db.record_lowering(
+        original_loop.cache_key(),
+        "loop",
+        fallback_key,
+        "cuda",
+        knobs=fallback,
+        measured_median_us=monolithic.median,
+    )
+    db.record_perf(
+        ctx.structural_key(),
+        fallback_key,
+        backend="cuda",
+        status="ok",
+        stats=monolithic,
+        knobs={**ctx.features(), **live_features, **fallback},
+        captured=True,
+    )
+    db.close()
+    reloaded_db = SearchDB.open_readonly(db_path)
+    route_perf = reloaded_db.lookup_perf(ctx.structural_key(), route_parent.cache_key(), backend="cuda")
+    loop_perf = reloaded_db.lookup_perf(ctx.structural_key(), original_loop.cache_key(), backend="cuda")
+    assert route_perf is not None and route_perf.stats.median == pytest.approx(59.61)
+    assert loop_perf is not None and loop_perf.stats.median == pytest.approx(106.95)
+    lowering = reloaded_db.lookup_lowering(original_loop.cache_key())
+    assert lowering is not None and lowering.child_key == fallback_key
+    candidates = [{**live_features, **fallback}, {**live_features, **route}]
+    assert _db_measured_pick(_db_measured_index(reloaded_db, ctx), candidates) == (1, 59.61)
+    reloaded_db.close()
+    persist_proposal_rankings(path, document, targets[0], rankings)
+    reloaded, reloaded_targets = load_working_targets(path)
+    proposal = reloaded["configs"][0]["realizations"][1]
+    assert proposal["knobs"] == route
+    assert proposal["ranking"]["measured_knobs"] == route
+    assert proposal["ranking"]["status"] == "ok"
+    assert reloaded_targets[0].proposals == [((0, 1), route)]
+
+    place = {"PLACE@a7": "cut"}
+    active_route = place
+    place_db = SearchDB(tmp_path / "place.db")
+    [place_ranking] = asyncio.run(
+        measure_proposals(
+            stable_graph,
+            [((0, 1), place)],
+            backend=object(),
+            db=place_db,
+            ctx=ctx,
+            max_candidates=1,
+            run_id="place-proposal-run",
+        )
+    )
+    place_parent = TileOp(knobs={**live_features, **place})
+    assert place_parent.cache_key() != original_loop.cache_key()
+    place_perf = place_db.lookup_perf(ctx.structural_key(), place_parent.cache_key(), backend="cuda")
+    assert place_ranking["status"] == "ok"
+    assert place_ranking["measured_knobs"] == place
+    assert place_perf is not None
+    assert place_perf.knobs == {**ctx.features(), **live_features, **place}
+    assert place_db.lookup_perf(ctx.structural_key(), original_loop.cache_key(), backend="cuda") is None
+    place_db.close()
+
+    nonstructural = {**route, "REDUCE": ""}
+    active_route = nonstructural
+    negative_db = SearchDB(tmp_path / "negative.db")
+    [ambiguous] = asyncio.run(
+        measure_proposals(
+            stable_graph,
+            [((0, 1), nonstructural)],
+            backend=object(),
+            db=negative_db,
+            ctx=ctx,
+            max_candidates=1,
+            run_id="proposal-run",
+        )
+    )
+    assert negative_db.lookup_perf(ctx.structural_key(), original_loop.cache_key(), backend="cuda") is None
+    negative_db.close()
+    assert ambiguous["status"] == "ambiguous_multi_kernel"
+    assert ambiguous["measured_knobs"] is None
 
 
 def test_working_file_rejects_canonical_path_and_symlink(monkeypatch, tmp_path):

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -533,10 +533,15 @@ def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(
     root = LoopOp(body=original_loop.body, knobs=live_features)
     fork = SimpleNamespace(ctx=ctx, root_op=root, options=leaves, node_id="root", score=None)
     monkeypatch.setattr("emmy.compiler.pipeline.search.policy.greedy._verified_index", lambda _ctx: ({}, {}))
-    monkeypatch.setattr("emmy.compiler.pipeline.search.policy.greedy._priced_pick", lambda *_args: None)
+    priced_calls = []
+    monkeypatch.setattr(
+        "emmy.compiler.pipeline.search.policy.greedy._priced_pick",
+        lambda *_args: priced_calls.append(True) or leaves[0],
+    )
     selected = greedy_decide(prior=NoEvidencePrior(), db=reloaded_db)(fork)
     assert selected is leaves[2]
     assert fork.score == pytest.approx(59.61)
+    assert priced_calls == []
     reloaded_db.close()
 
     def stats(us):
@@ -556,6 +561,12 @@ def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(
     reloaded_db = SearchDB.open_readonly(tmp_path / "place.db")
     index = _db_measured_index(reloaded_db, ctx)
     assert _db_measured_pick(index, evidence_rows, exact_families=frozenset({"PLACE"})) == (0, 40.0)
+    fork = SimpleNamespace(ctx=ctx, root_op=root, options=leaves, node_id="root", score=None)
+    priced_calls.clear()
+    selected = greedy_decide(prior=NoEvidencePrior(), db=reloaded_db)(fork)
+    assert selected is leaves[0]
+    assert fork.score == pytest.approx(40.0)
+    assert priced_calls == []
     reloaded_db.close()
 
     place_db = SearchDB(tmp_path / "place.db")
@@ -598,8 +609,21 @@ def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(
         ]
     )
     assert reservoir.evidence_pick(evidence_rows, exact_families=frozenset({"PLACE"})) == (0, 40.0)
+    fork = SimpleNamespace(ctx=ctx, root_op=root, options=leaves, node_id="root", score=None)
+    priced_calls.clear()
+    selected = greedy_decide(prior=reservoir, db=None)(fork)
+    assert selected is leaves[0]
+    assert fork.score == pytest.approx(40.0)
+    assert priced_calls == []
+
     reservoir.add_rows([({**ctx.features(), **live_features, "PLACE@a": "cut"}, 30.0)])
     assert reservoir.evidence_pick(evidence_rows, exact_families=frozenset({"PLACE"})) == (1, 30.0)
+    fork = SimpleNamespace(ctx=ctx, root_op=root, options=leaves, node_id="root", score=None)
+    priced_calls.clear()
+    selected = greedy_decide(prior=reservoir, db=None)(fork)
+    assert selected is leaves[1]
+    assert fork.score == pytest.approx(30.0)
+    assert priced_calls == []
 
     nonstructural = {**route, "REDUCE": ""}
     active_route = nonstructural

--- a/tests/compiler/pipeline/search/test_node_record_collection.py
+++ b/tests/compiler/pipeline/search/test_node_record_collection.py
@@ -12,6 +12,11 @@ RTX 4090 at target 12, after six run-stage timeouts had produced exactly this no
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
+from emmy.compiler.pipeline.knob import stamp_schedule_families
 from emmy.compiler.pipeline.search.db import PerfStats
 from emmy.compiler.pipeline.search.policy.mcts import SearchNode, SearchTree, TuningSearch
 
@@ -24,6 +29,15 @@ def _bench_fail_leaf(*, realized_knobs: dict | None) -> SearchNode:
     node.realized_knobs = realized_knobs
     node.bench_status = "bench_fail"
     node.bench_stats = PerfStats(median=2_000_000.0, min=2_000_000.0, max=2_000_000.0, mean=2_000_000.0, variance=0.0, n_samples=1)
+    return node
+
+
+def _ok_leaf(us: float, *, realized_knobs: dict | None, cuda_ops: int) -> SearchNode:
+    node = SearchNode(candidate=object())
+    node.realized_knobs = realized_knobs
+    node.realized_cuda_ops = cuda_ops
+    node.bench_status = "ok"
+    node.bench_stats = PerfStats(median=us, min=us, max=us, mean=us, variance=0.0, n_samples=1)
     return node
 
 
@@ -60,3 +74,95 @@ def test_a_healthy_sibling_survives_an_unrealized_failure() -> None:
 
     rows = _collect(tree)
     assert [row.features for row in rows] == [{"WORK": "w4x2"}]
+
+
+def test_best_realized_does_not_fall_back_from_a_faster_unrepresentable_terminal() -> None:
+    tree = SearchTree()
+    tree.root.children = [
+        _ok_leaf(18.0, realized_knobs={"WORK": "t64"}, cuda_ops=1),
+        _ok_leaf(6.0, realized_knobs=None, cuda_ops=2),
+    ]
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+
+    assert search.best_realized() is None
+
+
+def test_validated_structural_input_records_the_original_parent_linked_edge() -> None:
+    route = {
+        "WORK": "w2x1",
+        "TILE": "mma_m16n8k16_f16_f32/f4x8/k8",
+        "REDUCE": "g4k",
+        "STAGE": "d1/smem-async",
+        "RASTER": "",
+    }
+    tree = SearchTree()
+    leaf = _ok_leaf(59.61, realized_knobs=None, cuda_ops=2)
+    leaf.visits = 1
+    leaf.best_reward = 1.0 / 59.61
+    tree.root.children = [leaf]
+    tree.root.visits = 1
+    tree.root.best_reward = leaf.best_reward
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+    search._base_knobs = {"H_opt": 3.0, "S_loop": 1.0}
+
+    assert search.best_realized() is None
+    assert search.best_realized(validated_input_route=route) == (stamp_schedule_families(route), 59.61, 2, True)
+    rows = search._collect_node_records(
+        context_key="cc89/o3",
+        op_sig="original-loop",
+        gpu="NVIDIA GeForce RTX 4090",
+        run_id="proposal-run",
+        validated_input_route=route,
+    )
+
+    assert len(rows) == 2
+    parent = next(row for row in rows if row.parent_key is None)
+    branch = next(row for row in rows if row.parent_key is not None)
+    assert parent.features == {"H_opt": 3.0, "S_loop": 1.0}
+    assert branch.parent_key == parent.node_key
+    assert branch.features == {"H_opt": 3.0, "S_loop": 1.0, **stamp_schedule_families(route)}
+    assert branch.value_us == pytest.approx(59.61)
+    assert branch.is_leaf
+
+
+def test_best_realized_returns_the_fastest_terminal_with_its_structural_replay_row() -> None:
+    tree = SearchTree()
+    row = {"WORK": "w1x1", "TILE": "mma_m16n8k16_f16_f32/f1x4/k8", "REDUCE": "g8k", "STAGE": "d1/smem"}
+    route = SearchNode(candidate=SimpleNamespace(resolved_knobs=row), parent=tree.root)
+    fast = _ok_leaf(6.0, realized_knobs=None, cuda_ops=2)
+    fast.parent = route
+    route.children = [fast]
+    tree.root.children = [_ok_leaf(18.0, realized_knobs={"WORK": "t64"}, cuda_ops=1), route]
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+
+    assert search.best_realized() == (stamp_schedule_families(row), 6.0, 2, True)
+
+
+def test_best_realized_keeps_only_the_routing_row_for_a_placement_cut() -> None:
+    tree = SearchTree()
+    route = SearchNode(candidate=SimpleNamespace(resolved_knobs={"PLACE@map": "cut", "WORK": "w1x1"}), parent=tree.root)
+    fast = _ok_leaf(6.0, realized_knobs=None, cuda_ops=2)
+    fast.parent = route
+    route.children = [fast]
+    tree.root.children = [route]
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+
+    assert search.best_realized() == ({"PLACE@map": "cut"}, 6.0, 2, True)
+
+
+def test_best_realized_returns_an_ordinary_one_kernel_row() -> None:
+    tree = SearchTree()
+    tree.root.children = [_ok_leaf(6.0, realized_knobs={"WORK": "t64"}, cuda_ops=1)]
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+
+    assert search.best_realized() == ({"WORK": "t64"}, 6.0, 1, False)

--- a/tests/compiler/pipeline/search/test_node_record_collection.py
+++ b/tests/compiler/pipeline/search/test_node_record_collection.py
@@ -144,6 +144,22 @@ def test_best_realized_returns_the_fastest_terminal_with_its_structural_replay_r
     assert search.best_realized() == (stamp_schedule_families(row), 6.0, 2, True)
 
 
+def test_best_realized_uses_a_compatible_multi_cuda_terminal_placement_route() -> None:
+    tree = SearchTree()
+    tree.root.children = [
+        _ok_leaf(
+            6.0,
+            realized_knobs={"WORK": "w1x1", "TILE": "mma_m16n8k16_f16_f32/f1x4/k8", "PLACE@map": "cut"},
+            cuda_ops=2,
+        )
+    ]
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+
+    assert search.best_realized() == ({"PLACE@map": "cut"}, 6.0, 2, True)
+
+
 def test_best_realized_keeps_only_the_routing_row_for_a_placement_cut() -> None:
     tree = SearchTree()
     route = SearchNode(candidate=SimpleNamespace(resolved_knobs={"PLACE@map": "cut", "WORK": "w1x1"}), parent=tree.root)

--- a/tests/compiler/pipeline/search/test_two_level_strategy.py
+++ b/tests/compiler/pipeline/search/test_two_level_strategy.py
@@ -93,11 +93,13 @@ def _fuse(graph: Graph) -> Graph:
     return Pipeline.build(LOOP_PASSES).run(graph, db=SearchDB())
 
 
-def test_searched_winner_requires_one_post_fusion_and_one_cuda_kernel() -> None:
+def test_searched_winner_requires_one_post_fusion_kernel_and_an_exact_replay_row() -> None:
     one = OpResult(name="k", op_key="key", best_us=4.0, searched_knobs={"TILE": "f2x2"}, searched_us=5.0, searched_cuda_ops=1)
     assert InnerReward(total_us=4.0, ok=True, per_op=[one]).searched_winner() == ({"TILE": "f2x2"}, 5.0)
     multi_cuda = OpResult(**{**one.__dict__, "searched_cuda_ops": 2})
     assert InnerReward(total_us=4.0, ok=True, per_op=[multi_cuda]).searched_winner() is None
+    split = OpResult(**{**multi_cuda.__dict__, "searched_knobs": {"REDUCE": "g8k"}, "searched_structural": True})
+    assert InnerReward(total_us=4.0, ok=True, per_op=[split]).searched_winner() == ({"REDUCE": "g8k"}, 5.0)
     assert InnerReward(total_us=8.0, ok=True, per_op=[one, one]).searched_winner() is None
 
 


### PR DESCRIPTION
## Summary

- preserve a validated structural route when the selected search terminal realizes multiple CUDA kernels
- persist proposal aggregate latency under the exact route-specific parent consumed by the structural splice
- replay measured placement evidence against the exact `PLACE` subset for each fused or cut candidate
- consult direct whole-route measurements before estimating structural routes from child-kernel costs

## Why

Structural search terminals do not always have one homogeneous schedule row. Treating every multi-kernel result as
ambiguous discarded valid placement and cross-CTA routes, allowing a slower monolithic sibling to become the persisted
winner. The existing representation already separates these cases: a placement cut is a routing row, while a
cross-CTA reduction retains its complete pre-split schedule row and its minted kernels remain independent targets.

Proposal measurement now captures the exact consumed parent at the kernel-set-changing splice. After realized-pin
validation and a successful structural terminal, the aggregate latency is recorded under that route-specific cache
key and context. The unpinned Loop key remains ordinary two-level cost and lowering bookkeeping; parent-linked node
rows remain diagnostic and training evidence; unrepresentable multi-kernel results remain explicitly ambiguous.

For an unpinned placement fork, each candidate is identified by the complete `PLACE` subset stamped by its fragment;
the fused candidate has the empty subset. Both O3 reservoir evidence and tune-DB evidence require exact subset equality
for `PLACE` while retaining prefix matching for other knobs. A direct aggregate fused/cut measurement is consulted
before child-kernel structural pricing, so an estimate cannot override a measured whole route.

## Verification

Exact current head: `fab33d783d9625bd90fa8cbec19051349ca7c293`, based on main
`125e1df03c63715d7b34300d77aa9067bfda9040`.

- focused tests: 91 passed
- `make test`: 3,155 passed, 577 skipped, 1 xfailed
- `make lint`: passed
- `git diff --check`: passed
- exact A100 task: `/home/riftuser/.cache/emmy/a100-kernel-pr628-fab33d78-place-proof-001`
- proposal-terminal DB and fresh DB-only replay DB were byte-identical:
  `da0ac50abde2bfe73db7c23502434d216d2c509e89b19c0d534e472b5b286a0f`
- cold replay had no online checkpoint and selected the exact two-kernel `PLACE@map=cut` route at 96.256 us
- cold selection and strict pinned replay had identical kernel names, route knobs, and CUDA source hashes
- five independent strict O3 pinned repeats passed against `same-input-greedy`; max, mean, and relative error were
  `0.0` in every repeat; whole-route latency range was 86.733–86.938 us
- summary SHA256: `8bc5f99b8fd6f42ff86ce9b9803453f4f498a2df95916ef08da627232347a124`
- repeated-case receipt SHA256: `098b4d5f7a574e2d798cf8abe1e44b7d4848d7cbae3b248faa27beb8d4b7a28a`
