### PR TITLE
Preserve typed assignments in register epilogues

### DIFF
--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1842,16 +1842,16 @@ class RegEpilogue:
     Captured by ``kernel/005_lower_atom_tile`` from the backward slice between
     the accumulator and the Write (the scalar Load / Assign stmts are stripped
     — the accumulator has no scalar SSA name on the fragment path). The render
-    evaluates the chain per fragment element in f32 with ``acc`` substituted
-    by the element and each leaf loaded at the element's own (row, col); the
-    chain ops reuse the scalar renderer's ``op_to_expr`` translation, so any
-    elementwise op with a CUDA spelling works. ``ops`` are ``(name, op_name,
-    args)`` in topological (body) order; ``result`` is the SSA name the Write
+    evaluates the chain per fragment element with ``acc`` substituted by the
+    element and each leaf loaded at the element's own (row, col). Chain ops
+    reuse :class:`Assign` rendering, including its optional dtype, promotion,
+    native-op, and conversion rules. ``ops`` are ``(name, op_name, args,
+    dtype)`` in topological (body) order; ``result`` is the SSA name the Write
     stored."""
 
     acc: str
     loads: tuple[EpilogueLoad, ...]
-    ops: tuple[tuple[str, str, tuple[str, ...]], ...]
+    ops: tuple[tuple[str, str, tuple[str, ...], DataType | None], ...]
     result: str
     # Coord-predicated Selects (the causal attention mask), rendered before the
     # ``ops`` chain as per-element ternaries. Each is ``(name, branches)`` where
@@ -1954,7 +1954,7 @@ class RegStore(Stmt):
         idx = ", ".join(e.pretty() for e in self.dst_index)
         epi = ""
         if self.epilogue is not None:
-            chain = ", ".join(op for _, op, _ in self.epilogue.ops)
+            chain = ", ".join(op for _, op, _, _ in self.epilogue.ops)
             bufs = ", ".join(ld.buffer for ld in self.epilogue.loads)
             epi = f" epilogue[{chain}]({bufs or 'no loads'})"
         guards = ""
@@ -2017,17 +2017,15 @@ class RegStore(Stmt):
         an epilogue the values are the bare ``frag[i]`` and the preambles are
         empty. With one, each element ``i`` (row ``_g``/``_g+8``, col
         ``2_t+{0,1}``) declares its leaf loads (converted to f32; offsets per
-        the dim roles at each buffer's own stride) and the chain ops (via
-        ``op_to_expr`` — the same translation the scalar ``Assign`` render
-        uses), all scoped inside the store's ``{ }`` block. Leaf loads are
+        the dim roles at each buffer's own stride) and the chain ops (via the
+        scalar ``Assign`` renderer), all scoped inside the store's ``{ }``
+        block. Leaf loads are
         scalar; lanes ``_t = 0..3`` cover 8 contiguous columns, so the warp's
         accesses coalesce regardless."""
         coords = self._element_coords()
         if self.epilogue is None:
             return [[] for _ in coords], [f"{self.frag}[{i}]" for i in range(len(coords))]
-        from emmy.compiler.ir.expr import Var  # noqa: PLC0415
         from emmy.compiler.ir.stmt import render_index  # noqa: PLC0415
-        from emmy.compiler.ir.stmt.base import op_to_expr  # noqa: PLC0415
 
         epi = self.epilogue
         conv = {"f16": "__half2float({})", "bf16": "__bfloat162float({})"}
@@ -2036,11 +2034,14 @@ class RegStore(Stmt):
         for i, (row, col, row_off, col_off) in enumerate(coords):
             lines: list[str] = []
             env = {epi.acc: f"{self.frag}[{i}]", **{a: f"{fr}[{i}]" for a, fr in epi.extra_accs}}
+            for value in env.values():
+                ctx.ssa_dtypes[value] = "f32"
             for ld in epi.loads:
                 temp = f"{ld.name}_e{i}"
                 if ld.buffer in ctx.literal_constants:
                     lines.append(f"const float {temp} = {float(ctx.literal_constants[ld.buffer])!r}f;")
                     env[ld.name] = temp
+                    ctx.ssa_dtypes[temp] = "f32"
                     continue
                 flat = render_index(ld.buffer, ld.index, ctx)
                 parts = [flat]
@@ -2054,6 +2055,7 @@ class RegStore(Stmt):
                 dt = ctx.buffer_dtypes.get(ld.buffer, "f32")
                 lines.append(f"const float {temp} = {conv.get(dt, '{}').format(f'{ld.buffer}[{addr}]')};")
                 env[ld.name] = temp
