### PR TITLE
serving: point the vLLM dummy-run clamp at its upstream issue

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -443,7 +443,8 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `cdiv(max_model_len, block_size)`-page rows — TRITON_ATTN's unmasked block-table load then feeds garbage page
   ids into its K/V loads (capture-warmup illegal memory access, reproduced standalone: clean at 4096, faulting
   from 4097, at head_dim 256 AND 512 — head width is irrelevant), and FLEX_ATTENTION fails the same arithmetic
-  loudly in its sliding-window block-mask shapes. 5090-measured with the earlier 2112 rung cap (2026-08-15,
+  loudly in its sliding-window block-mask shapes. Reported upstream as vllm-project/vllm#53658; the patch goes
+  away once the vllm pin reaches a release that closes it. 5090-measured with the earlier 2112 rung cap (2026-08-15,
   fcbc880f+fix tree, medians of 3): small_c1 256/256 TTFT 90.4 → 72.2 ms (capture off → on; stock 66.5 — the
   1.36x gap closes to 1.09x)
   with TPOT unchanged, and c64 np256 on the capped lane TPOT 34.9 → 33.1 ms, 1243 → 1255 tok/s, greedy chat

--- a/emmy/serving/vllm_patches.py
+++ b/emmy/serving/vllm_patches.py
@@ -1,7 +1,7 @@
 """Runtime workarounds for vLLM defects, applied from the plugin ``register`` hook.
 
-Each patch documents the upstream defect and the pinned vLLM version it targets; drop the
-patch when the pin moves to a release that ships the fix.
+Each patch documents the upstream defect, the upstream issue tracking it, and the pinned vLLM
+version it targets; drop the patch when the pin moves to a release that closes that issue.
 """
 
 import logging
@@ -31,6 +31,10 @@ def clamp_dummy_run_seq_lens() -> None:
     stock Llama/Mistral/Qwen3 only, and its dummy batches use legal per-request seq lens).
     Verified end to end on the default runner: a 4128-token capture with max-model-len 4096
     warms up and captures cleanly with the clamp, greedy output correct.
+
+    Reported upstream as vllm-project/vllm#53658 (with the standalone kernel repro); still open
+    against vLLM main as of 2026-08-25. Drop this patch once the vllm pin reaches a release
+    that closes it.
     """
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 


### PR DESCRIPTION
Follow-up to #520, comments only — no behavior change.

`vllm_patches.clamp_dummy_run_seq_lens` said to drop the patch "when the pin moves to a release
that ships the fix", without naming which fix to watch for. Now that the defect is reported
upstream as [vllm-project/vllm#53658](https://github.com/vllm-project/vllm/issues/53658) (with the
standalone kernel repro), record it in the module docstring, the function docstring, and
`serving/ARCHITECTURE.md` so the removal trigger is something a reader can actually check.

Still open against vLLM main as of 2026-08-25.

Verified with `ruff check` and `ruff format --check` (which also confirms the file still parses);
the full suite was not re-run since the change touches only docstrings and prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)