### PR TITLE
FC-1336: New Rust-like pseudocode for torch and tensor IR dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ URLs, which the workflow runs because PyPI renders the README detached from the 
     - [inspect_graph.py](emmy/commands/inspect_graph.py) — `inspect` command (graph summary)
   - [compiler/](emmy/compiler/) — PyTorch → Graph IR → CUDA compiler (see [ARCHITECTURE.md](emmy/compiler/ARCHITECTURE.md))
     - [graph.py](emmy/compiler/graph.py) — `Graph`, `Node`, `Tensor`, `Hints` container
+    - [pretty.py](emmy/compiler/pretty.py) — graph dumps as Rust-shaped pseudocode (see [IR-PSEUDOCODE-TORCH.md](emmy/compiler/IR-PSEUDOCODE-TORCH.md))
     - [ir/](emmy/compiler/ir/) — per-dialect op definitions (torch / tensor / loop / kernel / cuda) (see [ARCHITECTURE.md](emmy/compiler/ir/ARCHITECTURE.md))
     - [trace/](emmy/compiler/trace/) — PyTorch/HuggingFace → Graph IR capture (see [ARCHITECTURE.md](emmy/compiler/trace/ARCHITECTURE.md))
     - [pipeline/](emmy/compiler/pipeline/) — rewrite engine + passes + dump hooks (see [ARCHITECTURE.md](emmy/compiler/pipeline/ARCHITECTURE.md))

--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 Three layers over a shared `Graph` container.
 
+Reading a `--ir torch` / `--ir tensor` dump: [IR-PSEUDOCODE-TORCH.md](IR-PSEUDOCODE-TORCH.md).
+
 ```
 PyTorch module
    │  trace/              ── PyTorch → Graph IR capture

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -17,7 +17,7 @@ possible in Rust:
 
 - No mutation: no `mut` keyword, once a name is bound with `let`, it can't be rebound.
 - No I/O, no side effects. Whole program is `main` function that deterministically maps its arguments to its return value.
-- No control flow, no pattern matchign: `if`, `for`, `while`, `match`.
+- No control flow and no pattern matching: `if`, `for`, `while`, `match`.
 - No traits.
 - First-class typed tensors support. Example: `let x : f32[16,8,64] = ...` is a three-dimensional tensor.
 - Tensor's shape is given by its type. You may not omit the dimensions that go in `[]` of `f32[16,8,64]`.
@@ -31,6 +31,36 @@ programmer's knowledge of Rust, and enable them to intuitively read 90% of the c
 following sections introduce the pseudocode by example.
 
 ## Examples
+
+High-level structure of the IR dump is demonstrated below.
+
+```rust
+struct Dynamic {
+  // dynamic arguments
+}
+
+struct Inputs<dynamic: Dynamic> {
+  // input tensor shapes, may depend on `dynamic`
+}
+
+struct Outputs<dynamic: Dynamic> {
+  // output tensor shapes, may depend on `dynamic`
+}
+
+// the actual computations of tensor IR program
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  // constants list
+  let constant1 : Type = ...;
+  ...
+
+  // assignments defining nodes, each with a tensor operation
+  let result1 : Type = operation(arg1, arg2);
+  ...
+
+  // final collection of the IR program's outputs, each comes from one of the assignment above
+  Outputs { output1, output2, ... }
+}
+```
 
 ### Main function
 
@@ -64,6 +94,9 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
 This is a program with two inputs that applies `F.linear` to them.
 It does not use any dynamic parameters, so the `Dynamic` and `dynamic` can be disregarded here, they're just noise.
 The program's main meaning is in `main`: it maps its `inputs.x0` and `inputs.x1` to `linear` output.
+
+Note that `linear` also takes a named argument `has_bias=False`.
+The `False` value does not come from a previous assignment, declared constant or input, this value is inlined in the `linear` call.
 
 ### Scalars and constants
 
@@ -211,19 +244,12 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
 travels under the node id, the rest under their own buffer names, so every name a later line can refer to is
 bound. Only the later dialects build such nodes; a torch or tensor dump has none.
 
-## Discussion
+## Constants
 
-Then `main`. Its body opens with the graph's constants, in their own block under a comment; each compute node
-becomes one more `let`; and the tail expression builds `Outputs`. An input is reached through its struct,
-`inputs.hidden_states`, while a constant or an earlier result is a plain name.
-
-**Order** is a dependency order, not an execution schedule.
-
-**Trailing `key=value` arguments** are the operation's own fields, not tensor operands:
-`linear(mul_1, p_attn_q_proj_weight, has_bias=False)`, `reshape(x, shape=(1, 512, -1))`. A `-1` inside `shape=`
-is the request the trace captured; the declared type on the left shows the extent it resolved to.
-
-## Where a constant's value comes from
+In the simplest case, a constant's value is given by a literal, e.g. `let add_c1: f32[1] = 1.0;`.  But in some cases
+they may be loaded from disk (like model weights) or be declared externally in some other way; the key is that all these
+values are known before the values of `inputs` tensors are chosen, and such constants don't depend on inputs.  This
+section summarizes a few examples of syntax our pseudocode uses for that.
 
 | Right-hand side | Meaning |
 | --- | --- |
@@ -231,40 +257,25 @@ is the request the trace captured; the declared type on the left shows the exten
 | `load("self_attn.q_proj.weight")` | a tensor read by path, from the checkpoint or from the traced wrapper |
 | `load("a.weight", "b.weight")` | several tensors read and concatenated along axis 0 |
 | `load("x.weight_scale_2").reshape(shape=(1, 1))` | layout operations the loader applies after reading |
-| `emmy::const_eval()` | a tensor the loader computes by evaluating a small graph, rather than reading one |
 | `context(num_tokens)` | a scalar bound at launch from the symbolic-dimension environment |
+| `emmy::const_eval()` | a tensor the loader computes by evaluating a small graph, rather than reading one |
 | `emmy::input_data()` | a tensor the caller supplies at run time |
 
-A path is relative to whatever wrapper the trace ran over. A single layer gives short names
-(`self_attn.q_proj.weight`); a whole model gives long ones (`model.model.layers.0.input_layernorm.weight`), and
-buffers keep their own registered names (`causal_mask`) beside them. So one dump can carry both shapes.
+The last two are the less common ones; feel free to skip them if they don't make sense at first.
 
-The multi-path form appears once passes have run: `035_merge_sibling_linears` fuses the sibling projections, so
-a tensor dump reads `load("self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight")`.
-`emmy::const_eval()` needs a constant the loader computes rather than reads — constant folding collapsing a
-chain, or a quantized checkpoint's decode table. `context(...)` needs a decomposition pass and a symbolic
-dimension, so it cannot appear at `--ir torch` or in a static-shape dump. `emmy::input_data()` is the fallback
-when a constant has no value and no address of any kind, which also covers constants a pass synthesized and
-the loader never sees.
+## Operations: PyTorch/NumPy and Emmy
 
-## Operations
+We've seen a few examples of applying operations to tensors inside `main`, like
 
-A bare name means what torch or numpy already means by it. The model-level ones appear only in a torch dump —
-`linear`, `mean`, `softmax`, `reshape`, `slice`, `cat`, `transpose`, `sdpa`, `silu` — while `multiply`, `add`,
-`pow`, `sum`, `divide`, `exp` and the rest of the scalar and reduction names appear at both stages. Five names
-need care.
+```rust
+let linear: f32[4,16] = linear(inputs.x0, inputs.x1, has_bias=False);
+```
 
-A **reduction** prints as its combine's name with an `axis=` argument — `sum(pow_1, axis=-1)`,
-`maximum(x, axis=-1)`. That is the same spelling as the elementwise operation of the same name, so the `axis=`
-argument is the only mark; the reduced axis stays in the result at size 1. A running reduction prints
-`scan_sum(x, axis=-1)`, a name neither library has — nothing in the repo builds one today.
-
-**`transpose`** carries an `axes` field, and its length tells you which reading applies: two entries are the
-pair torch's `transpose` swaps, more are a full permutation, as numpy's reads.
-
-**`slice`** takes three captured scalars as operands. Two duplicate its `dim` and `start` fields; the third is
-the end, which the declared result shape already carries. **`cat`** ends in a captured scalar too, and that one
-is not a duplicate: `CatOp` has no fields, so the constant is the only record of the concatenation axis.
+At this point, you may be wondering where do operation names like `linear` come from, and whether there's an exhaustive
+list of operation names one might see in tensor IR. They come from PyTorch/NumPy operations that are valid in PyTorch
+graph, as well as a few of Emmy's own operations. We mark Emmy's own operations with `emmy::` namespace. Operations that
+don't have a namespace like `linear`, `add` or `mul` are from either PyTorch or NumPy. We can't tell exactly which of the
+two is meant in each case, because the tracing code does not thoroughly record the source.
 
 **`rms_norm`** and **`layer_norm`** are respellings: the class names behind them would otherwise lowercase to
 `rmsnorm` and `layernorm`. Every other operation without an `emmy::` prefix prints under its own name, `sdpa`

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -1,10 +1,24 @@
 # Reading a graph dump
 
-`emmy compile <model> --ir torch` and `--ir tensor` print the graph as Rust-shaped pseudocode. Nothing parses it
+`emmy compile <model> --ir torch` and `--ir tensor` print the graph as pseudocode with Rust-like syntax. Nothing parses it
 back; it exists so a reader can follow what the compiler holds at that point. The renderer is
 `emmy/compiler/pretty.py`, and `EMMY_DUMP_DIR` writes every stage's graph through the same code.
 
-## The program
+Torch and Tensor IR represent a very special kind of programs that work in a restricted model.
+There is no branching, loops or any other control flow.
+The whole program is a static (not changing at execution time dynamically) sequence of applying operations to values,
+  starting from input values, and finally arriving at the output values.
+Each such operation can be expressed as an assignment of an operation result to a name: `<result_name> = <operation>(<arg1>, ... <argn>)`,
+  where args are names of either program inputs or previous operation results.
+Once a name `<result_name>` is assigned like that, its value cannot be changed.
+Some names are marked as outputs.
+Their values at the end of program execution define the program's result.
+
+The pseudocode, in which emmy dumps torch and tensor IRs, looks like a subset of Rust with extra types and primitives for working with tensors.
+It aims to concisely express the IR code, while also making it easy to read intuitively for someone who is familiar with Rust.
+The following sections introduce by example.
+
+## IR Dump Examples
 
 Three small ones first. A whole-tensor operation, with its own fields after the operands:
 
@@ -24,6 +38,8 @@ pub fn main(
     linear
 }
 ```
+
+
 
 A scalar added to a tensor. The scalar becomes a constant, and reaching the tensor's shape takes an explicit
 node — the closure ignores both indices, which is what a broadcast looks like:

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -309,7 +309,7 @@ The following section presents `emmy::` helpers in more detail.
 
 ### The `emmy::` helpers
 
-Written as definitions in the same pseudocode, with three conventions.
+Each one below is written as a definition in the same pseudocode, under three conventions.
 
 `T` and `U` are element types. A shape is one const parameter holding all the axis sizes —
 `const d: usize[rank]` — so a definition can index it (`d[axis]`), slice it (`d[0..axis]`) and join pieces
@@ -321,33 +321,47 @@ coordinates before the axis, and `i[0..axis] ++ [v] ++ i[axis+1..rank]` is `i` w
 replaced by `v`. An index *tensor* holds `i64`, the dtype a traced index carries; splicing one of its values
 into an index vector converts it.
 
+#### `emmy::tensor_from_fn`
+
+Builds a tensor from a function of its indices. The closure takes one index vector; a printed line names its
+components instead, `|i, j, k|` for rank three, which is why rank six is the limit — the printer has six index
+names.
+
 ```rust
-// Build a tensor from a function of its indices. The closure takes one index
-// vector; a printed line names its components instead, `|i, j, k|` for rank three,
-// which is why rank six is the limit — the printer has six index names.
 fn emmy::tensor_from_fn<T, const rank: usize, const d: usize[rank]>(f: |usize[rank]| -> T) -> T[d]
     // produces the tensor whose element at i is f(i), for every index i with
     // i[k] < d[k]
+```
 
-// A dtype change. No node computes it: the declared result type is the whole
-// operation, and the backend converts when it materializes that type. The values
-// can still change, since a narrowing conversion rounds.
+#### `emmy::cast`
+
+A dtype change. No node computes it: the declared result type is the whole operation, and the backend converts
+when it materializes that type. The values can still change, since a narrowing conversion rounds.
+
+```rust
 fn emmy::cast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
+```
 
-// Reinterpret each element's bits as another type of the same width.
+#### `emmy::bitcast`
+
+Reinterprets each element's bits as another type of the same width.
+
+```rust
 fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
     where size_of::<U>() == size_of::<T>()
+```
 
-// One graph node covers the next two, and the operand shapes decide which: the
-// per-element reading applies when `idx` matches `data` in rank and in every axis
-// but `axis`, and the slice lookup applies otherwise.
+#### `emmy::gather`
 
-// Pick one element per output position. `idx` has the result's shape, and each of
-// its entries says which position along `axis` that one output element reads; the
-// other coordinates come from the output position itself. Close to torch's
-// `gather`, but not the same: torch allows `idx` to be smaller than `data` on the
-// axes it does not gather, while this requires them equal. A narrower index is a
-// legal `torch.gather` that prints — and computes — as `emmy::gather_by_axis`.
+Picks one element per output position. `idx` has the result's shape, and each of its entries says which
+position along `axis` that one output element reads; the other coordinates come from the output position
+itself.
+
+Close to torch's `gather`, but not the same: torch allows `idx` to be smaller than `data` on the axes it does
+not gather, while this requires them equal. A narrower index is a legal `torch.gather` that prints — and
+computes — as `emmy::gather_by_axis`.
+
+```rust
 fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]>(
     data: T[d],
     idx: i64[e],
@@ -356,10 +370,15 @@ fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]
     where e[k] == d[k] for every k != axis
     // produces the tensor whose element at i is
     // data[i[0..axis] ++ [idx[i]] ++ i[axis+1..rank]]
+```
 
-// Look up whole slices by index. Each entry of `idx` names a position along `axis`,
-// and the slice of `data` sitting there is copied out; `idx`'s own axes take the
-// place of `axis`. A token embedding is this: one row of a table per token id.
+#### `emmy::gather_by_axis`
+
+Looks up whole slices by index. Each entry of `idx` names a position along `axis`, and the slice of `data`
+sitting there is copied out; `idx`'s own axes take the place of `axis`. A token embedding is this: one row of a
+table per token id.
+
+```rust
 fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize[rank], const e: usize[irank]>(
     data: T[d],
     idx: i64[e],
@@ -368,25 +387,35 @@ fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize
     // produces the tensor whose element at i, writing j for the index tensor's own
     // coordinates i[axis..axis+irank], is
     // data[i[0..axis] ++ [idx[j]] ++ i[axis+irank..rank+irank-1]]
+```
 
-// A reindexing the builder above cannot hold: no source, several sources, a
-// selection deciding which source feeds which output position, or rank above six.
-// A printed call lists the operand tensors; the coordinate map that pairs each one
-// with the output index, and the condition under which it supplies a position, stay
-// inside the node.
+#### `emmy::index_map`
+
+A reindexing `emmy::tensor_from_fn` cannot hold: no source, several sources, a selection deciding which source
+feeds which output position, or rank above six. A printed call lists the operand tensors; the coordinate map
+that pairs each one with the output index, and the condition under which it supplies a position, stay inside
+the node.
+
+```rust
 fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: [tensor]) -> T[d]
+```
 
-// Decode or encode a narrow float format, element by element. Unlike `cast`, these
-// have a real implementation behind them (`emmy/compiler/ir/elementwise.py`).
+#### `emmy::scalar::*`
+
+Functions on one number, applied to every element. Unlike `cast`, these have a real implementation behind them,
+in `emmy/compiler/ir/elementwise.py`.
+
+```rust
 fn emmy::scalar::from_f8e4m3<const rank: usize, const d: usize[rank]>(x: f8e4m3[d]) -> f32[d]
 fn emmy::scalar::to_f8e4m3<const rank: usize, const d: usize[rank]>(x: f32[d]) -> f8e4m3[d]
 ```
 