+                ctx.ssa_dtypes[temp] = "f32"
             # Coord-predicated Selects (the causal mask): a per-element ternary.
             # ``__M__`` / ``__N__`` substitute to this element's row/col offset;
             # the captured predicate already carries its semantic cell base.
@@ -2065,10 +2067,17 @@ class RegStore(Stmt):
                     expr = f"(({rc}) ? {env[value]} : {expr})"
                 lines.append(f"const float {sel_name}_e{i} = {expr};")
                 env[sel_name] = f"{sel_name}_e{i}"
-            for name, op_name, args in epi.ops:
-                expr = op_to_expr(op_name, [Var(env[a]) for a in args])
-                lines.append(f"const float {name}_e{i} = {expr.render(ctx)};")
-                env[name] = f"{name}_e{i}"
+                ctx.ssa_dtypes[env[sel_name]] = "f32"
+            for name, op_name, args, dtype in epi.ops:
+                rendered_name = f"{name}_e{i}"
+                rendered = Assign(
+                    name=rendered_name,
+                    op=op_name,
+                    args=tuple(env[arg] for arg in args),
+                    dtype=dtype,
+                ).render(replace(ctx, indent=0))[0]
+                lines.append(f"const {rendered}")
+                env[name] = rendered_name
             per_elem.append(lines)
             vals.append(env[epi.result])
         return per_elem, vals

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -227,6 +227,10 @@ per-fragment row/column placeholders. The destination index remains only an addr
 index to a tile-local slab, but it must not rebase a causal or other coordinate predicate. Later cell replication
 substitutes the predicate's real coordinate variables and the store fills only its element offsets. Inferring the
 predicate origin from `RegStore.dst_index` would make every nonzero chunk compare slab-local coordinates instead.
+The epilogue also retains every captured `Assign.dtype`: fragment-local pointwise operations use the same promotion,
+native-operation, and final-conversion rules as the scalar Loop tail. In particular, an f32 accumulator crossing a
+declared f16 tensor boundary narrows before a later activation consumes it; register fusion cannot erase that store/load
+semantic boundary.
 
 The chained fill takes one of two forms, and the first is preferred wherever it reads:
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -185,10 +185,12 @@ def _warp_epilogue(
     The projection is the post-reduce ``tail`` stmts: the leaf ``Load``s + pointwise ``Assign``s +
     an optional causal ``Select``. Each leaf ``Load`` becomes an :class:`EpilogueLoad` at the
     cell-base coordinate (σ-applied; the render adds the per-element row/col motion on the
-    ``m``/``n`` dims); each ``Assign`` becomes an ``(name, op, args)`` op; a coord-predicated
+    ``m``/``n`` dims); each ``Assign`` becomes an ``(name, op, args, dtype)`` op; a coord-predicated
     ``Select`` (causal mask) captures its σ-applied cell bases plus ``__M__`` / ``__N__``
     placeholders; the store substitutes only the element's row/col offsets. This keeps semantic
-    source coordinates independent of a later store to a tile-local shared-memory slab."""
+    source coordinates independent of a later store to a tile-local shared-memory slab. Keeping
+    the optional dtype makes the register epilogue obey the scalar Loop tail's promotion and
+    conversion rules."""
     loads, ops, selects = [], [], []
     write = None
     ph = {
@@ -206,7 +208,7 @@ def _warp_epilogue(
                 )
             )
         elif isinstance(s, Assign):
-            ops.append((s.name, s.op.name, tuple(s.args)))
+            ops.append((s.name, s.op.name, tuple(s.args), s.dtype))
         elif isinstance(s, Select):
             selects.append((s.name, tuple((br.select.substitute(ph), br.value) for br in s.branches)))
         elif isinstance(s, Write):
