### PR TITLE
Preserve grouped placement through output layout

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -348,9 +348,13 @@ decided by whichever match the enumeration hit first, and one order costs a 1-la
 `loop/prefusion` runs the same splice through the same `_merge.merge_region` with the same refusals, and
 differs from `loop/fusion` in one predicate: it takes only merges whose sink is no wider than the producer.
 Those can only shrink what gets written, so draining them first means every contraction has CLOSED before
-anything is offered a chance to splice into its open product. It **refuses nothing** — a widening merge is
-DEFERRED, and `loop/fusion` offers every one of them afterwards, where the existing refusals decide. That is
-why this is an ordering and not a gate: no legal form leaves the enumeration, so the doctrine above is intact.
+anything is offered a chance to splice into its open product. A same-width pure index-map chain ending at a
+graph output is deferred with the widening merges: dissolving that output-coordinate change first can hide a
+grouped placement inverse which becomes exact only after the producer closes. Ordinary fusion then preserves
+the existing inverse or merges the layout normally when none exists; the graph-output identity rule may also
+retarget the producer's `Write` when the layout is a flat-memory identity. `loop/prefusion` **refuses nothing** —
+every deferred merge is offered again by `loop/fusion`, where the existing refusals decide. This remains an
+ordering rather than a gate: no legal form leaves the enumeration, so the doctrine above is intact.
 
 It must be a PASS, not another rule inside `loop/fusion`. The cursor advances rule-by-rule within a pass and
 re-enumerates, so two rules' batches interleave — measured, the same predicate as a `009_` rule left the trunk

--- a/emmy/compiler/pipeline/passes/loop/prefusion/010_dissolve_narrowing.py
+++ b/emmy/compiler/pipeline/passes/loop/prefusion/010_dissolve_narrowing.py
@@ -8,7 +8,13 @@ A merge is DIRECTIONAL: it makes the SINK the region's output, so whatever width
 must now be written. Ordering on that fact is what this pass is for. A merge whose sink is no
 wider than its producer can only shrink what gets written — a product folding into its own reduce,
 an index map dissolving into its consumer's index. Taking all of those first means each contraction
-has CLOSED before anything is offered a chance to splice into its open product.
+has CLOSED before anything is offered a chance to splice into its open product. The one ordering
+exception is a same-width pure index-map chain ending at a graph output: it changes only the output
+coordinate basis, so dissolving it before its producer closes can hide an exact grouped placement
+inverse that ordinary fusion already knows how to preserve. Defer that plumbing to ordinary
+fusion too; a producer with no such inverse still merges there, while a recognized inverse reaches
+the existing preservation guard and the graph-output identity rule can retarget its Write without
+changing the loop tree.
 
 Without that ordering the outcome depends on which match the enumeration reached first, and one
 order is catastrophic: splice a compute producer into a still-open product and the product becomes
@@ -32,7 +38,12 @@ from __future__ import annotations
 from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
-from emmy.compiler.pipeline.passes.loop.fusion._helpers import closed_loop_consumer_region as _closed_loop_consumer_region
+from emmy.compiler.pipeline.passes.loop.fusion._helpers import (
+    closed_loop_consumer_region as _closed_loop_consumer_region,
+)
+from emmy.compiler.pipeline.passes.loop.fusion._helpers import (
+    is_pure_indexmap as _is_pure_indexmap,
+)
 from emmy.compiler.pipeline.passes.loop.fusion._merge import merge_region as _merge_region
 
 PATTERN = [Pattern("producer", LoopOp)]
@@ -53,6 +64,19 @@ def _output_numel(node: Node) -> int:
     return numel
 
 
+def _ends_at_output_layout(graph: Graph, sink: Node) -> bool:
+    """Whether ``sink`` starts a single-consumer pure index-map chain to a graph output."""
+    node = sink
+    while isinstance(node.op, LoopOp) and _is_pure_indexmap(node.op):
+        if node.id in graph.outputs:
+            return True
+        users = graph.users(node.id)
+        if len(users) != 1:
+            return False
+        node = graph.nodes[next(iter(users))]
+    return False
+
+
 def rewrite(match: Match, producer: Node) -> Graph | None:
     graph = match.graph
     if not isinstance(producer.op, LoopOp):
@@ -61,6 +85,9 @@ def rewrite(match: Match, producer: Node) -> Graph | None:
     if found is None:
         raise RuleSkipped("producer has no closed Loop consumer region")
     region, sink = found
-    if _output_numel(sink) > _output_numel(producer):
+    producer_numel, sink_numel = _output_numel(producer), _output_numel(sink)
+    if sink_numel > producer_numel:
         raise RuleSkipped("widening merge — deferred to loop/fusion, after every narrowing one has run")
+    if sink_numel == producer_numel and _ends_at_output_layout(graph, sink):
+        raise RuleSkipped("same-width output layout — deferred until its producer has closed")
     return _merge_region(match, region, sink)

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -83,6 +83,7 @@ the pass tests exercise the resulting graph end to end.
 | `loop/lifting/025_lift_scan.py`        | `ScanOp` → `LoopOp`        | `test_pipeline_semantics.py::test_scan_*`                                          |
 | `loop/lifting/030_lift_indexmap.py`    | `IndexMapOp` → `LoopOp`    | `test_optimization_rules.py::test_matmul_with_transpose_fuses_to_one_kernel` (e2e) |
 | `loop/lifting/040_lift_gather.py`      | `GatherOp` → `LoopOp`      | `test_torch_ops.py::test_gather`                                                   |