-`emmy::const_eval()` and `emmy::input_data()` are not operations. They stand for where a constant's value comes
-from and appear only on the right of a module-level binding. `const_eval` means the loader computes the value
-by running a small graph — a chain of layout operations over other constants that folding collapsed into one.
-`input_data` means the constant has no value and no address at all, so whoever runs the graph must supply it by
-name.
+#### `emmy::const_eval` and `emmy::input_data`
+
+Not operations. They stand for where a constant's value comes from, and appear only on the right of a binding
+in the constants block. `const_eval` means the loader computes the value by running a small graph — a chain of
+layout operations over other constants that folding collapsed into one. `input_data` means the constant has no
+value and no address at all, so whoever runs the graph must supply it by name.
 
 ### Reading `emmy::tensor_from_fn`
 

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -144,10 +144,10 @@ up an array by given a function of its indices.  Let's look at its application m
 ```
 
 This produces an $$4\times8$$ tensor filled with the same constant `add_c1`.  The `emmy::tensor_from_fn`
-primitive is polymorphic over the shape of the tensor it produces, so its type signature is something like `fn
-emmy::tensor_from_fn<T, n: usize, m:usize>(...) -> T[n, m]` so it may be called by the same name `emmy::tensor_from_fn`
-to produce tensors of different shapes and dimensions. Since the result's type is always annotated, the shape is never
-unambiguous.
+primitive is polymorphic over the shape of the tensor it produces and over the shape of the tensor it reads, so
+its type signature is something like `fn emmy::tensor_from_fn<T, const n: usize, const m: usize, …>(operand, coord)
+-> T[n, m]` and the same name serves tensors of any shape and rank. Since the result's type is always annotated,
+the shape is never ambiguous.
 
 In practice, tensor IR can't express `emmy::tensor_from_fn` calls with arbitrary lambdas, only some specific restricted
 forms.  But it's not a problem for you, since you only read these lambdas and never write them.  For the precise
@@ -488,11 +488,11 @@ emmy compile -c 'torch.cat([torch.randn(2,3), torch.randn(2,5)], dim=1)' --ir te
 ```
 
 ```rust
-let cat: f32[2,8]
-    = emmy::index_map([
-    IndexSource { operand: inputs.x0, coord: |i, j| [i, ((j < 3) ? j : 0)], select: |_i, j| (j < 3) },
-    IndexSource { operand: inputs.x1, coord: |i, j| [i, ((j < 3) ? 0 : (j - 3))] },
-  ]);
+  let cat: f32[2,8]
+      = emmy::index_map([
+      IndexSource { operand: inputs.x0, coord: |i, j| [i, ((j < 3) ? j : 0)], select: |_i, j| (j < 3) },
+      IndexSource { operand: inputs.x1, coord: |i, j| [i, ((j < 3) ? 0 : (j - 3))] },
+    ]);
 ```
 
 The first source supplies the columns below 3 and reads `x0` there; the second has no condition, so it takes

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -333,6 +333,28 @@ fn emmy::tensor_from_fn<T, const rank: usize, const d: usize[rank]>(f: |usize[ra
     // i[k] < d[k]
 ```
 
+Inside the closure, a tensor is read with brackets. An axis the body never uses takes Rust's `_` prefix, which
+is how a broadcast looks:
+
+```rust
+let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+```
+
+One number per column, repeated over batch and tokens. Coordinates can also be arithmetic over the parameters,
+which is how a slice or a dropped axis reads:
+
+```rust
+let linear_5: f16[1,512,3072] = emmy::tensor_from_fn(|i, j, k| linear_4__cat__linear_5[i, j, (k + 3072)]);
+let linear_3: f16[1,512,1024] = emmy::tensor_from_fn(|i, j, k| linear_3_reduce[i, j, 0, k]);
+```
+
+The first reads the upper half of a concatenated tensor, the second drops a size-1 axis.
+
+Valid: every coordinate is arithmetic over the closure's parameters, literals, and — under `--dynamic` — the
+symbolic dimension names, which appear free in the body because the launch binds them. A coordinate is never a
+value read from another tensor; that is what `emmy::gather` and `emmy::gather_by_axis` are for. Invalid: a
+parameter count that disagrees with the result's rank, which would mean the printer has a bug.
+
 #### `emmy::cast`
 
 A dtype change. No node computes it: the declared result type is the whole operation, and the backend converts
@@ -416,27 +438,3 @@ Not operations. They stand for where a constant's value comes from, and appear o
 in the constants block. `const_eval` means the loader computes the value by running a small graph — a chain of
 layout operations over other constants that folding collapsed into one. `input_data` means the constant has no
 value and no address at all, so whoever runs the graph must supply it by name.
-
-### Reading `emmy::tensor_from_fn`
-
-The closure takes one parameter per axis of the **result**, and the type gives their ranges. Inside, a tensor
-is read with brackets. An axis the body never uses takes Rust's `_` prefix, which is how a broadcast looks:
-
-```rust
-let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
-```
-
-One number per column, repeated over batch and tokens. Coordinates can also be arithmetic over the parameters,
-which is how a slice or a dropped axis reads:
-
-```rust
-let linear_5: f16[1,512,3072] = emmy::tensor_from_fn(|i, j, k| linear_4__cat__linear_5[i, j, (k + 3072)]);
-let linear_3: f16[1,512,1024] = emmy::tensor_from_fn(|i, j, k| linear_3_reduce[i, j, 0, k]);
-```
-
-The first reads the upper half of a concatenated tensor, the second drops a size-1 axis.
-
-Valid: every coordinate is arithmetic over the closure's parameters, literals, and — under `--dynamic` — the
-symbolic dimension names, which appear free in the body because the launch binds them. A coordinate is never a
-value read from another tensor; that is what `emmy::gather` and `emmy::gather_by_axis` are for. Invalid: a
-parameter count that disagrees with the result's rank, which would mean the printer has a bug.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -6,8 +6,11 @@ back; it exists so a reader can follow what the compiler holds at that point. Th
 
 ## The program
 
-Three small ones first, from `emmy compile --code`. A whole-tensor operation, with its own fields after the
-operands:
+Three small ones first. A whole-tensor operation, with its own fields after the operands:
+
+```
+emmy compile -c 'F.linear(torch.randn(4,64), torch.randn(16,64))' --ir torch
+```
 
 ```rust
 // 3 nodes, 2 inputs, 1 outputs
@@ -25,6 +28,10 @@ pub fn main(
 A scalar added to a tensor. The scalar becomes a constant, and reaching the tensor's shape takes an explicit
 node — the closure ignores both indices, which is what a broadcast looks like:
 
+```
+emmy compile -c 'torch.randn(4,8) + 1' --ir torch
+```
+
 ```rust
 // 4 nodes, 1 inputs, 1 outputs
 
@@ -40,8 +47,14 @@ pub fn main(
 }
 ```
 
-Two operations, and the constants the trace captured along the way — `transpose_c1` and `softmax_c1` end up
-bound and unused, since the fields carry the same information:
+Two operations, and three constants that nothing refers to. Resolving a traced call's inputs materializes every
+scalar argument as a constant, and a handler that folds the scalar into a field instead — `transpose`'s `axes`,
+`softmax`'s `axis` — never wires the constant up. They are real nodes, so they print; the count in the header
+includes them:
+
+```
+emmy compile -c 'F.softmax(torch.randn(2,4,8).transpose(1,2), dim=-1)' --ir torch
+```
 
 ```rust
 // 6 nodes, 1 inputs, 1 outputs
@@ -60,15 +73,23 @@ pub fn main(
 }
 ```
 
-A model layer has the same shape, with more of it. This is `--layer 0` of a Llama-architecture model, cut down
+Those leftovers do not survive the pipeline. One Qwen3-0.6B layer carries 33 such constants at `--ir torch`
+and 4 at `--ir tensor`, and the four that remain are the norm epsilons, which really are operands. A `slice`
+keeps its captured scalars as operands too, redundantly with its own fields.
+
+A model layer has the same shape, with more of it. Below is one layer of a Llama-architecture model, cut down
 to its landmarks:
+
+```
+emmy compile TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --ir torch
+```
 
 ```rust
 // 106 nodes, 4 inputs, 1 outputs
 
-let p_input_layernorm_weight: f16[2048] = load("input_layernorm.weight");
 let p_attn_q_proj_weight: f16[2048,2048] = load("self_attn.q_proj.weight");
-// … 33 constants in all
+let p_attn_k_proj_weight: f16[256,2048] = load("self_attn.k_proj.weight");
+// … 38 constants in all
 
 pub fn main(
     hidden_states: f16[1,512,2048],
@@ -76,8 +97,7 @@ pub fn main(
     position_embeddings_1: f16[1,512,64],
     attention_mask: f32,
 ) -> f16[1,512,2048] {
-    let p_input_layernorm_weight_bc: f16[1,512,2048]
-        = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+    let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
     let to: f32[1,512,2048] = emmy::cast(hidden_states);
     // … the norm, then the q / k / v projections
     let scaled_dot_product_attention: f16[1,32,512,64]
@@ -96,10 +116,17 @@ compute node becomes one `let`, and its outputs become the tail expression. A gr
 returns an `Outputs` struct, declared after the function; a graph with none returns `()`.
 
 ```rust
+// 8 nodes, 2 inputs, 2 outputs
+
+let add_c1: f32[1] = 1.0;
+let mul_c1: f32[1] = 2.0;
+
 pub fn main(
     x0: f32[4,8],
     x1: f32[4,8],
 ) -> Outputs {
+    let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
+    let mul_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| mul_c1[0]);
     let add: f32[4,8] = add(x0, add_c1_bc);
     let mul: f32[4,8] = multiply(x1, mul_c1_bc);
 
@@ -113,7 +140,8 @@ struct Outputs {
 ```
 
 **Types** carry the shape: `f16[1,512,4096]`. A rank-0 tensor is just its dtype (`f32`). Dtype names are the
-repo's own, including the narrow float formats (`f8e4m3`).
+repo's own, including the narrow float formats (`f8e4m3`). Under `--dynamic` an extent can be a name or an
+expression rather than a number — `f32[2,seq_len,4]`, `f32[1,(2 * seq_len),4]`.
 
 **Order** is a dependency order, not an execution schedule.
 
@@ -121,8 +149,12 @@ repo's own, including the narrow float formats (`f8e4m3`).
 `linear(mul_1, p_attn_q_proj_weight, has_bias=False)`, `reshape(x, shape=(1, 512, -1))`. A `-1` inside `shape=`
 is the request the trace captured; the declared type on the left shows the extent it resolved to.
 
-**Constants named `<node>_c<N>`** are scalars the trace captured, named after the node that consumes them and
-the argument position they sat at: `add_c1` is the epsilon inside the node called `add`.
+**Constants named `<node>_c<N>`** are scalars the trace captured, named after the traced call they came from
+and their position in that call's resolved operand list: `add_c1` is the epsilon inside the node called `add`.
+
+**A node that writes several buffers destructures.** `let (nid, buf1): (f32[4,8], f32[4,8]) = op(x);` — slot 0
+travels under the node id, the rest under their own buffer names, so every name a later line can refer to is
+bound. Only the later dialects build such nodes; a torch or tensor dump has none.
 
 **Binding names are node ids.** Every node carries two labels: the id the graph stores it under and refers to
 it by, and its output tensor's name. They are usually the same string, because a new node takes its tensor name
@@ -131,8 +163,8 @@ name — `broadcast_to` names its result after its source, so one source broadca
 one name twice. Bindings print the id, so no two can collide, and a differing tensor name follows in a comment:
 
 ```rust
-let n0: f16[1,8,512,128] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);  // aka tensor name `unsqueeze_bc`
-let unsqueeze_bc: f16[1,32,512,128] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);
+let n0: f16[1,4,512,64] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);  // aka tensor name `unsqueeze_bc`
+let unsqueeze_bc: f16[1,32,512,64] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);
 ```
 
 **Memory, loops, threads, kernels, fusion and hardware choices are absent** because these levels cannot express
@@ -140,9 +172,9 @@ them, not because the printer hides them. They arrive with the later dialects, w
 forms.
 
 **Four fields are hidden.** Every operation carries `source` (its predecessor in a rewrite chain), `knobs` (the
-tuning choices passes stamp on it), and a map of its own input and output tensors. They record where a node
-came from rather than what it computes — `Graph.to_dict` skips the same four when it serializes a graph — and
-at the torch stage they are empty anyway, since no pass has run yet.
+tuning choices passes stamp on it), and `inputs` / `outputs`, a derived view of the tensors around it that the
+matcher fills in. None of them says what the node computes, and `Graph.to_dict` skips them too when it
+serializes a graph. At the torch stage they are empty anyway, since no pass has run yet.
 
 When `EMMY_DUMP_DIR` dumps a later stage, whose nodes hold whole statement trees, an operation prints its own
 body instead:
@@ -150,48 +182,87 @@ body instead:
 ```rust
     let linear: f32[4,16]
         = loop(x1, x0) {
-        for a0 in 0..4
-            for a1 in 0..16
-                for a2 in 0..64
-                    in0 = load x1[a1, a2]
-                    ...
+    for a0 in 0..4
+        for a1 in 0..16
+            for a2 in 0..64
+                in0 = load x1[a1, a2]
+                in1 = load x0[a0, a2]
+                v0 = multiply(in0, in1)
+                acc0 <- add(acc0, v0)
+            linear[a0, a1] = acc0
     };
 ```
+
+`acc0 <- add(acc0, v0)` is that dialect's accumulate, not an assignment this notation defines.
+
+## Two stages, one notation
+
+`--ir torch` and `--ir tensor` print through the same renderer, and every reading rule below applies to both.
+What changes is the vocabulary of operations, because decomposition runs between them.
+
+A torch dump is the trace as recorded, so it holds model-level operations — `linear`, `sdpa`, `mean`,
+`softmax`, `reshape`, `transpose`, `slice`, `cat`, `unsqueeze` — each carrying a whole idea in one node
+(`emmy/compiler/ir/frontend/ir.py`). A tensor dump has none of them. Decomposition rewrites every one into the
+generic set in `emmy/compiler/ir/tensor/ir.py`: elementwise operations, reductions, scans, the two gathers,
+scatter, index maps, casts.
+
+The same Qwen3-0.6B layer at both stages:
+
+```
+--ir torch    136 nodes    linear x7, mean x4, transpose x4, slice x4, reshape x4, sdpa, softmax
+--ir tensor   153 nodes    none of those; sum x11, divide x5, exp x2, emmy::tensor_from_fn x51
+```
+
+A `linear` becomes a broadcast, an elementwise multiply and a `sum` over the contracted axis. A `mean` becomes
+that `sum` times a reciprocal. An `sdpa` becomes masked scores, the three-pass softmax spelled out, then the
+second contraction. The layout operations become index maps carrying real arithmetic, which is why the builder
+count more than doubles: what sat inside a `slice` node's fields at the torch stage is
+`linear_4__cat__linear_5[i, j, (k + 3072)]` at the tensor stage.
+
+One node becoming several is why the count grows, even though the pipeline sweeps dead nodes on the way.
 
 ## Where a constant's value comes from
 
 | Right-hand side | Meaning |
 | --- | --- |
 | `1e-06` | a literal fixed at trace time |
-| `load("model.layers.0…")` | a tensor read by path, from the checkpoint or from the traced wrapper |
-| `load("…").reshape(shape=(1, 1))` | layout operations the loader applies after reading, in order |
+| `load("self_attn.q_proj.weight")` | a tensor read by path, from the checkpoint or from the traced wrapper |
+| `load("a.weight", "b.weight")` | several tensors read and concatenated along axis 0 |
+| `load("x.weight_scale_2").reshape(shape=(1, 1))` | layout operations the loader applies after reading |
 | `emmy::const_eval()` | a tensor the loader computes by evaluating a small graph, rather than reading one |
 | `context(num_tokens)` | a scalar bound at launch from the symbolic-dimension environment |
 | `emmy::input_data()` | a tensor the caller supplies at run time |
 
-Two notes on paths. A quantized checkpoint's dump mixes two naming schemes: parameters are rewritten to
-absolute model paths (`model.layers.0.self_attn.q_proj.weight`), while buffers keep the traced wrapper's own
-names (`causal_mask`). Unquantized dumps leave both wrapper-relative.
+A path is relative to whatever wrapper the trace ran over. A single layer gives short names
+(`self_attn.q_proj.weight`); a whole model gives long ones (`model.model.layers.0.input_layernorm.weight`), and
+buffers keep their own registered names (`causal_mask`) beside them. So one dump can carry both shapes.
 
-The last three rows are rare. `context(...)` needs a decomposition pass and a symbolic dimension, so it cannot
-appear at `--ir torch` or in a static-shape dump. A caller-supplied tensor and the multi-path form
-(`load("…a", "…b")`, concatenated on axis 0) exist in the renderer, but no traced model produces them.
+The multi-path form appears once passes have run: `035_merge_sibling_linears` fuses the sibling projections, so
+a tensor dump reads `load("self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight")`.
+`emmy::const_eval()` needs a constant the loader computes rather than reads — constant folding collapsing a
+chain, or a quantized checkpoint's decode table. `context(...)` needs a decomposition pass and a symbolic
+dimension, so it cannot appear at `--ir torch` or in a static-shape dump. `emmy::input_data()` is the fallback
+when a constant has no value and no address of any kind, which also covers constants a pass synthesized and
+the loader never sees.
 
 ## Operations
 
-A bare name means what torch or numpy already means by it: `multiply`, `add`, `pow`, `mean`, `sum`, `linear`,
-`silu`, `softmax`, `reshape`, `slice`, `cat`, `transpose`. Four cases need care.
+A bare name means what torch or numpy already means by it. The model-level ones appear only in a torch dump —
+`linear`, `mean`, `softmax`, `reshape`, `slice`, `cat`, `transpose`, `sdpa`, `silu` — while `multiply`, `add`,
+`pow`, `sum`, `divide`, `exp` and the rest of the scalar and reduction names appear at both stages. Five names
+need care.
 
 A **reduction** prints as its combine's name with an `axis=` argument — `sum(pow_1, axis=-1)`,
 `maximum(x, axis=-1)`. That is the same spelling as the elementwise operation of the same name, so the `axis=`
-argument is the only mark; the reduced axis stays in the result at size 1.
+argument is the only mark; the reduced axis stays in the result at size 1. A running reduction prints
+`scan_sum(x, axis=-1)`, a name neither library has — nothing in the repo builds one today.
 
-**`transpose`** carries an `axes` field that is either a pair to swap, as torch's `transpose` takes, or a full
-permutation, as numpy's reads. Both print identically, so check the declared result type.
+**`transpose`** carries an `axes` field, and its length tells you which reading applies: two entries are the
+pair torch's `transpose` swaps, more are a full permutation, as numpy's reads.
 
-**`slice`** also carries the scalar constants the trace captured, which duplicate its own fields. **`cat`** ends
-in a captured scalar too, but that one is not a duplicate: `CatOp` has no fields, so the constant is the only
-record of the concatenation axis.
+**`slice`** takes three captured scalars as operands. Two duplicate its `dim` and `start` fields; the third is
+the end, which the declared result shape already carries. **`cat`** ends in a captured scalar too, and that one
+is not a duplicate: `CatOp` has no fields, so the constant is the only record of the concatenation axis.
 
 **`rms_norm`** and **`layer_norm`** are respellings: the class names behind them would otherwise lowercase to
 `rmsnorm` and `layernorm`. Every other operation without an `emmy::` prefix prints under its own name, `sdpa`
@@ -201,10 +272,10 @@ An `emmy::` name is emmy's own:
 
 | Name | Meaning |
 | --- | --- |
-| `emmy::tensor_from_fn(\|i, j\| …)` | build a tensor from a function of its indices |
+| `emmy::tensor_from_fn(\|i, j\| body)` | build a tensor from a function of its indices, here rank two |
 | `emmy::cast(x)` | a dtype change (see the gotchas below — no node computes it) |
 | `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
-| `emmy::index_map(…)` | a reindexing the closure form cannot hold |
+| `emmy::index_map(a, b)` | a reindexing `emmy::tensor_from_fn` cannot hold |
 | `emmy::gather(data, idx, axis=n)` | pick one element per output position |
 | `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
@@ -214,8 +285,8 @@ that torch or numpy does not already name prints under the prefix:
 
 | Name | Meaning |
 | --- | --- |
-| `emmy::intrinsics::from_f8e4m3(x)`, `emmy::intrinsics::to_f8e5m2(x)`, … | decode or encode a narrow float format |
-| `emmy::intrinsics::bitcast(x)` | the elementwise spelling of a same-width reinterpretation |
+| `emmy::intrinsics::from_f8e4m3(x)`, `from_f8e5m2`, `to_f8e4m3`, `to_f8e5m2` | decode or encode a narrow float format |
+| `emmy::intrinsics::bitcast(x)` | the same reinterpretation as `emmy::bitcast`, reached through the intrinsic table |
 | `emmy::intrinsics::gelu_tanh(x)` | gelu's tanh approximation, torch's `approximate="tanh"` |
 | `emmy::intrinsics::exp_fast(x)` | `exp` with the fast-math CUDA spelling, from a kernel-stage pass |
 
@@ -223,29 +294,31 @@ that torch or numpy does not already name prints under the prefix:
 
 Written as definitions in the same pseudocode, with three conventions.
 
-`T` and `U` are element types. A shape is one const parameter holding all the axis sizes — `const d: usize[n]`
-— so a definition can index it (`d[axis]`), slice it (`d[0..axis]`) and join pieces with `++`.
+`T` and `U` are element types. A shape is one const parameter holding all the axis sizes —
+`const d: usize[rank]` — so a definition can index it (`d[axis]`), slice it (`d[0..axis]`) and join pieces
+with `++`.
 
-An index into a rank-`n` tensor is itself a vector of `n` numbers, so `x[i]` with `i: usize[n]` is one element,
+An index into a rank-`r` tensor is itself a vector of `r` numbers, so `x[i]` with `i: usize[r]` is one element,
 and `x[i0, i1]` is the same thing written out. Slicing and joining work on an index too: `i[0..axis]` is the
-coordinates before the axis, and `i[0..axis] ++ [v] ++ i[axis+1..n]` is `i` with the coordinate at `axis`
-replaced by `v`.
+coordinates before the axis, and `i[0..axis] ++ [v] ++ i[axis+1..rank]` is `i` with the coordinate at `axis`
+replaced by `v`. An index *tensor* holds `i64`, the dtype a traced index carries; splicing one of its values
+into an index vector converts it.
 
 ```rust
-// Build a tensor from a function of its indices. The result type fixes how many
-// parameters the closure takes and what each one ranges over. Rank six is the
-// limit, because the printer has six index names.
-fn emmy::tensor_from_fn<T, const n: usize, const d: usize[n]>(f: |usize, …, usize| -> T) -> T[d]
+// Build a tensor from a function of its indices. The closure takes one index
+// vector; a printed line names its components instead, `|i, j, k|` for rank three,
+// which is why rank six is the limit — the printer has six index names.
+fn emmy::tensor_from_fn<T, const rank: usize, const d: usize[rank]>(f: |usize[rank]| -> T) -> T[d]
     // produces the tensor whose element at i is f(i), for every index i with
     // i[k] < d[k]
 
 // A dtype change. No node computes it: the declared result type is the whole
 // operation, and the backend converts when it materializes that type. The values
 // can still change, since a narrowing conversion rounds.
-fn emmy::cast<T, U, const n: usize, const d: usize[n]>(x: T[d]) -> U[d]
+fn emmy::cast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
 
 // Reinterpret each element's bits as another type of the same width.
-fn emmy::bitcast<T, U, const n: usize, const d: usize[n]>(x: T[d]) -> U[d]
+fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
     where size_of::<U>() == size_of::<T>()
 
 // One graph node covers the next two, and the operand shapes decide which: the
@@ -256,35 +329,38 @@ fn emmy::bitcast<T, U, const n: usize, const d: usize[n]>(x: T[d]) -> U[d]
 // its entries says which position along `axis` that one output element reads; the
 // other coordinates come from the output position itself. Close to torch's
 // `gather`, but not the same — see the gotchas.
-fn emmy::gather<T, const n: usize, const d: usize[n], const e: usize[n]>(
+fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]>(
     data: T[d],
     idx: i64[e],
     axis: usize,
 ) -> T[e]
     where e[k] == d[k] for every k != axis
     // produces the tensor whose element at i is
-    // data[i[0..axis] ++ [idx[i]] ++ i[axis+1..n]]
+    // data[i[0..axis] ++ [idx[i]] ++ i[axis+1..rank]]
 
 // Look up whole slices by index. Each entry of `idx` names a position along `axis`,
 // and the slice of `data` sitting there is copied out; `idx`'s own axes take the
 // place of `axis`. A token embedding is this: one row of a table per token id.
-fn emmy::gather_by_axis<T, const n: usize, const m: usize, const d: usize[n], const e: usize[m]>(
+fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize[rank], const e: usize[irank]>(
     data: T[d],
     idx: i64[e],
     axis: usize,
-) -> T[d[0..axis] ++ e ++ d[axis+1..n]]
+) -> T[d[0..axis] ++ e ++ d[axis+1..rank]]
     // produces the tensor whose element at i, writing j for the index tensor's own
-    // coordinates i[axis..axis+m], is
-    // data[i[0..axis] ++ [idx[j]] ++ i[axis+m..n+m-1]]
+    // coordinates i[axis..axis+irank], is
+    // data[i[0..axis] ++ [idx[j]] ++ i[axis+irank..rank+irank-1]]
 
-// A reindexing the closure form cannot hold: no source, several sources, a
+// A reindexing the builder above cannot hold: no source, several sources, a
 // selection deciding which source feeds which output position, or rank above six.
-fn emmy::index_map<T, const n: usize, const d: usize[n]>(sources: …) -> T[d]
+// A printed call lists the operand tensors; the coordinate map that pairs each one
+// with the output index, and the condition under which it supplies a position, stay
+// inside the node.
+fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: [tensor]) -> T[d]
 
 // Decode or encode a narrow float format, element by element. Unlike `cast`, these
 // have a real implementation behind them (`emmy/compiler/ir/elementwise.py`).
-fn emmy::intrinsics::from_f8e4m3<const n: usize, const d: usize[n]>(x: f8e4m3[d]) -> f32[d]
-fn emmy::intrinsics::to_f8e4m3<const n: usize, const d: usize[n]>(x: f32[d]) -> f8e4m3[d]
+fn emmy::intrinsics::from_f8e4m3<const rank: usize, const d: usize[rank]>(x: f8e4m3[d]) -> f32[d]
+fn emmy::intrinsics::to_f8e4m3<const rank: usize, const d: usize[rank]>(x: f32[d]) -> f8e4m3[d]
 ```
 
 `emmy::const_eval()` and `emmy::input_data()` are not operations. They stand for where a constant's value comes
@@ -299,20 +375,23 @@ The closure takes one parameter per axis of the **result**, and the type gives t
 is read with brackets. An axis the body never uses takes Rust's `_` prefix, which is how a broadcast looks:
 
 ```rust
-let p_input_layernorm_weight_bc: f16[1,512,4096]
-    = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
 ```
 
-One number per column, repeated over batch and tokens. A read whose index is itself a tensor value — a table
-lookup — prints the same way, with the inner bracket producing the row:
+One number per column, repeated over batch and tokens. Coordinates can also be arithmetic over the parameters,
+which is how a slice or a dropped axis reads:
 
 ```rust
-let pairs: f16[4096,2048,2] = emmy::tensor_from_fn(|i, j, k| pair_table[idx[i, j], k]);
+let linear_5: f16[1,512,3072] = emmy::tensor_from_fn(|i, j, k| linear_4__cat__linear_5[i, j, (k + 3072)]);
+let linear_3: f16[1,512,1024] = emmy::tensor_from_fn(|i, j, k| linear_3_reduce[i, j, 0, k]);
 ```
 
-Valid: every index variable in the body comes from the closure's parameters, or is a literal, or is another
-tensor read. Invalid: a free variable, or a parameter count that disagrees with the result's rank — if you see
-either, the printer has a bug.
+The first reads the upper half of a concatenated tensor, the second drops a size-1 axis.
+
+Valid: every coordinate is arithmetic over the closure's parameters, literals, and — under `--dynamic` — the
+symbolic dimension names, which appear free in the body because the launch binds them. A coordinate is never a
+value read from another tensor; that is what `emmy::gather` and `emmy::gather_by_axis` are for. Invalid: a
+parameter count that disagrees with the result's rank, which would mean the printer has a bug.
 
 ## Gotchas
 
@@ -338,10 +417,13 @@ let to: f32[1,512,1024] = to_cast;
 
 **`emmy::gather` is not `torch.gather`.** The formula is torch's, and on the inputs emmy accepts the two agree
 element for element. But torch requires only `index.size(d) <= input.size(d)` on every axis other than the
-gathered one, while emmy demands equality there. A narrower index is a legal `torch.gather` that emmy reads as
-the other operation: data `[4,8]` with an index `[4,3]` on axis 0 gives `[4,3]` in torch and `[4,3,8]` here.
-Four ATen operators collapse onto one node and only the axis survives, so operand shapes are the only evidence
-of which was meant.
+gathered one, while emmy demands equality there. A narrower index is a legal `torch.gather` that prints as the
+other operation: `torch.gather` on data `[4,8]` with an index `[4,3]` at axis 0 prints
+`let gather: f32[4,3] = emmy::gather_by_axis(x0, x1, axis=0);`. That line is the one place a dump contradicts
+itself — the declared type is torch's answer, while `emmy::gather_by_axis` as defined above would give
+`[4,3,8]`, and that is also what emmy computes. Four ATen operators collapse onto one node and only the axis
+survives, so operand shapes are the only evidence of which was meant.
 
-**Some captured constants go unused.** `transpose` and `softmax` leave the scalars the trace captured bound at
-module level, with nothing referring to them.
+**Some captured constants go unused.** The layer above captures 29 scalars and refers to 18 of them. The 11
+left over come from `transpose` (8), `unsqueeze` (2) and `sdpa` (1) — the handlers that read a scalar argument
+off the trace and store it in a field, rather than keeping the constant the resolver had already made.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -4,21 +4,35 @@
 back; it exists so a reader can follow what the compiler holds at that point. The renderer is
 `emmy/compiler/pretty.py`, and `EMMY_DUMP_DIR` writes every stage's graph through the same code.
 
-Torch and Tensor IR represent a very special kind of programs that work in a restricted model.
-There is no branching, loops or any other control flow.
-The whole program is a static (not changing at execution time dynamically) sequence of applying operations to values,
-  starting from input values, and finally arriving at the output values.
-Each such operation can be expressed as an assignment of an operation result to a name: `<result_name> = <operation>(<arg1>, ... <argn>)`,
-  where args are names of either program inputs or previous operation results.
-Once a name `<result_name>` is assigned like that, its value cannot be changed.
-Some names are marked as outputs.
-Their values at the end of program execution define the program's result.
+Torch and Tensor IR represent a very special kind of programs that work in a restricted model.  There is no branching,
+loops or any other control flow.  The whole program is a static (not changing at execution time dynamically) sequence of
+applying pre-defined operations to values.  Values in this model are typically tensors, and the operations are common
+pytorch/numpy primitives, plus a few ones Emmy adds for convenience.
 
-The pseudocode, in which emmy dumps torch and tensor IRs, looks like a subset of Rust with extra types and primitives for working with tensors.
-It aims to concisely express the IR code, while also making it easy to read intuitively for someone who is familiar with Rust.
-The following sections introduce by example.
+## Overview
 
-## IR Dump Examples
+The pseudocode in which emmy dumps torch and tensor IRs is a *dependently-typed*, *purely functional*, *array*
+programming language.  Despite using Rust syntax, it removes some of the things Rust can do and adds a few things not
+possible in Rust:
+
+- No mutation: no `mut` keyword, once a name is bound with `let`, it can't be rebound.
+- No I/O, no side effects. Whole program is `main` function that deterministically maps its arguments to its return value.
+- No control flow, no pattern matchign: `if`, `for`, `while`, `match`.
+- No traits.
+- First-class typed tensors support. Example: `let x : f32[16,8,64] = ...` is a three-dimensional tensor.
+- Tensor's shape is given by its type. You may not omit the dimensions that go in `[]` of `f32[16,8,64]`.
+- Types (of a struct or a function) can be polymorphic over values. This is particularly useful to support `--dynamic`
+  parameters. Example: if some *value* `dyn_len: usize` is in scope, you can declare a tensor whose *type-level* shape
+  depends on that value `let x : [16,dyn_len,64]`.
+
+These features are hand-picked from existing functional programming languages (Agda, Idris, Futhark) to concisely
+and unambiguously express programs in tensor IR's programming model.  Using Rust syntax allows us to piggyback on a
+programmer's knowledge of Rust, and enable them to intuitively read 90% of the code and ease the learning curve.  The
+following sections introduce the pseudocode by example.
+
+## Examples
+
+### Main function
 
 Three small ones first. A whole-tensor operation, with its own fields after the operands:
 
@@ -47,7 +61,11 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
 }
 ```
 
+This is a program with two inputs that applies `F.linear` to them.
+It does not use any dynamic parameters, so the `Dynamic` and `dynamic` can be disregarded here, they're just noise.
+The program's main meaning is in `main`: it maps its `inputs.x0` and `inputs.x1` to `linear` output.
 
+### Scalars and constants
 
 A scalar added to a tensor. The scalar becomes a constant, and reaching the tensor's shape takes an explicit
 node — the closure ignores both indices, which is what a broadcast looks like:
@@ -80,85 +98,56 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
 }
 ```
 
-Two operations, and three constants that nothing refers to. Resolving a traced call's inputs materializes every
-scalar argument as a constant, and a handler that folds the scalar into a field instead — `transpose`'s `axes`,
-`softmax`'s `axis` — never wires the constant up. They are real nodes, so they print; the count in the header
-includes them:
+The `add_c1` in this example is a constant, it does not depend on `inputs`, but some later operations use it as an
+argument.  The torch tracing logic has decided that `torch.randn(4,8)` is an input called `inputs.x`, while the plain
+literal `1` is a constant `add_c1`.  This example also features the `emmy::tensor_from_fn` primitive, it is used to fill
+up an array by given a function of its indices.  Let's look at its application more closely.
 
 ```
