### PR TITLE
Reject unreplayable structural tune winners

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -967,8 +967,11 @@ and the final tune winner is annotated or appended as another proposal only when
 provides both its knob row and cost. When the fastest searched terminal changes the kernel set, the winner is its first
 exact structural replay row: a `PLACE`-only routing row for a placement cut, or the complete pre-split schedule row for
 a cross-CTA reduction. The pieces remain independent tuning targets; promotion never fabricates their heterogeneous
-schedules into one row or falls back to a slower monolithic sibling. A later greedy deploy replay can select different
-golden/DB evidence and is never paired with that search reward. These `-O1` ranking numbers never populate
+schedules into one row or falls back to a slower monolithic sibling. A cross-CTA parent becomes a tune winner only
+when its ordinary schedule pins reproduce the decisions on every directly measured child kernel; a parent whose pins
+name a different independently tuned child is left unpromoted. `PLACE`-only rows remain routing receipts and do not
+claim the child schedules. A later greedy deploy replay can select different golden/DB evidence and is never paired
+with that search reward. These `-O1` ranking numbers never populate
 `emmy_us` / `cublas_us`; promotion still requires the separate repeated, correct, deployable `-O3` A/B gate.
 
 Hybrid-vs-MCTS baselines start from identical inventory-only working files: verified rows are not copied into either

--- a/emmy/compiler/pipeline/search/pins.py
+++ b/emmy/compiler/pipeline/search/pins.py
@@ -33,12 +33,14 @@ def _stampable_reduce(want: str) -> str | None:
     return "/".join(tokens[1:])
 
 
-def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | None:
+def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict], *, reject_conflicts: bool = False) -> str | None:
     """Describe pins not realized by any compiled CUDA kernel, or return ``None``.
 
     A registered family with no realized key is ungateable because serialized IR
     can omit knob stamps. Declared OFF values mean not-applicable rather than a
     conflicting realization; an unknown absent family remains a likely typo.
+    ``reject_conflicts`` additionally rejects any matching child scope that decided
+    a different non-OFF value, even when another child realized the requested pin.
     """
     if not any(kernel_knobs):
         return None
@@ -57,13 +59,15 @@ def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | Non
                     continue
                 probe = rest
         others: list[str] = []
+        conflicts: list[str] = []
         saw_off = False
         hit = False
         for raw in kernel_knobs:
             for key, got in raw.items():
                 if family_of(key) != fam:
                     continue
-                if pin_key_matches(name, key) and values_equal(name, probe, got):
+                same_scope = pin_key_matches(name, key)
+                if same_scope and values_equal(name, probe, got):
                     hit = True
                 elif is_off_value(fam, got):
                     saw_off = True
@@ -71,13 +75,16 @@ def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | Non
                     spell = f"{key}={got}" if key != name else str(got)
                     if spell not in others:
                         others.append(spell)
-            if hit:
+                    if same_scope and spell not in conflicts:
+                        conflicts.append(spell)
+            if hit and not reject_conflicts:
                 break
-        if hit:
+        if hit and (not reject_conflicts or not conflicts):
             continue
         if not others and not saw_off and get(fam) is not None:
             continue
-        ran = "/".join(others) if others else ("(off)" if saw_off else "(unset)")
+        ran_values = conflicts if reject_conflicts and conflicts else others
+        ran = "/".join(ran_values) if ran_values else ("(off)" if saw_off else "(unset)")
         misses.append(f"{name}={want} realized {ran}")
     return f"unreproducible pin: {'; '.join(misses)}" if misses else None
 

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -46,6 +46,7 @@ from emmy.compiler.pipeline.knob import (
 )
 from emmy.compiler.pipeline.search.candidate import LazyCandidate
 from emmy.compiler.pipeline.search.db import NodeRow, PerfStats
+from emmy.compiler.pipeline.search.pins import unreproducible_pin_flag
 from emmy.compiler.pipeline.search.policy.base import Search
 from emmy.compiler.pipeline.search.policy.terminal_bench import bench_terminal_async, rebench_o3_async
 from emmy.compiler.structural import digest
