### PR TITLE
Use one nominal warmup for autotune terminals

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1218,6 +1218,9 @@ cached `perf` rows ensure no re-bench on warm starts. Greedy compiles build no t
 backend). It short-circuits when every `CudaOp` in the graph already has a `perf` row for the current `(context_key,
 backend)`. Otherwise it does one `await backend.benchmark_async(...)`, walks `Op.source` once to record op inventory +
 lowering edges + the `perf` row per kernel, and returns the aggregate `PerfStats` for the search to score.
+Tune terminals request one nominal warmup; the CUDA benchmark's existing clock-ramp floor extends that warmup until
+it covers 10 ms of GPU time. A slow candidate therefore spends one iteration warming instead of exhausting the
+run-stage budget on discarded repeats. Pinned and deployable comparisons retain their caller-selected warmup count.
 
 ## Part 7: Golden records and the A/B integrity gates
 

--- a/emmy/compiler/pipeline/search/policy/terminal_bench.py
+++ b/emmy/compiler/pipeline/search/policy/terminal_bench.py
@@ -309,7 +309,7 @@ async def bench_terminal_async(cand, *, backend, db):
     if kind == "done":
         return *payload, False, b.per_kernel
     try:
-        result = await backend.benchmark_async(b.graph, num_iters="auto")
+        result = await backend.benchmark_async(b.graph, warmup=1, num_iters="auto")
     except Exception as exc:  # noqa: BLE001
         return *b.finalize_exc(exc), True, b.per_kernel
     return *b.finalize_result(result), True, b.per_kernel

--- a/tests/compiler/backend/test_bench_worker_compare.py
+++ b/tests/compiler/backend/test_bench_worker_compare.py
@@ -424,6 +424,29 @@ def test_benchmark_pinned_isolated_async_ships_inputs_once_and_retries_on_miss()
     assert bench == "B" and outputs == {"o": 1}
 
 