-emmy compile -c 'F.softmax(torch.randn(2,4,8).transpose(1,2), dim=-1)' --ir torch
+  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
+  //                 ^ emmy::tensor_from_fn infers the result size from here, it's not unambiguous,
+  //                 so it knows it has to iterate _i over 0..=3 and _j over 0..=7
+```
+
+This produces an $$4\times8$$ tensor filled with the same constant `add_c1`.  The `emmy::tensor_from_fn`
+primitive is polymorphic over the shape of the tensor it produces, so its type signature is something like `fn
+emmy::tensor_from_fn<T, n: usize, m:usize>(...) -> T[n, m]` so it may be called by the same name `emmy::tensor_from_fn`
+to produce tensors of different shapes and dimensions. Since the result's type is always annotated, the shape is never
+unambiguous.
+
+In practice, tensor IR can't express `emmy::tensor_from_fn` calls with arbitrary lambdas, only some specific restricted
+forms.  But it's not a problem for you, since you only read these lambdas and never write them.  For the precise
+definition of what lambdas can occur in `emmy::tensor_from_fn` calls, check the tensor IR definition and the code that
+generates it.
+
+### Dynamic parameters
+
+```
+emmy compile -c 'torch.nn.RMSNorm(4)(torch.randn(2,8,4))' --dynamic 'seq_len@x:1' --ir torch
 ```
 
 ```rust
-// 6 nodes, 1 inputs, 1 outputs
+// 3 nodes, 1 inputs, 1 outputs
 
-struct Dynamic {}
+struct Dynamic {
+    seq_len: usize,
+}
 
 struct Inputs<dynamic: Dynamic> {
-    x: f32[2,4,8],
+    x: f32[2,dynamic.seq_len,4],
 }
 
 struct Outputs<dynamic: Dynamic> {
-    softmax: f32[2,8,4],
+    rms_norm: f32[2,dynamic.seq_len,4],
 }
 
 fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
   // constants: checkpoint tensors, and the literals the trace captured
-  let transpose_c1: f32[1] = 1.0;
-  let transpose_c2: f32[1] = 2.0;
-  let softmax_c1: f32[1] = -1.0;
+  let p_weight: f32[4] = load("weight");
 
-  let transpose: f32[2,8,4] = transpose(inputs.x, axes=(1, 2));
-  let softmax: f32[2,8,4] = softmax(transpose, axis=-1);
+  let rms_norm: f32[2,dynamic.seq_len,4] = rms_norm(inputs.x, p_weight, eps=1e-06);
 
-  Outputs { softmax }
-}
-```
-
-Those leftovers do not survive the pipeline. One Qwen3-0.6B layer carries 33 such constants at `--ir torch`
-and 4 at `--ir tensor`, and the four that remain are the norm epsilons, which really are operands. A `slice`
-keeps its captured scalars as operands too, redundantly with its own fields.
-
-A model layer has the same shape, with more of it. Below is one layer of a Llama-architecture model, cut down
-to its landmarks:
-
-```
-emmy compile TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --ir torch
-```
-
-```rust
-
-// 106 nodes, 4 inputs, 1 outputs
-
-struct Dynamic {}
-
-struct Inputs<dynamic: Dynamic> {
-    hidden_states: f16[1,512,2048],
-    position_embeddings_0: f16[1,512,64],
-    position_embeddings_1: f16[1,512,64],
-    attention_mask: f32,
-}
-
-struct Outputs<dynamic: Dynamic> {
-    add_5: f16[1,512,2048],
-}
-
-fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
-  // constants: checkpoint tensors, and the literals the trace captured
-  let p_attn_q_proj_weight: f16[2048,2048] = load("self_attn.q_proj.weight");
-  // … 38 constants in all
-
-  let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
-  let to: f32[1,512,2048] = emmy::cast(inputs.hidden_states);
-  // … the norm, then the q / k / v projections
-  let scaled_dot_product_attention: f16[1,32,512,64]
-      = sdpa(add_1, add_2, transpose_2, is_causal=True, sliding_window=None, scale=0.125);
-  let linear_3: f16[1,512,2048] = linear(reshape, p_attn_o_proj_weight, has_bias=False);
-  let add_3: f16[1,512,2048] = add(inputs.hidden_states, linear_3);
-  // … the post-attention norm and the feed-forward block
-  let add_5: f16[1,512,2048] = add(add_3, linear_6);
-
-  Outputs { add_5 }
+  Outputs { rms_norm }
 }
 ```
 
@@ -167,13 +156,66 @@ Three types come first. `Dynamic` carries the symbolic extents a `--dynamic` tra
 `x: f32[2,dynamic.seq_len,4]` — and that parameter is what binds the name an extent refers to. Every dump
 prints all three, empty ones included, so one shape fits every graph.
 
-Then `main`. Its body opens with the graph's constants, in their own block under a comment; each compute node
-becomes one more `let`; and the tail expression builds `Outputs`. An input is reached through its struct,
-`inputs.hidden_states`, while a constant or an earlier result is a plain name.
-
 **Types** carry the shape: `f16[1,512,4096]`. A rank-0 tensor is just its dtype (`f32`). Dtype names are the
 repo's own, including the narrow float formats (`f8e4m3`). Under `--dynamic` an extent can be a name or an
 expression rather than a number — `f32[2,seq_len,4]`, `f32[1,(2 * seq_len),4]`.
+
+### Detructuring
+
+No traced model produces a node with several outputs — `aten.chunk` becomes one `slice` per piece, and
+`aten.split` and `aten.max.dim` are refused. So this listing starts from a graph written straight to an IR
+file, which `emmy compile` takes as readily as a model id:
+
+```
+python - > /tmp/split.json <<'PY'
+import json, sys
+from emmy.compiler.graph import Graph
+from emmy.compiler.tensor import Tensor
+from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp
+
+g = Graph()
+g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (4, 8), "f32"), node_id="x")
+g.inputs = ["x"]
+g.add_node(op=ElementwiseOp(op="negative"), inputs=["x"], node_id="split",
+           outputs=[Tensor("lo", (4, 8), "f32"), Tensor("hi", (4, 8), "f32")])
+g.outputs = ["split", "hi"]
+json.dump(g.to_dict(), sys.stdout)
+PY
+
+emmy compile /tmp/split.json --ir torch
+```
+
+```rust
+// 2 nodes, 1 inputs, 2 outputs
+
+struct Dynamic {}
+
+struct Inputs<dynamic: Dynamic> {
+    x: f32[4,8],
+}
+
+struct Outputs<dynamic: Dynamic> {
+    split: f32[4,8],
+    hi: f32[4,8],
+}
+
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  let (split, hi): (f32[4,8], f32[4,8]) = negative(inputs.x);
+
+  Outputs { split, hi }
+}
+```
+
+**A node that writes several buffers destructures.** `let (nid, buf1): (f32[4,8], f32[4,8]) = op(x);` — slot 0
+travels under the node id, the rest under their own buffer names, so every name a later line can refer to is
+bound. Only the later dialects build such nodes; a torch or tensor dump has none.
+
+## Discussion
+
+Then `main`. Its body opens with the graph's constants, in their own block under a comment; each compute node
+becomes one more `let`; and the tail expression builds `Outputs`. An input is reached through its struct,
+`inputs.hidden_states`, while a constant or an earlier result is a plain name.
 
 **Order** is a dependency order, not an execution schedule.
 
@@ -181,32 +223,9 @@ expression rather than a number — `f32[2,seq_len,4]`, `f32[1,(2 * seq_len),4]`
 `linear(mul_1, p_attn_q_proj_weight, has_bias=False)`, `reshape(x, shape=(1, 512, -1))`. A `-1` inside `shape=`
 is the request the trace captured; the declared type on the left shows the extent it resolved to.
 
-**Constants named `<node>_c<N>`** are scalars the trace captured, named after the traced call they came from
-and their position in that call's resolved operand list: `add_c1` is the epsilon inside the node called `add`.
+## Wut
 
-**A node that writes several buffers destructures.** `let (nid, buf1): (f32[4,8], f32[4,8]) = op(x);` — slot 0
-travels under the node id, the rest under their own buffer names, so every name a later line can refer to is
-bound. Only the later dialects build such nodes; a torch or tensor dump has none.
-
-**Binding names are node ids.** Every node carries two labels: the id the graph stores it under and refers to
-it by, and its output tensor's name. They are usually the same string, because a new node takes its tensor name
-as its id when that id is free. When it is taken, the id falls back to `n0`, `n1`, … and the tensor keeps its
-name — `broadcast_to` names its result after its source, so one source broadcast to two different shapes yields
-one name twice. Bindings print the id, so no two can collide, and a differing tensor name follows in a comment:
-
-```rust
-let n0: f16[1,4,512,64] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);  // aka tensor name `unsqueeze_bc`
-let unsqueeze_bc: f16[1,32,512,64] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);
-```
-
-**Memory, loops, threads, kernels, fusion and hardware choices are absent** because these levels cannot express
-them, not because the printer hides them. They arrive with the later dialects, which have their own printed
-forms.
-
-**Four fields are hidden.** Every operation carries `source` (its predecessor in a rewrite chain), `knobs` (the
-tuning choices passes stamp on it), and `inputs` / `outputs`, a derived view of the tensors around it that the
-matcher fills in. None of them says what the node computes, and `Graph.to_dict` skips them too when it
-serializes a graph. At the torch stage they are empty anyway, since no pass has run yet.
+Wut:
 
 When `EMMY_DUMP_DIR` dumps a later stage, whose nodes hold whole statement trees, an operation prints its own
 body instead:
@@ -225,33 +244,9 @@ body instead:
   };
 ```
 
+Wut:
+
 `acc0 <- add(acc0, v0)` is that dialect's accumulate, not an assignment this notation defines.
-
-## Two stages, one notation
-
-`--ir torch` and `--ir tensor` print through the same renderer, and every reading rule below applies to both.
-What changes is the vocabulary of operations, because decomposition runs between them.
-
-A torch dump is the trace as recorded, so it holds model-level operations — `linear`, `sdpa`, `mean`,
-`softmax`, `reshape`, `transpose`, `slice`, `cat`, `unsqueeze` — each carrying a whole idea in one node
-(`emmy/compiler/ir/frontend/ir.py`). A tensor dump has none of them. Decomposition rewrites every one into the
-generic set in `emmy/compiler/ir/tensor/ir.py`: elementwise operations, reductions, scans, the two gathers,
-scatter, index maps, casts.
-
-The same Qwen3-0.6B layer at both stages:
-
-```
---ir torch    136 nodes    linear x7, mean x4, transpose x4, slice x4, reshape x4, sdpa, softmax
---ir tensor   153 nodes    none of those; sum x11, divide x5, exp x2, emmy::tensor_from_fn x51
-```
-
-A `linear` becomes a broadcast, an elementwise multiply and a `sum` over the contracted axis. A `mean` becomes
-that `sum` times a reciprocal. An `sdpa` becomes masked scores, the three-pass softmax spelled out, then the
-second contraction. The layout operations become index maps carrying real arithmetic, which is why the builder
-count more than doubles: what sat inside a `slice` node's fields at the torch stage is
-`linear_4__cat__linear_5[i, j, (k + 3072)]` at the tensor stage.
-
-One node becoming several is why the count grows, even though the pipeline sweeps dead nodes on the way.
 
 ## Where a constant's value comes from
 
@@ -424,38 +419,3 @@ Valid: every coordinate is arithmetic over the closure's parameters, literals, a
 symbolic dimension names, which appear free in the body because the launch binds them. A coordinate is never a
 value read from another tensor; that is what `emmy::gather` and `emmy::gather_by_axis` are for. Invalid: a
 parameter count that disagrees with the result's rank, which would mean the printer has a bug.
-
-## Gotchas
-
-These are oddities of the compiler that the new spelling makes visible rather than hiding.
-
-**A conversion has no operation of its own.** It is an identity node whose output tensor *declares* the new
-dtype, and the backend converts when it materializes that type. `emmy::cast` is the printer naming a node it
-recognized by comparing the declared types.
-
-**`CastOp` exists and nothing builds it.** `emmy/compiler/ir/tensor/ir.py` defines a cast operation carrying an
-explicit dtype. `torch_wire.py` can rebuild one from a stored graph and the constant-folding pass knows it, but
-no production code creates one, so every real conversion arrives as the identity node above. `copy` and
-`bitcast` are the two elementwise names whose implementation is the identity; the narrow-float decoders do
-compute.
-
-**A binding can be a plain rebinding.** An identity node whose declared dtype already matches its input prints
-as its argument alone — `005_split_cast_from_indexmap.py` leaves one behind whenever it splits a conversion out
-of an index map, so a `--ir tensor` dump carries several:
-
-```rust
-let to: f32[1,512,1024] = to_cast;
-```
-
-**`emmy::gather` is not `torch.gather`.** The formula is torch's, and on the inputs emmy accepts the two agree
-element for element. But torch requires only `index.size(d) <= input.size(d)` on every axis other than the
-gathered one, while emmy demands equality there. A narrower index is a legal `torch.gather` that prints as the
-other operation: `torch.gather` on data `[4,8]` with an index `[4,3]` at axis 0 prints
-`let gather: f32[4,3] = emmy::gather_by_axis(x0, x1, axis=0);`. That line is the one place a dump contradicts
-itself — the declared type is torch's answer, while `emmy::gather_by_axis` as defined above would give
-`[4,3,8]`, and that is also what emmy computes. Four ATen operators collapse onto one node and only the axis
-survives, so operand shapes are the only evidence of which was meant.
-
-**Some captured constants go unused.** The layer above captures 29 scalars and refers to 18 of them. The 11
-left over come from `transpose` (8), `unsqueeze` (2) and `sdpa` (1) — the handlers that read a scalar argument
-off the trace and store it in a field, rather than keeping the constant the resolver had already made.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -125,7 +125,7 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
   // constants: checkpoint tensors, and the literals the trace captured
   let add_c1: f32[1] = 1.0;
 
-  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(add_c1, |_i, _j| [0]);
+  let add_c1_bc: f32[4,8] = emmy::index_map_simple(add_c1, |_i, _j| [0]);
   let add: f32[4,8] = add(inputs.x, add_c1_bc);
 
   Outputs { add }
@@ -134,24 +134,24 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
 
 The `add_c1` in this example is a constant, it does not depend on `inputs`, but some later operations use it as an
 argument.  The torch tracing logic has decided that `torch.randn(4,8)` is an input called `inputs.x`, while the plain
-literal `1` is a constant `add_c1`.  This example also features the `emmy::tensor_from_fn` primitive, it is used to fill
+literal `1` is a constant `add_c1`.  This example also features the `emmy::index_map_simple` primitive, it is used to fill
 up an array by given a function of its indices.  Let's look at its application more closely.
 
 ```
-  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(add_c1, |_i, _j| [0]);
-  //                 ^ emmy::tensor_from_fn infers the result size from here, it's not unambiguous,
+  let add_c1_bc: f32[4,8] = emmy::index_map_simple(add_c1, |_i, _j| [0]);
+  //                 ^ emmy::index_map_simple infers the result size from here, it's not unambiguous,
   //                 so it knows it has to iterate _i over 0..=3 and _j over 0..=7
 ```
 
-This produces an $$4\times8$$ tensor filled with the same constant `add_c1`.  The `emmy::tensor_from_fn` primitive
+This produces an $$4\times8$$ tensor filled with the same constant `add_c1`.  The `emmy::index_map_simple` primitive
 is polymorphic over the shape of the tensor it produces and over the shape of the tensor it reads. You can assume
-for simplicity that its signature is something like `fn emmy::tensor_from_fn<T, const n: usize, const m: usize,
+for simplicity that its signature is something like `fn emmy::index_map_simple<T, const n: usize, const m: usize,
 …>(operand, coord) -> T[n, m]` (the real signature serves tensors of any shape and rank, we show it in the following
 sections). Since the result's type is always annotated, the shape is never ambiguous.
 
-In practice, tensor IR can't express `emmy::tensor_from_fn` calls with arbitrary lambdas, only some specific restricted
+In practice, tensor IR can't express `emmy::index_map_simple` calls with arbitrary lambdas, only some specific restricted
 forms.  But it's not a problem for you, since you only read these lambdas and never write them.  For the precise
-definition of what lambdas can occur in `emmy::tensor_from_fn` calls, check the tensor IR definition and the code that
+definition of what lambdas can occur in `emmy::index_map_simple` calls, check the tensor IR definition and the code that
 generates it.
 
 ### Dynamic parameters
@@ -282,10 +282,10 @@ Below, we overview the `emmy::` operations.
 
 | Name | Meaning |
 | --- | --- |
-| `emmy::tensor_from_fn(x, \|i, j\| [i, j])` | build a tensor from a function of its indices (rank 2 in this example for simplicity, in principle this supports any rank) |
+| `emmy::index_map_simple(x, \|i, j\| [i, j])` | build a tensor from a function of its indices (rank 2 in this example for simplicity, in principle this supports any rank) |
 | `emmy::cast(x)` | a dtype change, the IR uses it to make the implicit casts in graph IR explicit |
 | `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
-| `emmy::index_map(a, b)` | a more advanced reindexing `emmy::tensor_from_fn` cannot hold |
+| `emmy::index_map(a, b)` | a more advanced reindexing `emmy::index_map_simple` cannot hold |
 | `emmy::gather(data, idx, axis=n)` | pick one element per output position |
 | `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
@@ -382,14 +382,14 @@ fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
     where size_of::<U>() == size_of::<T>()
 ```
 
-#### `emmy::tensor_from_fn`
+#### `emmy::index_map_simple`
 
 Reads one tensor into another shape. The lambda maps an index of the result to the index it reads from the
 operand — it computes coordinates, never values, so nothing here can change a value on the way through. A printed
 line names the index vector's components instead of the vector, `|i, j, k|` for rank three.
 
 ```rust
-fn emmy::tensor_from_fn<T, const rank: usize, const orank: usize, const d: usize[rank], const od: usize[orank]>(
+fn emmy::index_map_simple<T, const rank: usize, const orank: usize, const d: usize[rank], const od: usize[orank]>(
     operand: T[od],
     coord: |usize[rank]| -> usize[orank],
 ) -> T[d]
@@ -400,15 +400,15 @@ An axis the closure never uses takes Rust's `_` prefix, which is how a broadcast
 
 ```rust
 let p_input_layernorm_weight_bc: f16[1,512,2048]
-    = emmy::tensor_from_fn(p_input_layernorm_weight, |_i, _j, k| [k]);
+    = emmy::index_map_simple(p_input_layernorm_weight, |_i, _j, k| [k]);
 ```
 
 One number per column, repeated over batch and tokens. Coordinates can also be arithmetic over the parameters,
 which is how a slice or a dropped axis reads:
 
 ```rust
-let linear_5: f16[1,512,3072] = emmy::tensor_from_fn(linear_4__cat__linear_5, |i, j, k| [i, j, (k + 3072)]);
-let linear_3: f16[1,512,1024] = emmy::tensor_from_fn(linear_3_reduce, |i, j, k| [i, j, 0, k]);
+let linear_5: f16[1,512,3072] = emmy::index_map_simple(linear_4__cat__linear_5, |i, j, k| [i, j, (k + 3072)]);
+let linear_3: f16[1,512,1024] = emmy::index_map_simple(linear_3_reduce, |i, j, k| [i, j, 0, k]);
 ```
 
 The first reads the upper half of a concatenated tensor, the second drops a size-1 axis.
@@ -455,8 +455,8 @@ fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize
 
 #### `emmy::index_map`
 
-This is the advanced version of `emmy::tensor_from_fn`. Under the hood, both are represented by the same operation, but
-we differentiate them when printing because `emmy::tensor_from_fn` represents a rather simple, but extremely common
+This is the advanced version of `emmy::index_map_simple`. Under the hood, both are represented by the same operation, but
+we differentiate them when printing because `emmy::index_map_simple` represents a rather simple, but extremely common
 special case, and using the clumsy, overly verbose `emmy::index_map` in those cases is not reasonable.
 
 Reads values from several tensors into one result, choosing per output position which tensor to read and where.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -29,13 +29,21 @@ emmy compile -c 'F.linear(torch.randn(4,64), torch.randn(16,64))' --ir torch
 ```rust
 // 3 nodes, 2 inputs, 1 outputs
 
-pub fn main(
+struct Dynamic {}
+
+struct Inputs<dynamic: Dynamic> {
     x0: f32[4,64],
     x1: f32[16,64],
-) -> f32[4,16] {
-    let linear: f32[4,16] = linear(x0, x1, has_bias=False);
+}
 
-    linear
+struct Outputs<dynamic: Dynamic> {
+    linear: f32[4,16],
+}
+
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  let linear: f32[4,16] = linear(inputs.x0, inputs.x1, has_bias=False);
+
+  Outputs { linear }
 }
 ```
 
@@ -51,15 +59,24 @@ emmy compile -c 'torch.randn(4,8) + 1' --ir torch
 ```rust
 // 4 nodes, 1 inputs, 1 outputs
 
-let add_c1: f32[1] = 1.0;
+struct Dynamic {}
 
-pub fn main(
+struct Inputs<dynamic: Dynamic> {
     x: f32[4,8],
-) -> f32[4,8] {
-    let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
-    let add: f32[4,8] = add(x, add_c1_bc);
+}
 
-    add
+struct Outputs<dynamic: Dynamic> {
+    add: f32[4,8],
+}
+
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  // constants: checkpoint tensors, and the literals the trace captured
+  let add_c1: f32[1] = 1.0;
+
+  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
+  let add: f32[4,8] = add(inputs.x, add_c1_bc);
+
+  Outputs { add }
 }
 ```
 
@@ -75,17 +92,26 @@ emmy compile -c 'F.softmax(torch.randn(2,4,8).transpose(1,2), dim=-1)' --ir torc
 ```rust
 // 6 nodes, 1 inputs, 1 outputs
 
-let transpose_c1: f32[1] = 1.0;
-let transpose_c2: f32[1] = 2.0;
-let softmax_c1: f32[1] = -1.0;
+struct Dynamic {}
 
-pub fn main(
+struct Inputs<dynamic: Dynamic> {
     x: f32[2,4,8],
-) -> f32[2,8,4] {
-    let transpose: f32[2,8,4] = transpose(x, axes=(1, 2));
-    let softmax: f32[2,8,4] = softmax(transpose, axis=-1);
+}
 
-    softmax
+struct Outputs<dynamic: Dynamic> {
+    softmax: f32[2,8,4],
+}
+
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  // constants: checkpoint tensors, and the literals the trace captured
+  let transpose_c1: f32[1] = 1.0;
+  let transpose_c2: f32[1] = 2.0;
+  let softmax_c1: f32[1] = -1.0;
+
+  let transpose: f32[2,8,4] = transpose(inputs.x, axes=(1, 2));
+  let softmax: f32[2,8,4] = softmax(transpose, axis=-1);
+
+  Outputs { softmax }
 }
 ```
 
@@ -101,59 +127,49 @@ emmy compile TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --ir torch
 ```
 
 ```rust
+
 // 106 nodes, 4 inputs, 1 outputs
 
-let p_attn_q_proj_weight: f16[2048,2048] = load("self_attn.q_proj.weight");
-let p_attn_k_proj_weight: f16[256,2048] = load("self_attn.k_proj.weight");
-// … 38 constants in all
+struct Dynamic {}
 
-pub fn main(
+struct Inputs<dynamic: Dynamic> {
     hidden_states: f16[1,512,2048],
     position_embeddings_0: f16[1,512,64],
     position_embeddings_1: f16[1,512,64],
     attention_mask: f32,
-) -> f16[1,512,2048] {
-    let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
-    let to: f32[1,512,2048] = emmy::cast(hidden_states);
-    // … the norm, then the q / k / v projections
-    let scaled_dot_product_attention: f16[1,32,512,64]
-        = sdpa(add_1, add_2, transpose_2, is_causal=True, sliding_window=None, scale=0.125);
-    let linear_3: f16[1,512,2048] = linear(reshape, p_attn_o_proj_weight, has_bias=False);
-    let add_3: f16[1,512,2048] = add(hidden_states, linear_3);
-    // … the post-attention norm and the feed-forward block
-    let add_5: f16[1,512,2048] = add(add_3, linear_6);
+}
 
-    add_5
+struct Outputs<dynamic: Dynamic> {
+    add_5: f16[1,512,2048],
+}
+
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  // constants: checkpoint tensors, and the literals the trace captured
+  let p_attn_q_proj_weight: f16[2048,2048] = load("self_attn.q_proj.weight");
+  // … 38 constants in all
+
+  let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+  let to: f32[1,512,2048] = emmy::cast(inputs.hidden_states);
+  // … the norm, then the q / k / v projections
+  let scaled_dot_product_attention: f16[1,32,512,64]
+      = sdpa(add_1, add_2, transpose_2, is_causal=True, sliding_window=None, scale=0.125);
+  let linear_3: f16[1,512,2048] = linear(reshape, p_attn_o_proj_weight, has_bias=False);
+  let add_3: f16[1,512,2048] = add(inputs.hidden_states, linear_3);
+  // … the post-attention norm and the feed-forward block
+  let add_5: f16[1,512,2048] = add(add_3, linear_6);
+
+  Outputs { add_5 }
 }
 ```
 
