### PR TITLE
Record Qwen3.8 attention carrier boundary

### DIFF
--- a/recipes/Qwen3.8-27B-AWQ-INT4/RESULTS.md
+++ b/recipes/Qwen3.8-27B-AWQ-INT4/RESULTS.md
@@ -89,6 +89,16 @@ is not a serving speedup. Profiling a strict k2 kernel attributes the gap to 14.
 255 registers per thread, and 3.4% DRAM throughput; schedule-neighbor, staging, raster, and fast-exponential sweeps did
 not close it.
 
+A follow-up exact-source audit at revision `4db44ff182073898a0c1589cee7a9a9361a2d971` tested whether a structural
+split could close the attention gap. The split recovered the stable-softmax `(m, l, O)` carrier and passed strict
+`-O3` comparison with maximum absolute error 0.001953125. Its partial and finalize kernels measured 150,246.4 and
+85.8 us, however, for 150,643.7 us end to end versus 63.66 us for eager PyTorch.
+
+The recovered P@V contraction remained a derived singleton site, and lowering offered zero warp/MMA candidates for
+it. The existing scheduler has no route that schedules and materializes the outer carrier as a tensor-core
+contraction. The algebraically correct split is therefore a compiler-boundary result, not a competitive candidate or
+a serving improvement.
+
 Until strict correctness passes across the inventory and attention reaches parity, this recipe intentionally has no
 `golden/` directory and no Emmy serving lane.
 


### PR DESCRIPTION
## Summary

- record the exact strict structural-split audit for Qwen3.8 full attention on an RTX 4090;
- preserve the correct stable-softmax `(m, l, O)` carrier result and its measured performance;
- identify the missing outer-carrier tensor-core scheduling/materialization route without claiming a serving gain.

This is a report-only increment. It changes no compiler, recipe, serving, or experiment code.

## Exact evidence

- Compiler source: `4db44ff182073898a0c1589cee7a9a9361a2d971`, tree
  `024f541460806d60f062a639e60a29b0b7548b3f`
- Strict deployable `-O3`: pass, maximum absolute error `0.001953125`
- Result receipt SHA-256: `0270c5b5ea213ee708e60c9cc910ce7e3a794499210fbb7c79bd55dde415b1a7`
- Recognize-dump SHA-256: `a32a075167be60e0cb096d7ce36140b8272c018cbbaa2336f8b4bc461e857b36`
- Schedule-dump SHA-256: `c38a8873b9d92f809574660452c05af92aede68a9e50aa059c7c5a548b8d1445`
- Partial/finalize/whole: `150246.4 / 85.8 / 150643.7 us`; eager PyTorch: `63.66 us`
- Lowering inventory: zero warp/MMA candidates for the derived singleton P@V site

The correct split is about 2,366x slower than eager. It is evidence of a compiler boundary, not a deployable winner,
canonical golden, Emmy serving lane, or serving improvement.

## Checks and audits

- `make test`: 3,194 passed, 563 skipped, 1 xfailed
- `make lint`: green
- `git diff --check`: green
- README, STYLE, AGENTS, glossary, recipe architecture, plan-count/reference, terminology, line-wrap, provenance,
  and minimal-diff audits completed