@@ -90,6 +91,10 @@ class SearchNode:
     # CUDA kernels (for example a split reduction + combine). A candidate-file
     # annotation is only unambiguous in the one-CudaOp case.
     realized_cuda_ops: int | None = field(default=None, repr=False)
+    # Decision rows from the directly measured per-kernel receipts. Structural winners use them to
+    # reject a parent row whose ordinary schedule pins describe a different
+    # independently tuned child than the terminal actually measured.
+    realized_cuda_knobs: list[dict] | None = field(default=None, repr=False)
     # The leaf's deployable -O3 re-bench median (``observe_o3``), ``None`` when the
     # config wasn't in the re-bench tolerance band (or the sweep already ran at -O3).
     # Read back by ``_collect_node_records`` to emit the leaf's -O3-regime node row.
@@ -250,6 +255,7 @@ class TuningSearch(Search):
         # fork-prefix when no candidate is supplied.
         token.realized_knobs = self._realized_knobs(candidate) if candidate is not None else self._node_knobs(token)
         token.realized_cuda_ops = self._realized_cuda_op_count(candidate)
+        token.realized_cuda_knobs = [dict(decision_view(knobs)) for knobs, _us, _status in kernels] if kernels is not None else None
         token.bench_stats = stats
         token.bench_status = status
         reward = (1.0 / stats.median) if status == "ok" and stats.median > 0 else 0.0
@@ -429,6 +435,12 @@ class TuningSearch(Search):
         if structural is None and node.realized_knobs is None and (node.realized_cuda_ops or 0) > 1:
             structural = self._structural_row(validated_input_route)
         if structural is not None:
+            place_only = all(family_of(key) == "PLACE" for key in structural)
+            if not place_only and (
+                not node.realized_cuda_knobs
+                or unreproducible_pin_flag(structural, node.realized_cuda_knobs, reject_conflicts=True) is not None
+            ):
+                return None
             return structural, float(node.bench_stats.median), node.realized_cuda_ops, True
         if node.realized_knobs is None:
             return None

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -374,6 +374,7 @@ def test_structural_multi_cuda_proposal_survives_search_continuation_and_reload(
             leaf.best_reward = 1.0 / 59.61
             leaf.realized_knobs = None
             leaf.realized_cuda_ops = 2
+            leaf.realized_cuda_knobs = [dict(node.op.knobs) for node in terminal.nodes.values()]
             leaf.bench_status = "ok"
             leaf.bench_stats = search.last_stats
             search.tree.root.children = [leaf]

--- a/tests/compiler/pipeline/search/test_node_record_collection.py
+++ b/tests/compiler/pipeline/search/test_node_record_collection.py
@@ -32,10 +32,11 @@ def _bench_fail_leaf(*, realized_knobs: dict | None) -> SearchNode:
     return node
 
 
-def _ok_leaf(us: float, *, realized_knobs: dict | None, cuda_ops: int) -> SearchNode:
+def _ok_leaf(us: float, *, realized_knobs: dict | None, cuda_ops: int, cuda_knobs: list[dict] | None = None) -> SearchNode:
     node = SearchNode(candidate=object())
     node.realized_knobs = realized_knobs
     node.realized_cuda_ops = cuda_ops
+    node.realized_cuda_knobs = cuda_knobs
     node.bench_status = "ok"
     node.bench_stats = PerfStats(median=us, min=us, max=us, mean=us, variance=0.0, n_samples=1)
     return node
@@ -98,7 +99,15 @@ def test_validated_structural_input_records_the_original_parent_linked_edge() ->
         "RASTER": "",
     }
     tree = SearchTree()