+| `loop/prefusion/010_dissolve_narrowing.py` | narrowing merge order  | `test_placement_routing.py::test_output_flatten_*`                                 |
 | `loop/fusion/010_merge_loop_ops.py`    | `LoopOp → LoopOp` (splice) | `test_fusion_rules.py` (fixpoint)                                                  |
 
 Numerical correctness for lifted + merged kernels runs through the

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -21,9 +21,9 @@ from emmy.compiler.dtype import F16
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
-from emmy.compiler.ir.frontend.ir import MatmulOp, RmsNormOp
-from emmy.compiler.ir.tensor.ir import ElementwiseOp
-from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Pipeline
+from emmy.compiler.ir.frontend.ir import MatmulOp, ReshapeOp, RmsNormOp, SdpaOp, TransposeOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
+from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
 from emmy.compiler.pipeline.pipeline import Run
 from emmy.compiler.pipeline.search.golden import GoldenRecord
@@ -75,6 +75,35 @@ def _activation_linear_graph(S: int = 2, H: int = 16, inter: int = 32) -> Graph:
     g.add_node(ElementwiseOp("silu"), ["x"], Tensor("xa", (Dim(S), Dim(H)), dtype=F16), node_id="xa")
     g.add_node(MatmulOp(), ["xa", "w"], Tensor("y", (Dim(S), Dim(inter)), dtype=F16), node_id="y")
     g.inputs, g.outputs = ["x", "w"], ["y"]
+    return g
+
+
+def _gqa_sdpa_flatten_graph() -> Graph:
+    """A small grouped-query attention cell followed by its output-layout flatten."""
+    batch, query_heads, kv_heads, seq, head_dim = 1, 6, 2, 8, 16
+    g = Graph()
+    _inp(g, "q", (batch, query_heads, seq, head_dim))
+    _inp(g, "k", (batch, kv_heads, seq, head_dim))
+    _inp(g, "v", (batch, kv_heads, seq, head_dim))
+    g.add_node(
+        SdpaOp(is_causal=True, scale=head_dim**-0.5),
+        ["q", "k", "v"],
+        Tensor("attention", (batch, query_heads, seq, head_dim), F16),
+        node_id="attention",
+    )
+    g.add_node(
+        TransposeOp(axes=(1, 2)),
+        ["attention"],
+        Tensor("attention_t", (batch, seq, query_heads, head_dim), F16),
+        node_id="attention_t",
+    )
+    g.add_node(
+        ReshapeOp(shape=(batch, seq, query_heads * head_dim)),
+        ["attention_t"],
+        Tensor("flat", (batch, seq, query_heads * head_dim), F16),
+        node_id="flat",
+    )
+    g.inputs, g.outputs = ["q", "k", "v"], ["flat"]
     return g
 
 
@@ -342,6 +371,37 @@ def test_followup_fusion_preserves_the_sdpa_grouped_inverse() -> None:
     assert len(loops) == 2, "the producer must stay outside the reusable attention cell"
     attention = fused.nodes["scaled_dot_product_attention"]
     assert reusable_cut_pieces(attention.op) is not None
+
+
+def test_output_flatten_preserves_the_gqa_sdpa_grouped_inverse() -> None:
+    """Pure output layout must not erase attention's exact materialized sibling."""
+    from emmy.compiler.ir.loop import LoopOp
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import reusable_cut_pieces
+
+    lowered = Pipeline.build(LOOP_PASSES).run(_gqa_sdpa_flatten_graph(), ctx=Context.from_target((8, 9)))
+    loops = [node for node in lowered.nodes.values() if isinstance(node.op, LoopOp)]
+    assert {node.id for node in loops} == {"attention_reduce", "flat"}
+    attention = lowered.nodes["attention_reduce"]
+    assert reusable_cut_pieces(attention.op) is not None
+    assert lowered.nodes["flat"].inputs == [attention.id]
+
+
+def test_output_flatten_keeps_an_ordinary_reduce_on_the_normal_fusion_path() -> None:
+    """An equal-size layout after a plain fold does not mint grouped placement evidence."""
+    from emmy.compiler.ir.loop import LoopOp
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import reusable_cut_pieces
+
+    g = Graph()
+    _inp(g, "x", (2, 3, 8))
+    g.add_node(ReduceOp(op="sum", axis=-1), ["x"], Tensor("sum", (2, 3, 1), F16), node_id="sum")
+    g.add_node(ReshapeOp(shape=(2, 3)), ["sum"], Tensor("flat", (2, 3), F16), node_id="flat")
+    g.inputs, g.outputs = ["x"], ["flat"]
+
+    lowered = Pipeline.build(LOOP_PASSES).run(g, ctx=Context.from_target((8, 9)))
+    loops = [node for node in lowered.nodes.values() if isinstance(node.op, LoopOp)]
+    assert len(loops) == 1
+    assert loops[0].id == "flat"
+    assert reusable_cut_pieces(loops[0].op) is None
 
 
 # --- the realizer: pin-driven cuts, fuse-default, recursion ---------------------------------------


### PR DESCRIPTION
## Summary

- defer a same-width pure output-layout chain from prefusion until ordinary fusion
- preserve the grouped attention placement inverse through transpose/reshape output plumbing
- keep ordinary reductions on the existing fusion path

This restores structural schedule reachability for grouped attention. It makes no performance claim; exact-GPU tuning and O3 replay remain separate evidence.

## Verification

- `make test` on Linux: 3,174 passed, 577 skipped, 1 xfailed
- `make lint`
- focused placement-routing suite: 22 passed
- rebased on `5642d020`