-The graph's constants become module-level bindings, its inputs become the parameters of `pub fn main`, every
-compute node becomes one `let`, and its outputs become the tail expression. A graph with several outputs
-returns an `Outputs` struct, declared after the function; a graph with none returns `()`.
+Three types come first. `Dynamic` carries the symbolic extents a `--dynamic` trace introduced. `Inputs` and
+`Outputs` both take it as a parameter, because a shape on either side can be a function of those extents —
+`x: f32[2,dynamic.seq_len,4]` — and that parameter is what binds the name an extent refers to. Every dump
+prints all three, empty ones included, so one shape fits every graph.
 
-```rust
-// 8 nodes, 2 inputs, 2 outputs
-
-let add_c1: f32[1] = 1.0;
-let mul_c1: f32[1] = 2.0;
-
-pub fn main(
-    x0: f32[4,8],
-    x1: f32[4,8],
-) -> Outputs {
-    let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
-    let mul_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| mul_c1[0]);
-    let add: f32[4,8] = add(x0, add_c1_bc);
-    let mul: f32[4,8] = multiply(x1, mul_c1_bc);
-
-    Outputs { add, mul }
-}
-
-struct Outputs {
-    add: f32[4,8],
-    mul: f32[4,8],
-}
-```
+Then `main`. Its body opens with the graph's constants, in their own block under a comment; each compute node
+becomes one more `let`; and the tail expression builds `Outputs`. An input is reached through its struct,
+`inputs.hidden_states`, while a constant or an earlier result is a plain name.
 
 **Types** carry the shape: `f16[1,512,4096]`. A rank-0 tensor is just its dtype (`f32`). Dtype names are the
 repo's own, including the narrow float formats (`f8e4m3`). Under `--dynamic` an extent can be a name or an