-    leaf = _ok_leaf(59.61, realized_knobs=None, cuda_ops=2)
+    leaf = _ok_leaf(
+        59.61,
+        realized_knobs=None,
+        cuda_ops=2,
+        cuda_knobs=[
+            {**route, "REDUCE": ""},
+            {"WORK": "", "TILE": "", "REDUCE": "", "STAGE": "", "RASTER": ""},
+        ],
+    )
     leaf.visits = 1
     leaf.best_reward = 1.0 / 59.61
     tree.root.children = [leaf]
@@ -133,7 +142,15 @@ def test_best_realized_returns_the_fastest_terminal_with_its_structural_replay_r
     tree = SearchTree()
     row = {"WORK": "w1x1", "TILE": "mma_m16n8k16_f16_f32/f1x4/k8", "REDUCE": "g8k", "STAGE": "d1/smem"}
     route = SearchNode(candidate=SimpleNamespace(resolved_knobs=row), parent=tree.root)
-    fast = _ok_leaf(6.0, realized_knobs=None, cuda_ops=2)
+    fast = _ok_leaf(
+        6.0,
+        realized_knobs=None,
+        cuda_ops=2,
+        cuda_knobs=[
+            {**row, "REDUCE": ""},
+            {"WORK": "", "TILE": "", "REDUCE": "", "STAGE": "", "RASTER": ""},
+        ],
+    )
     fast.parent = route
     route.children = [fast]
     tree.root.children = [_ok_leaf(18.0, realized_knobs={"WORK": "t64"}, cuda_ops=1), route]
@@ -142,6 +159,29 @@ def test_best_realized_returns_the_fastest_terminal_with_its_structural_replay_r
     search.tree = tree
 
     assert search.best_realized() == (stamp_schedule_families(row), 6.0, 2, True)
+
+
+def test_best_realized_rejects_a_structural_parent_that_names_a_different_child_schedule() -> None:
+    tree = SearchTree()
+    row = {"WORK": "w4x2", "TILE": "mma_m16n8k16_f16_f32/f1x2/k8", "REDUCE": "g8k", "STAGE": "d1/smem"}
+    route = SearchNode(candidate=SimpleNamespace(resolved_knobs=row), parent=tree.root)
+    fast = _ok_leaf(
+        6.0,
+        realized_knobs=None,
+        cuda_ops=2,
+        cuda_knobs=[
+            {**row, "WORK": "w1x2", "REDUCE": ""},
+            {"WORK": "", "TILE": "", "REDUCE": "", "STAGE": "", "RASTER": ""},
+        ],
+    )
+    fast.parent = route
+    route.children = [fast]
+    tree.root.children = [_ok_leaf(18.0, realized_knobs={"WORK": "t64"}, cuda_ops=1), route]
+
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+
+    assert search.best_realized() is None
 
 
 def test_best_realized_uses_a_compatible_multi_cuda_terminal_placement_route() -> None:


### PR DESCRIPTION
## Summary

- retain the directly measured CUDA child decision rows on MCTS terminals
- reject a cross-CTA structural tune winner when its parent schedule pins do not reproduce every measured child decision
- preserve PLACE-only rows as routing receipts and document the fail-closed promotion contract

## GPU defect receipt

The exact A100 hybrid search at `/home/riftuser/.cache/emmy/a100-kernels-94e2a74a-002` persisted a parent
`WORK=w4x2, REDUCE=g8k` winner whose aggregate latency used an independently optimized `WORK=w1x2` partial child. The
W1x2 child source was `d6c42985...` (block 64), while a fresh parent-pinned replay emitted `a9eaa3f1...` (W4x2, block
256). A copied-DB replay and an absent-state terminal-working-golden replay selected different schedules, so the
winner was not self-contained deploy evidence. The exact765 finalist manifest quarantined both affected aggregate
rows and promoted no evidence from them.

This change leaves that measured terminal unpromoted instead of pairing its reward with a parent row that cannot
reproduce the child schedule. It makes no performance claim.

## Verification

- focused search/working-golden tests: 37 passed
- `make test`: 3182 passed, 563 skipped, 1 xfailed
- `make lint`: clean; 637 files formatted
- `git diff --check`: clean
