### PR TITLE
compiler: bound paired contraction fragment state

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -88,9 +88,10 @@ fork = build_fork_tree(list(space), levels=[WORK, *site keys, RASTER], materiali
 ```
 
 **The pool is a SPACE, not a list** (`lowering/tile/_pool.py`). A site offers BLOCKS — one rectangle per assignment
-of everything but `STAGE`, crossed with the stages legal for it — because legality never reads the transport:
-`_work_holds` and the row union see the resolved tiles and the cooperative width alone, so `STAGE` and the
-kernel-global `RASTER` multiply through the filter unconditionally. A row therefore stands for
+of everything but `STAGE`, crossed with the stages legal for it. Stage resolution and its resource checks first
+filter that stage axis; `_work_holds` and the row union then see only the resolved tiles and cooperative width, so
+the remaining `STAGE` values and kernel-global `RASTER` multiply through the row filter unconditionally. A row
+therefore stands for
 `width x len(rasters)` candidates rather than one, the validation runs once per legal `(TILE, REDUCE)` assignment
 (~10k instead of ~122k on a static f16 square matmul), and the exact candidate count is a prefix-sum lookup that
 builds nothing. `PoolSpace` reads that structure two ways — iterate every member, or address member *i* — through
@@ -146,8 +147,16 @@ Three layers own three different questions, and keeping them apart is what stops
   inner stride); the categorical ones (operand dtype, transport, a fragment-unrealizable gather epilogue) are plain
   predicates. The smem budget is enforced by the stage RESOLVERS there, which return the largest legal `Stage` or
   decline — a size, not a yes/no. These are also the recursion's downward filter.
+  A paired score + value contraction has one additional resource lower bound: the enclosing C fragments stay live
+  while the score block's `RegFragment` families are emitted; the enclosing A/B fragments begin afterwards. The
+  larger of that overlap and the ordinary enclosing A/B/C drain must fit both the 255-register thread limit and the
+  64K-register CTA file. This is not an occupancy or profitability heuristic: it counts the fragment arrays under
+  their stated lifetimes, before scalar state and address temporaries, and refuses only a row whose required state
+  cannot reside in the register-file envelope. Standalone contractions and smaller worker inventories remain
+  governed by their ordinary per-tile fragment bound.
 - **CHOICE** is the walk itself: which families a SITE offers and how a row becomes a `TileOp` — which values are
-  legal here, never which of them is better. Dispatch is TWO stored-param predicates on the node — `node.axis is None` (the register
+  legal here, never which of them is better. Dispatch is TWO stored-param predicates on the node —
+  `node.axis is None` (the register
   strip) and `is_contraction(node)` (tile × stage × reduce), else the reduce partition. **Not `AxisRole`**: the role
   never selected a fourth arm, `TWISTED` is derived by matching the combine's operation family (an operation match
   wearing an algebraic name), and `PLANAR` is the residue. The role stays a loop annotation and a materializer read.

--- a/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
@@ -42,7 +42,12 @@ from emmy.compiler.ir.stmt import Body, Load, Loop, Write
 from emmy.compiler.ir.stmt.passes import has_contraction_tail
 from emmy.compiler.ir.tile.ops import chain_edge, cone_seam
 from emmy.compiler.pipeline.passes.lowering._addr import BYTE_SLAB_PAD, gmem_axis_step, split_pair
-from emmy.compiler.pipeline.search.space import MAX_BLOCK_THREADS, WARP_LANES
+from emmy.compiler.pipeline.search.space import (
+    MAX_BLOCK_THREADS,
+    MAX_REGISTERS_PER_CTA,
+    MAX_REGISTERS_PER_THREAD,
+    WARP_LANES,
+)
 
 # TMA hardware: every box dim must fall in 1..256, and the swizzle-split box caps the operand rank
 # at 4 so it stays within the 5-dim limit.
@@ -236,6 +241,66 @@ def warp_k_step(node: Fold, plan: TilePlan) -> str | None:
         f"warp TILE K-step {step} (atom_k={plan.atom.atom_k}*bk={plan.bk}) does not divide the static "
         f"contraction K={k}, and atom {plan.atom.name}'s byte-gather loaders have no masked-K zero-fill; "
         f"pin a K that is a multiple of {step}, or drop the fp8 atom token."
+    )
+
+
+def _fragment_registers(atom, role: str) -> int:
+    """The exact per-lane register count of one emitted mma fragment."""
+    explicit = atom.fragment_nregs(role)
+    if explicit is not None:
+        return explicit
+    m, n, k = atom.ptx_shape
+    dtype = atom.operand_dtype(role)
+    if role == "a":
+        return m * k * dtype.nbytes // 128
+    if role == "b":
+        return n * k * dtype.nbytes // 128
+    return m * n // (64 if dtype.nbytes == 2 else 32)
+
+
+def paired_fragment_registers(node: Fold, tile: TilePlan, stage: Stage | None) -> tuple[int, int] | None:
+    """Return ``(required, available)`` peak live registers/lane for a paired score + value contraction.
+
+    A chained computed-A fill keeps the enclosing output fragments live while it builds one score
+    block through the same mma atom. Count the exact ``RegFragment`` families emitted by
+    ``_MmaOps.state`` for both contractions. This is a lower bound: scalar carrier state and
+    address temporaries are intentionally absent, so the check rejects only rows whose fragments
+    alone cannot fit the CTA register file.
+    """
+    score_node = chain_edge(node.a, node.axis.name)
+    if not (tile.is_warp and stage is not None and score_node is not None):
+        return None
+    atom = tile.atom
+    if stage.bk_elems % atom.atom_n:
+        return None  # the fragment score block does not realize this geometry
+    a_regs = _fragment_registers(atom, "a")
+    b_regs = _fragment_registers(atom, "b")
+    c_regs = _fragment_registers(atom, "c")
+    # The f16-accumulate atom keeps an additional f32 shadow C family.
+    if atom.operand_dtype("c").nbytes == 2:
+        c_regs += atom.atom_m * atom.atom_n // 32
+    depth = max(1, stage.reg_depth)
+    channels = len(node.channels)
+    outer_c = channels * tile.reg_m * tile.reg_n * c_regs
+    outer = tile.reg_m * depth * a_regs + channels * (tile.reg_n * depth * b_regs + tile.reg_m * tile.reg_n * c_regs)
+    score_n = stage.bk_elems // atom.atom_n
+    score_channels = len(score_node.channels)
+    score = tile.reg_m * a_regs + score_channels * (score_n * b_regs + tile.reg_m * score_n * c_regs)
+    available = min(MAX_REGISTERS_PER_THREAD, MAX_REGISTERS_PER_CTA // tile.block_threads)
+    # Outer A/B are first loaded in the drain after the score block. Only the initialized outer C
+    # fragments span both regions; the two A/B families may reuse registers.
+    return max(outer, outer_c + score), available
+
+
+def paired_fragment_register_budget(node: Fold, tile: TilePlan, stage: Stage | None) -> str | None:
+    """Whether coexisting score/output mma fragments fit the CTA register-file envelope."""
+    counts = paired_fragment_registers(node, tile, stage)
+    if counts is None or counts[0] <= counts[1]:
+        return None
+    required, available = counts
+    return (
+        f"paired contractions require at least {required} live fragment registers/thread, over the "
+        f"{available}-register envelope at {tile.block_threads} threads/CTA"
     )
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1114,10 +1114,12 @@ def _contraction_blocks(term: _Term, node, work: Workers | None) -> list[Block]:
     out = []
     for plan in plans:
         for red in _contraction_reduces(term, node, plan):
+            pinned = pin is not None
             stages = tuple(
                 stage
                 for stage in _stage_values(term, node, plan)
                 if not (work is not None and work.producer) or legal.enforce(legal.producer_transport(stage), pinned=False)
+                if red.needs_split or legal.enforce(legal.paired_fragment_register_budget(node, plan, stage), pinned=pinned)
             )
             if stages:
                 out.append(Block({"TILE": plan, "REDUCE": red}, stages))

--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -336,6 +336,13 @@ MAX_FRAGMENT_CELLS = 32
 # so 32 cells remain legal; Volta's logical 16x16 cell spends eight and is capped at 16 cells.
 MAX_FRAGMENT_REGISTERS = 128
 
+# Hardware register ceilings shared by every NVIDIA target Emmy supports. A schedule whose
+# statically declared fragments alone exceed either limit must spill before accounting for scalar
+# state, addresses, or compiler temporaries. The paired-contraction legality gate uses these as a
+# lower-bound check; it does not try to predict occupancy or profitability.
+MAX_REGISTERS_PER_THREAD = 255
+MAX_REGISTERS_PER_CTA = 64 * 1024
+
 # The scalar register-tile candidate SPACE: ``(par_n, par_m)`` parallel thread-tile widths ×
 # ``(reg_n, reg_m)`` per-thread register sub-tile widths, generated from the one constraint that
 # bounds it — the CTA thread budget, which a scalar tile spends ``par_n·par_m`` of. The register

--- a/tests/compiler/passes/test_pool_space.py
+++ b/tests/compiler/passes/test_pool_space.py
@@ -91,7 +91,9 @@ EXPECTED: dict[str, list[tuple[tuple[str, ...], int, str]]] = {
     "warp_matmul": [(("TILE", "STAGE", "REDUCE"), 74926, "67b94c73a84918b48aa104e1575f2399")],
     "reduce_matvec": [(("TILE", "STAGE", "REDUCE"), 20, "bc42c1d8f8640471f226c25327e6d792")],
     "fused_norm_linear": [(("TILE", "STAGE@a1", "STAGE", "REDUCE@a1", "REDUCE"), 21495, "3931bd58b58a61f03789de5e68ea4747")],
-    "flash_pair": [(("TILE", "STAGE", "REDUCE"), 3541, "4d3f19fcca6a294d9651ea9bc7ddba4b")],
+    # Over-budget paired score + value rows are intentionally absent; other fixture pools do not
+    # carry concurrently-live contraction fragments and remain byte-identical.
+    "flash_pair": [(("TILE", "STAGE", "REDUCE"), 3457, "b3ecfbf96e98237f7e1fe8ee258d6dec")],
 }
 
 

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -429,7 +429,7 @@ def test_norm_linear_cone_is_an_inline_node_tree():
     assert operand_body(c.a) == tuple(cone.lower()) == (*pro, *cell)
 
 
-def _attention_cone_term() -> tuple[Fold, Fold]:
+def _attention_cone_term(kv_extent: int = 32, score_extent: int = 16) -> tuple[Fold, Fold]:
     """The attention shape of the computed-A cone, built directly: the ``softmax(Q·Kᵀ)·V``
     contraction over the KV axis whose A cone is ``exp(s − m)·(1/d)`` over a COMPUTED score — one
     edge for the row statistic (the twisted ``(m, d)`` pair) and one for the per-cell score
@@ -445,8 +445,8 @@ def _attention_cone_term() -> tuple[Fold, Fold]:
 
     names, other = ("mx", "dn"), ("mx__o", "dn__o")
     stat = Fold(
-        axis=Axis("kv", Dim(32)),
-        operands=(score("kv", Axis("dd", Dim(16)), "s1"),),
+        axis=Axis("kv", Dim(kv_extent)),
+        operands=(score("kv", Axis("dd", Dim(score_extent)), "s1"),),
         lift=Lambda(params=("kv", "s1"), body=Body(()), results=("s1", 1.0)),
         init=(float("-inf"), 0.0),
         combine=Lambda(params=names + other, body=Body(exp_combine_states(names, other)), results=names),
@@ -462,11 +462,94 @@ def _attention_cone_term() -> tuple[Fold, Fold]:
                 Assign(name="pw", op="multiply", args=("rd", "ex1")),
             )
         ),
-        operands=(prologue, score("kvb", Axis("ddb", Dim(16)), "s2")),
+        operands=(prologue, score("kvb", Axis("ddb", Dim(score_extent)), "s2")),
     )
     v = Load(names=("vl",), input="v", index=(Var("kvb"), Var("n")))
-    pv = Fold.contraction(k_axis=Axis("kvb", Dim(32)), a=cone, channels=(Channel(b=v, acc="o"),))
+    pv = Fold.contraction(k_axis=Axis("kvb", Dim(kv_extent)), a=cone, channels=(Channel(b=v, acc="o"),))
     return Fold.projection(body=Body(()), operands=(pv,)), cone
+
+
+def _attention_schedule_term(kv_extent: int = 512, value_extent: int = 128):
+    """An A100 head128 paired-contraction term and its outer value fold."""
+    from emmy.compiler.ir.tile import Placement
+
+    root, _ = _attention_cone_term(kv_extent=kv_extent, score_extent=128)
+    pv = root.operands[0]
+    inputs = {name: Tensor(name, (Dim(1),), dtype=F16) for name in ("q", "k", "v")}
+    tile = TileOp(op=root, place=Placement(free=(Axis("m", Dim(kv_extent)), Axis("n", Dim(value_extent)))), inputs=inputs)
+    return tile, pv
+
+
+def test_paired_fragment_register_bound_matches_emitted_lifetimes():
+    """The bound counts the peak live score/output ``RegFragment`` families."""
+    from emmy.compiler.ir.schedule import Stage, TilePlan, Workers
+    from emmy.compiler.pipeline.passes.lowering.tile import _legality as legal
+
+    _tile, pv = _attention_schedule_term()
+    bad = TilePlan.parse("mma_m16n8k16_f16_f32/f1x8/k8", Workers.parse("w8x2"))
+    fixed = TilePlan.parse("mma_m16n8k16_f16_f32/f1x8/k4", Workers.parse("w8x2"))
+    historical = TilePlan.parse("mma_m16n8k16_f16_f32/f1x16/k8", Workers.parse("w4x1"))
+    wide_k4 = TilePlan.parse("mma_m16n8k16_f16_f32/f1x16/k4", Workers.parse("w8x2"))
+
+    assert legal.paired_fragment_registers(pv, bad, Stage(depth=1, transport="smem", bk_elems=128)) == (132, 128)
+    assert legal.paired_fragment_registers(pv, fixed, Stage(depth=1, transport="smem", bk_elems=64)) == (84, 128)
+    assert legal.paired_fragment_registers(pv, historical, Stage(depth=1, transport="smem", bk_elems=128)) == (164, 255)
+    assert legal.paired_fragment_registers(pv, wide_k4, Stage(depth=1, transport="smem", bk_elems=64)) == (116, 128)
+
+
+def test_attention_schedule_refuses_only_the_over_budget_paired_row(monkeypatch):
+    """The real seq512 structure drops bad K8, retains K4, and accepts the historical K8 pin."""
+    from emmy.compiler.ir.schedule import Workers
+    from emmy.compiler.pipeline.passes.lowering.tile import _schedule as schedule
+
+    tile, pv = _attention_schedule_term()
+    ctx = Context.from_target((8, 0), gpu_name="NVIDIA A100 80GB")
+    term = schedule._Term(tile, tile.place.on_grid(), ctx)
+    blocks = schedule._contraction_blocks(term, pv, Workers.parse("w8x2"))
+    unsplit = {block.values["TILE"].spell() for block in blocks if not block.values["REDUCE"].needs_split}
+    assert "mma_m16n8k16_f16_f32/f1x8/k8" not in unsplit
+    assert "mma_m16n8k16_f16_f32/f1x8/k4" in unsplit
+    split_tile, split_pv = _attention_schedule_term(kv_extent=1024)
+    split_term = schedule._Term(split_tile, split_tile.place.on_grid(), ctx)
+    split_blocks = schedule._contraction_blocks(split_term, split_pv, Workers.parse("w8x2"))
+    assert any(
+        block.values["TILE"].spell() == "mma_m16n8k16_f16_f32/f1x8/k8" and block.values["REDUCE"].spell() == "g8k" for block in split_blocks
+    ), "the split route reschedules its child kernels, so the unsafe unsplit parent's bound does not apply"
+
+    monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f1x16/k8")
+    monkeypatch.setenv("EMMY_STAGE", "d1/smem")
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    pinned = schedule._Term(tile, tile.place.on_grid(), ctx)
+    assert schedule._contraction_blocks(pinned, pv, Workers.parse("w4x1"))
+
+    monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f1x16/k4")
+    wide_tile, wide_pv = _attention_schedule_term(value_extent=256)
+    wide_k4 = schedule._Term(wide_tile, wide_tile.place.on_grid(), ctx)
+    assert schedule._contraction_blocks(wide_k4, wide_pv, Workers.parse("w8x2"))
+
+    monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f1x8/k8")
+    refused = schedule._Term(tile, tile.place.on_grid(), ctx)
+    with pytest.raises(ValueError, match="132 live fragment registers/thread.*128-register envelope"):
+        schedule._contraction_blocks(refused, pv, Workers.parse("w8x2"))
+
+    monkeypatch.setenv("EMMY_REDUCE", "g8k")
+    pinned_split = schedule._Term(split_tile, split_tile.place.on_grid(), ctx)
+    assert schedule._contraction_blocks(pinned_split, split_pv, Workers.parse("w8x2"))
+
+
+def test_standalone_k8_contraction_has_no_paired_fragment_bound():
+    """A K8 tile without a chained score remains governed by the ordinary per-tile budget."""
+    from emmy.compiler.ir.pure.fold import Channel
+    from emmy.compiler.ir.schedule import Stage, TilePlan, Workers
+    from emmy.compiler.pipeline.passes.lowering.tile import _legality as legal
+
+    node = Fold.contraction(
+        k_axis=Axis("k", Dim(512)),
+        a=Load(name="a", input="a", index=(Var("m"), Var("k"))),
+        channels=(Channel(b=Load(name="b", input="b", index=(Var("k"), Var("n"))), acc="o"),),
+    )
+    plan = TilePlan.parse("mma_m16n8k16_f16_f32/f1x8/k8", Workers.parse("w8x2"))
+    assert legal.paired_fragment_register_budget(node, plan, Stage(depth=1, transport="smem", bk_elems=128)) is None
 
 
 def test_cone_per_cell_edge_is_evaluated_inline_and_carries_no_slice():


### PR DESCRIPTION
## Summary

- reject unsplit paired score + value contraction schedules when their peak live `RegFragment` state cannot fit the hardware register envelope
- retain smaller legal rows, historical safe K8 rows, standalone contractions, and split-K structural routes whose child kernels are rescheduled
- document the legality invariant and pin the intentional attention pool-space change

## Correctness evidence

The failing A100 W8x2/f1x8/k8/d1-smem row requires at least 132 live fragment registers per lane at 512 threads, above the 128-register per-thread CTA envelope. Its deployed kernel compiled at REG128 + STACK184 and produced nondeterministic incorrect output. The strict W8x2/f1x8/k4 row requires 84 registers; the historical W4x1/f1x16/k8 row requires 164 at 128 threads and remains legal. The bound is the exact peak of the ordinary enclosing drain and the enclosing C fragments plus nested score fragments, so outer A/B state is not double-counted.

The flash-pair pool changes intentionally from 3,541 rows (`4d3f19fcca6a294d9651ea9bc7ddba4b`) to 3,457 rows (`b3ecfbf96e98237f7e1fe8ee258d6dec`).

## Verification

- `make test` equivalent with worktree-first imports: 3,186 passed, 563 skipped, 1 xfailed
- `ruff check .`: passed
- `ruff format --check .`: 638 files clean
- focused attention legality, pool-space, move-catalog, and Volta MMA suites: passed
- `git diff --check`: passed

Base: `c39d405c898143d9451d29bfe23e83f05e10b201`
Commit: `02e48e792995ff477edfa2641e74f736d2539ddf`
Tree: `024f541460806d60f062a639e60a29b0b7548b3f`
