### PR TITLE
Fix MoE rider activation dtype

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -149,7 +149,8 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   per-token-independent; since A3 both halves copy once into slices of one persistent shared joint destination
   (`_rider_dest`, cached per column width for gemma-4's heterogeneous layers) instead of clone + `torch.cat`,
   halving the rider seam bytes and removing the per-layer allocation churn — the caller must consume rider
-  outputs before its next rider call (attention does, within the layer) — which is what lets
+  outputs before its next rider call (attention does, within the layer). Each destination uses its declared output
+  dtype, so an fp32 residual model's normalized MoE activation remains in the projection dtype. This is what lets
   `--max-num-batched-tokens` default to `capacity + bucket`: a full
   chunk step keeps carrying its decode riders and the previous prompt's 1-token BOS tail instead of freezing every
   decoding request for the whole chunk and deferring first-token sampling (the measured c=4/c=8 TTFT structure), and

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -1929,7 +1929,7 @@ class EmmyGenRunner:
             if output_count == 1:
                 specs = (("hidden", residual.dtype),)
             elif output_count == 2:
-                specs = (("hidden", residual.dtype), ("moe_xn", residual.dtype))
+                specs = (("hidden", residual.dtype), ("moe_xn", self._activation_dtype))
             elif output_count == 3:
                 specs = (("hidden", residual.dtype), ("moe_xn", self._activation_dtype), ("shared_expert", torch.float32))
             else:

--- a/tests/serving/generation/test_gen_runner.py
+++ b/tests/serving/generation/test_gen_runner.py
@@ -94,6 +94,37 @@ def test_static_only_runner_counts_layers_without_symbolic_programs():
         )
 
 
+def test_float32_residual_moe_rider_keeps_normalized_activation_in_float16():
+    """The two-output fp32-residual post rider must not allocate ``xn`` in residual dtype."""
+    torch = pytest.importorskip("torch")
+
+    class PostProgram:
+        output_names = ("hidden", "moe_xn")
+
+        def run_device(self, inputs, *, out):
+            _attn_out, residual = inputs
+            out[0].copy_(residual)
+            out[1].copy_(residual.to(out[1].dtype))
+
+    runner = EmmyGenRunner.__new__(EmmyGenRunner)
+    runner._post_m1 = None
+    runner._post_decode = [PostProgram()]
+    runner._post_prefill = [PostProgram()]
+    runner._post = []
+    runner._pre_decode = [object()]
+    runner._pre_prefill = [object()]
+    runner._decode_bucket = 2
+    runner._prefill_bucket = 4
+    runner._activation_dtype = torch.float16
+
+    residual = torch.randn(6, 8, dtype=torch.float32)
+    hidden, normalized = runner._route_post_device(0, torch.randn(6, 8, dtype=torch.float16), residual)
+
+    assert hidden.dtype == torch.float32
+    assert normalized.dtype == torch.float16
+    assert torch.nn.Linear(8, 2, dtype=torch.float16)(normalized).dtype == torch.float16
+
+
 def test_pipeline_runner_tracks_absolute_layers_and_boundary_ownership():
     runner = EmmyGenRunner(
         embed_weight=None,


### PR DESCRIPTION
## Summary

- keep normalized MoE rider outputs in the activation dtype when the residual stream is fp32
- cover the two-output rider path and its downstream projection with a CPU regression
- document the rider destination dtype contract

## Testing

- focused serving generation test file: 16 passed
- full make test: 3159 passed, 583 skipped, 1 xfailed
- make lint

The macOS full-suite run prepended a temporary non-repository timeout shim because GNU timeout is not installed; the shim only executes the synthetic test commands, which return immediately.