### PR TITLE
Preserve Boolean pins in A/B replay

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -214,7 +214,11 @@ process unless `--target` narrows the file to one exact or unambiguous substring
 Invoke `emmy run` again when independent process observations are required. Inventory and proposal rows select the
 graph but are not trusted as automatic A/B pins; only verified rows with paired measurements auto-pin, while a
 proposal is tested explicitly with `run --bench --ab 'KNOBS…'`. Embedded Loop IR stores stable algebra rather than
-derived structural stamps, so `run --golden` replays it through the full compiler pipeline. When that replay has
+derived structural stamps. Registered Boolean values in an explicit `--ab` row remain input pins, so false values are
+not dropped with kernel pass markers and the JSON record identifies the inputs that were compiled. A failed row with
+no realized graph reports the precision lane requested by those parsed input pins, including explicit false
+overrides, rather than defaulting every failure to the standard lane. `run --golden` replays it through the full
+compiler pipeline. When that replay has
 pinned rows, its greedy execution returns same-input outputs so every pinned schedule receives the normal wrong-answer
 check; strict JSON labels the reference `same-input-greedy` when no Torch twin exists. That reference is accepted only
 for an embedded Loop target whose worker returned the exact same inputs and outputs; runnable frontend targets still

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -643,15 +643,23 @@ _GoldenBench = namedtuple("_GoldenBench", "sample graph bench flags status corre
 
 
 def _lane(knobs: dict) -> str:
-    """The precision REGIME a knob dict realizes: ``"fm"`` (an f16-accumulate mma atom or
-    ``FAST_EXP``, :func:`~emmy.compiler.pipeline.search.golden.fast_math_knobs`) else ``"std"``.
-    Derived from the knobs, never a stored flag, so it can't drift. A working-golden target
+    """The precision REGIME a knob dict realizes or explicitly requests: ``"fm"`` for a
+    precision-trading input pin, f16-accumulate mma atom, or ``FAST_EXP``; else ``"std"``.
+    Successful rows derive it from realized knobs; a failed row falls back to its parsed pins.
+    A working-golden target
     pins BOTH the std and the ``[fm]`` config recorded under one name; comparing a pinned ``[fm]``
     latency against a ``"std"`` greedy manufactures a phantom regression, so every A/B row (and the
     greedy it's compared to) carries its lane and the parser filters to matching lanes."""
-    from emmy.compiler.pipeline.search.golden import fast_math_knobs  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import get  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.golden import fast_math_knobs, precision_trading_pins  # noqa: PLC0415
 
-    return "fm" if fast_math_knobs(knobs) else "std"
+    input_pins = {}
+    for name in ("FAST_MATH", "FAST_EXP", "F16_MMA_F32_ACC", "FP8_MMA"):
+        if name not in knobs:
+            continue
+        raw = knobs[name]
+        input_pins[name] = raw if isinstance(raw, bool) else get(name).parse(str(raw))
+    return "fm" if fast_math_knobs(knobs) or precision_trading_pins(input_pins) else "std"
 
 
 def _graph_lane(graph) -> str:
@@ -661,6 +669,13 @@ def _graph_lane(graph) -> str:
     the union keeps only the last kernel's value, and the reported lane becomes
     launch-order-dependent — the phantom-regression trap this feature exists to prevent."""
     return "fm" if any(_lane(d) == "fm" for d in _cuda_knob_dicts(graph)) else "std"
+
+
+def _pinned_lane(golden_bench) -> str:
+    """The realized lane of a pinned row, with its requested lane only as a failure fallback."""
+    if golden_bench.graph is not None:
+        return _graph_lane(golden_bench.graph)
+    return _lane(_sample_replay_knobs(golden_bench.sample))
 
 
 def _intensity_floor_flag(sample, total_us: float) -> str | None:
@@ -834,18 +849,28 @@ def _cuda_knob_dicts(graph) -> list[dict]:
 
 
 def _ab_samples(specs, dynamic=None):
-    """One shapeless pseudo-sample per ``--ab "K1=V1,K2=V2"`` spec: ``.knobs`` to pin
-    (the ``EMMY_KNOBS`` grammar), ``.name`` the table label, ``.shape None`` —
+    """One shapeless pseudo-sample per ``--ab "K1=V1,K2=V2"`` spec: ``.knobs`` holds
+    schedule pins, ``.pins`` Boolean input pins, ``.name`` the table label, and ``.shape None`` —
     the marker :func:`_print_kernel_stats` uses to nest the row by the benched
     kernel's own ``S_*`` signature instead of a golden's matmul shape. ``dynamic``
     stamps the run's own ``--dynamic`` specs on each pseudo-sample so the A/B
     re-trace builds the same symbolic graph as the greedy run."""
     from types import SimpleNamespace  # noqa: PLC0415
 
-    from emmy.compiler.pipeline.knob import parse_knob_spec  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import KnobType, family_of, get, parse_knob_spec  # noqa: PLC0415
 
     dyn = tuple(dynamic) if dynamic else None
-    return [SimpleNamespace(name=f"ab {raw}", knobs=parse_knob_spec(raw), shape=None, dynamic=dyn) for raw in specs]
+    samples = []
+    for raw in specs:
+        parsed = parse_knob_spec(raw)
+        pins = {
+            name: value
+            for name, value in parsed.items()
+            if (descriptor := get(family_of(name))) is not None and descriptor.type is KnobType.BOOL
+        }
+        knobs = {name: value for name, value in parsed.items() if name not in pins}
+        samples.append(SimpleNamespace(name=f"ab {raw}", pins=pins, knobs=knobs, shape=None, dynamic=dyn))
+    return samples
 
 
 def _sample_replay_knobs(sample) -> dict:
@@ -1124,7 +1149,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, gre
         kernels with ``--`` timings (a compile failure has no kernels — one bare
         label row keeps the failure visible)."""
         label = f"golden {gb.sample.name}" if gb.sample.shape is not None else gb.sample.name
-        label = f"{label} [{_lane(gb.sample.knobs)}]"  # so an [fm]-vs-std A/B can't be misread
+        label = f"{label} [{_pinned_lane(gb)}]"  # so an [fm]-vs-std A/B can't be misread
         if gb.flags:
             label = f"! {label}"
         if gb.graph is None:
@@ -1301,7 +1326,7 @@ def _write_ab_json(
             {
                 "name": sample.name,
                 "kind": "golden" if sample.shape is not None else "ab",
-                "lane": _lane(sample.knobs),
+                "lane": _pinned_lane(gb),
                 "status": gb.status,
                 "pinned_knobs": {k: str(v) for k, v in _sample_replay_knobs(sample).items()},
                 **_timing(gb.bench),
@@ -2359,8 +2384,9 @@ async def _bench_ab_variants_ir(backend, ir_path, tail, specs, *, warmup, iters,
 
     out = []
     for sample in _ab_samples(specs):
+        replay_knobs = _sample_replay_knobs(sample)
         try:
-            with pinned_knobs(sample.knobs):
+            with pinned_knobs(replay_knobs):
                 g = Graph.from_dict(_json.loads(Path(ir_path).read_text()))
                 if tail:
                     g = Pipeline.build(tail).run(g, db=db)
@@ -2368,7 +2394,7 @@ async def _bench_ab_variants_ir(backend, ir_path, tail, specs, *, warmup, iters,
             logger.warning("[ab] %s: compile of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
             out.append(_GoldenBench(sample, None, None, [f"compile failed: {exc}"], "bench_fail"))
             continue
-        flag = unreproducible_pin_flag(sample.knobs, _cuda_knob_dicts(g))
+        flag = unreproducible_pin_flag(replay_knobs, _cuda_knob_dicts(g))
         if flag:
             logger.error("[ab] %s: %s — the pinned config did not realize; fix the pin spelling (row kept unbenched)", sample.name, flag)
             out.append(_GoldenBench(sample, g, None, [f"{flag} — row NOT benched"], "pin_unmatched"))

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -247,10 +247,11 @@ def test_ab_samples_parse_label_and_shape():
     """``_ab_samples`` parses each spec with the ``EMMY_KNOBS`` grammar, labels
     the row with the raw spec, and marks it shapeless (the ``_print_kernel_stats``
     cue to nest by kernel ``S_*`` signature instead of a golden matmul shape)."""
-    from emmy.commands.run import _ab_samples
+    from emmy.commands.run import _ab_samples, _sample_replay_knobs
 
     (s,) = _ab_samples(["tile=f2x4, STAGE=d2/smem-async"])
     assert s.knobs == {"TILE": "f2x4", "STAGE": "d2/smem-async"}  # names uppercased, whitespace tolerated
+    assert s.pins == {}
     assert s.name == "ab tile=f2x4, STAGE=d2/smem-async"
     assert s.shape is None
     assert s.dynamic is None
@@ -258,6 +259,51 @@ def test_ab_samples_parse_label_and_shape():
     # builds the same symbolic graph as the greedy run.
     (d,) = _ab_samples(["TILE=f2x4"], dynamic=["seq_len@x0:0"])
     assert d.dynamic == ("seq_len@x0:0",)
+
+    # Registered Boolean values are input pins, not kernel-row knobs: replay must
+    # retain an explicit False instead of dropping it with pass-marker booleans.
+    (p,) = _ab_samples(["FAST_MATH=False,FAST_EXP=0,VECTORIZE_LOADS=False,TILE=f2x4"])
+    assert p.pins == {"FAST_MATH": "False", "FAST_EXP": "0", "VECTORIZE_LOADS": "False"}
+    assert p.knobs == {"TILE": "f2x4"}
+
+    assert _sample_replay_knobs(p) == {
+        "FAST_MATH": "False",
+        "FAST_EXP": "0",
+        "VECTORIZE_LOADS": "False",
+        "TILE": "f2x4",
+    }
+
+
+def test_ir_ab_replay_retains_boolean_input_pins(tmp_path, monkeypatch):
+    """The re-lowered IR path must use the same merged input-and-schedule pin map."""
+    import contextlib
+    from types import SimpleNamespace
+
+    from emmy.commands import run as run_mod
+    from emmy.compiler.graph import Graph
+
+    seen = []
+
+    @contextlib.contextmanager
+    def capture_pins(knobs):
+        seen.append(knobs)
+        yield
+
+    class Backend:
+        async def bench_pinned_async(self, _graph, *, warmup, num_iters):
+            assert (warmup, num_iters) == (1, 2)
+            return SimpleNamespace(min_ms=0.1, time_ms=0.1), None
+
+    source = tmp_path / "loop.json"
+    source.write_text("{}")
+    monkeypatch.setattr(run_mod, "pinned_knobs", capture_pins)
+    monkeypatch.setattr(run_mod, "_cuda_knob_dicts", lambda _graph: [{"TILE": "f2x4"}])
+    monkeypatch.setattr(Graph, "from_dict", staticmethod(lambda _document: object()))
+
+    rows = asyncio.run(run_mod._bench_ab_variants_ir(Backend(), source, (), ["FAST_MATH=False,TILE=f2x4"], warmup=1, iters=2))
+
+    assert seen == [{"FAST_MATH": "False", "TILE": "f2x4"}]
+    assert len(rows) == 1 and rows[0].status == "ok"
 
 
 def test_bench_golden_variants_retraces_with_dynamic_spec(monkeypatch):
@@ -613,6 +659,43 @@ def test_graph_lane_is_any_kernel_not_a_dict_union(monkeypatch):
     assert run_mod._graph_lane(object()) == "std"
 
 
+def test_pinned_lane_uses_realized_boolean_policy(monkeypatch):
+    from types import SimpleNamespace
+
+    from emmy.commands import run as run_mod
+
+    sample = SimpleNamespace(knobs={}, pins={"FAST_EXP": "1"})
+    row = run_mod._GoldenBench(sample, object(), None, (), "ok")
+    monkeypatch.setattr(run_mod, "_cuda_knob_dicts", lambda _graph: [{"FAST_EXP": True}])
+
+    assert run_mod._pinned_lane(row) == "fm"
+
+
+@pytest.mark.parametrize(
+    ("pins", "lane"),
+    [
+        ({"FAST_MATH": "True"}, "fm"),
+        ({"FAST_MATH": "False"}, "std"),
+        ({"F16_MMA_F32_ACC": "1"}, "fm"),
+        ({"FP8_MMA": True}, "fm"),
+        (
+            {"FAST_MATH": True, "FAST_EXP": False, "F16_MMA_F32_ACC": False, "FP8_MMA": False},
+            "std",
+        ),
+    ],
+)
+def test_failed_pinned_lane_uses_requested_precision_inputs(pins, lane):
+    """A row without a compiled graph keeps the lane its Boolean pins requested."""
+    from types import SimpleNamespace
+
+    from emmy.commands import run as run_mod
+
+    sample = SimpleNamespace(knobs={}, pins=pins)
+    row = run_mod._GoldenBench(sample, None, None, (), "bench_fail")
+
+    assert run_mod._pinned_lane(row) == lane
+
+
 def test_ab_json_labels_each_row_with_its_lane(tmp_path, monkeypatch):
     """The A/B ``--json`` carries a ``lane`` on the greedy block and on every pinned row so a
     sweep can filter to the greedy's lane — never comparing a pinned ``[fm]`` latency against a
@@ -629,8 +712,13 @@ def test_ab_json_labels_each_row_with_its_lane(tmp_path, monkeypatch):
     def _node(knobs):
         return _FakeNode(SimpleNamespace(kernel_name="k_matmul", smem_bytes=0, knobs=knobs))
 
-    # Greedy deployed a std kernel; the stub stands in for every kernel-node walk.
-    monkeypatch.setattr(run_mod, "_launch_order_cuda_nodes", lambda g: [_node({"TILE": "f2x8", "WORK": "t32x8"})])
+    greedy_graph, fm_graph, std_graph = object(), object(), object()
+
+    def _nodes(graph):
+        knobs = {"TILE": "mma_m16n8k16_f16_f16/f2x2/k4"} if graph is fm_graph else {"TILE": "f2x8", "WORK": "t32x8"}
+        return [_node(knobs)]
+
+    monkeypatch.setattr(run_mod, "_launch_order_cuda_nodes", _nodes)
 
     fm = Sample(
         knobs={"TILE": "mma_m16n8k16_f16_f16/f2x2/k4"},
@@ -646,11 +734,14 @@ def test_ab_json_labels_each_row_with_its_lane(tmp_path, monkeypatch):
         name="mlp_gate_up",
         shape=object(),
     )
-    golden_benches = [run_mod._GoldenBench(s, object(), None, (), "ok") for s in (fm, std)]
+    golden_benches = [
+        run_mod._GoldenBench(fm, fm_graph, None, (), "ok"),
+        run_mod._GoldenBench(std, std_graph, None, (), "ok"),
+    ]
 
     out = tmp_path / "ab.json"
     args = SimpleNamespace(code="x", input=None, ir=None, golden="mlp_gate_up", dynamic=None, warmup=2, iters=5, json=str(out))
-    run_mod._write_ab_json(args, {}, object(), None, golden_benches, greedy_fail=None, greedy_iso=None)
+    run_mod._write_ab_json(args, {}, greedy_graph, None, golden_benches, greedy_fail=None, greedy_iso=None)
 
     rec = json.loads(out.read_text())
     assert rec["greedy"]["lane"] == "std"


### PR DESCRIPTION
## Summary

- separate registered Boolean input pins from schedule pins in explicit A/B rows so an explicit false survives replay
- merge both pin maps for frontend and serialized-IR replay
- report the realized precision lane for successful rows and the requested lane for failed rows

## Correctness evidence

- focused `tests/compiler/cli/test_run.py`: 58 passed, 40 skipped
- full `make test`: 3,165 passed, 583 skipped, 1 xfailed
- `make lint`: passed
- `git diff --check`: passed

The macOS full-suite run used a temporary non-repository `timeout` compatibility wrapper because GNU timeout is not installed. The branch is based directly on `4db44ff182073898a0c1589cee7a9a9361a2d971`.