@@ -196,17 +212,17 @@ When `EMMY_DUMP_DIR` dumps a later stage, whose nodes hold whole statement trees
 body instead:
 
 ```rust
-    let linear: f32[4,16]
-        = loop(x1, x0) {
-    for a0 in 0..4
-        for a1 in 0..16
-            for a2 in 0..64
-                in0 = load x1[a1, a2]
-                in1 = load x0[a0, a2]
-                v0 = multiply(in0, in1)
-                acc0 <- add(acc0, v0)
-            linear[a0, a1] = acc0
-    };
+  let linear: f32[4,16]
+      = loop(inputs.x1, inputs.x0) {
+        for a0 in 0..4
+            for a1 in 0..16
+                for a2 in 0..64
+                    in0 = load x1[a1, a2]
+                    in1 = load x0[a0, a2]
+                    v0 = multiply(in0, in1)
+                    acc0 <- add(acc0, v0)
+                linear[a0, a1] = acc0
+  };
 ```
 
 `acc0 <- add(acc0, v0)` is that dialect's accumulate, not an assignment this notation defines.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -143,11 +143,11 @@ up an array by given a function of its indices.  Let's look at its application m
   //                 so it knows it has to iterate _i over 0..=3 and _j over 0..=7
 ```
 
-This produces an $$4\times8$$ tensor filled with the same constant `add_c1`.  The `emmy::tensor_from_fn`
-primitive is polymorphic over the shape of the tensor it produces and over the shape of the tensor it reads, so
-its type signature is something like `fn emmy::tensor_from_fn<T, const n: usize, const m: usize, …>(operand, coord)
--> T[n, m]` and the same name serves tensors of any shape and rank. Since the result's type is always annotated,
-the shape is never ambiguous.
+This produces an $$4\times8$$ tensor filled with the same constant `add_c1`.  The `emmy::tensor_from_fn` primitive
+is polymorphic over the shape of the tensor it produces and over the shape of the tensor it reads. You can assume
+for simplicity that its signature is something like `fn emmy::tensor_from_fn<T, const n: usize, const m: usize,
+…>(operand, coord) -> T[n, m]` (the real signature serves tensors of any shape and rank, we show it in the following
+sections). Since the result's type is always annotated, the shape is never ambiguous.
 
 In practice, tensor IR can't express `emmy::tensor_from_fn` calls with arbitrary lambdas, only some specific restricted
 forms.  But it's not a problem for you, since you only read these lambdas and never write them.  For the precise
@@ -386,8 +386,7 @@ fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
 
 Reads one tensor into another shape. The lambda maps an index of the result to the index it reads from the
 operand — it computes coordinates, never values, so nothing here can change a value on the way through. A printed
-line names the index vector's components instead of the vector, `|i, j, k|` for rank three, which is why rank six is
-the limit — the printer has six index names.
+line names the index vector's components instead of the vector, `|i, j, k|` for rank three.
 
 ```rust
 fn emmy::tensor_from_fn<T, const rank: usize, const orank: usize, const d: usize[rank], const od: usize[orank]>(

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -277,22 +277,24 @@ graph, as well as a few of Emmy's own operations. We mark Emmy's own operations 
 don't have a namespace like `linear`, `add` or `mul` are from either PyTorch or NumPy. We can't tell exactly which of the
 two is meant in each case, because the tracing code does not thoroughly record the source.
 
-**`rms_norm`** and **`layer_norm`** are respellings: the class names behind them would otherwise lowercase to
-`rmsnorm` and `layernorm`. Every other operation without an `emmy::` prefix prints under its own name, `sdpa`
-included — emmy's short spelling of scaled dot product attention.
-
-An `emmy::` name is emmy's own:
+Below, we overview the `emmy::` operations.
 
 | Name | Meaning |
 | --- | --- |
-| `emmy::tensor_from_fn(\|i, j\| body)` | build a tensor from a function of its indices, here rank two |
-| `emmy::cast(x)` | a dtype change (see the gotchas below — no node computes it) |
+| `emmy::tensor_from_fn(\|i, j\| body)` | build a tensor from a function of its indices (rank 2 in this example for simplicity, in principle this supports any rank) |
+| `emmy::cast(x)` | a dtype change, the IR uses it to make the implicit casts in graph IR explicit |
 | `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
 | `emmy::index_map(a, b)` | a reindexing `emmy::tensor_from_fn` cannot hold |
 | `emmy::gather(data, idx, axis=n)` | pick one element per output position |
 | `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
-A second namespace, `emmy::scalar::`, holds functions on a single number, applied to every element. They are
+The `emmy::gather` and `emmy::gather_by_axis` are internally represented as one operation `"gather"` in graph IR.
+Depending on the shapes of inputs and outputs, the `"gather"` in graph IR does one of two unrelated things.  We
+make the two cases easy to distinguish by differentiating them at IR dump time, and calling them `emmy::gather` and
+`emmy::gather_by_axis`. The `emmy::gather` is very similar to PyTorch `gather`, but has some slight differences, so we
+keep it distinct.
+
+A second namespace, `emmy::scalar::`, holds functions on a single number, applied to scalars. They are
 the entries of one table — `_NAME_TO_FN` in `emmy/compiler/ir/elementwise.py` — minus the ones torch or numpy
 already names, which print bare.
 
@@ -303,7 +305,9 @@ already names, which print bare.
 | `emmy::scalar::gelu_tanh(x)` | gelu's tanh approximation, torch's `approximate="tanh"` |
 | `emmy::scalar::exp_fast(x)` | `exp` with the fast-math CUDA spelling, from a kernel-stage pass |
 
-### What the `emmy::` helpers mean
+The following section presents `emmy::` helpers in more detail.
+
+### The `emmy::` helpers
 
 Written as definitions in the same pseudocode, with three conventions.
 
@@ -341,7 +345,9 @@ fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
 // Pick one element per output position. `idx` has the result's shape, and each of
 // its entries says which position along `axis` that one output element reads; the
 // other coordinates come from the output position itself. Close to torch's
-// `gather`, but not the same — see the gotchas.
+// `gather`, but not the same: torch allows `idx` to be smaller than `data` on the
+// axes it does not gather, while this requires them equal. A narrower index is a
+// legal `torch.gather` that prints — and computes — as `emmy::gather_by_axis`.
 fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]>(
     data: T[d],
     idx: i64[e],

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -292,16 +292,16 @@ An `emmy::` name is emmy's own:
 | `emmy::gather(data, idx, axis=n)` | pick one element per output position |
 | `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
-A second namespace, `emmy::intrinsics::`, holds the scalar functions emmy defines itself, the ones with no
-torch or numpy function behind them. `emmy/compiler/ir/elementwise.py` holds that table, and everything in it
-that torch or numpy does not already name prints under the prefix:
+A second namespace, `emmy::scalar::`, holds functions on a single number, applied to every element. They are
+the entries of one table — `_NAME_TO_FN` in `emmy/compiler/ir/elementwise.py` — minus the ones torch or numpy
+already names, which print bare.
 
 | Name | Meaning |
 | --- | --- |
-| `emmy::intrinsics::from_f8e4m3(x)`, `from_f8e5m2`, `to_f8e4m3`, `to_f8e5m2` | decode or encode a narrow float format |
-| `emmy::intrinsics::bitcast(x)` | the same reinterpretation as `emmy::bitcast`, reached through the intrinsic table |
-| `emmy::intrinsics::gelu_tanh(x)` | gelu's tanh approximation, torch's `approximate="tanh"` |
-| `emmy::intrinsics::exp_fast(x)` | `exp` with the fast-math CUDA spelling, from a kernel-stage pass |
+| `emmy::scalar::from_f8e4m3(x)`, `from_f8e5m2`, `to_f8e4m3`, `to_f8e5m2` | decode or encode a narrow float format |
+| `emmy::scalar::bitcast(x)` | the same reinterpretation as `emmy::bitcast`, reached through that table |
+| `emmy::scalar::gelu_tanh(x)` | gelu's tanh approximation, torch's `approximate="tanh"` |
+| `emmy::scalar::exp_fast(x)` | `exp` with the fast-math CUDA spelling, from a kernel-stage pass |
 
 ### What the `emmy::` helpers mean
 
@@ -372,8 +372,8 @@ fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: [tensor
 
 // Decode or encode a narrow float format, element by element. Unlike `cast`, these
 // have a real implementation behind them (`emmy/compiler/ir/elementwise.py`).
-fn emmy::intrinsics::from_f8e4m3<const rank: usize, const d: usize[rank]>(x: f8e4m3[d]) -> f32[d]
-fn emmy::intrinsics::to_f8e4m3<const rank: usize, const d: usize[rank]>(x: f32[d]) -> f8e4m3[d]
+fn emmy::scalar::from_f8e4m3<const rank: usize, const d: usize[rank]>(x: f8e4m3[d]) -> f32[d]
+fn emmy::scalar::to_f8e4m3<const rank: usize, const d: usize[rank]>(x: f32[d]) -> f8e4m3[d]
 ```
 
 `emmy::const_eval()` and `emmy::input_data()` are not operations. They stand for where a constant's value comes

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -125,7 +125,7 @@ fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
   // constants: checkpoint tensors, and the literals the trace captured
   let add_c1: f32[1] = 1.0;
 
-  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
+  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(add_c1, |_i, _j| [0]);
   let add: f32[4,8] = add(inputs.x, add_c1_bc);
 
   Outputs { add }
@@ -138,7 +138,7 @@ literal `1` is a constant `add_c1`.  This example also features the `emmy::tenso
 up an array by given a function of its indices.  Let's look at its application more closely.
 
 ```
-  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
+  let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(add_c1, |_i, _j| [0]);
   //                 ^ emmy::tensor_from_fn infers the result size from here, it's not unambiguous,
   //                 so it knows it has to iterate _i over 0..=3 and _j over 0..=7
 ```
@@ -282,10 +282,10 @@ Below, we overview the `emmy::` operations.
 
 | Name | Meaning |
 | --- | --- |
-| `emmy::tensor_from_fn(\|i, j\| body)` | build a tensor from a function of its indices (rank 2 in this example for simplicity, in principle this supports any rank) |
+| `emmy::tensor_from_fn(x, \|i, j\| [i, j])` | build a tensor from a function of its indices (rank 2 in this example for simplicity, in principle this supports any rank) |
 | `emmy::cast(x)` | a dtype change, the IR uses it to make the implicit casts in graph IR explicit |
 | `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
-| `emmy::index_map(a, b)` | a reindexing `emmy::tensor_from_fn` cannot hold |
+| `emmy::index_map(a, b)` | a more advanced reindexing `emmy::tensor_from_fn` cannot hold |
 | `emmy::gather(data, idx, axis=n)` | pick one element per output position |
 | `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
@@ -384,29 +384,32 @@ fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
 
 #### `emmy::tensor_from_fn`
 
-Builds a tensor from a lambda function that maps tensor indices to values. The lambda takes one index vector; a printed
-line names its components instead, `|i, j, k|` for rank three, which is why rank six is the limit — the printer has
-six index names.
+Reads one tensor into another shape. The lambda maps an index of the result to the index it reads from the
+operand — it computes coordinates, never values, so nothing here can change a value on the way through. A printed
+line names the index vector's components instead of the vector, `|i, j, k|` for rank three, which is why rank six is
+the limit — the printer has six index names.
 
 ```rust
-fn emmy::tensor_from_fn<T, const rank: usize, const d: usize[rank]>(f: |usize[rank]| -> T) -> T[d]
-    // produces the tensor whose element at i is f(i), for every index i with
-    // i[k] < d[k]
+fn emmy::tensor_from_fn<T, const rank: usize, const orank: usize, const d: usize[rank], const od: usize[orank]>(
+    operand: T[od],
+    coord: |usize[rank]| -> usize[orank],
+) -> T[d]
+    // result[i] = operand[coord(i)], for every index i with i[k] < d[k]
 ```
 
-Inside the closure, a tensor is read with brackets. An axis the body never uses takes Rust's `_` prefix, which
-is how a broadcast looks:
+An axis the closure never uses takes Rust's `_` prefix, which is how a broadcast looks:
 
 ```rust
-let p_input_layernorm_weight_bc: f16[1,512,2048] = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+let p_input_layernorm_weight_bc: f16[1,512,2048]
+    = emmy::tensor_from_fn(p_input_layernorm_weight, |_i, _j, k| [k]);
 ```
 
 One number per column, repeated over batch and tokens. Coordinates can also be arithmetic over the parameters,
 which is how a slice or a dropped axis reads:
 
 ```rust
-let linear_5: f16[1,512,3072] = emmy::tensor_from_fn(|i, j, k| linear_4__cat__linear_5[i, j, (k + 3072)]);
-let linear_3: f16[1,512,1024] = emmy::tensor_from_fn(|i, j, k| linear_3_reduce[i, j, 0, k]);
+let linear_5: f16[1,512,3072] = emmy::tensor_from_fn(linear_4__cat__linear_5, |i, j, k| [i, j, (k + 3072)]);
+let linear_3: f16[1,512,1024] = emmy::tensor_from_fn(linear_3_reduce, |i, j, k| [i, j, 0, k]);
 ```
 
 The first reads the upper half of a concatenated tensor, the second drops a size-1 axis.
@@ -414,7 +417,8 @@ The first reads the upper half of a concatenated tensor, the second drops a size
 Valid: every coordinate is arithmetic over the closure's parameters, literals, and — under `--dynamic` — the
 symbolic dimension names, which appear free in the body because the launch binds them. A coordinate is never a
 value read from another tensor; that is what `emmy::gather` and `emmy::gather_by_axis` are for. Invalid: a
-parameter count that disagrees with the result's rank, which would mean the printer has a bug.
+parameter count that disagrees with the result's rank, or a coordinate count that disagrees with the operand's,
+either of which would mean the printer has a bug.
 
 #### `emmy::gather`
 
@@ -451,6 +455,10 @@ fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize
 ```
 
 #### `emmy::index_map`
+
+This is the advanced version of `emmy::tensor_from_fn`. Under the hood, both are represented by the same operation, but
+we differentiate them when printing because `emmy::tensor_from_fn` represents a rather simple, but extremely common
+special case, and using the clumsy, overly verbose `emmy::index_map` in those cases is not reasonable.
 
 Reads values from several tensors into one result, choosing per output position which tensor to read and where.
 A source is three things: an operand, a map from an output index to an index into that operand, and a condition
@@ -494,10 +502,3 @@ other source supplies.
 A source carries its operand's rank and shape as its own fields because the operands need not agree on either
 — `f32[2,3]` and `f32[2,5]` above, and a mask built from two `f16[1]` scalars. They do agree on the element
 type: `Graph.validate` rejects a node whose sources disagree on it, since converting is `emmy::cast`'s job.
-
-One node class covers both spellings. `emmy::tensor_from_fn` and `emmy::index_map` are the same underlying
-operation, which is general enough to read from several tensors under a condition. Almost no node needs that:
-of the 154 index maps in a TinyLlama and a Qwen3-0.6B layer, 148 read one tensor with no condition, and those
-are the broadcasts, reshapes, transposes, slices and unsqueezes a reader meets on nearly every line. Printing
-the general form for all of them would bury a one-line coordinate map in the record around it, so the simple
-case gets the simple spelling and `emmy::index_map` prints only what the closure form cannot hold.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -19,6 +19,7 @@ possible in Rust:
 - No I/O, no side effects. Whole program is `main` function that deterministically maps its arguments to its return value.
 - No control flow and no pattern matching: `if`, `for`, `while`, `match`.
 - No traits.
+- No ownership or borrow checker.
 - First-class typed tensors support. Example: `let x : f32[16,8,64] = ...` is a three-dimensional tensor.
 - Tensor's shape is given by its type. You may not omit the dimensions that go in `[]` of `f32[16,8,64]`.
 - Types (of a struct or a function) can be polymorphic over values. This is particularly useful to support `--dynamic`
@@ -422,9 +423,7 @@ position along `axis` that one output element reads; the other coordinates come 
 itself.
 
 Close to torch's `gather`, but stricter. Torch allows `idx` to be smaller than `data` on the axes it does not
-gather; `emmy::gather` requires them equal there. A node whose `idx` is smaller on such an axis is therefore
-not this operation at all — it prints as `emmy::gather_by_axis`, and that is what the graph computes, even
-though the same call in torch would have been a gather.
+gather; `emmy::gather` requires them equal there.
 
 ```rust
 fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]>(
@@ -453,24 +452,43 @@ fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize
 
 #### `emmy::index_map`
 
-A reindexing `emmy::tensor_from_fn` cannot hold: no source, several sources, a selection deciding which source
-feeds which output position, or rank above six. A printed call lists the operand tensors; the coordinate map
-that pairs each one with the output index, and the condition under which it supplies a position, stay inside
-the node.
+Reads values from several tensors into one result, choosing per output position which tensor to read and where.
+A source is three things: an operand, a map from an output index to an index into that operand, and a condition
+selecting the output positions it supplies. Sources are ordered, and the first whose condition holds at a
+position supplies it.
 
 ```rust
-// A tensor whose rank and shape the type does not expose — an existential type,
-// https://en.wikipedia.org/wiki/Type_system#Existential_types
-struct Tensor<T> {
-  rank: usize,
-  d: usize[rank],
-  t: T[d],
+struct IndexSource<T, const rank: usize> {
+  operand_rank: usize,
+  operand_d: usize[operand_rank],
+  operand: T[operand_d],
+  coord: |usize[rank]| -> usize[operand_rank],
+  select: |usize[rank]| -> bool,
 }
 
-fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: Tensor<T>[]) -> T[d]
+fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(
+    sources: IndexSource<T, rank>[],
+) -> T[d]
+    // result[i] = s.operand[s.coord(i)]
+    //   where s is the first source with s.select(i)
 ```
 
-The operands need a container because they need not share a shape — the two halves of a `cat` do, the two
-constants of a mask do not. They do share the element type `T`, and only by convention: `IndexMapOp.forward`
-takes the result's dtype from the first operand and copies every other one into it, so a mixed-dtype node would
-silently follow operand zero rather than be rejected.
+`emmy::tensor_from_fn` is the printed form when there is one source and no condition; this is what prints
+otherwise. A `cat` is the everyday case — two sources filling different parts of the result:
+
+```
+emmy compile -c 'torch.cat([torch.randn(2,3), torch.randn(2,5)], dim=1)' --ir tensor
+```
+
+```rust
+let cat: f32[2,8] = emmy::index_map(inputs.x0, inputs.x1);
+```
+
+Here the first source reads `x0[i, j]` where `j < 3` and the second reads `x1[i, j - 3]` where `j >= 3`. The
+printed call carries neither: it lists the operands, and each source's `coord` and `select` stay inside the
+node. Reading a line like this one, you know which tensors feed the result and not which parts come from
+which.
+
+A source carries its operand's rank and shape as its own fields because the operands need not agree on either
+— `f32[2,3]` and `f32[2,5]` above, and a mask built from two `f16[1]` scalars. They do agree on the element
+type: `Graph.validate` rejects a node whose sources disagree on it, since converting is `emmy::cast`'s job.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -180,7 +180,7 @@ appear at `--ir torch` or in a static-shape dump. A caller-supplied tensor and t
 ## Operations
 
 A bare name means what torch or numpy already means by it: `multiply`, `add`, `pow`, `mean`, `sum`, `linear`,
-`silu`, `softmax`, `reshape`, `slice`, `cat`, `transpose`. Four cases need care.
+`silu`, `softmax`, `reshape`, `slice`, `cat`, `transpose`, `gather`. Four cases need care.
 
 A **reduction** prints as its combine's name with an `axis=` argument — `sum(pow_1, axis=-1)`,
 `maximum(x, axis=-1)`. That is the same spelling as the elementwise operation of the same name, so the `axis=`
@@ -204,8 +204,8 @@ An `emmy::` name is emmy's own:
 | `emmy::tensor_from_fn(\|i, j\| …)` | build a tensor from a function of its indices |
 | `emmy::cast(x)` | a dtype change (see the gotchas below — no node computes it) |
 | `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
-| `emmy::gather(data, idx, axis=n)` | read positions along an axis, when the closure form below does not apply |
 | `emmy::index_map(…)` | a reindexing the closure form cannot hold |
+| `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
 A second namespace, `emmy::intrinsics::`, holds the scalar functions emmy defines itself, the ones with no
 torch or numpy function behind them. `emmy/compiler/ir/elementwise.py` holds that table, and everything in it
@@ -220,56 +220,70 @@ that torch or numpy does not already name prints under the prefix:
 
 ### What the `emmy::` helpers mean
 
-Written as definitions in the same pseudocode. `T` and `U` are element types, and each axis size is a const
-parameter — `d0, …, dn` for the result, `e0, …, em` for a second operand. A `…` stands for the rest of a list
-whose length the shapes fix.
+Written as definitions in the same pseudocode, with three conventions.
+
+`T` and `U` are element types. A shape is one const parameter holding all the axis sizes — `const d: usize[n]`
+— so a definition can index it (`d[axis]`), slice it (`d[0..axis]`) and join pieces with `++`.
+
+An index into a rank-`n` tensor is itself a vector of `n` numbers, so `x[i]` with `i: usize[n]` is one element,
+and `x[i0, i1]` is the same thing written out. Slicing and joining work on an index too: `i[0..axis]` is the
+coordinates before the axis, and `i[0..axis] ++ [v] ++ i[axis+1..n]` is `i` with the coordinate at `axis`
+replaced by `v`.
 
 ```rust
 // Build a tensor from a function of its indices. The result type fixes how many
 // parameters the closure takes and what each one ranges over. Rank six is the
 // limit, because the printer has six index names.
-fn emmy::tensor_from_fn<T, const d0: usize, …, const dn: usize>(f: |usize, …, usize| -> T) -> T[d0,…,dn]
-    // produces the tensor whose element at (i0, …, in) is f(i0, …, in), for every
-    // i0 < d0, …, in < dn
+fn emmy::tensor_from_fn<T, const n: usize, const d: usize[n]>(f: |usize, …, usize| -> T) -> T[d]
+    // produces the tensor whose element at i is f(i), for every index i with
+    // i[k] < d[k]
 
 // A dtype change. No node computes it: the declared result type is the whole
 // operation, and the backend converts when it materializes that type. The values
 // can still change, since a narrowing conversion rounds.
-fn emmy::cast<T, U, const d0: usize, …, const dn: usize>(x: T[d0,…,dn]) -> U[d0,…,dn]
+fn emmy::cast<T, U, const n: usize, const d: usize[n]>(x: T[d]) -> U[d]
 
 // Reinterpret each element's bits as another type of the same width.
-fn emmy::bitcast<T, U, const d0: usize, …, const dn: usize>(x: T[d0,…,dn]) -> U[d0,…,dn]
+fn emmy::bitcast<T, U, const n: usize, const d: usize[n]>(x: T[d]) -> U[d]
     where size_of::<U>() == size_of::<T>()
 
-// Read positions along one axis, in one of two forms that the operand shapes
-// tell apart. When `idx` matches `data` in rank and in every axis but `axis`, it
-// names one position per output element:
-fn emmy::gather<T, const d0: usize, …, const dn: usize, const e0: usize, …, const en: usize>(
-    data: T[d0,…,dn],
-    idx: i32[e0,…,en],
-    axis: usize,
-) -> T[e0,…,en]
-    // produces the tensor whose element at (i0, …, in) is
-    // data[i0, …, idx[i0,…,in], …, in], with the index landing on `axis`
+// One graph node covers the next two, and the operand shapes decide which: the
+// per-element reading applies when `idx` matches `data` in rank and in every axis
+// but `axis`, and the slice lookup applies otherwise.
 
-// Otherwise `idx` replaces the gather axis, and its own axes land in that axis's
-// place:
-fn emmy::gather<T, const d0: usize, …, const dn: usize, const e0: usize, …, const em: usize>(
-    data: T[d0,…,dn],
-    idx: i32[e0,…,em],
+// Pick one element per output position, which is what torch means by `gather`.
+// `idx` has the result's shape, and each of its entries says which position along
+// `axis` that one output element reads; the other coordinates come from the output
+// position itself.
+fn gather<T, const n: usize, const d: usize[n], const e: usize[n]>(
+    data: T[d],
+    idx: i32[e],
     axis: usize,
-) -> T[d0,…,d(axis-1), e0,…,em, d(axis+1),…,dn]
-    // produces the tensor whose element at (…, j0,…,jm, …) is
-    // data[…, idx[j0,…,jm], …], with the index landing on `axis`
+) -> T[e]
+    where e[k] == d[k] for every k != axis
+    // produces the tensor whose element at i is
+    // data[i[0..axis] ++ [idx[i]] ++ i[axis+1..n]]
+
+// Look up whole slices by index. Each entry of `idx` names a position along `axis`,
+// and the slice of `data` sitting there is copied out; `idx`'s own axes take the
+// place of `axis`. A token embedding is this: one row of a table per token id.
+fn emmy::gather_by_axis<T, const n: usize, const m: usize, const d: usize[n], const e: usize[m]>(
+    data: T[d],
+    idx: i32[e],
+    axis: usize,
+) -> T[d[0..axis] ++ e ++ d[axis+1..n]]
+    // produces the tensor whose element at i, writing j for the index tensor's own
+    // coordinates i[axis..axis+m], is
+    // data[i[0..axis] ++ [idx[j]] ++ i[axis+m..n+m-1]]
 
 // A reindexing the closure form cannot hold: no source, several sources, a
 // selection deciding which source feeds which output position, or rank above six.
-fn emmy::index_map<T, const d0: usize, …, const dn: usize>(sources: …) -> T[d0,…,dn]
+fn emmy::index_map<T, const n: usize, const d: usize[n]>(sources: …) -> T[d]
 
 // Decode or encode a narrow float format, element by element. Unlike `cast`, these
 // have a real implementation behind them (`emmy/compiler/ir/elementwise.py`).
-fn emmy::intrinsics::from_f8e4m3<const d0: usize, …, const dn: usize>(x: f8e4m3[d0,…,dn]) -> f32[d0,…,dn]
-fn emmy::intrinsics::to_f8e4m3<const d0: usize, …, const dn: usize>(x: f32[d0,…,dn]) -> f8e4m3[d0,…,dn]
+fn emmy::intrinsics::from_f8e4m3<const n: usize, const d: usize[n]>(x: f8e4m3[d]) -> f32[d]
+fn emmy::intrinsics::to_f8e4m3<const n: usize, const d: usize[n]>(x: f32[d]) -> f8e4m3[d]
 ```
 
 `emmy::const_eval()` and `emmy::input_data()` are not operations. They stand for where a constant's value comes

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -473,21 +473,23 @@ fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(
     //   where s is the first source with s.select(i)
 ```
 
-`emmy::tensor_from_fn` is the printed form when there is one source and no condition; this is what prints
-otherwise. A `cat` is the everyday case — two sources filling different parts of the result:
+A `cat` is the everyday case:
 
 ```
 emmy compile -c 'torch.cat([torch.randn(2,3), torch.randn(2,5)], dim=1)' --ir tensor
 ```
 
 ```rust
-let cat: f32[2,8] = emmy::index_map(inputs.x0, inputs.x1);
+let cat: f32[2,8]
+    = emmy::index_map([
+    IndexSource { operand: inputs.x0, coord: |i, j| [i, ((j < 3) ? j : 0)], select: |_i, j| (j < 3) },
+    IndexSource { operand: inputs.x1, coord: |i, j| [i, ((j < 3) ? 0 : (j - 3))] },
+  ]);
 ```
 
-Here the first source reads `x0[i, j]` where `j < 3` and the second reads `x1[i, j - 3]` where `j >= 3`. The
-printed call carries neither: it lists the operands, and each source's `coord` and `select` stay inside the
-node. Reading a line like this one, you know which tensors feed the result and not which parts come from
-which.
+The first source supplies the columns below 3 and reads `x0` there; the second has no condition, so it takes
+what is left. Both coordinate maps are guarded, so each one stays inside its operand even at the positions the
+other source supplies.
 
 A source carries its operand's rank and shape as its own fields because the operands need not agree on either
 — `f32[2,3]` and `f32[2,5]` above, and a mask built from two `f16[1]` scalars. They do agree on the element

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -494,3 +494,10 @@ other source supplies.
 A source carries its operand's rank and shape as its own fields because the operands need not agree on either
 — `f32[2,3]` and `f32[2,5]` above, and a mask built from two `f16[1]` scalars. They do agree on the element
 type: `Graph.validate` rejects a node whose sources disagree on it, since converting is `emmy::cast`'s job.
+
+One node class covers both spellings. `emmy::tensor_from_fn` and `emmy::index_map` are the same underlying
+operation, which is general enough to read from several tensors under a condition. Almost no node needs that:
+of the 154 index maps in a TinyLlama and a Qwen3-0.6B layer, 148 read one tensor with no condition, and those
+are the broadcasts, reshapes, transposes, slices and unsqueezes a reader meets on nearly every line. Printing
+the general form for all of them would bury a one-line coordinate map in the record around it, so the simple
+case gets the simple spelling and `emmy::index_map` prints only what the closure form cannot hold.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -180,7 +180,7 @@ appear at `--ir torch` or in a static-shape dump. A caller-supplied tensor and t
 ## Operations
 
 A bare name means what torch or numpy already means by it: `multiply`, `add`, `pow`, `mean`, `sum`, `linear`,
-`silu`, `softmax`, `reshape`, `slice`, `cat`, `transpose`, `gather`. Four cases need care.
+`silu`, `softmax`, `reshape`, `slice`, `cat`, `transpose`. Four cases need care.
 
 A **reduction** prints as its combine's name with an `axis=` argument — `sum(pow_1, axis=-1)`,
 `maximum(x, axis=-1)`. That is the same spelling as the elementwise operation of the same name, so the `axis=`
@@ -205,6 +205,7 @@ An `emmy::` name is emmy's own:
 | `emmy::cast(x)` | a dtype change (see the gotchas below — no node computes it) |
 | `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
 | `emmy::index_map(…)` | a reindexing the closure form cannot hold |
+| `emmy::gather(data, idx, axis=n)` | pick one element per output position |
 | `emmy::gather_by_axis(data, idx, axis=n)` | look up whole slices along an axis, by index |
 
 A second namespace, `emmy::intrinsics::`, holds the scalar functions emmy defines itself, the ones with no
@@ -251,13 +252,13 @@ fn emmy::bitcast<T, U, const n: usize, const d: usize[n]>(x: T[d]) -> U[d]
 // per-element reading applies when `idx` matches `data` in rank and in every axis
 // but `axis`, and the slice lookup applies otherwise.
 
-// Pick one element per output position, which is what torch means by `gather`.
-// `idx` has the result's shape, and each of its entries says which position along
-// `axis` that one output element reads; the other coordinates come from the output
-// position itself.
-fn gather<T, const n: usize, const d: usize[n], const e: usize[n]>(
+// Pick one element per output position. `idx` has the result's shape, and each of
+// its entries says which position along `axis` that one output element reads; the
+// other coordinates come from the output position itself. Close to torch's
+// `gather`, but not the same — see the gotchas.
+fn emmy::gather<T, const n: usize, const d: usize[n], const e: usize[n]>(
     data: T[d],
-    idx: i32[e],
+    idx: i64[e],
     axis: usize,
 ) -> T[e]
     where e[k] == d[k] for every k != axis
@@ -269,7 +270,7 @@ fn gather<T, const n: usize, const d: usize[n], const e: usize[n]>(
 // place of `axis`. A token embedding is this: one row of a table per token id.
 fn emmy::gather_by_axis<T, const n: usize, const m: usize, const d: usize[n], const e: usize[m]>(
     data: T[d],
-    idx: i32[e],
+    idx: i64[e],
     axis: usize,
 ) -> T[d[0..axis] ++ e ++ d[axis+1..n]]
     // produces the tensor whose element at i, writing j for the index tensor's own
@@ -334,6 +335,13 @@ of an index map, so a `--ir tensor` dump carries several:
 ```rust
 let to: f32[1,512,1024] = to_cast;
 ```
+
+**`emmy::gather` is not `torch.gather`.** The formula is torch's, and on the inputs emmy accepts the two agree
+element for element. But torch requires only `index.size(d) <= input.size(d)` on every axis other than the
+gathered one, while emmy demands equality there. A narrower index is a legal `torch.gather` that emmy reads as
+the other operation: data `[4,8]` with an index `[4,3]` on axis 0 gives `[4,3]` in torch and `[4,3,8]` here.
+Four ATen operators collapse onto one node and only the axis survives, so operand shapes are the only evidence
+of which was meant.
 
 **Some captured constants go unused.** `transpose` and `softmax` leave the scalars the trace captured bound at
 module level, with nothing referring to them.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -1,0 +1,325 @@
+# Reading a graph dump
+
+`emmy compile <model> --ir torch` and `--ir tensor` print the graph as Rust-shaped pseudocode. Nothing parses it
+back; it exists so a reader can follow what the compiler holds at that point. The renderer is
+`emmy/compiler/pretty.py`, and `EMMY_DUMP_DIR` writes every stage's graph through the same code.
+
+## The program
+
+Three small ones first, from `emmy compile --code`. A whole-tensor operation, with its own fields after the
+operands:
+
+```rust
+// 3 nodes, 2 inputs, 1 outputs
+
+pub fn main(
+    x0: f32[4,64],
+    x1: f32[16,64],
+) -> f32[4,16] {
+    let linear: f32[4,16] = linear(x0, x1, has_bias=False);
+
+    linear
+}
+```
+
+A scalar added to a tensor. The scalar becomes a constant, and reaching the tensor's shape takes an explicit
+node — the closure ignores both indices, which is what a broadcast looks like:
+
+```rust
+// 4 nodes, 1 inputs, 1 outputs
+
+let add_c1: f32[1] = 1.0;
+
+pub fn main(
+    x: f32[4,8],
+) -> f32[4,8] {
+    let add_c1_bc: f32[4,8] = emmy::tensor_from_fn(|_i, _j| add_c1[0]);
+    let add: f32[4,8] = add(x, add_c1_bc);
+
+    add
+}
+```
+
+Two operations, and the constants the trace captured along the way — `transpose_c1` and `softmax_c1` end up
+bound and unused, since the fields carry the same information:
+
+```rust
+// 6 nodes, 1 inputs, 1 outputs
+
+let transpose_c1: f32[1] = 1.0;
+let transpose_c2: f32[1] = 2.0;
+let softmax_c1: f32[1] = -1.0;
+
+pub fn main(
+    x: f32[2,4,8],
+) -> f32[2,8,4] {
+    let transpose: f32[2,8,4] = transpose(x, axes=(1, 2));
+    let softmax: f32[2,8,4] = softmax(transpose, axis=-1);
+
+    softmax
+}
+```
+
+A model layer has the same shape, with more of it. This is `--layer 0` of a Llama-architecture model, cut down
+to its landmarks:
+
+```rust
+// 106 nodes, 4 inputs, 1 outputs
+
+let p_input_layernorm_weight: f16[2048] = load("input_layernorm.weight");
+let p_attn_q_proj_weight: f16[2048,2048] = load("self_attn.q_proj.weight");
+// … 33 constants in all
+
+pub fn main(
+    hidden_states: f16[1,512,2048],
+    position_embeddings_0: f16[1,512,64],
+    position_embeddings_1: f16[1,512,64],
+    attention_mask: f32,
+) -> f16[1,512,2048] {
+    let p_input_layernorm_weight_bc: f16[1,512,2048]
+        = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+    let to: f32[1,512,2048] = emmy::cast(hidden_states);
+    // … the norm, then the q / k / v projections
+    let scaled_dot_product_attention: f16[1,32,512,64]
+        = sdpa(add_1, add_2, transpose_2, is_causal=True, sliding_window=None, scale=0.125);
+    let linear_3: f16[1,512,2048] = linear(reshape, p_attn_o_proj_weight, has_bias=False);
+    let add_3: f16[1,512,2048] = add(hidden_states, linear_3);
+    // … the post-attention norm and the feed-forward block
+    let add_5: f16[1,512,2048] = add(add_3, linear_6);
+
+    add_5
+}
+```
+
+The graph's constants become module-level bindings, its inputs become the parameters of `pub fn main`, every
+compute node becomes one `let`, and its outputs become the tail expression. A graph with several outputs
+returns an `Outputs` struct, declared after the function; a graph with none returns `()`.
+
+```rust
+pub fn main(
+    x0: f32[4,8],
+    x1: f32[4,8],
+) -> Outputs {
+    let add: f32[4,8] = add(x0, add_c1_bc);
+    let mul: f32[4,8] = multiply(x1, mul_c1_bc);
+
+    Outputs { add, mul }
+}
+
+struct Outputs {
+    add: f32[4,8],
+    mul: f32[4,8],
+}
+```
+
+**Types** carry the shape: `f16[1,512,4096]`. A rank-0 tensor is just its dtype (`f32`). Dtype names are the
+repo's own, including the narrow float formats (`f8e4m3`).
+
+**Order** is a dependency order, not an execution schedule.
+
+**Trailing `key=value` arguments** are the operation's own fields, not tensor operands:
+`linear(mul_1, p_attn_q_proj_weight, has_bias=False)`, `reshape(x, shape=(1, 512, -1))`. A `-1` inside `shape=`
+is the request the trace captured; the declared type on the left shows the extent it resolved to.
+
+**Constants named `<node>_c<N>`** are scalars the trace captured, named after the node that consumes them and
+the argument position they sat at: `add_c1` is the epsilon inside the node called `add`.
+
+**Binding names are node ids.** Every node carries two labels: the id the graph stores it under and refers to
+it by, and its output tensor's name. They are usually the same string, because a new node takes its tensor name
+as its id when that id is free. When it is taken, the id falls back to `n0`, `n1`, … and the tensor keeps its
+name — `broadcast_to` names its result after its source, so one source broadcast to two different shapes yields
+one name twice. Bindings print the id, so no two can collide, and a differing tensor name follows in a comment:
+
+```rust
+let n0: f16[1,8,512,128] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);  // aka tensor name `unsqueeze_bc`
+let unsqueeze_bc: f16[1,32,512,128] = emmy::tensor_from_fn(|i, _j, k, l| unsqueeze[i, 0, k, l]);
+```
+
+**Memory, loops, threads, kernels, fusion and hardware choices are absent** because these levels cannot express
+them, not because the printer hides them. They arrive with the later dialects, which have their own printed
+forms.
+
+**Four fields are hidden.** Every operation carries `source` (its predecessor in a rewrite chain), `knobs` (the
+tuning choices passes stamp on it), and a map of its own input and output tensors. They record where a node
+came from rather than what it computes — `Graph.to_dict` skips the same four when it serializes a graph — and
+at the torch stage they are empty anyway, since no pass has run yet.
+
+When `EMMY_DUMP_DIR` dumps a later stage, whose nodes hold whole statement trees, an operation prints its own
+body instead:
+
+```rust
+    let linear: f32[4,16]
+        = loop(x1, x0) {
+        for a0 in 0..4
+            for a1 in 0..16
+                for a2 in 0..64
+                    in0 = load x1[a1, a2]
+                    ...
+    };
+```
+
+## Where a constant's value comes from
+
+| Right-hand side | Meaning |
+| --- | --- |
+| `1e-06` | a literal fixed at trace time |
+| `load("model.layers.0…")` | a tensor read by path, from the checkpoint or from the traced wrapper |
+| `load("…").reshape(shape=(1, 1))` | layout operations the loader applies after reading, in order |
+| `emmy::const_eval()` | a tensor the loader computes by evaluating a small graph, rather than reading one |
+| `context(num_tokens)` | a scalar bound at launch from the symbolic-dimension environment |
+| `emmy::input_data()` | a tensor the caller supplies at run time |
+
+Two notes on paths. A quantized checkpoint's dump mixes two naming schemes: parameters are rewritten to
+absolute model paths (`model.layers.0.self_attn.q_proj.weight`), while buffers keep the traced wrapper's own
+names (`causal_mask`). Unquantized dumps leave both wrapper-relative.
+
+The last three rows are rare. `context(...)` needs a decomposition pass and a symbolic dimension, so it cannot
+appear at `--ir torch` or in a static-shape dump. A caller-supplied tensor and the multi-path form
+(`load("…a", "…b")`, concatenated on axis 0) exist in the renderer, but no traced model produces them.
+
+## Operations
+
+A bare name means what torch or numpy already means by it: `multiply`, `add`, `pow`, `mean`, `sum`, `linear`,
+`silu`, `softmax`, `reshape`, `slice`, `cat`, `transpose`. Four cases need care.
+
+A **reduction** prints as its combine's name with an `axis=` argument — `sum(pow_1, axis=-1)`,
+`maximum(x, axis=-1)`. That is the same spelling as the elementwise operation of the same name, so the `axis=`
+argument is the only mark; the reduced axis stays in the result at size 1.
+
+**`transpose`** carries an `axes` field that is either a pair to swap, as torch's `transpose` takes, or a full
+permutation, as numpy's reads. Both print identically, so check the declared result type.
+
+**`slice`** also carries the scalar constants the trace captured, which duplicate its own fields. **`cat`** ends
+in a captured scalar too, but that one is not a duplicate: `CatOp` has no fields, so the constant is the only
+record of the concatenation axis.
+
+**`rms_norm`** and **`layer_norm`** are respellings: the class names behind them would otherwise lowercase to
+`rmsnorm` and `layernorm`. Every other operation without an `emmy::` prefix prints under its own name, `sdpa`
+included — emmy's short spelling of scaled dot product attention.
+
+An `emmy::` name is emmy's own:
+
+| Name | Meaning |
+| --- | --- |
+| `emmy::tensor_from_fn(\|i, j\| …)` | build a tensor from a function of its indices |
+| `emmy::cast(x)` | a dtype change (see the gotchas below — no node computes it) |
+| `emmy::bitcast(x)` | reinterpret same-width elements as another dtype |
+| `emmy::gather(data, idx, axis=n)` | read positions along an axis, when the closure form below does not apply |
+| `emmy::index_map(…)` | a reindexing the closure form cannot hold |
+
+A second namespace, `emmy::intrinsics::`, holds the scalar functions emmy defines itself, the ones with no
+torch or numpy function behind them. `emmy/compiler/ir/elementwise.py` holds that table, and everything in it
+that torch or numpy does not already name prints under the prefix:
+
+| Name | Meaning |
+| --- | --- |
+| `emmy::intrinsics::from_f8e4m3(x)`, `emmy::intrinsics::to_f8e5m2(x)`, … | decode or encode a narrow float format |
+| `emmy::intrinsics::bitcast(x)` | the elementwise spelling of a same-width reinterpretation |
+| `emmy::intrinsics::gelu_tanh(x)` | gelu's tanh approximation, torch's `approximate="tanh"` |
+| `emmy::intrinsics::exp_fast(x)` | `exp` with the fast-math CUDA spelling, from a kernel-stage pass |
+
+### What the `emmy::` helpers mean
+
+Written as definitions in the same pseudocode. `T` and `U` are element types, and each axis size is a const
+parameter — `d0, …, dn` for the result, `e0, …, em` for a second operand. A `…` stands for the rest of a list
+whose length the shapes fix.
+
+```rust
+// Build a tensor from a function of its indices. The result type fixes how many
+// parameters the closure takes and what each one ranges over. Rank six is the
+// limit, because the printer has six index names.
+fn emmy::tensor_from_fn<T, const d0: usize, …, const dn: usize>(f: |usize, …, usize| -> T) -> T[d0,…,dn]
+    // produces the tensor whose element at (i0, …, in) is f(i0, …, in), for every
+    // i0 < d0, …, in < dn
+
+// A dtype change. No node computes it: the declared result type is the whole
+// operation, and the backend converts when it materializes that type. The values
+// can still change, since a narrowing conversion rounds.
+fn emmy::cast<T, U, const d0: usize, …, const dn: usize>(x: T[d0,…,dn]) -> U[d0,…,dn]
+
+// Reinterpret each element's bits as another type of the same width.
+fn emmy::bitcast<T, U, const d0: usize, …, const dn: usize>(x: T[d0,…,dn]) -> U[d0,…,dn]
+    where size_of::<U>() == size_of::<T>()
+
+// Read positions along one axis, in one of two forms that the operand shapes
+// tell apart. When `idx` matches `data` in rank and in every axis but `axis`, it
+// names one position per output element:
+fn emmy::gather<T, const d0: usize, …, const dn: usize, const e0: usize, …, const en: usize>(
+    data: T[d0,…,dn],
+    idx: i32[e0,…,en],
+    axis: usize,
+) -> T[e0,…,en]
+    // produces the tensor whose element at (i0, …, in) is
+    // data[i0, …, idx[i0,…,in], …, in], with the index landing on `axis`
+
+// Otherwise `idx` replaces the gather axis, and its own axes land in that axis's
+// place:
+fn emmy::gather<T, const d0: usize, …, const dn: usize, const e0: usize, …, const em: usize>(
+    data: T[d0,…,dn],
+    idx: i32[e0,…,em],
+    axis: usize,
+) -> T[d0,…,d(axis-1), e0,…,em, d(axis+1),…,dn]
+    // produces the tensor whose element at (…, j0,…,jm, …) is
+    // data[…, idx[j0,…,jm], …], with the index landing on `axis`
+
+// A reindexing the closure form cannot hold: no source, several sources, a
+// selection deciding which source feeds which output position, or rank above six.
+fn emmy::index_map<T, const d0: usize, …, const dn: usize>(sources: …) -> T[d0,…,dn]
+
+// Decode or encode a narrow float format, element by element. Unlike `cast`, these
+// have a real implementation behind them (`emmy/compiler/ir/elementwise.py`).
+fn emmy::intrinsics::from_f8e4m3<const d0: usize, …, const dn: usize>(x: f8e4m3[d0,…,dn]) -> f32[d0,…,dn]
+fn emmy::intrinsics::to_f8e4m3<const d0: usize, …, const dn: usize>(x: f32[d0,…,dn]) -> f8e4m3[d0,…,dn]
+```
+
+`emmy::const_eval()` and `emmy::input_data()` are not operations. They stand for where a constant's value comes
+from and appear only on the right of a module-level binding. `const_eval` means the loader computes the value
+by running a small graph — a chain of layout operations over other constants that folding collapsed into one.
+`input_data` means the constant has no value and no address at all, so whoever runs the graph must supply it by
+name.
+
+### Reading `emmy::tensor_from_fn`
+
+The closure takes one parameter per axis of the **result**, and the type gives their ranges. Inside, a tensor
+is read with brackets. An axis the body never uses takes Rust's `_` prefix, which is how a broadcast looks:
+
+```rust
+let p_input_layernorm_weight_bc: f16[1,512,4096]
+    = emmy::tensor_from_fn(|_i, _j, k| p_input_layernorm_weight[k]);
+```
+
+One number per column, repeated over batch and tokens. A read whose index is itself a tensor value — a table
+lookup — prints the same way, with the inner bracket producing the row:
+
+```rust
+let pairs: f16[4096,2048,2] = emmy::tensor_from_fn(|i, j, k| pair_table[idx[i, j], k]);
+```
+
+Valid: every index variable in the body comes from the closure's parameters, or is a literal, or is another
+tensor read. Invalid: a free variable, or a parameter count that disagrees with the result's rank — if you see
+either, the printer has a bug.
+
+## Gotchas
+
+These are oddities of the compiler that the new spelling makes visible rather than hiding.
+
+**A conversion has no operation of its own.** It is an identity node whose output tensor *declares* the new
+dtype, and the backend converts when it materializes that type. `emmy::cast` is the printer naming a node it
+recognized by comparing the declared types.
+
+**`CastOp` exists and nothing builds it.** `emmy/compiler/ir/tensor/ir.py` defines a cast operation carrying an
+explicit dtype. `torch_wire.py` can rebuild one from a stored graph and the constant-folding pass knows it, but
+no production code creates one, so every real conversion arrives as the identity node above. `copy` and
+`bitcast` are the two elementwise names whose implementation is the identity; the narrow-float decoders do
+compute.
+
+**A binding can be a plain rebinding.** An identity node whose declared dtype already matches its input prints
+as its argument alone — `005_split_cast_from_indexmap.py` leaves one behind whenever it splits a conversion out
+of an index map, so a `--ir tensor` dump carries several:
+
+```rust
+let to: f32[1,512,1024] = to_cast;
+```
+
+**Some captured constants go unused.** `transpose` and `softmax` leave the scalars the trace captured bound at
+module level, with nothing referring to them.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -474,7 +474,7 @@ struct IndexSource<T, const rank: usize> {
 }
 
 fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(
-    sources: IndexSource<T, rank>[],
+    sources: [IndexSource<T, rank>][],
 ) -> T[d]
     // result[i] = s.operand[s.coord(i)]
     //   where s is the first source with s.select(i)

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -421,9 +421,10 @@ Picks one element per output position. `idx` has the result's shape, and each of
 position along `axis` that one output element reads; the other coordinates come from the output position
 itself.
 
-Close to torch's `gather`, but not the same: torch allows `idx` to be smaller than `data` on the axes it does
-not gather, while this requires them equal. A narrower index is a legal `torch.gather` that prints — and
-computes — as `emmy::gather_by_axis`.
+Close to torch's `gather`, but stricter. Torch allows `idx` to be smaller than `data` on the axes it does not
+gather; `emmy::gather` requires them equal there. A node whose `idx` is smaller on such an axis is therefore
+not this operation at all — it prints as `emmy::gather_by_axis`, and that is what the graph computes, even
+though the same call in torch would have been a gather.
 
 ```rust
 fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]>(
@@ -432,8 +433,7 @@ fn emmy::gather<T, const rank: usize, const d: usize[rank], const e: usize[rank]
     axis: usize,
 ) -> T[e]
     where e[k] == d[k] for every k != axis