@@ -221,7 +223,7 @@ def _warp_epilogue(
     from emmy.compiler.pipeline import RuleSkipped  # noqa: PLC0415 — avoid an import cycle
 
     bound = {acc, *(a for a, _ in extra_accs), *(ld.name for ld in loads), *(nm for nm, _ in selects)}
-    for name, _op, args in ops:
+    for name, _op, args, _dtype in ops:
         unbound = [a for a in args if a not in bound]
         if unbound:
             raise RuleSkipped(f"projection epilogue reads {unbound} this node does not compute (mis-sliced multi-channel tail)")

--- a/tests/compiler/passes/test_reg_epilogue_dtype.py
+++ b/tests/compiler/passes/test_reg_epilogue_dtype.py
@@ -1,0 +1,44 @@
+"""Register epilogues retain the Loop tail's per-Assign dtype semantics."""
+
+from emmy.compiler.dtype import F16
+from emmy.compiler.ir.elementwise import ElementwiseImpl
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.kernel.ir import RegStore
+from emmy.compiler.ir.sigma import Sigma
+from emmy.compiler.ir.stmt import Assign, RenderCtx, Write
+from emmy.compiler.pipeline.passes.lowering.kernel._atom import _warp_epilogue
+
+
+def _render(*assigns: Assign) -> tuple[str, object]:
+    tail = [*assigns, Write(output="out", index=(Var("m"), Var("n")), value=assigns[-1].name)]
+    epilogue = _warp_epilogue(tail, "acc", "m", "n", Sigma.IDENTITY)
+    assert epilogue is not None
+    store = RegStore(
+        dst_buffer="out",
+        dst_index=(Var("m"), Var("n")),
+        frag="_c",
+        shape=(16, 8, 16),
+        ldm=16,
+        epilogue=epilogue,
+    )
+    ctx = RenderCtx(shapes={"out": (16, 16)}, buffer_dtypes={"out": "f16"})
+    return "\n".join(store.render(ctx)), epilogue
+
+
+def test_typed_copy_narrows_the_fragment_value_before_its_consumer() -> None:
+    source, epilogue = _render(
+        Assign(name="narrow", op=ElementwiseImpl("copy"), args=("acc",), dtype=F16),
+        Assign(name="result", op=ElementwiseImpl("copy"), args=("narrow",)),
+    )
+
+    assert epilogue.ops[0][3] is F16
+    assert "const __half narrow_e0 = __float2half(_c[0]);" in source
+    assert "const __half result_e0 = narrow_e0;" in source
+
+
+def test_untyped_copy_keeps_the_existing_f32_epilogue() -> None:
+    source, epilogue = _render(Assign(name="result", op=ElementwiseImpl("copy"), args=("acc",)))
+
+    assert epilogue.ops[0][3] is None
+    assert "const float result_e0 = _c[0];" in source
+    assert "__float2half(_c[0])" not in source


### PR DESCRIPTION
## Summary

- retain each captured Loop `Assign.dtype` in `RegEpilogue`
- render fragment-local epilogues through the scalar `Assign` promotion, native-operation, and conversion rules
- document the typed tensor-boundary invariant and cover typed and untyped copies

An f32 accumulator may feed a later pointwise operation through a declared f16 tensor. Register fusion previously
discarded the `Assign.dtype`, so the CUDA epilogue consumed the accumulator directly and erased that narrowing boundary.

## Checks

- focused compiler tests: 83 passed, 1 xfailed
- `make test`: 3,168 passed, 563 skipped, 1 xfailed
- `make lint`: passed
- `git diff --check`: passed

## Exact V100 evidence

Two independently cold runs used Tesla V100-SXM3-32GB GPUs with compute capability 7.0, separate cubin/DB/online/dump
state, exact source/import receipts, and the same frozen Laguna M512 frontend graph and deterministic inputs.

- repository main: `1c8e211e27854a965370e8e22bd969b6d7ab9891`
- this PR commit: `e65626235e0a413902b3930f88253ee9fb4cd997`
- proof-only source: `657a8337d70b3c4237ee65f45444243d27ba3c5a`
- graph SHA256: `f6fa16f4f61675939a25dfd6bab7e1116128bf02b04096455ac40e531a360075`
- GPUs: `GPU-b415579d-cdad-42bb-23d1-32c20cdb729d` and
  `GPU-ad8ee0c7-2aa8-d2da-d82c-af7374386071`

Both repetitions realized the exact requested unsplit upstream and downstream Volta MMA rows, produced byte-identical
CUDA, and passed strict full-program, upstream, and downstream comparisons. The upstream maximum absolute error was
`0.000244140625`; the full-program maximum absolute error was `0.001953125`. The rendered upstream CUDA contains the
declared f32-to-f16 and f16-to-f32 boundaries (96 `__float2half` and 32 `__half2float` conversions).

On the same graph and deterministic inputs, the prerequisite shared-A source without this PR failed with 81 upstream
and 22,392 final strict mismatches. With this PR, both mismatch counts are zero in both cold repetitions.

The proof-only source also contains the separate, unmerged shared-A compiler prerequisite needed to expose this unsplit
Laguna MMA route. This PR does **not** contain or claim that prerequisite. The evidence isolates the numerical change by
holding the graph, inputs, and requested schedules fixed. It qualifies this compiler boundary increment, not the full
Laguna onboarding or its remaining 96-target tuning campaign.

Raw evidence is preserved on the caller-owned V100 host under
`/home/riftuser/.cache/emmy/onb-laguna-reg-epilogue-1c8.PelWgO`.
