### PR TITLE
Recognize commutative computed contraction operands

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -401,7 +401,9 @@ commutative-monoid ⊕, by the `ElementwiseImpl` traits, never op names) arbitra
 loads, hoistable k-invariant factor chains, computed cones), with role purity checked per index EXPR — another
 free axis may ride a separate dim of an operand load (a batch offset the grid absorbs) but never the same expr
 as the role axis, since that composite has no slab address and must decline instead of reaching an emitter
-that cannot spell it; the monoid composition (`fused_view`) binding its
+that cannot spell it. For a commutative product, the lift's SSA argument order does not decide which edge is the
+direct operand and which is a computed cone: the binder derives those roles from their indices. A noncommutative
+product is never reordered. The monoid composition (`fused_view`) binds its
 channels through the same read. A stage that declines rewrites nothing — the fold already derives PLANAR
 structurally. What stays case-by-case is the dispatch — which composition applies — never the parsing: no
 classification stage holds a private stmt-pattern reading of the algebra.

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -981,7 +981,12 @@ def bind_bilinear(
         if lift.args[0] == lift.args[1]:
             return None  # a square product (both args one value — Σ x·x) has no role split
         b_arg = next((a for a in lift.args if role_load(a, n_name, m_name) is not None), None)
-        a_arg = next(a for a in lift.args if a != b_arg)
+        if b_arg is None and lift.op.commutative:
+            # A composite B may need the computed-operand path. Pick the direct A by
+            # role, independent of the commutative product's SSA argument order.
+            a_arg = next((a for a in lift.args if role_load(a, m_name, n_name) is not None), lift.args[0])
+        else:
+            a_arg = next(a for a in lift.args if a != b_arg)
         reads.append((lift, loads.get(b_arg) if b_arg is not None else None, a_arg))
     if len({lift.op for lift, _, _ in reads}) != 1:
         return None  # the channels must share ONE ⊗ — a mixed-product body is not a bilinear form

--- a/tests/compiler/passes/test_fuse_split_free_axes.py
+++ b/tests/compiler/passes/test_fuse_split_free_axes.py
@@ -249,14 +249,14 @@ def test_canonical_nest_classifies_as_contraction():
     assert isinstance(node.b, Load) and node.b.input == "w"
 
 
-def _bilinear_fold(w_index: tuple, x_index: tuple):
+def _bilinear_fold(w_index: tuple, x_index: tuple, product: str = "multiply"):
     loop = Loop(
         axis=Axis("k", Dim(K)),
         body=Body(
             (
                 Load(name="wv", input="w", index=w_index),
                 Load(name="xv", input="x", index=x_index),
-                Assign(name="prod", op=ElementwiseImpl("multiply"), args=("wv", "xv")),
+                Assign(name="prod", op=ElementwiseImpl(product), args=("wv", "xv")),
                 Accum(name="acc", value="prod", op=ElementwiseImpl("add"), axes=("k",)),
             )
         ),
@@ -286,6 +286,53 @@ def test_bind_bilinear_declines_composite_role_expr():
         con, _ = r
         for ch in con.channels:
             assert not isinstance(ch.b, Load), "the impure composite must not become a direct slab load"
+
+
+def test_bind_bilinear_accepts_grouped_computed_b_independent_of_product_order():
+    """A flattened GQA value row is a computed B cone when the query-head group and channel
+    share one index expression. The multiply's commutative argument order cannot decide whether
+    that cone is discovered: fusion emits the value load first in the deployed attention cell."""
+    group = BinaryExpr("//", Var("h"), Literal(3, "int"))
+    flat = BinaryExpr("+", BinaryExpr("*", group, Literal(D, "int")), Var("n"))
+    f = _bilinear_fold(
+        (Literal(0, "int"), Var("k"), Literal(0, "int"), flat),
+        (Var("h"), Var("m"), Var("k")),
+    )
+
+    r = bind_bilinear(f, "m", "n", frozenset({"h", "m", "n"}))
+
+    assert r is not None
+    con, epi = r
+    assert not epi
+    assert isinstance(con.a, Load) and con.a.input == "x"
+    assert all(not isinstance(channel.b, Load) for channel in con.channels), "the flattened grouped value must use a computed B cone"
+
+
+def test_bind_bilinear_rejects_grouped_b_that_changes_with_the_row():
+    """A grouped value address that also reads the output row is not one B slab per tile.
+    Trying the commutative product's other orientation must still fail closed."""
+    group = BinaryExpr("//", Var("h"), Literal(3, "int"))
+    row = BinaryExpr("*", Var("m"), Literal(H * D, "int"))
+    flat = BinaryExpr("+", BinaryExpr("+", row, BinaryExpr("*", group, Literal(D, "int"))), Var("n"))
+    f = _bilinear_fold(
+        (Literal(0, "int"), Var("k"), Literal(0, "int"), flat),
+        (Var("h"), Var("m"), Var("k")),
+    )
+
+    assert bind_bilinear(f, "m", "n", frozenset({"h", "m", "n"})) is None
+
+
+def test_bind_bilinear_does_not_reorder_a_noncommutative_product():
+    """Trying the opposite direct/computed role is licensed only for a commutative product."""
+    group = BinaryExpr("//", Var("h"), Literal(3, "int"))
+    flat = BinaryExpr("+", BinaryExpr("*", group, Literal(D, "int")), Var("n"))
+    f = _bilinear_fold(
+        (Literal(0, "int"), Var("k"), Literal(0, "int"), flat),
+        (Var("h"), Var("m"), Var("k")),
+        product="subtract",
+    )
+
+    assert bind_bilinear(f, "m", "n", frozenset({"h", "m", "n"})) is None
 
 
 # --- the warp tier's split-store addressability --------------------------------------------------- #


### PR DESCRIPTION
## Summary

- derive the direct contraction operand from index roles when a commutative product has no direct B load, so SSA
  argument order does not hide a closed computed B cone
- preserve fail-closed behavior for row-dependent B addresses and noncommutative products
- document the role-binding contract and add target-shaped positive and negative controls

## Verification

- `make test`: 3,164 passed, 562 skipped, 1 xfailed
- `make lint`: green
- RTX 4090 proof used exact PR head `d6b36883569add245ee08e3a202d33c87cc393bc`, tree
  `8dc894dbb5488c3573cf8878074f3e5ad266896a`, and immutable Qwen row 206 grouped P@V capture 046
- exact `main` `3d505b0c4ff811e321753d9cba711bc2dce21dfa` leaves the target planar and cannot offer the requested
  `w16x2` worker inventory
- the PR recognizes the same byte-identical Loop as a computed-B contraction and realizes
  `w16x2 / mma_m16n8k16_f16_f32/f1x8/k8 / d1/smem`
- frozen real-model P/V replay was bit-identical to eager across 3,145,728 outputs: zero mismatches, zero maximum
  or mean absolute error, and matching output SHA-256 `9ad4160f2cc9d6cc9bca08c7b32cc6c58adcbb6f40f4b3bdedf7d287bc40ebc4`

## Qualification boundary

This qualifies contraction recognition and correctness only. It makes no performance claim and promotes no golden.