-    // produces the tensor whose element at i is
-    // data[i[0..axis] ++ [idx[i]] ++ i[axis+1..rank]]
+    // result[i] = data[i[0..axis] ++ [idx[i]] ++ i[axis+1..rank]]
 ```
 
 #### `emmy::gather_by_axis`
@@ -448,9 +448,7 @@ fn emmy::gather_by_axis<T, const rank: usize, const irank: usize, const d: usize
     idx: i64[e],
     axis: usize,
 ) -> T[d[0..axis] ++ e ++ d[axis+1..rank]]
-    // produces the tensor whose element at i, writing j for the index tensor's own
-    // coordinates i[axis..axis+irank], is
-    // data[i[0..axis] ++ [idx[j]] ++ i[axis+irank..rank+irank-1]]
+    // result[i] = data[i[0..axis] ++ [idx[i[axis..axis+irank]]] ++ i[axis+irank..rank+irank-1]]
 ```
 
 #### `emmy::index_map`
@@ -461,5 +459,18 @@ that pairs each one with the output index, and the condition under which it supp
 the node.
 
 ```rust
-fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: [tensor]) -> T[d]
+// A tensor whose rank and shape the type does not expose — an existential type,
+// https://en.wikipedia.org/wiki/Type_system#Existential_types
+struct Tensor<T> {
+  rank: usize,
+  d: usize[rank],
+  t: T[d],
+}
+
+fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: Tensor<T>[]) -> T[d]
 ```
+
+The operands need a container because they need not share a shape — the two halves of a `cat` do, the two
+constants of a mask do not. They do share the element type `T`, and only by convention: `IndexMapOp.forward`
+takes the result's dtype from the first operand and copies every other one into it, so a mixed-dtype node would
+silently follow operand zero rather than be rejected.

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -223,31 +223,6 @@ becomes one more `let`; and the tail expression builds `Outputs`. An input is re
 `linear(mul_1, p_attn_q_proj_weight, has_bias=False)`, `reshape(x, shape=(1, 512, -1))`. A `-1` inside `shape=`
 is the request the trace captured; the declared type on the left shows the extent it resolved to.
 
-## Wut
-
-Wut:
-
-When `EMMY_DUMP_DIR` dumps a later stage, whose nodes hold whole statement trees, an operation prints its own
-body instead:
-
-```rust
-  let linear: f32[4,16]
-      = loop(inputs.x1, inputs.x0) {
-        for a0 in 0..4
-            for a1 in 0..16
-                for a2 in 0..64
-                    in0 = load x1[a1, a2]
-                    in1 = load x0[a0, a2]
-                    v0 = multiply(in0, in1)
-                    acc0 <- add(acc0, v0)
-                linear[a0, a1] = acc0
-  };
-```
-
-Wut:
-
-`acc0 <- add(acc0, v0)` is that dialect's accumulate, not an assignment this notation defines.
-
 ## Where a constant's value comes from
 
 | Right-hand side | Meaning |

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -305,27 +305,87 @@ already names, which print bare.
 | `emmy::scalar::gelu_tanh(x)` | gelu's tanh approximation, torch's `approximate="tanh"` |
 | `emmy::scalar::exp_fast(x)` | `exp` with the fast-math CUDA spelling, from a kernel-stage pass |
 
-The following section presents `emmy::` helpers in more detail.
+The following section presents `emmy::` helper operations in more detail.
+We do not discuss the PyTorch- and NumPy-based operations in detail, consult those repsective projects for that.
 
 ### The `emmy::` helpers
 
-Each one below is written as a definition in the same pseudocode, under three conventions.
+In this section, we will have a deeper look at the `emmy::*` tensor opreations.
+Before we start, let's recap our notation for tensor types and shapes we use in torch IR.
 
-`T` and `U` are element types. A shape is one const parameter holding all the axis sizes —
-`const d: usize[rank]` — so a definition can index it (`d[axis]`), slice it (`d[0..axis]`) and join pieces
-with `++`.
+A tensor is an $$n$$-dimensional array.
+When $$n=1$$, it's just a vector indexed by a single value; when $$n=2$$ it's a 2D matrix.
+In our IR, a tensor value's type must specify its size across every dimension.
 
-An index into a rank-`r` tensor is itself a vector of `r` numbers, so `x[i]` with `i: usize[r]` is one element,
-and `x[i0, i1]` is the same thing written out. Slicing and joining work on an index too: `i[0..axis]` is the
-coordinates before the axis, and `i[0..axis] ++ [v] ++ i[axis+1..rank]` is `i` with the coordinate at `axis`
-replaced by `v`. An index *tensor* holds `i64`, the dtype a traced index carries; splicing one of its values
-into an index vector converts it.
+```rust
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+  // examples of declaring 1D and 2D tensors
+  let tensor_1d: f32[16] = ...
+  let tensor_2d: f32[8, 32] = ...;
+}
+```
+
+Most of the time, tensor's size across each dimensions is just a constant literal like 16, 8 or 32 above.
+Sometimes, a tensor's size across some of the dimensions can be give by a `dynamic` variable or some expression of `dynamic` variables.
+
+```rust
+fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
+	let var_len_tensor: f32[dynamic.dyn_len] = ...;
+}
+```
+
+The number of tensor's dimensions though is always fixed and known inside `main`.  You can never have a tensor value
+whose number of dimensions varies with tensor IR program inputs.  But the `emmy::*` operations we present here are
+re-usable across many different programs, and we'd like them to work with tensors of any size and dimensionality.  So in
+order to show their types correctly and concisely, we empower notation with tensors of variable dimensionality.  This
+extension of our Rust pseudocode is only needed to present the `emmy::` helper operations in this section, it's not used
+in actual IR dumps.  In the following, we define this pseudocode extension and present the `emmy::` tensor helpers using
+it.
+
+A 1-dimensional tensor is just a vector. Its shape is given by a single number: vector's length.  A 2-dimensional tensor
+is a 2D matrix, its shape is a pair of numbers that specify the matrix height and width.  Likewise, the shape of an
+$$n$$-dimensional tensor is a tuple of $$n$$ integers, specifying its size across each of $$n$$ axes.  Let `n` be some
+integer. Then:
+
+1. `shape: usize[n]` is a 1D vector of `n` integers.
+2. `t: f32[shape]` denodes an `n`-dimensional tensor of `f32` whose size across axis `i` is `shape[i]`.
+3. `i: usize[n]` is another 1D vector on `n` integers such that `i[k] < shape[k]` for all `k`.
+4. `t[i]: f32` is a scalar in `t` addressed by `i`. Note that `i` that serves as an index into the tensor has the same
+   type `usize[n]` as the tensor shape.
+
+We use standard notation for slicing vectors/tensors and concatenating them. For example, `t[[i[0]+1] + i[1..]]` is the
+element just one position "up" from `t[i]` in `t` across axis 0.
+
+The following sections present `emmy::` tensor operation helpers. Their type signatures use this tensor notation
+heavily, this helps precisely pin down the types and shapes of tensors they consume and produce. We don't show their
+implementation as code, but intead define it in prose.
+
+#### `emmy::cast`
+
+A dtype change. The graph IR does not have an explicit node for cast operation: casts there are implicit, and assumed
+to happen whenever an tensor of one type is assigned to a tensor of a different type. In tensor IR pseudocode dumps, we
+print them explicitly since such conversions actually change the data.
+
+```rust
+fn emmy::cast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
+```
+
+Note that the dtype changes from `T` to `U`, while the shape `d` stays the same.
+
+#### `emmy::bitcast`
+
+Reinterprets each element's bits as another type of the same width.
+
+```rust
+fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
+    where size_of::<U>() == size_of::<T>()
+```
 
 #### `emmy::tensor_from_fn`
 
