### PR TITLE
Let Volta MMA reuse materialized A across channels

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -539,6 +539,13 @@ failing several passes later:
   memory floor. A non-unit or structurally missing row declines this reading. SSA renames track the stored algebra
   through the `Fold` rewrite handler (`rename_combine` — a verbatim combine left the cooperative combine reading a
   state name the renamed body no longer defined).
+- a **direct product contraction** whose channels read one MATERIALIZED A binds the same N-channel algebra when every
+  B load agrees on K orientation and role axes. Its warp rows use the mandatory `sync` compute-fill when the copied B
+  dtypes agree with the atom: one A slab is copied once, every B channel gets its own slab, and the one A fragment
+  feeds all C accumulator channels. The gmem-direct, byte-transport, and scalar contraction emitters remain
+  single-channel; the original demoted `PLANAR` spelling therefore stays as the scalar fallback sibling. A mixed B
+  layout, mixed role expression, or byte-copy dtype mismatch declines the warp rows instead of reaching an emitter
+  that cannot represent it.
 - a cooperative / ILP reduce (`PLANAR` / `TWISTED`, or a non-output-tiled `CONTRACTION`) needs **no** binding here — its
   accumulator dtype + the shuffle/tree fold mechanism are **derived** at materialize time (`emit_combine` off the fold
   node's `Reduction` view + `ReduceStage.combine`), never stored. Its one schedule-time staging decision follows the same
@@ -809,8 +816,8 @@ contraction-fold leaf keyed `TILE@<axis>` in a hierarchical `build_fork_tree`; a
 The producer band is the fourth level (`""` = uniform SIMT — since step 7 a resolved band
 is spelled in `WORK`'s `+p<n>` suffix, never a per-row `WSPEC` key) — offered only on a warp row over a
 resolved **TMA** stage without a cross-CTA split, and resolved/thread-budget-gated at materialization
-(an ineligible spec degrades to uniform). A computed-A (fused-cone) contraction enumerates its own
-warp-only rows (the mandatory resolved `sync` compute-fill stage at BOTH depths
+(an ineligible spec degrades to uniform). A computed-A (fused-cone) contraction or a product contraction over one
+materialized A enumerates its own warp-only rows (the mandatory resolved `sync` compute-fill stage at BOTH depths
 (`d1` + the asymmetric B-only prefetch ring `d2` as fork siblings — the M=512 occupancy loss inverts at decode M,
 so the depth is measured per shape), crossed with the shared `RASTER` launch-order candidates (its B stripes
 re-stream per M-tile row, exactly the grouped order's L2 reuse — `gn8` measured −8% on the gemma gate_up fused

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -275,9 +275,11 @@ nothing and the drain still reads whole chunks), while a canonical materialized 
 so its `cp.async` chunk stays contiguous. The K-MAJOR orientations keep the refusal, and the reason names why: a
 materialized A and a transposed B both stage K as the slab's contiguous inner dim, so their copy chunk runs ALONG K
 and clamping only its start still copies past the extent. A **multi-channel product node** (the gate/up MLP edge — N
-`(b, acc)` channels over the ONE shared inline cone; `_AtomOps.channels` reads them off the node) fills one B slab per
-channel, drains N mma chains off the ONE ldmatrix'd A fragment into per-channel C fragments (`_fold_frag`), and the
-projection (SwiGLU) combines the channels per element in the store's `RegEpilogue` (`extra_accs`).
+`(b, acc)` channels over one shared A edge, either a computed cone or a materialized load; `_AtomOps.channels` reads
+them off the node) fills one B slab per channel, drains N mma chains off the ONE ldmatrix'd A fragment into
+per-channel C fragments (`_fold_frag`), and the projection (SwiGLU) combines the channels per element in the store's
+`RegEpilogue` (`extra_accs`). Materialized A copies into the same single A slab; computed A evaluates into it. Both
+forms use the synchronous compute fill because the gmem-direct and byte-copy MMA paths remain single-channel.
 
 **Staged fp8 (1-byte) operand slabs.** A storage-dtype (fp8) operand stages as a RAW BYTE slab — each `Operand`
 sized at its OWN element width (the mixed-dtype seam the scalar tier already had), the cp.async fill running 16 B

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -1032,12 +1032,10 @@ def bind_bilinear(
         if a_edge is not None and stat is not None:
             return None  # a materialized A beside a chained statistic is not the computed-A shape
         if a_edge is not None:
-            if len(reads) > 1:
-                # A multi-channel node over a MATERIALIZED shared A (the merged QKV cell) has no
-                # consumer tier yet: cp.async / TMA staging is single-fold, and only the smem
-                # compute fill (a COMPUTED A) rides multi-channel. The fold keeps its PLANAR
-                # reading — exactly the old single-Accum candidacy's behavior.
-                return None
+            # A materialized shared A may feed every compatible channel through the synchronous
+            # smem fill. Classification only binds the one algebraic node here; scheduling keeps
+            # byte transports and gmem-direct MMA single-channel and retains the demoted planar
+            # sibling for scalar execution.
             consumed.add(id(a_edge))
         else:
             h = hoisted()

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -434,11 +434,11 @@ class _Term:
         atoms = _warp_atoms(self, node)
         warp = [p for p in warp_tile_moves(atoms) if _tile_ok(self, node, p)] if atoms else []
         self.warp_eligible = self.warp_eligible or bool(warp)
-        # A COMPUTED ``a`` edge is warp-ONLY: the fill that evaluates a producer cone is the mma
-        # tier's compute fill, and a per-cell / scalar expansion would re-run the cone on every K
-        # step. The reduce tiers stay reachable — through the COLLAPSE view, whose spliced fold
-        # computes the whole body per cell (:func:`_views`).
-        scalar = scalar_tile_moves() if not _has_computed_operand(node) else []
+        # A synchronous-fill node is warp-ONLY: computed edges need evaluation, while a product
+        # node has several B/C channels that the gmem-direct and scalar emitters cannot carry.
+        # Reduce tiers remain reachable through the COLLAPSE view, whose demoted spelling is the
+        # original planar fold (:func:`_views`).
+        scalar = scalar_tile_moves() if not _requires_sync_fill(node) else []
         grouped: dict[str, list[TilePlan]] = {}
         for plan in scalar + warp:
             w = plan_workers(plan)
@@ -497,13 +497,13 @@ def _views(tile: TileOp, ctx) -> tuple[list[_Term], int]:
     if unit is not None:
         contraction = _view(tile, unit[0], ctx, free=unit[1])
         unit_node = head(unit[0])
-        if unit_node is not None and _has_computed_operand(unit_node):
+        if unit_node is not None and _requires_sync_fill(unit_node):
             return [_Term(cell, tile.place.on_grid(), ctx, ref=contraction.sched), contraction], 1
         return [contraction], 0
     node = head(tile.op)
     if node is None or not is_contraction(node):
         return [base], 0
-    if _has_computed_operand(node):
+    if _requires_sync_fill(node):
         return [base, _view(tile, _rewrap(tile.op, node.demoted()), ctx, ref=base.sched)], 0
     return [base], 0
 
@@ -528,6 +528,17 @@ def _has_computed_operand(node) -> bool:
     return eligible(node.a) or any(eligible(ch.b) for ch in node.channels)
 
 
+def _requires_sync_fill(node) -> bool:
+    """Whether a warp contraction must use the synchronous shared-memory fill.
+
+    A computed edge must be evaluated into a slab. A product contraction with more than one B/C
+    channel must copy one shared A slab plus every compatible B slab before one A fragment feeds
+    all MMA accumulator channels; the gmem-direct, async-copy, and scalar emitters are deliberately
+    single-channel. Both forms keep their original planar spelling as the scalar fallback view.
+    """
+    return _has_computed_operand(node) or len(node.channels) > 1
+
+
 def _converting_a(node, atom, inputs) -> bool:
     """Whether the ``a`` edge is a MATERIALIZED load whose dtype the atom cannot bind directly —
     the CONVERTING smem compute fill's case (Gemma's erased ``.float()`` cast ahead of an f16
@@ -545,16 +556,16 @@ def _converting_a(node, atom, inputs) -> bool:
 
 def _needs_fill(term: _Term, node, plan: TilePlan) -> bool:
     """Whether this warp candidate's operands take the mandatory smem compute fill — a computed
-    edge, or a materialized ``a`` the fill must convert. The ONE predicate every fill dispatch
-    reads (tile legality, stage enumeration, the resolver, the split-K partial), so the four
-    cannot drift."""
-    return _has_computed_operand(node) or (plan.is_warp and _converting_a(node, plan.atom, term.tile.inputs))
+    edge, a multi-channel product, or a materialized ``a`` the fill must convert. The ONE predicate
+    every fill dispatch reads (tile legality, stage enumeration, the resolver, the split-K
+    partial), so the four cannot drift."""
+    return _requires_sync_fill(node) or (plan.is_warp and _converting_a(node, plan.atom, term.tile.inputs))
 
 
 def _tile_ok(term: _Term, node, plan: TilePlan) -> bool:
     """Whether a warp tile candidate is realizable on ``node`` — the K-step divisibility every warp
-    row needs, plus the exact-cover geometry a COMPUTED ``a`` edge's compute fill adds. Both are
-    ``_legality`` predicates, dropped here and RAISED on a pin (:func:`_contraction_values`)."""
+    row needs, plus the exact-cover geometry the smem compute fill adds. Both are ``_legality``
+    predicates, dropped here and RAISED on a pin (:func:`_contraction_values`)."""
     if not legal.enforce(legal.warp_atom_target(plan.atom, term.ctx), pinned=False):
         return False
     shapes = {**term.tile.inputs, **term.tile.outputs}
@@ -567,7 +578,7 @@ def _tile_ok(term: _Term, node, plan: TilePlan) -> bool:
         return False
     if not legal.enforce(legal.warp_k_step(node, plan), pinned=False):
         return False
-    if not _has_computed_operand(node) and not conv:
+    if not _requires_sync_fill(node) and not conv:
         return True
     placed = plan.placed_on(term.place)
     if placed.axes is None:
@@ -868,11 +879,12 @@ def _band_of(plan: ReducePlan) -> Workers | None:
 def _resolve_stage(term: _Term, node, tile: TilePlan, want: Stage | None, why: list[str] | None = None) -> Stage | None:
     """The ONE transport-resolver dispatch — which operand edges and tier select.
 
-    Any COMPUTED contraction operand takes the smem compute fill, which is MANDATORY (no byte
-    transport can evaluate a cone), so ``want=None`` still resolves and only the DEPTH is ever
-    free. Fully MATERIALIZED operands take the mma resolver on a warp tile and the scalar one
-    otherwise, with ``want=None`` the gmem-direct baseline; TMA declines below sm_90 rather than
-    failing to compile. ``tile`` is the PLACED slice.
+    Any COMPUTED contraction operand and every multi-channel product take the smem compute fill,
+    which is MANDATORY (no byte transport can evaluate a cone or carry several B/C channels), so
+    ``want=None`` still resolves and only the DEPTH is ever free. A single-channel, fully
+    MATERIALIZED contraction takes the mma resolver on a warp tile and the scalar one otherwise,
+    with ``want=None`` the gmem-direct baseline; TMA declines below sm_90 rather than failing to
+    compile. ``tile`` is the PLACED slice.
 
     Enumeration, the split-K composition and re-materialization all reach the resolvers through
     here, so a row's resolved spelling is reproducible BY CONSTRUCTION rather than by three copies
@@ -881,10 +893,11 @@ def _resolve_stage(term: _Term, node, tile: TilePlan, want: Stage | None, why: l
     if want is not None and legal.stage_target(want, term.ctx) is not None:
         return None
     if _needs_fill(term, node, tile):
-        # A computed (or converting materialized) edge takes only the ``smem`` compute fill — a
-        # want naming an asynchronous byte transport declines rather than silently resolving to
-        # the fill. The fill IS asynchronous on its B slabs; that ring is its own depth 2, so the
-        # decline names that spelling instead of leaving the caller hunting a smem budget.
+        # A computed edge, a multi-channel product, or a converting materialized edge takes only
+        # the ``smem`` compute fill — a want naming an asynchronous byte transport declines rather
+        # than silently resolving to the fill. The fill IS asynchronous on its B slabs; that ring
+        # is its own depth 2, so the decline names that spelling instead of leaving the caller
+        # hunting a smem budget.
         if want is not None and want.transport != "smem":
             legal.decline(
                 why,
@@ -921,10 +934,11 @@ def _resolved(moves, resolve, *, gmem_direct: bool = True) -> list[Stage | None]
 
 
 def _fill_values(term: _Term, node, tile: TilePlan) -> list[Stage | None]:
-    """The RESOLVED compute-fill stages a COMPUTED operand offers — its depths, and nothing else:
-    the fill is MANDATORY (there is no gmem-direct ``None`` sibling and no byte transport can
-    evaluate a cone), so a ``STAGE`` pin can only choose the depth. ``d1`` and the asynchronous-peer
-    prefetch ring ``d2`` are fork siblings — the ring is measured per shape (see
+    """The RESOLVED compute-fill stages a computed operand or multi-channel product offers — its
+    depths, and nothing else: the fill is MANDATORY (there is no gmem-direct ``None`` sibling and
+    no byte transport can evaluate a cone or carry several B/C channels), so a ``STAGE`` pin can
+    only choose the depth. ``d1`` and the asynchronous-peer prefetch ring ``d2`` are fork siblings
+    — the ring is measured per shape (see
     :func:`_legality.resolve_fill_stage`) — and a ``d2`` that clamps back to ``d1`` under the smem
     budget spells identically, so it dedupes to one row."""
     pin = term.pin("STAGE", node)
@@ -1074,7 +1088,7 @@ def _contraction_blocks(term: _Term, node, work: Workers | None) -> list[Block]:
                 legal.enforce(legal.fragment_epilogue(term.proj), pinned=True)
                 shapes = {**term.tile.inputs, **term.tile.outputs}
                 legal.enforce(legal.warp_split_store(projection_tail(term.tile), term.place.free, plan.atom.shape, shapes), pinned=True)
-                if _has_computed_operand(node) or conv:
+                if _requires_sync_fill(node) or conv:
                     legal.enforce(legal.computed_operand_cover(node, plan.placed_on(term.place), converting_a=conv), pinned=True)
                     legal.enforce(
                         legal.computed_operand_copy_dtype(node, plan.placed_on(term.place), term.tile.inputs, converting_a=conv),
@@ -1085,7 +1099,7 @@ def _contraction_blocks(term: _Term, node, work: Workers | None) -> list[Block]:
                 # scheduler-only fixtures that carry no Tensor metadata.
                 elif not legal.enforce(legal.warp_operand_dtype(node, plan, _a_dtype(node, term.tile.inputs)), pinned=False):
                     return []
-            elif _has_computed_operand(node):
+            elif _requires_sync_fill(node):
                 return []  # a scalar pin belongs to the per-cell view, not the compute-filled edge
             else:
                 # The CTA thread budget, raised HERE rather than left to materialization: a pinned

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -701,6 +701,80 @@ def _mlp_gate_up_graph(S: int = 32) -> Graph:
     return g
 
 
+def _materialized_gate_up_graph(S: int = 32, *, up_dtype=F16) -> Graph:
+    """Two projections over one materialized activation, followed by SwiGLU."""
+    H, inter = 256, 512
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, Dim(S), Dim(H)), dtype=F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("wg", (Dim(inter), Dim(H)), dtype=F16), node_id="wg")
+    g.add_node(InputOp(), [], Tensor("wu", (Dim(inter), Dim(H)), dtype=up_dtype), node_id="wu")
+    g.add_node(LinearOp(), ["x", "wg"], Tensor("gate", (1, Dim(S), Dim(inter)), dtype=F16), node_id="gate")
+    g.add_node(LinearOp(), ["x", "wu"], Tensor("up", (1, Dim(S), Dim(inter)), dtype=F16), node_id="up")
+    g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("sg", (1, Dim(S), Dim(inter)), dtype=F16), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, Dim(S), Dim(inter)), dtype=F16), node_id="o")
+    g.inputs, g.outputs = ["x", "wg", "wu"], ["o"]
+    return g
+
+
+def test_materialized_gate_up_offers_one_shared_a_mma_fill_and_scalar_fallback():
+    """One materialized A may feed compatible gate/up MMA channels through one sync fill."""
+    from emmy.compiler.ir.pure.fold import is_contraction
+    from emmy.compiler.pipeline.knob import family_value
+
+    rows, tile = _resolve(_materialized_gate_up_graph(), pick=_is_warp_row, ctx=Context.from_target((7, 0)))
+    node = tile.op.operands[0] if isinstance(tile.op, Fold) and tile.op.axis is None else tile.op
+    assert is_contraction(node)
+    assert isinstance(node.a, Load) and len(node.channels) == 2
+    assert {ch.b.input for ch in node.channels} == {"wg", "wu"}
+    warp = [row for row in rows if _is_warp_row(row)]
+    assert warp and any(not _is_warp_row(row) for row in rows), "the original planar fallback remains a sibling"
+    assert {family_value(row, "STAGE") for row in warp} == {"d1/smem", "d2/smem"}
+    assert all(family_value(row, "STAGE") for row in warp), "multi-channel MMA cannot use the single-fold gmem-direct path"
+    assert all(str(family_value(row, "TILE")).startswith("mma_m8n8k4_f16_f32/") for row in warp)
+
+
+def test_materialized_gate_up_mixed_b_dtypes_keeps_scalar_fallback_only():
+    """A byte-copied B channel whose dtype differs from the atom must decline the MMA fill."""
+    rows, _tile = _resolve(_materialized_gate_up_graph(up_dtype=F32), ctx=Context.from_target((7, 0)))
+    assert rows and not any(_is_warp_row(row) for row in rows)
+
+
+def _bind_materialized_channels(*, b_layouts=("kn", "kn"), mix_a_axis=False):
+    """Bind the minimal two-channel product fold, or return ``None`` when it is ineligible."""
+    from emmy.compiler.pipeline.passes.lowering.tile._classify import bind_bilinear
+    from emmy.compiler.pipeline.passes.lowering.tile._fromloop import _stamp_axes
+
+    body = [
+        Load(
+            name="av",
+            input="x",
+            index=(Var("m") + Var("n"), Var("k")) if mix_a_axis else (Var("m"), Var("k")),
+        )
+    ]
+    for i, layout in enumerate(b_layouts):
+        index = (Var("k"), Var("n")) if layout == "kn" else (Var("n"), Var("k"))
+        body.extend(
+            (
+                Load(name=f"b{i}", input=f"w{i}", index=index),
+                Assign(name=f"p{i}", op="multiply", args=("av", f"b{i}")),
+                Accum(name=f"acc{i}", value=f"p{i}", op="add", axes=("k",)),
+            )
+        )
+    fold = fold_from_loop(_stamp_axes(Loop(axis=Axis("k", Dim(32)), body=Body(tuple(body)))))
+    assert fold is not None
+    return bind_bilinear(fold, "m", "n", frozenset({"m", "n"}))
+
+
+def test_materialized_channels_with_disagreeing_b_layouts_decline():
+    """One shared A fragment cannot feed B slabs with different K orientations."""
+    assert _bind_materialized_channels(b_layouts=("kn", "nk")) is None
+
+
+def test_materialized_channels_with_mixed_role_axis_decline():
+    """An A index mixing both output axes has no addressable MMA slab role."""
+    assert _bind_materialized_channels(mix_a_axis=True) is None
+
+
 def test_mlp_gate_up_nodifies_as_two_channel_product_contraction():
     """The fused gate/up MLP edge — TWO ⊗-folds sharing one normalized-row A value (fusion
     duplicates the cone SSA per fold; the matcher dedupes by value-tree equality) with the SwiGLU


### PR DESCRIPTION
## Summary

- classify compatible multi-channel product contractions over one materialized A edge
- route those Volta MMA rows through the existing synchronous shared-memory fill while retaining the planar scalar fallback
- decline mixed B layouts, mixed role axes, and incompatible copied dtypes with focused regressions

## Verification

- exact base: `f6c562b7ad0d0a31e01ee329d6eeb2e3580d9322`
- `make test`: 3159 passed, 577 skipped, 1 xfailed
- `make lint`: green
- `git diff --check`: green
- exact 8x V100-SXM3-32GB / SM70 proof on head `859d940c1512d3e6a26c19df18149be7b09c79a9`: retraced M32/M512/M1024 inventories byte-identical to the prior exact source; six fresh O3 replays on six GPU UUIDs all passed full-program, upstream, and downstream strict checks twice
- repeated total O3: M32 0.38468-0.38476 ms; M512 0.50289-0.50405 ms; M1024 0.77602-0.77807 ms

Raw task evidence: `/home/riftuser/.cache/emmy/onb-laguna-f6.tY4Am4` on `riftuser@66.172.10.131`.

## Scope

This is a compiler eligibility increment, not a whole-model or serving speedup claim. The current Laguna TP8 recipe uses the pinned 1Cat image and does not consume Emmy goldens; full tuned-golden serving remains gated on a complete serving-twin realization audit and a Laguna vLLM-Emmy serving config.