+async def test_cuda_backend_pinned_bench_keeps_default_warmup(monkeypatch) -> None:
+    import emmy.compiler.backend.cuda.program as program_mod
+    from emmy.compiler.backend.cuda.backend import CudaBackend
+
+    seen = {}
+
+    async def _fake_pinned(compiled, **kwargs):
+        seen.update(compiled=compiled, **kwargs)
+        return "bench", None
+
+    monkeypatch.setattr(program_mod, "benchmark_pinned_isolated_async", _fake_pinned)
+    backend = CudaBackend()
+    worker = object()
+    monkeypatch.setattr(backend, "_async_worker", lambda: worker)
+
+    result = await backend.bench_pinned_async("G")
+
+    assert result == ("bench", None)
+    assert seen["worker"] is worker
+    assert seen["warmup"] == 5
+    assert seen["num_iters"] == 20
+
+
 def test_run_job_trace_args_accuracy_gates_the_bench(monkeypatch) -> None:
     """A ``trace_args`` job with ``accuracy``: the child binds the rebuilt module's real
     inputs, runs the emmy program on them, and compares vs eager. A numeric failure ships

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -1,5 +1,8 @@
 """Tests for cupy dispatch of a lowered ``Graph[CudaOp]``."""
 
+from contextlib import nullcontext
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -230,6 +233,44 @@ def test_benchmark_program_returns_timing():
     assert result.num_launches == 1
     assert result.per_launch is not None
     assert len(result.per_launch) == 1
+
+
+def _fake_benchmark_program(monkeypatch, iter_ms: float):
+    import emmy.compiler.backend.cuda.program as program_mod
+    import emmy.compiler.backend.gpu_lock as lock_mod
+
+    class _FakeProgram:
+        def __init__(self) -> None:
+            self.compiled = SimpleNamespace(launches=[SimpleNamespace(kernel_name="k")])
+            self.calls = 0
+
+        def iter_once(self, *, batch_sizes=None, pre_iter=None):
+            self.calls += 1
+            return [iter_ms]
+
+    fake = _FakeProgram()
+    monkeypatch.setattr(program_mod.CompiledProgram, "build", classmethod(lambda _cls, *_args, **_kwargs: fake))
+    monkeypatch.setattr(lock_mod, "gpu_lock", nullcontext)
+    return fake
+
+
+def test_benchmark_program_explicit_warmup_count_is_unchanged(monkeypatch):
+    fake = _fake_benchmark_program(monkeypatch, iter_ms=5.0)
+
+    result = benchmark_program(Graph(), warmup=5, num_iters=1, run_timeout_s=2.0, capture_graphs=False)
+
+    assert fake.calls == 6
+    assert result.time_ms == 5.0
+    assert result.per_launch[0].samples == (5.0,)
+
+
+def test_benchmark_program_run_budget_still_fails_on_first_slow_iteration(monkeypatch):
+    fake = _fake_benchmark_program(monkeypatch, iter_ms=2100.0)
+
+    with pytest.raises(RuntimeError, match="benchmark run stage exceeded 2.0s of GPU time"):
+        benchmark_program(Graph(), warmup=1, num_iters="auto", run_timeout_s=2.0, capture_graphs=False)
+
+    assert fake.calls == 1
 
 
 @requires_cuda

--- a/tests/compiler/pipeline/search/policy/test_terminal_bench.py
+++ b/tests/compiler/pipeline/search/policy/test_terminal_bench.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from emmy.compiler.backend.base import BenchmarkResult, LaunchTime
+from emmy.compiler.context import Context
+from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.cuda.ir import CudaOp
+from emmy.compiler.pipeline.search.db import SearchDB
+from emmy.compiler.pipeline.search.policy.terminal_bench import bench_terminal_async
+
+
+def _candidate():
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (1,)), node_id="x")
+    graph.add_node(
+        CudaOp(kernel_source='extern "C" __global__ void k(float* out) {}', kernel_name="k", arg_order=("out",)),
+        [],
+        Tensor("out", (1,)),
+        node_id="out",
+    )
+    graph.inputs = ["x"]
+    graph.outputs = ["out"]
+    return SimpleNamespace(graph=graph, ctx=Context.from_target((8, 0)))
+
+
+class _BudgetedBackend:
+    name = "cuda"
+    bench_run_timeout_s = 2.0
+
+    def __init__(self, iter_ms: float) -> None:
+        self.iter_ms = iter_ms
+        self.calls: list[tuple[int, int | str]] = []
+
+    async def benchmark_async(self, _graph, *, warmup: int = 5, num_iters: int | str = 20) -> BenchmarkResult:
+        self.calls.append((warmup, num_iters))
+        total_ms = 0.0
+        for _ in range(warmup):
+            total_ms += self.iter_ms
+            if total_ms > self.bench_run_timeout_s * 1000.0:
+                raise RuntimeError("benchmark run stage exceeded 2.0s of GPU time — variant marked bench_fail")
+        total_ms += self.iter_ms
+        if total_ms > self.bench_run_timeout_s * 1000.0:
+            raise RuntimeError("benchmark run stage exceeded 2.0s of GPU time — variant marked bench_fail")
+        launch = LaunchTime(idx=0, kernel_name="k", time_ms=self.iter_ms, samples=(self.iter_ms,))
+        return BenchmarkResult(time_ms=self.iter_ms, num_launches=1, per_launch=[launch])
+
+
+async def test_auto_tune_uses_one_nominal_warmup_before_run_budget() -> None:
+    backend = _BudgetedBackend(iter_ms=750.0)
+
+    stats, status, measured, _per_kernel = await bench_terminal_async(_candidate(), backend=backend, db=SearchDB())
+
+    assert backend.calls == [(1, "auto")]
+    assert measured is True
+    assert status == "ok"
+    assert stats.median == 750_000.0

--- a/tests/compiler/pipeline/search/test_two_level_strategy.py
+++ b/tests/compiler/pipeline/search/test_two_level_strategy.py
@@ -69,7 +69,8 @@ class _CountingBackend:
             per.append(LaunchTime(idx=i, kernel_name=getattr(n.op, "kernel_name", "k"), time_ms=us / 1000.0, samples=(us / 1000.0,)))
         return BenchmarkResult(time_ms=sum(p.time_ms for p in per), num_launches=len(per), per_launch=per)
 
-    async def benchmark_async(self, graph, num_iters="auto") -> BenchmarkResult:
+    async def benchmark_async(self, graph, num_iters="auto", warmup=5) -> BenchmarkResult:
+        del warmup
         return self.benchmark(graph, num_iters=num_iters)
 
 


### PR DESCRIPTION
## Summary

- request one nominal warmup for autotune terminal measurements
- retain the CUDA benchmark existing 10 ms clock-ramp floor for fast kernels
- leave pinned and deployable comparison counts and the 2-second fail-closed run budget unchanged

## Motivation

The A100 target `k_sdpa_4fdcc5.78c3e586a997` had four finite fused proposals whose individual launches completed in roughly 0.4-0.8 seconds, but five discarded warmups exhausted the cumulative 2-second run budget before any measured sample. One warmup plus one measured iteration fits that budget. Candidates with a single launch over two seconds and structural OOMs remain `bench_fail`.

## Exact A100 verification

The target was retuned at commit `310a6d16629f3dc98a5cc90bfd52c822d645f354` on an A100-SXM4-80GB. All four proposals changed from `bench_fail` to captured `ok` rows under the unchanged watchdog; the log contains no timeout, benchmark failure, or error signature.

The fastest search row was then replayed in five fresh strict deployable-O3 processes. All five realized source SHA-256 `776c27bde445c18b6374c4d2637e31ee0949a7780ec8f05fcb2f191fa4d12489` with identical pins and launch geometry and passed the same-input greedy correctness check. The tuned range was 29,018.112-29,086.720 us versus greedy Emmy at 47,296.511-47,342.081 us, a 1.6292x geometric-mean speedup.

This exact target is an embedded Loop slice without an eager twin, so the verification proves the timeout fix and an Emmy-over-greedy gain. It does not claim eager, cuBLAS, or external-baseline parity and does not promote a canonical golden.

## Verification

- `PYTEST_XDIST_AUTO_NUM_WORKERS=16 make test` - 3176 passed, 577 skipped, 1 xfailed before rebase; rebased CI is green
- `make lint`
- focused policy and backend tests - 37 passed, 7 skipped
- exact A100 proposal retune - 4/4 captured `ok`
- strict O3 replay - 5/5 pass with non-overlapping tuned and greedy ranges