-Builds a tensor from a function of its indices. The closure takes one index vector; a printed line names its
-components instead, `|i, j, k|` for rank three, which is why rank six is the limit — the printer has six index
-names.
+Builds a tensor from a lambda function that maps tensor indices to values. The lambda takes one index vector; a printed
+line names its components instead, `|i, j, k|` for rank three, which is why rank six is the limit — the printer has
+six index names.
 
 ```rust
 fn emmy::tensor_from_fn<T, const rank: usize, const d: usize[rank]>(f: |usize[rank]| -> T) -> T[d]
@@ -354,24 +414,6 @@ Valid: every coordinate is arithmetic over the closure's parameters, literals, a
 symbolic dimension names, which appear free in the body because the launch binds them. A coordinate is never a
 value read from another tensor; that is what `emmy::gather` and `emmy::gather_by_axis` are for. Invalid: a
 parameter count that disagrees with the result's rank, which would mean the printer has a bug.
-
-#### `emmy::cast`
-
-A dtype change. No node computes it: the declared result type is the whole operation, and the backend converts
-when it materializes that type. The values can still change, since a narrowing conversion rounds.
-
-```rust
-fn emmy::cast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
-```
-
-#### `emmy::bitcast`
-
-Reinterprets each element's bits as another type of the same width.
-
-```rust
-fn emmy::bitcast<T, U, const rank: usize, const d: usize[rank]>(x: T[d]) -> U[d]
-    where size_of::<U>() == size_of::<T>()
-```
 
 #### `emmy::gather`
 

--- a/emmy/compiler/IR-PSEUDOCODE-TORCH.md
+++ b/emmy/compiler/IR-PSEUDOCODE-TORCH.md
@@ -421,20 +421,3 @@ the node.
 ```rust
 fn emmy::index_map<T, const rank: usize, const d: usize[rank]>(operands: [tensor]) -> T[d]
 ```
-
-#### `emmy::scalar::*`
-
-Functions on one number, applied to every element. Unlike `cast`, these have a real implementation behind them,
-in `emmy/compiler/ir/elementwise.py`.
-
-```rust
-fn emmy::scalar::from_f8e4m3<const rank: usize, const d: usize[rank]>(x: f8e4m3[d]) -> f32[d]
-fn emmy::scalar::to_f8e4m3<const rank: usize, const d: usize[rank]>(x: f32[d]) -> f8e4m3[d]
-```
-
-#### `emmy::const_eval` and `emmy::input_data`
-
-Not operations. They stand for where a constant's value comes from, and appear only on the right of a binding
-in the constants block. `const_eval` means the loader computes the value by running a small graph — a chain of
-layout operations over other constants that folding collapsed into one. `input_data` means the constant has no
-value and no address at all, so whoever runs the graph must supply it by name.

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -824,6 +824,21 @@ class Graph:
             for buf in refs:
                 if buf not in expected_producers:
                     raise ValueError(f"graph.{label} names unknown buffer {buf!r}")
+        # ``copy`` is the identity, so its declared output dtype is the whole
+        # operation and its shape must be its input's. Nothing else enforces this:
+        # ``ElementwiseOp.infer_output_shape`` states the rule for every elementwise
+        # op but no compile path calls it, and a shape-changing copy would reach the
+        # loop stage as a silent broadcast.
+        from emmy.compiler.ir.tensor.ir import ElementwiseOp  # noqa: PLC0415 — avoids a dialect import cycle at module load
+
+        for nid, node in self.nodes.items():
+            if not (isinstance(node.op, ElementwiseOp) and node.op.name == "copy"):
+                continue
+            out_shape = tuple(node.output.shape)
+            for inp in node.inputs:
+                t = self.buffer(inp)
+                if t is not None and tuple(t.shape) != out_shape:
+                    raise ValueError(f"copy node {nid!r} reads {inp!r} with shape {tuple(t.shape)} but declares {out_shape}")
 
     # ------------------------------------------------------------------
     # Boundary / symbolic-dim queries
@@ -1121,48 +1136,10 @@ class Graph:
         return g
 
     def pretty_print(self) -> str:
-        """Render the graph as readable text (topological order + sections)."""
-        from emmy.compiler.ir.base import ConstantOp, InputOp
+        """Render the graph as Rust-like pseudocode (see :mod:`emmy.compiler.pretty`)."""
+        from emmy.compiler.pretty import render_graph
 
-        order = self.topological_order()
-        lines: list[str] = [
-            f"# Graph: {len(self.nodes)} nodes, {len(self.inputs)} inputs, {len(self.outputs)} outputs",
-            "",
-        ]
-
-        if self.inputs:
-            lines.append("inputs:")
-            for nid in self.inputs:
-                lines.append(f"  {_fmt_tensor(self.buffer(nid))}")
-            lines.append("")
-
-        const_ids = [nid for nid in order if isinstance(self.nodes[nid].op, ConstantOp)]
-        if const_ids:
-            lines.append("constants:")
-            for nid in const_ids:
-                n = self.nodes[nid]
-                val = getattr(n.op, "value", None)
-                suffix = f" = {val}" if val is not None else ""
-                lines.append(f"  {_fmt_tensor(n.output)}{suffix}")
-            lines.append("")
-
-        compute_ids = [nid for nid in order if not isinstance(self.nodes[nid].op, (InputOp, ConstantOp))]
-        if compute_ids:
-            name_w = max(len(self.nodes[nid].output.name) for nid in compute_ids)
-            op_w = max(len(_fmt_op(self.nodes[nid], self)) for nid in compute_ids)
-            for nid in compute_ids:
-                n = self.nodes[nid]
-                op_str = _fmt_op(n, self)
-                shape_str = _fmt_shape(n.output.shape)
-                lines.append(f"{n.output.name:<{name_w}}  =  {op_str:<{op_w}}  -> {shape_str} {n.output.dtype}")
-            lines.append("")
-
-        if self.outputs:
-            lines.append("outputs:")
-            for nid in self.outputs:
-                lines.append(f"  {_fmt_tensor(self.buffer(nid))}")
-
-        return "\n".join(lines)
+        return render_graph(self)
 
     def to_dict(self) -> dict:
         """Serialize graph to a JSON-compatible dict."""
@@ -1258,19 +1235,9 @@ def _rename_buf_in_op(op, old: str, new: str):
 
 
 # ---------------------------------------------------------------------------
-# Pretty-print helpers (used by Graph.pretty_print)
+# Node-rendering helpers (used by pipeline/search/candidate.py; the graph
+# dump itself lives in compiler/pretty.py)
 # ---------------------------------------------------------------------------
-
-
-def _fmt_shape(shape: tuple) -> str:
-    inside = ", ".join(str(d) for d in shape)
-    if len(shape) == 1:
-        inside += ","
-    return f"({inside})"
-
-
-def _fmt_tensor(t: Tensor) -> str:
-    return f"{t.name}: {_fmt_shape(t.shape)} {t.dtype}"
 
 
 _DIM_NAMES = ("i", "j", "k", "l", "m", "n")

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -829,7 +829,18 @@ class Graph:
         # ``ElementwiseOp.infer_output_shape`` states the rule for every elementwise
         # op but no compile path calls it, and a shape-changing copy would reach the
         # loop stage as a silent broadcast.
-        from emmy.compiler.ir.tensor.ir import ElementwiseOp  # noqa: PLC0415 — avoids a dialect import cycle at module load
+        # noqa: PLC0415 below — a module-level import of the dialect would cycle.
+        from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp  # noqa: PLC0415
+
+        # An index map moves values, it does not convert them, so several sources
+        # feeding one result must agree on the element type. A source that differed
+        # would be a conversion, which is what a dtype-changing copy is for.
+        for nid, node in self.nodes.items():
+            if not isinstance(node.op, IndexMapOp) or len(node.inputs) < 2:
+                continue
+            dtypes = {str(t.dtype) for inp in node.inputs if (t := self.buffer(inp)) is not None}
+            if len(dtypes) > 1:
+                raise ValueError(f"index map {nid!r} reads sources of differing dtypes: {sorted(dtypes)}")
 
         for nid, node in self.nodes.items():
             if not (isinstance(node.op, ElementwiseOp) and node.op.name == "copy"):

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -789,12 +789,13 @@ class Graph:
         return self._users.get(buf, set())
 
     def validate(self) -> None:
-        """Check the graph's structural invariants; raise ``ValueError`` on the
-        first violation. Covers: non-empty ``node.outputs``; SSA per buffer
+        """Check the graph's structural and per-op invariants; raise ``ValueError``
+        on the first violation. Covers: non-empty ``node.outputs``; SSA per buffer
         (``_producers`` maps every buffer to exactly its producing node/slot,
         no orphan or missing entries); ``_users`` consistency with every
         ``node.inputs`` edge; ``graph.inputs`` / ``graph.outputs`` naming known
-        buffers. Runs in tests always and behind ``EMMY_VALIDATE_GRAPH`` at
+        buffers; a ``copy`` reading its output's shape; an index map whose sources
+        agree on element type. Runs in tests always and behind ``EMMY_VALIDATE_GRAPH`` at
         pass boundaries — never in production compile paths."""
         expected_producers: dict[str, tuple[str, int]] = {}
         for nid, node in self.nodes.items():
@@ -824,11 +825,6 @@ class Graph:
             for buf in refs:
                 if buf not in expected_producers:
                     raise ValueError(f"graph.{label} names unknown buffer {buf!r}")
-        # ``copy`` is the identity, so its declared output dtype is the whole
-        # operation and its shape must be its input's. Nothing else enforces this:
-        # ``ElementwiseOp.infer_output_shape`` states the rule for every elementwise
-        # op but no compile path calls it, and a shape-changing copy would reach the
-        # loop stage as a silent broadcast.
         # noqa: PLC0415 below — a module-level import of the dialect would cycle.
         from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp  # noqa: PLC0415
 
@@ -842,6 +838,10 @@ class Graph:
             if len(dtypes) > 1:
                 raise ValueError(f"index map {nid!r} reads sources of differing dtypes: {sorted(dtypes)}")
 
+        # ``copy`` is the identity, so its declared output dtype is the whole
+        # operation and its shape must be its input's. ``ElementwiseOp.infer_output_shape``
+        # states the rule for every elementwise op, but no compile path calls it on one,
+        # and a shape-changing copy would reach the loop stage as a silent broadcast.
         for nid, node in self.nodes.items():
             if not (isinstance(node.op, ElementwiseOp) and node.op.name == "copy"):
                 continue

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -2,7 +2,7 @@
 
 The graph stages (``--ir torch`` / ``--ir tensor``) print as one program: the
 constants become module-level bindings, the graph's inputs become the
-parameters of ``pub fn main``, every compute node becomes a ``let``, and the
+parameters of ``fn main``, every compute node becomes a ``let``, and the
 graph's outputs become the tail expression. Types carry the shape
 (``f16[1,512,4096]``), so a reader checks a line by reading its type rather
 than a trailing shape column.
@@ -22,6 +22,14 @@ from emmy.compiler.ir.frontend.ir import TransposeOp
 from emmy.compiler.ir.tensor.ir import BitcastOp, CastOp, ElementwiseOp, GatherOp, IndexMapOp, ReduceOp, ScanOp
 
 _DIM_NAMES = ("i", "j", "k", "l", "m", "n")
+
+
+def _index_names(rank: int) -> list[str]:
+    """One name per axis of a result. Past the six short letters the names keep
+    counting, so a closure always binds every axis it is written for."""
+    return [_DIM_NAMES[d] if d < len(_DIM_NAMES) else f"i{d}" for d in range(rank)]
+
+
 # Elementwise names torch or numpy already means. Everything else in
 # ``elementwise.py``'s table is one of emmy's own scalar functions, printed under
 # ``emmy::scalar::``, so a new entry there needs no edit here.
@@ -67,7 +75,7 @@ def _binders(op: IndexMapOp) -> list[str]:
     for src in op.sources:
         for e in (*src.coord_map, *(() if src.select is None else (src.select,))):
             used |= e.free_vars()
-    return [(n if f"{PLACEHOLDER_PREFIX}{d}" in used else f"_{n}") for d, n in enumerate(_DIM_NAMES[: len(op.out_shape)])]
+    return [(n if f"{PLACEHOLDER_PREFIX}{d}" in used else f"_{n}") for d, n in enumerate(_index_names(len(op.out_shape)))]
 
 
 def _index_expr(op: IndexMapOp, names: list[str], syms: dict[str, Var]) -> str:
@@ -107,10 +115,10 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
     if isinstance(op, IndexMapOp):
         if src_t is not None and op.is_identity(tuple(src_t.shape)):
             return args[0] if same_dtype else f"emmy::cast({args[0]})"
-        if len(op.sources) == 1 and op.sources[0].select is None and len(op.out_shape) <= len(_DIM_NAMES):
+        if len(op.sources) == 1 and op.sources[0].select is None:
             names = _binders(op)
             operand = args[op.sources[0].input_idx]
-            return f"emmy::tensor_from_fn({operand}, |{', '.join(names)}| {_index_expr(op, names, syms)})"
+            return f"emmy::index_map_simple({operand}, |{', '.join(names)}| {_index_expr(op, names, syms)})"
         return _fmt_index_sources(op, args, syms)
     if isinstance(op, GatherOp):
         # One op class, two operations. The operand shapes decide which, by the same
@@ -143,7 +151,7 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
 def _fmt_index_sources(op: IndexMapOp, args: list[str], syms: dict[str, Var]) -> str:
     """The general reindexing form: one ``IndexSource`` per operand, each carrying the
     coordinate map and the condition that decides which output positions it supplies."""
-    names = list(_DIM_NAMES[: len(op.out_shape)])
+    names = _index_names(len(op.out_shape))
     rename = {f"{PLACEHOLDER_PREFIX}{d}": Var(n) for d, n in enumerate(names)} | syms
 
     def closure(expr_list: tuple, body: str) -> str:

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -88,10 +88,11 @@ def fmt_expr(node, graph, names: dict[str, str]) -> str:
         return f"emmy::index_map({', '.join(args)})"
     if isinstance(op, GatherOp):
         # One op class, two operations. The operand shapes decide which, by the same
-        # test the evaluator applies. ``gather`` picks one element per output
-        # position, which is what torch means by the name. ``emmy::gather_by_axis``
-        # looks up whole slices by index — torch spells that ``index_select`` or
-        # ``embedding``, neither of which covers both, so the name is emmy's.
+        # test the evaluator applies. Both names are emmy's: ``gather`` picks one
+        # element per output position, close to torch's ``gather`` but demanding
+        # equal non-axis extents where torch allows a narrower index;
+        # ``gather_by_axis`` looks up whole slices, which torch splits across
+        # ``index_select`` and ``embedding``.
         data, idx = (graph.buffer(i) for i in node.inputs[:2])
         axis = op.axis
         if data is not None and idx is not None:
@@ -100,7 +101,7 @@ def fmt_expr(node, graph, names: dict[str, str]) -> str:
             per_element = len(idx.shape) == len(data.shape) and all(
                 e == d for k, (e, d) in enumerate(zip(idx.shape, data.shape, strict=True)) if k != axis
             )
-            name = "gather" if per_element else "emmy::gather_by_axis"
+            name = "emmy::gather" if per_element else "emmy::gather_by_axis"
             return f"{name}({', '.join(args)}, axis={axis})"
         return f"emmy::gather({', '.join(args)}, axis={op.axis})"
 

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -111,7 +111,7 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
         if len(op.sources) == 1 and op.sources[0].select is None and len(op.out_shape) <= len(_DIM_NAMES):
             names = _binders(op)
             return f"emmy::tensor_from_fn(|{', '.join(names)}| {_index_expr(op, names, args, syms)})"
-        return f"emmy::index_map({', '.join(args)})"
+        return _fmt_index_sources(op, args, syms)
     if isinstance(op, GatherOp):
         # One op class, two operations. The operand shapes decide which, by the same
         # test the evaluator applies. Both names are emmy's: ``gather`` picks one
@@ -138,6 +138,29 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
         nested = "\n".join(f"    {line}" for line in body.splitlines())
         return f"{name}({', '.join(args)}) {{\n{nested}\n  }}"
     return f"{name}({', '.join([*args, *_fields(op)])})"
+
+
+def _fmt_index_sources(op: IndexMapOp, args: list[str], syms: dict[str, Var]) -> str:
+    """The general reindexing form: one ``IndexSource`` per operand, each carrying the
+    coordinate map and the condition that decides which output positions it supplies."""
+    names = list(_DIM_NAMES[: len(op.out_shape)])
+    rename = {f"{PLACEHOLDER_PREFIX}{d}": Var(n) for d, n in enumerate(names)} | syms
+
+    def closure(expr_list: tuple, body: str) -> str:
+        used: set[str] = set()
+        for e in expr_list:
+            used |= e.free_vars()
+        params = ", ".join(n if f"{PLACEHOLDER_PREFIX}{d}" in used else f"_{n}" for d, n in enumerate(names))
+        return f"|{params}| {body}"
+
+    lines = []
+    for src in op.sources:
+        coords = ", ".join(e.substitute(rename).pretty() for e in src.coord_map)
+        fields = [f"operand: {args[src.input_idx]}", f"coord: {closure(src.coord_map, f'[{coords}]')}"]
+        if src.select is not None:
+            fields.append(f"select: {closure((src.select,), src.select.substitute(rename).pretty())}")
+        lines.append(f"      IndexSource {{ {', '.join(fields)} }},")
+    return "emmy::index_map([\n" + "\n".join(lines) + "\n    ])"
 
 
 def fmt_constant(node, syms: dict[str, Var]) -> str:

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -70,11 +70,10 @@ def _binders(op: IndexMapOp) -> list[str]:
     return [(n if f"{PLACEHOLDER_PREFIX}{d}" in used else f"_{n}") for d, n in enumerate(_DIM_NAMES[: len(op.out_shape)])]
 
 
-def _index_expr(op: IndexMapOp, names: list[str], arg_names: list[str], syms: dict[str, Var]) -> str:
-    src = op.sources[0]
+def _index_expr(op: IndexMapOp, names: list[str], syms: dict[str, Var]) -> str:
+    """The coordinate vector one source reads, in the result's index variables."""
     rename = {f"{PLACEHOLDER_PREFIX}{d}": Var(n.lstrip("_")) for d, n in enumerate(names)} | syms
-    coords = ", ".join(e.substitute(rename).pretty() for e in src.coord_map)
-    return f"{arg_names[src.input_idx]}[{coords}]"
+    return "[" + ", ".join(e.substitute(rename).pretty() for e in op.sources[0].coord_map) + "]"
 
 
 def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
@@ -110,7 +109,8 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
             return args[0] if same_dtype else f"emmy::cast({args[0]})"
         if len(op.sources) == 1 and op.sources[0].select is None and len(op.out_shape) <= len(_DIM_NAMES):
             names = _binders(op)
-            return f"emmy::tensor_from_fn(|{', '.join(names)}| {_index_expr(op, names, args, syms)})"
+            operand = args[op.sources[0].input_idx]
+            return f"emmy::tensor_from_fn({operand}, |{', '.join(names)}| {_index_expr(op, names, syms)})"
         return _fmt_index_sources(op, args, syms)
     if isinstance(op, GatherOp):
         # One op class, two operations. The operand shapes decide which, by the same

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -23,8 +23,8 @@ from emmy.compiler.ir.tensor.ir import BitcastOp, CastOp, ElementwiseOp, GatherO
 
 _DIM_NAMES = ("i", "j", "k", "l", "m", "n")
 # Elementwise names torch or numpy already means. Everything else in
-# ``elementwise.py``'s table is one of emmy's own intrinsics and prints under
-# ``emmy::intrinsics::``, so a new entry there needs no edit here.
+# ``elementwise.py``'s table is one of emmy's own scalar functions, printed under
+# ``emmy::scalar::``, so a new entry there needs no edit here.
 _BORROWED_ELEMENTWISE = frozenset({"copy", "where", "arange", "rsqrt", "relu", "sigmoid", "silu", "softplus", "erf", "gelu"})
 # Attribution metadata every op carries; never part of what an op computes.
 _SKIP_FIELDS = frozenset({"source", "knobs", "inputs", "outputs"})
@@ -90,7 +90,7 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
         # so a copy either changes the declared dtype — a conversion — or nothing.
         return args[0] if same_dtype else f"emmy::cast({args[0]})"
     if isinstance(op, ElementwiseOp):
-        prefix = "emmy::intrinsics::" if op.name in _NAME_TO_FN and op.name not in _BORROWED_ELEMENTWISE else ""
+        prefix = "emmy::scalar::" if op.name in _NAME_TO_FN and op.name not in _BORROWED_ELEMENTWISE else ""
         return f"{prefix}{op.name}({', '.join(args)})"
     if isinstance(op, (ReduceOp, ScanOp)):
         # A reduction over `maximum` is what both libraries call `amax`, which

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -32,9 +32,26 @@ _WRAP = 118
 _OP_SPELLING = {"RmsNormOp": "rms_norm", "LayerNormOp": "layer_norm"}
 
 
-def fmt_type(shape: tuple, dtype) -> str:
-    """``f16[1,512,4096]``; a rank-0 tensor is just its dtype."""
-    return str(dtype) if not shape else f"{dtype}[{','.join(str(d) for d in shape)}]"
+def fmt_type(shape: tuple, dtype, syms: dict[str, Var] | None = None) -> str:
+    """``f16[1,512,4096]``; a rank-0 tensor is just its dtype. A symbolic extent
+    prints qualified by the struct that carries it — ``f32[2,dynamic.seq_len,4]``."""
+    return str(dtype) if not shape else f"{dtype}[{','.join(_fmt_dim(d, syms) for d in shape)}]"
+
+
+def _fmt_dim(d, syms: dict[str, Var] | None) -> str:
+    expr = getattr(d, "expr", None)
+    return str(d) if expr is None or not syms else expr.substitute(syms).pretty()
+
+
+def _symbols(graph) -> dict[str, Var]:
+    """Every symbolic extent in the graph, mapped to its field on ``Dynamic``."""
+    names: set[str] = set()
+    for node in graph.nodes.values():
+        for t in node.outputs:
+            for d in t.shape:
+                if (expr := getattr(d, "expr", None)) is not None:
+                    names |= expr.free_vars()
+    return {n: Var(f"dynamic.{n}") for n in sorted(names)}
 
 
 def _fields(op) -> list[str]:
@@ -50,14 +67,14 @@ def _binders(op: IndexMapOp) -> list[str]:
     return [(n if f"{PLACEHOLDER_PREFIX}{d}" in used else f"_{n}") for d, n in enumerate(_DIM_NAMES[: len(op.out_shape)])]
 
 
-def _index_expr(op: IndexMapOp, names: list[str], arg_names: list[str]) -> str:
+def _index_expr(op: IndexMapOp, names: list[str], arg_names: list[str], syms: dict[str, Var]) -> str:
     src = op.sources[0]
-    rename = {f"{PLACEHOLDER_PREFIX}{d}": Var(n.lstrip("_")) for d, n in enumerate(names)}
+    rename = {f"{PLACEHOLDER_PREFIX}{d}": Var(n.lstrip("_")) for d, n in enumerate(names)} | syms
     coords = ", ".join(e.substitute(rename).pretty() for e in src.coord_map)
     return f"{arg_names[src.input_idx]}[{coords}]"
 
 
-def fmt_expr(node, graph, names: dict[str, str]) -> str:
+def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
     """The right-hand side of one ``let``."""
     op = node.op
     args = [names.get(i, i) for i in node.inputs]
@@ -84,7 +101,7 @@ def fmt_expr(node, graph, names: dict[str, str]) -> str:
             return args[0] if same_dtype else f"emmy::cast({args[0]})"
         if len(op.sources) == 1 and op.sources[0].select is None and len(op.out_shape) <= len(_DIM_NAMES):
             names = _binders(op)
-            return f"emmy::tensor_from_fn(|{', '.join(names)}| {_index_expr(op, names, args)})"
+            return f"emmy::tensor_from_fn(|{', '.join(names)}| {_index_expr(op, names, args, syms)})"
         return f"emmy::index_map({', '.join(args)})"
     if isinstance(op, GatherOp):
         # One op class, two operations. The operand shapes decide which, by the same
@@ -110,17 +127,17 @@ def fmt_expr(node, graph, names: dict[str, str]) -> str:
         # Loop / tile / kernel ops: their fields are whole statement trees, so the
         # dialect's own body rendering reads where a dataclass repr does not.
         nested = "\n".join(f"    {line}" for line in body.splitlines())
-        return f"{name}({', '.join(args)}) {{\n{nested}\n    }}"
+        return f"{name}({', '.join(args)}) {{\n{nested}\n  }}"
     return f"{name}({', '.join([*args, *_fields(op)])})"
 
 
-def fmt_constant(node) -> str:
+def fmt_constant(node, syms: dict[str, Var]) -> str:
     """Where a constant's value comes from: a literal, the launch context, or the checkpoint."""
     op: ConstantOp = node.op
     if op.value is not None:
         base = repr(op.value)
     elif getattr(op, "context_value", None) is not None:
-        base = f"context({op.context_value.pretty()})"
+        base = f"context({op.context_value.substitute(syms).pretty()})"
     elif op.source_path:
         base = f'load("{op.source_path}")'
     elif getattr(op, "source_parts", ()):
@@ -147,48 +164,52 @@ def _let(name: str, ty: str, rhs: str, indent: str, tensor_name: str = "") -> li
 
 def render_graph(graph) -> str:
     order = graph.topological_order()
+    syms = _symbols(graph)
     # A binding name is the node id — the graph's own edge key, unique by
     # construction. Two nodes can share one tensor name (``broadcast_to`` names
     # its result after its source, so one table broadcast to two head counts
     # yields the name twice), so a differing tensor name rides in a comment.
-    names = {nid: nid for nid in order}
-    outs = [(names.get(b, b), graph.buffer(b)) for b in graph.outputs]
+    # An input is reached through the struct it arrives in.
+    names = {nid: (f"inputs.{nid}" if nid in graph.inputs else nid) for nid in order}
+    ins = [(buf, graph.buffer(buf)) for buf in graph.inputs]
+    outs = [(names.get(buf, buf).removeprefix("inputs."), graph.buffer(buf)) for buf in graph.outputs]
+
+    def struct(name: str, fields: list[tuple[str, str]]) -> list[str]:
+        if not fields:
+            return [f"struct {name} {{}}", ""]
+        return [f"struct {name} {{", *[f"    {n}: {ty}," for n, ty in fields], "}", ""]
 
     lines = [f"// {len(graph.nodes)} nodes, {len(graph.inputs)} inputs, {len(graph.outputs)} outputs", ""]
+    # ``Inputs`` and ``Outputs`` depend on the runtime extents, so both take
+    # ``dynamic`` as a parameter and every symbolic extent names one of its fields.
+    lines += struct("Dynamic", [(n, "usize") for n in syms])
+    lines += struct("Inputs<dynamic: Dynamic>", [(buf, fmt_type(t.shape, t.dtype, syms)) for buf, t in ins])
+    lines += struct("Outputs<dynamic: Dynamic>", [(n, fmt_type(t.shape, t.dtype, syms)) for n, t in outs])
+    lines.append("fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {")
 
     consts = [n for n in order if isinstance(graph.nodes[n].op, ConstantOp)]
+    if consts:
+        lines.append("  // constants: checkpoint tensors, and the literals the trace captured")
     for nid in consts:
         t = graph.nodes[nid].output
-        lines += _let(names[nid], fmt_type(t.shape, t.dtype), fmt_constant(graph.nodes[nid]), "", t.name)
+        lines += _let(names[nid], fmt_type(t.shape, t.dtype, syms), fmt_constant(graph.nodes[nid], syms), "  ", t.name)
     if consts:
         lines.append("")
 
-    ret = "Outputs" if len(outs) > 1 else fmt_type(outs[0][1].shape, outs[0][1].dtype) if outs else "()"
-
-    lines.append("pub fn main(")
-    for buf in graph.inputs:
-        t = graph.buffer(buf)
-        lines.append(f"    {names.get(buf, buf)}: {fmt_type(t.shape, t.dtype)},")
-    lines.append(f") -> {ret} {{")
-
     for nid in (n for n in order if not isinstance(graph.nodes[n].op, (InputOp, ConstantOp))):
         node = graph.nodes[nid]
-        rhs = fmt_expr(node, graph, names)
+        rhs = fmt_expr(node, graph, names, syms)
         if len(node.outputs) == 1:
             t = node.output
-            lines += _let(names[nid], fmt_type(t.shape, t.dtype), rhs, "    ", t.name)
+            lines += _let(names[nid], fmt_type(t.shape, t.dtype, syms), rhs, "  ", t.name)
         else:
             # A node writing several buffers destructures, so every buffer a later
             # line can name is bound here. Slot 0 travels under the node id, the
             # rest under their own buffer names.
             slots = ", ".join(node.buffer_names())
-            types = ", ".join(fmt_type(t.shape, t.dtype) for t in node.outputs)
-            lines += _let(f"({slots})", f"({types})", rhs, "    ")
+            types = ", ".join(fmt_type(t.shape, t.dtype, syms) for t in node.outputs)
+            lines += _let(f"({slots})", f"({types})", rhs, "  ")
 
-    lines.append("")
-    tail = "Outputs { " + ", ".join(n for n, _ in outs) + " }" if len(outs) > 1 else outs[0][0] if outs else "()"
-    lines += [f"    {tail}", "}"]
-    if len(outs) > 1:
-        # Declared after the function, next to its only use.
-        lines += ["", "struct Outputs {", *[f"    {n}: {fmt_type(t.shape, t.dtype)}," for n, t in outs], "}"]
+    lines += ["", "  Outputs { " + ", ".join(n for n, _ in outs) + " }", "}"]
+
     return "\n".join(lines)

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -18,6 +18,7 @@ from dataclasses import fields as dc_fields
 from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.elementwise import _NAME_TO_FN
 from emmy.compiler.ir.expr import PLACEHOLDER_PREFIX, Var
+from emmy.compiler.ir.frontend.ir import TransposeOp
 from emmy.compiler.ir.tensor.ir import BitcastOp, CastOp, ElementwiseOp, GatherOp, IndexMapOp, ReduceOp, ScanOp
 
 _DIM_NAMES = ("i", "j", "k", "l", "m", "n")
@@ -30,6 +31,8 @@ _SKIP_FIELDS = frozenset({"source", "knobs", "inputs", "outputs"})
 _WRAP = 118
 # Class names whose lowercased form is not the torch spelling.
 _OP_SPELLING = {"RmsNormOp": "rms_norm", "LayerNormOp": "layer_norm"}
+# Reduce combines whose library name differs from the elementwise one.
+_REDUCE_SPELLING = {"maximum": "amax", "minimum": "amin"}
 
 
 def fmt_type(shape: tuple, dtype, syms: dict[str, Var] | None = None) -> str:
@@ -90,8 +93,14 @@ def fmt_expr(node, graph, names: dict[str, str], syms: dict[str, Var]) -> str:
         prefix = "emmy::intrinsics::" if op.name in _NAME_TO_FN and op.name not in _BORROWED_ELEMENTWISE else ""
         return f"{prefix}{op.name}({', '.join(args)})"
     if isinstance(op, (ReduceOp, ScanOp)):
-        name = op.name if isinstance(op, ReduceOp) else f"scan_{op.name}"
+        # A reduction over `maximum` is what both libraries call `amax`, which
+        # keeps the name off the elementwise `maximum(a, b)`.
+        name = _REDUCE_SPELLING.get(op.name, op.name)
+        name = name if isinstance(op, ReduceOp) else f"scan_{name}"
         return f"{name}({', '.join(args)}, axis={op.axis})"
+    if isinstance(op, TransposeOp) and len(op.axes) != 2:
+        # Two axes are torch's `transpose`; a full permutation is its `permute`.
+        return f"permute({args[0]}, axes={op.axes})"
     if isinstance(op, CastOp):
         return f"emmy::cast({args[0]})"
     if isinstance(op, BitcastOp):

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -173,8 +173,17 @@ def render_graph(graph) -> str:
 
     for nid in (n for n in order if not isinstance(graph.nodes[n].op, (InputOp, ConstantOp))):
         node = graph.nodes[nid]
-        t = node.output
-        lines += _let(names[nid], fmt_type(t.shape, t.dtype), fmt_expr(node, graph, names), "    ", t.name)
+        rhs = fmt_expr(node, graph, names)
+        if len(node.outputs) == 1:
+            t = node.output
+            lines += _let(names[nid], fmt_type(t.shape, t.dtype), rhs, "    ", t.name)
+        else:
+            # A node writing several buffers destructures, so every buffer a later
+            # line can name is bound here. Slot 0 travels under the node id, the
+            # rest under their own buffer names.
+            slots = ", ".join(node.buffer_names())
+            types = ", ".join(fmt_type(t.shape, t.dtype) for t in node.outputs)
+            lines += _let(f"({slots})", f"({types})", rhs, "    ")
 
     lines.append("")
     tail = "Outputs { " + ", ".join(n for n, _ in outs) + " }" if len(outs) > 1 else outs[0][0] if outs else "()"

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -1,0 +1,180 @@
+"""Render a tensor graph as Rust-like pseudocode.
+
+The graph stages (``--ir torch`` / ``--ir tensor``) print as one program: the
+constants become module-level bindings, the graph's inputs become the
+parameters of ``pub fn main``, every compute node becomes a ``let``, and the
+graph's outputs become the tail expression. Types carry the shape
+(``f16[1,512,4096]``), so a reader checks a line by reading its type rather
+than a trailing shape column.
+
+Names that emmy owns carry an ``emmy::`` prefix; names that torch or numpy
+already mean print bare. See ``IR-PSEUDOCODE-TORCH.md`` for the semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields as dc_fields
+
+from emmy.compiler.ir.base import ConstantOp, InputOp
+from emmy.compiler.ir.elementwise import _NAME_TO_FN
+from emmy.compiler.ir.expr import PLACEHOLDER_PREFIX, Var
+from emmy.compiler.ir.tensor.ir import BitcastOp, CastOp, ElementwiseOp, GatherOp, IndexMapOp, ReduceOp, ScanOp
+
+_DIM_NAMES = ("i", "j", "k", "l", "m", "n")
+# Elementwise names torch or numpy already means. Everything else in
+# ``elementwise.py``'s table is one of emmy's own intrinsics and prints under
+# ``emmy::intrinsics::``, so a new entry there needs no edit here.
+_BORROWED_ELEMENTWISE = frozenset({"copy", "where", "arange", "rsqrt", "relu", "sigmoid", "silu", "softplus", "erf", "gelu"})
+# Attribution metadata every op carries; never part of what an op computes.
+_SKIP_FIELDS = frozenset({"source", "knobs", "inputs", "outputs"})
+_WRAP = 118
+# Class names whose lowercased form is not the torch spelling.
+_OP_SPELLING = {"RmsNormOp": "rms_norm", "LayerNormOp": "layer_norm"}
+
+
+def fmt_type(shape: tuple, dtype) -> str:
+    """``f16[1,512,4096]``; a rank-0 tensor is just its dtype."""
+    return str(dtype) if not shape else f"{dtype}[{','.join(str(d) for d in shape)}]"
+
+
+def _fields(op) -> list[str]:
+    return [f"{f.name}={getattr(op, f.name)}" for f in dc_fields(op) if f.name not in _SKIP_FIELDS and f.name != "name"]
+
+
+def _binders(op: IndexMapOp) -> list[str]:
+    """One name per output axis; unused axes take Rust's ``_`` prefix."""
+    used: set[str] = set()
+    for src in op.sources:
+        for e in (*src.coord_map, *(() if src.select is None else (src.select,))):
+            used |= e.free_vars()
+    return [(n if f"{PLACEHOLDER_PREFIX}{d}" in used else f"_{n}") for d, n in enumerate(_DIM_NAMES[: len(op.out_shape)])]
+
+
+def _index_expr(op: IndexMapOp, names: list[str], arg_names: list[str]) -> str:
+    src = op.sources[0]
+    rename = {f"{PLACEHOLDER_PREFIX}{d}": Var(n.lstrip("_")) for d, n in enumerate(names)}
+    coords = ", ".join(e.substitute(rename).pretty() for e in src.coord_map)
+    return f"{arg_names[src.input_idx]}[{coords}]"
+
+
+def fmt_expr(node, graph, names: dict[str, str]) -> str:
+    """The right-hand side of one ``let``."""
+    op = node.op
+    args = [names.get(i, i) for i in node.inputs]
+    out = node.output
+    src_t = graph.buffer(node.inputs[0]) if node.inputs else None
+    same_dtype = src_t is not None and str(src_t.dtype) == str(out.dtype)
+
+    if isinstance(op, ElementwiseOp) and op.name == "copy" and len(args) == 1:
+        # The identity. Elementwise preserves shape (``Graph.validate`` enforces it),
+        # so a copy either changes the declared dtype — a conversion — or nothing.
+        return args[0] if same_dtype else f"emmy::cast({args[0]})"
+    if isinstance(op, ElementwiseOp):
+        prefix = "emmy::intrinsics::" if op.name in _NAME_TO_FN and op.name not in _BORROWED_ELEMENTWISE else ""
+        return f"{prefix}{op.name}({', '.join(args)})"
+    if isinstance(op, (ReduceOp, ScanOp)):
+        name = op.name if isinstance(op, ReduceOp) else f"scan_{op.name}"
+        return f"{name}({', '.join(args)}, axis={op.axis})"
+    if isinstance(op, CastOp):
+        return f"emmy::cast({args[0]})"
+    if isinstance(op, BitcastOp):
+        return f"emmy::bitcast({args[0]})"
+    if isinstance(op, IndexMapOp):
+        if src_t is not None and op.is_identity(tuple(src_t.shape)):
+            return args[0] if same_dtype else f"emmy::cast({args[0]})"
+        if len(op.sources) == 1 and op.sources[0].select is None and len(op.out_shape) <= len(_DIM_NAMES):
+            names = _binders(op)
+            return f"emmy::tensor_from_fn(|{', '.join(names)}| {_index_expr(op, names, args)})"
+        return f"emmy::index_map({', '.join(args)})"
+    if isinstance(op, GatherOp):
+        data, idx = (graph.buffer(i) for i in node.inputs[:2])
+        if data is not None and idx is not None:
+            axis = op.axis if not isinstance(op.axis, int) or op.axis >= 0 else len(data.shape) + op.axis
+            expands = len(out.shape) == len(idx.shape) + len(data.shape) - 1
+        else:
+            axis, expands = op.axis, False
+        if expands and axis == 0:
+            names = list(_DIM_NAMES[: len(out.shape)])
+            head, tail = names[: len(idx.shape)], names[len(idx.shape) :]
+            read = ", ".join([f"{args[1]}[{', '.join(head)}]", *tail])
+            return f"emmy::tensor_from_fn(|{', '.join(names)}| {args[0]}[{read}])"
+        return f"emmy::gather({', '.join(args)}, axis={op.axis})"
+
+    name = _OP_SPELLING.get(type(op).__name__, type(op).__name__.removesuffix("Op").lower())
+    if (body := op.pretty_body()) is not None:
+        # Loop / tile / kernel ops: their fields are whole statement trees, so the
+        # dialect's own body rendering reads where a dataclass repr does not.
+        nested = "\n".join(f"    {line}" for line in body.splitlines())
+        return f"{name}({', '.join(args)}) {{\n{nested}\n    }}"
+    return f"{name}({', '.join([*args, *_fields(op)])})"
+
+
+def fmt_constant(node) -> str:
+    """Where a constant's value comes from: a literal, the launch context, or the checkpoint."""
+    op: ConstantOp = node.op
+    if op.value is not None:
+        base = repr(op.value)
+    elif getattr(op, "context_value", None) is not None:
+        base = f"context({op.context_value.pretty()})"
+    elif op.source_path:
+        base = f'load("{op.source_path}")'
+    elif getattr(op, "source_parts", ()):
+        base = "load(" + ", ".join(f'"{p}"' for p, _ in op.source_parts) + ")"
+    elif getattr(op, "source_graph", None) is not None:
+        base = "emmy::const_eval()"
+    else:
+        base = "emmy::input_data()"
+    for load_op in getattr(op, "load_ops", ()):
+        base += f".{type(load_op).__name__.removesuffix('Op').lower()}({', '.join(_fields(load_op))})"
+    return base
+
+
+def _let(name: str, ty: str, rhs: str, indent: str, tensor_name: str = "") -> list[str]:
+    """One binding. The name is the node id; a tensor name that differs from it
+    still carries information (``broadcast_to`` names its result after its
+    source), so it rides along in a trailing comment."""
+    note = f"  // aka tensor name `{tensor_name}`" if tensor_name and tensor_name != name else ""
+    line = f"{indent}let {name}: {ty} = {rhs};"
+    if len(line) <= _WRAP:
+        return [line + note]
+    return [f"{indent}let {name}: {ty}", f"{indent}    = {rhs};{note}"]
+
+
+def render_graph(graph) -> str:
+    order = graph.topological_order()
+    # A binding name is the node id — the graph's own edge key, unique by
+    # construction. Two nodes can share one tensor name (``broadcast_to`` names
+    # its result after its source, so one table broadcast to two head counts
+    # yields the name twice), so a differing tensor name rides in a comment.
+    names = {nid: nid for nid in order}
+    outs = [(names.get(b, b), graph.buffer(b)) for b in graph.outputs]
+
+    lines = [f"// {len(graph.nodes)} nodes, {len(graph.inputs)} inputs, {len(graph.outputs)} outputs", ""]
+
+    consts = [n for n in order if isinstance(graph.nodes[n].op, ConstantOp)]
+    for nid in consts:
+        t = graph.nodes[nid].output
+        lines += _let(names[nid], fmt_type(t.shape, t.dtype), fmt_constant(graph.nodes[nid]), "", t.name)
+    if consts:
+        lines.append("")
+
+    ret = "Outputs" if len(outs) > 1 else fmt_type(outs[0][1].shape, outs[0][1].dtype) if outs else "()"
+
+    lines.append("pub fn main(")
+    for buf in graph.inputs:
+        t = graph.buffer(buf)
+        lines.append(f"    {names.get(buf, buf)}: {fmt_type(t.shape, t.dtype)},")
+    lines.append(f") -> {ret} {{")
+
+    for nid in (n for n in order if not isinstance(graph.nodes[n].op, (InputOp, ConstantOp))):
+        node = graph.nodes[nid]
+        t = node.output
+        lines += _let(names[nid], fmt_type(t.shape, t.dtype), fmt_expr(node, graph, names), "    ", t.name)
+
+    lines.append("")
+    tail = "Outputs { " + ", ".join(n for n, _ in outs) + " }" if len(outs) > 1 else outs[0][0] if outs else "()"
+    lines += [f"    {tail}", "}"]
+    if len(outs) > 1:
+        # Declared after the function, next to its only use.
+        lines += ["", "struct Outputs {", *[f"    {n}: {fmt_type(t.shape, t.dtype)}," for n, t in outs], "}"]
+    return "\n".join(lines)

--- a/emmy/compiler/pretty.py
+++ b/emmy/compiler/pretty.py
@@ -87,17 +87,21 @@ def fmt_expr(node, graph, names: dict[str, str]) -> str:
             return f"emmy::tensor_from_fn(|{', '.join(names)}| {_index_expr(op, names, args)})"
         return f"emmy::index_map({', '.join(args)})"
     if isinstance(op, GatherOp):
+        # One op class, two operations. The operand shapes decide which, by the same
+        # test the evaluator applies. ``gather`` picks one element per output
+        # position, which is what torch means by the name. ``emmy::gather_by_axis``
+        # looks up whole slices by index — torch spells that ``index_select`` or
+        # ``embedding``, neither of which covers both, so the name is emmy's.
         data, idx = (graph.buffer(i) for i in node.inputs[:2])
+        axis = op.axis
         if data is not None and idx is not None:
-            axis = op.axis if not isinstance(op.axis, int) or op.axis >= 0 else len(data.shape) + op.axis
-            expands = len(out.shape) == len(idx.shape) + len(data.shape) - 1
-        else:
-            axis, expands = op.axis, False
-        if expands and axis == 0:
-            names = list(_DIM_NAMES[: len(out.shape)])
-            head, tail = names[: len(idx.shape)], names[len(idx.shape) :]
-            read = ", ".join([f"{args[1]}[{', '.join(head)}]", *tail])
-            return f"emmy::tensor_from_fn(|{', '.join(names)}| {args[0]}[{read}])"
+            if isinstance(axis, int) and axis < 0:
+                axis += len(data.shape)
+            per_element = len(idx.shape) == len(data.shape) and all(
+                e == d for k, (e, d) in enumerate(zip(idx.shape, data.shape, strict=True)) if k != axis
+            )
+            name = "gather" if per_element else "emmy::gather_by_axis"
+            return f"{name}({', '.join(args)}, axis={axis})"
         return f"emmy::gather({', '.join(args)}, axis={op.axis})"
 
     name = _OP_SPELLING.get(type(op).__name__, type(op).__name__.removesuffix("Op").lower())

--- a/tests/compiler/cli/test_compile.py
+++ b/tests/compiler/cli/test_compile.py
@@ -5,7 +5,7 @@ def test_compile_code_torch_ir(run_cli):
     rc, stdout, stderr = run_cli("compile", "--code", "torch.nn.RMSNorm(2048)(torch.randn(1,32,2048))", "--ir", "torch")
     assert rc == 0, f"stderr: {stderr}"
     assert "rms_norm" in stdout
-    assert "(1, 32, 2048)" in stdout
+    assert "f32[1,32,2048]" in stdout
 
 
 def test_compile_code_tensor_ir(run_cli):

--- a/tests/compiler/cli/test_compile.py
+++ b/tests/compiler/cli/test_compile.py
@@ -60,7 +60,7 @@ def test_compile_code_functional_softmax_bakes_kwargs(run_cli):
     rc, stdout, stderr = run_cli("compile", "--code", "F.softmax(torch.randn(1,32,128), dim=-1)", "--ir", "tensor")
     assert rc == 0, f"stderr: {stderr}"
     assert "1 inputs" in stdout
-    assert "maximum(" in stdout and "sum(" in stdout
+    assert "amax(" in stdout and "sum(" in stdout
 
 
 def test_compile_passes_shorthand(run_cli, tmp_path):

--- a/tests/compiler/ir/test_indexmap.py
+++ b/tests/compiler/ir/test_indexmap.py
@@ -147,3 +147,69 @@ def test_indexmap_sources_round_trip_through_json():
     assert [s.input_idx for s in sources] == [0, 1]
     assert sources[0].coord_map == src0.coord_map and sources[1].coord_map == src1.coord_map
     assert sources[0].select == src0.select and sources[1].select is None
+
+
+# ---------- coordinates stay inside their operand ----------
+
+
+def _selected_coords_in_bounds(graph):
+    """Yield ``(node_id, axis, extent, coords)`` for every coordinate expression an
+    IndexMapOp evaluates at a position its source actually supplies.
+
+    ``IndexMapOp.forward`` evaluates each source over the whole output grid and
+    only then applies ``select``, so a coordinate matters exactly where that
+    source is selected. Reading outside the operand there would be a silent wrong
+    value, which is what this checks for.
+    """
+    import numpy as np
+
+    from emmy.compiler.ir.tensor.ir import IndexMapOp
+
+    for nid, node in graph.nodes.items():
+        if not isinstance(node.op, IndexMapOp):
+            continue
+        shape = tuple(d.as_static() for d in node.op.out_shape)
+        env = {f"{PLACEHOLDER_PREFIX}{i}": grid for i, grid in enumerate(np.ogrid[tuple(slice(0, e) for e in shape)])}
+        for src in node.op.sources:
+            operand = graph.buffer(node.inputs[src.input_idx])
+            selected = np.ones(shape, bool) if src.select is None else np.broadcast_to(src.select.eval(env), shape)
+            for axis, expr in enumerate(src.coord_map):
+                coords = np.broadcast_to(np.asarray(expr.eval(env), dtype=np.intp), shape)
+                yield nid, axis, int(operand.shape[axis].as_static()), coords[selected]
+
+
+def _tensor_graph(module, *example):
+    from emmy.compiler.pipeline import TENSOR_PASSES, Pipeline
+    from emmy.compiler.trace.torch import trace_module
+
+    traced = trace_module(module, example)
+    return Pipeline.build(TENSOR_PASSES).run(traced[0] if isinstance(traced, tuple) else traced)
+
+
+def test_index_map_coords_stay_in_bounds_where_selected():
+    torch = __import__("torch")
+
+    class Cat(torch.nn.Module):
+        def forward(self, a, b):
+            return torch.cat([a, b], dim=1)
+
+    class RotateHalf(torch.nn.Module):
+        def forward(self, x):
+            return torch.cat([-x[:, 2:], x[:, :2]], dim=1)
+
+    class Softmax(torch.nn.Module):
+        def forward(self, x):
+            return torch.nn.functional.softmax(x, dim=-1)
+
+    graphs = [
+        _tensor_graph(Cat(), torch.randn(2, 3), torch.randn(2, 5)),
+        _tensor_graph(RotateHalf(), torch.randn(2, 4)),
+        _tensor_graph(Softmax(), torch.randn(2, 4, 8)),
+    ]
+    checked = 0
+    for graph in graphs:
+        for nid, axis, extent, coords in _selected_coords_in_bounds(graph):
+            checked += 1
+            assert coords.min() >= 0, f"{nid} axis {axis} reads a negative coordinate where selected"
+            assert coords.max() < extent, f"{nid} axis {axis} reads past extent {extent} where selected"
+    assert checked, "no index map coordinates were checked"


### PR DESCRIPTION
Make `emmy compile --ir torch` and `--ir tensor` print the graph as pseudocode with Rust-like syntax instead of a table of nodes. A dump now reads as an actual program: each tensor is annotated with dtype and shape, `main` takes the graph's inputs and returns its outputs, and every node is a `let` binding whose type carries the shape, every variable name that appears in the dump syntax is also declared (no surprising `i` and `l`s that pop out of nowhere), operation calls now fully reveal the parameters the operation depends on.

The new pseudocode language reuses much of Rust's syntax, and a Rust programmer should be able to read 90% of it intuitively. It cuts off parts of Rust that are not relevant for graph IR's abstraction level (borrow checker, control flow, mutation, traits), and augments it with features that are helpful for tensor programming. We add first-class types for tensors and shapes, and allow a value's type to depend on another value (this is called *dependent types*).

The new language comes with a doc that explains its syntax and conventions.

For an overview, the new structure of a graph IR dump looks like this. The whole program sits in the `main` function, `Dynamic`, `Inputs` and `Outputs` exhaustively declare its inputs and outputs. Every `let`-binding inside `main` is a graph node. Each such binding must be annotated with the type (and shape if it's a tensor), every variable name that's ever referred to is either an argument of `main` or a result of a previous `let`-binding.

```rust
struct Dynamic {
  // dynamic arguments
}

struct Inputs<dynamic: Dynamic> {
  // input tensor shapes, may depend on `dynamic`
}

struct Outputs<dynamic: Dynamic> {
  // output tensor shapes, may depend on `dynamic`
}

// the actual computations of tensor IR program
fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
  // constants list
  let constant1 : Type = ...;
  ...

  // assignments defining nodes, each with a tensor operation
  let result1 : Type = operation(arg1, arg2);
  ...

  // final collection of the IR program's outputs, each comes from one of the assignments above
  Outputs { output1, output2, ... }
}
```

This PR is meant to try out these pseudocode conventions on graph IR, the simplest IR level. The issues this pseudocode fixes in graph IR also exist in loop and tile IR. If the ideas work well on graph IR, we can try and build IRs for loop and tile on the same principles (with less effort because ideas can be borrowed).

## Why

The old format was a dump of internal structures rather than a program, and reading one meant knowing the structures and conventions, which are not well documented.
This section discusses a few issues with the old IR dump format that the new pseudocode addresses.

```rust
add_1_c1_bc   =  add_1_c1[l]               -> (1, 512, 32, 1) f32
to            =  hidden_states[i, j, k]    -> (1, 512, 2048) f32
unsqueeze_bc  =  unsqueeze[i, na, k, l]    -> (1, 32, 512, 64) f16
```

1. An assignment didn't say what it assigned where. What looked like an expression wasn't one.

   The `unsqueeze_bc` on the left-hand side is a tensor. The `unsqueeze[i, na, k, l]` on the right-hand side looks like a scalar inside `unsqueeze`. What does it mean to assign one to another? Unclear.

2. Names bound nowhere. Where do the index variables `i`, `na`, etc. in `unsqueeze[i, na, k, l]` come from? Without binding them, `unsqueeze[i, na, k, l]` is not an expression. Same goes for dynamic variables: they just appear in shapes, with nothing declaring them and no list of them anywhere:

   ```rust
   inputs:
     x: (2, seq_len, 4) f32
   ```

3. Operation lines were not calls.

   ```rust
   // shows extra stuff unrelated to the operation:
   linear  =  linear(mul_1, p_attn_q_proj_weight, source=None, knobs={}, inputs={}, outputs={}, has_bias=False) -> (1, 512, 2048) f16
   // does not show some arguments, because we don't have a language for it:
   cat  =  indexmap(x0, x1)  -> (2, 8) f32
   ```

   Model-level rows carried four fields that are attribution rather than computation — `source=None, knobs={}, inputs={}, outputs={}` — and the reindexing `indexmap()` rows carried none of what the node actually does, so no line was something you could read as code, because some parameters of `indexmap` that matter for what it does were not printed.

4. Types were implicit where they mattered. A conversion printed as a plain reindex, and the only evidence was a dtype in the trailing column differing from the operand's. Casts hid in plain sight.

5. Two nodes could print under one name. The listing named nodes by their output tensor's name, and `broadcast_to` names its result after its source, so one rotary table feeding two head counts printed twice, identically:

   ```
   unsqueeze_bc  =  unsqueeze[i, na, k, l]  -> (1, 32, 512, 64) f16
   unsqueeze_bc  =  unsqueeze[i, na, k, l]  -> (1, 4, 512, 64) f16
   ```

   Two consumers below then read `unsqueeze_bc`, and nothing in the dump said which of the two each meant. The graph itself stays unambiguous, since its edges use node ids, but the printed program did not.

## Highlights

0. Expressions and statements read as they would in a real programming language.

1. The new pseudocode prints some operations as higher-order functions configured with a lambda. In the example below, the lambda says how the indices of `unsqueeze_bc` map to the indices of `unsqueeze`, the tensor it reads.

   ```
   let unsqueeze_bc: f16[1,32,512,64] = emmy::index_map_simple(unsqueeze, |i, _j, k, l| [i, 0, k, l]);
   ```

   Every higher-order function like this carries the `emmy::` namespace, which tells it from a PyTorch or NumPy operation, and the doc covers each one. The documentation also states exactly how the shapes of such an operation's inputs and outputs relate.

2. Types for tensors and shapes. The `f32[64,32]` is a 2-D tensor: the part in brackets is the shape, the part before it is the dtype. The code `t: f32[64,32]` reads as "`t` has type `f32[64,32]`", while a scalar inside it is `t[0,0]: f32`. If `dyn_len: usize` is some integer (typically coming from `--dynamic` parameters), then `f32[64,dyn_len]` is a well-formed type for a 2-D tensor of shape 64 by `dyn_len`.

3. Casts are explicit, and an assignment always preserves the type. Casting a value from `f32` to `f16` changes the value. So the new pseudocode shows such casts explicitly with `emmy::cast()`.

4. Operations that do different things have different names. Before this PR, `gather` was a tricky operation that changed what it did based on how the shapes of input and output tensors were related. Now, the dumped IR checks those shape conditions and gives the two operations different names `emmy::gather` and `emmy::gather_by_axis`.

5. The PyTorch and NumPy operations graph IR uses keep their original names, while emmy's own get the `emmy::` namespace.

`emmy/compiler/IR-PSEUDOCODE-TORCH.md` documents the notation: the program shape, where a constant's value comes from, the operation names, and a definition of each `emmy::` helper. Every listing of real output carries the command that reproduces it.

## Before and after

### Example 1 — a whole program

`emmy compile -c 'F.linear(torch.randn(4,64), torch.randn(16,64))' --ir torch`

Before:

```
# Graph: 3 nodes, 2 inputs, 1 outputs

inputs:
  x0: (4, 64) f32
  x1: (16, 64) f32

linear  =  linear(x0, x1, source=None, knobs={}, inputs={}, outputs={}, has_bias=False)  -> (4, 16) f32

outputs:
  linear: (4, 16) f32
```

After:

```rust
// 3 nodes, 2 inputs, 1 outputs

struct Dynamic {}

struct Inputs<dynamic: Dynamic> {
    x0: f32[4,64],
    x1: f32[16,64],
}

struct Outputs<dynamic: Dynamic> {
    linear: f32[4,16],
}

fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
  let linear: f32[4,16] = linear(inputs.x0, inputs.x1, has_bias=False);

  Outputs { linear }
}
```

Every name has a binder, the four attribution fields are gone, and the type carries the shape.

### Example 2 — a constant and its broadcast

`emmy compile -c 'torch.randn(4,8) + 1' --ir torch`

Before:

```
# Graph: 4 nodes, 1 inputs, 1 outputs

inputs:
  x: (4, 8) f32

constants:
  add_c1: (1,) f32 = 1.0

add_c1_bc  =  add_c1[na]         -> (4, 8) f32
add        =  add(x, add_c1_bc)  -> (4, 8) f32

outputs:
  add: (4, 8) f32
```

After:

```rust
// 4 nodes, 1 inputs, 1 outputs

struct Dynamic {}

struct Inputs<dynamic: Dynamic> {
    x: f32[4,8],
}

struct Outputs<dynamic: Dynamic> {
    add: f32[4,8],
}

fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
  // constants: checkpoint tensors, and the literals the trace captured
  let add_c1: f32[1] = 1.0;

  let add_c1_bc: f32[4,8] = emmy::index_map_simple(add_c1, |_i, _j| [0]);
  let add: f32[4,8] = add(inputs.x, add_c1_bc);

  Outputs { add }
}
```

A constant used to sit in a section of its own, spelled the same way as the `inputs:` and `outputs:` sections, so a line never told a reader whether a name was an argument, a fixed value or a result. It is a `let` binding now, in a marked block at the top of the body, and its right-hand side says where the value comes from — a literal here, `load("…")` for a checkpoint tensor, `context(…)` for one the launch supplies.

The broadcast below it reads as what it is: build a tensor by reading `add_c1` at index `[0]` for every position, ignoring both indices. Before, `na` marked the same thing in a position where every neighbour is an index.

### Example 3 — a conversion

From one layer of TinyLlama, `emmy compile TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --ir torch`.

Before:

```
inputs:
  hidden_states: (1, 512, 2048) f16
  …

to  =  hidden_states[i, j, k]  -> (1, 512, 2048) f32
```

After:

```rust
struct Inputs<dynamic: Dynamic> {
    hidden_states: f16[1,512,2048],
    …
}

  let to: f32[1,512,2048] = emmy::cast(inputs.hidden_states);
```

The operand is `f16` and the result is `f32`, so this node converts and does nothing else. Before, it printed as a reindex whose index list changes nothing, and the only evidence of the conversion was a dtype in the trailing column differing from the operand's — which a reader has to look up in another section to compare.

### Example 4 — a merge of two tensors

`emmy compile -c 'torch.cat([torch.randn(2,3), torch.randn(2,5)], dim=1)' --ir tensor`

Before:

```
cat  =  indexmap(x0, x1)  -> (2, 8) f32
```

After:

```rust
  let cat: f32[2,8]
      = emmy::index_map([
      IndexSource { operand: inputs.x0, coord: |i, j| [i, ((j < 3) ? j : 0)], select: |_i, j| (j < 3) },
      IndexSource { operand: inputs.x1, coord: |i, j| [i, ((j < 3) ? 0 : (j - 3))] },
    ]);
```

The old line names the operands. Which columns come from which operand lives in the node, and the print drops it. The new code gives you complete info on what the operation does.

### Example 5 — two nodes under one name

Before:

```
unsqueeze_bc  =  unsqueeze[i, na, k, l]  -> (1, 32, 512, 64) f16
unsqueeze_bc  =  unsqueeze[i, na, k, l]  -> (1, 4, 512, 64) f16
```

After:

```rust
let unsqueeze_bc: f16[1,32,512,64] = emmy::index_map_simple(unsqueeze, |i, _j, k, l| [i, 0, k, l]);
let n0: f16[1,4,512,64] = emmy::index_map_simple(unsqueeze, |i, _j, k, l| [i, 0, k, l]);  // aka tensor name `unsqueeze_bc`
```

Bindings carry the node id, which the graph keeps unique; a tensor name that differs from it follows in a comment.

### Example 6 — a dynamic extent

`emmy compile -c 'torch.randn(2,8,4).mean(dim=1)' --dynamic 'seq_len@x:1' --ir tensor`

Before:

```
# Graph: 6 nodes, 1 inputs, 1 outputs

inputs:
  x: (2, seq_len, 4) f32

constants:
  mean_keepdim_count: (1,) f32

mean_keepdim_sum       =  sum(x, axis=1)                                   -> (2, 1, 4) f32
mean_keepdim_count_bc  =  mean_keepdim_count[na]                           -> (2, 1, 4) f32
mean_keepdim           =  divide(mean_keepdim_sum, mean_keepdim_count_bc)  -> (2, 1, 4) f32
mean                   =  mean_keepdim[i, na, j]                           -> (2, 4) f32

outputs:
  mean: (2, 4) f32
```

After:

```rust
// 6 nodes, 1 inputs, 1 outputs

struct Dynamic {
    seq_len: usize,
}

struct Inputs<dynamic: Dynamic> {
    x: f32[2,dynamic.seq_len,4],
}

struct Outputs<dynamic: Dynamic> {
    mean: f32[2,4],
}

fn main(dynamic: Dynamic, inputs: Inputs<dynamic>) -> Outputs<dynamic> {
  // constants: checkpoint tensors, and the literals the trace captured
  let mean_keepdim_count: f32[1] = context(dynamic.seq_len);

  let mean_keepdim_sum: f32[2,1,4] = sum(inputs.x, axis=1);
  let mean_keepdim_count_bc: f32[2,1,4] = emmy::index_map_simple(mean_keepdim_count, |_i, _j, _k| [0]);
  let mean_keepdim: f32[2,1,4] = divide(mean_keepdim_sum, mean_keepdim_count_bc);
  let mean: f32[2,4] = emmy::index_map_simple(mean_keepdim, |i, j| [i, 0, j]);

  Outputs { mean }
}
```

Averaging over a dynamic axis divides by its runtime extent. Before, `seq_len` appears in a shape tuple with nothing declaring it, and `mean_keepdim_count` — the constant that *is* that extent — prints with no value at all, since the old format appended `= value` only for static scalars. A reader's only clue is an absence. After, `seq_len` is a field of the struct `main` takes as its first argument, every extent that mentions it says so, and the constant states where its value comes from.

## Assertions added

This PR solidifies some of the assumptions about graph IR that seemed implicit in the code. Nothing was violating them, but nothing was asserting them either.

Two invariants now raise in `Graph.validate`. Nothing in `emmy/` calls that method, so they fire where tests call it by hand — the same reach the structural checks beside them have had.

- **A `copy` node's operand has the output's shape.** `ElementwiseOp.infer_output_shape` says every operand must match the output and that a broadcast has to be an explicit index map, but no compile path calls that method on an elementwise op, and neither `add_node` nor `validate` looked at shapes. A shape-changing `copy` would have reached the loop stage as a silent broadcast. The printer leans on this rather than re-checking, so the check covers `copy` rather than every elementwise operation.

- **An index map's sources agree on element type.** Nothing in the code stated this one; `IndexMapOp.forward` simply allocates the result from the first operand's dtype and copies the rest into it. A reindex moves values and does not convert them, so a source whose dtype differed from its siblings would be a conversion wearing the wrong node. Nothing produces one: across TinyLlama and Qwen3-0.6B at both graph stages, six of the 154 index maps have several sources and none mixes dtypes.

- One more invariant went into `tests/compiler/ir` rather than into `validate`, because checking it means evaluating every coordinate expression over the whole output space: **a coordinate stays inside its operand at the positions its source supplies.** `IndexMapOp.forward` evaluates each source over the entire output grid before applying `select`. The invariant therefore holds only where a source supplies a position, which is also the only place a wrong coordinate would reach the result.

## Bugs found, left for follow-up

This PR fixes none of them; it changes printing plus the two checks above.

**The tracer lowers `aten.permute` to a reshape.** `trace/torch.py` lowers `squeeze` and `permute` through the same branch, building a `ReshapeOp` with the output shape. A reshape reorders nothing, so a permutation that is not layout-neutral produces the right shape and the wrong values. Running the traced graph against torch: `x.permute(2, 0, 1)` on a `(2, 3, 4)` input gives `(4, 2, 3)` in both, and emmy's values match `x.reshape(4, 2, 3)` rather than the permutation. `squeeze` is unaffected.

**`emmy::gather` accepts a narrower index than `torch.gather` and reads it as a different operation.** One `GatherOp` carries two operations, and only the operand shapes distinguish them. The evaluator takes the per-element reading when the index matches the data in rank and in every non-gathered axis; torch requires only `index.size(d) <= input.size(d)`. So `torch.gather` on `[4,8]` data with a `[4,3]` index at axis 0 is a legal gather that emmy computes as the slice lookup instead.

**`GatherOp.infer_output_shape` computes neither result shape.** It returns the data's shape as a conservative fallback and leaves callers to pre-size the output, so nothing compares a declared shape against what the operands imply — which is what would have caught the previous item.

**`CastOp` exists and nothing builds it.** The class carries an explicit dtype, `torch_wire.py` can rebuild one from a stored graph and the constant-folding pass lists it, but no production code creates one. A conversion arrives instead as an identity node whose output tensor declares the new dtype — an index map at the torch stage, an elementwise `copy` once the tensor passes have run — which is why a cast has no operation of its own.

**The tracer materializes captured scalars that nothing then uses.** Resolving a traced call's inputs turns every scalar argument into a `ConstantOp`; a handler that folds the scalar into a field never wires it up. One TinyLlama layer captures 29 and refers to 18, the eleven left over coming from `transpose`, `unsqueeze` and `sdpa`. Later passes sweep them, so the cost is noise in a torch dump.

**`slice` carries operands that duplicate its own fields.** Three captured scalars ride along as operands; two duplicate `dim` and `start`, and the third is the end, which the declared result shape already carries.
