### PR TITLE
Report a compile-budget overrun instead of recording it as a slow kernel

### DIFF
--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -886,6 +886,17 @@ def _sample_replay_knobs(sample) -> dict:
     return {**getattr(sample, "pins", {}), **drop_uninformative_scopes(sample.knobs)}
 
 
+def _failed_bench_status(exc: BaseException) -> str:
+    """The status a raised bench earns. A compile-budget overrun measured nothing about the
+    kernel, so it gets its own status and is therefore NOT recorded into the node store
+    (:func:`_recordable_bench_leaves` records ``bench_fail`` exactly) — recording it would put a
+    false negative into the very rows the prior trains on. Anything else compiled and then failed,
+    which IS evidence about the config, and stays the honest ``bench_fail`` it has always been."""
+    from emmy.compiler.backend.cuda.program import compile_budget_overrun  # noqa: PLC0415
+
+    return "compile_timeout" if compile_budget_overrun(exc) else "bench_fail"
+
+
 async def _bench_golden_variants(
     backend,
     source,
@@ -975,8 +986,9 @@ async def _bench_golden_variants(
                 g_compiled, run_inputs=ref_inputs, run_inputs_key=ref_key, warmup=warmup, num_iters=iters
             )
         except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own bench table
-            logger.warning("[golden] %s: bench of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
-            out.append(_GoldenBench(sample, g_compiled, None, [f"bench_fail: {exc}"], "bench_fail"))
+            st = _failed_bench_status(exc)
+            logger.warning("[golden] %s: bench of the pinned config failed (%s) — row kept as %s", sample.name, exc, st)
+            out.append(_GoldenBench(sample, g_compiled, None, [f"{st}: {exc}"], st))
             continue
         run_outputs = _comparison_outputs(run_outputs, g_compiled) if run_outputs is not None else None
         correctness = None
@@ -1017,8 +1029,9 @@ async def _bench_greedy_isolated(backend, compiled, *, warmup, iters):
     try:
         g_bench, _ = await backend.bench_pinned_async(compiled, warmup=warmup, num_iters=iters)
     except Exception as exc:  # noqa: BLE001 — an iso-bench failure must not abort the pinned rows
-        logger.warning("greedy isolated re-bench failed (%s) — row kept as bench_fail; pinned rows still bench", exc)
-        return _GoldenBench(sample, compiled, None, [f"bench_fail: {exc}"], "bench_fail")
+        st = _failed_bench_status(exc)
+        logger.warning("greedy isolated re-bench failed (%s) — row kept as %s; pinned rows still bench", exc, st)
+        return _GoldenBench(sample, compiled, None, [f"{st}: {exc}"], st)
     return _GoldenBench(sample, compiled, g_bench, [], "ok")
 
 
@@ -2402,8 +2415,9 @@ async def _bench_ab_variants_ir(backend, ir_path, tail, specs, *, warmup, iters,
         try:
             g_bench, _ = await backend.bench_pinned_async(g, warmup=warmup, num_iters=iters)
         except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own table
-            logger.warning("[ab] %s: bench of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
-            out.append(_GoldenBench(sample, g, None, [f"bench_fail: {exc}"], "bench_fail"))
+            st = _failed_bench_status(exc)
+            logger.warning("[ab] %s: bench of the pinned config failed (%s) — row kept as %s", sample.name, exc, st)
+            out.append(_GoldenBench(sample, g, None, [f"{st}: {exc}"], st))
             continue
         out.append(_GoldenBench(sample, g, g_bench, []))
     return out

--- a/emmy/commands/tune.py
+++ b/emmy/commands/tune.py
@@ -179,13 +179,26 @@ def _tune_backend(device_id: int | None = None):
     with the worker and the **parent** CUDA stream stays clean. Tight per-variant
     budgets: tune benches isolated single kernels at -Xcicc -O1 (fast), but the
     big-N warp-MMA variants (fp16 N=28672, ``matmul.mlp_gate_up.h4096``) need ~5 s
-    of cicc even then — a 4 s compile budget would record that whole family as
-    bench failures and lock it out of the sweep, hence 12 s; 2 s run is ample and the wall SIGKILLs any runaway
-    (keeping a ~2 s margin over compile+run). ``device_id`` pins the async bench
-    worker to a physical GPU (multi-GPU tune)."""
+    of cicc even then — a 4 s compile budget would refuse that whole family, hence 12 s; 2 s run
+    is ample. A config that overruns the compile budget is REPORTED, not recorded (see
+    ``CompileBudgetExceeded``), which is why the wall must not pre-empt it. ``device_id`` pins the
+    async bench worker to a physical GPU (multi-GPU tune)."""
     from emmy.compiler.backend.cuda.backend import CudaBackend
 
-    return CudaBackend(bench_compile_timeout_s=12.0, bench_run_timeout_s=2.0, bench_wall_timeout_s=16.0, device_id=device_id)
+    compile_s, run_s = 12.0, 2.0
+    # The wall cap must sit ABOVE the in-child budgets, not beside them (the same formula the
+    # pinned path uses). A wall that can fire first silently converts the two honest in-child
+    # verdicts into one SIGKILL: a compile that overran is checked only when it RETURNS, so under
+    # the old ~2 s margin any compile slower than the wall was killed instead, and recorded as a
+    # sticky ``bench_fail`` — precisely the wide-tile family the compile budget exists to report.
+    # Hangs are still caught promptly in-child by the per-launch watchdog; the wall is a backstop
+    # for a wedged worker, and 60 s of headroom is what lets that watchdog's first-iter grace fire.
+    return CudaBackend(
+        bench_compile_timeout_s=compile_s,
+        bench_run_timeout_s=run_s,
+        bench_wall_timeout_s=compile_s + run_s + 60.0,
+        device_id=device_id,
+    )
 
 
 async def _warm_tune_backends(backends) -> None:

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -247,6 +247,24 @@ setting reaches every bench path uniformly — the in-child backend inherits the
 pinned-row cap, the comparison jobs' workload-scaled cap) recompute from the overridden values. Raising them is how a
 golden row whose recorded latency exceeds the default accumulated-GPU budget gets verified.
 
+The three budgets fail differently, and the differences are load-bearing. A `bench_run_timeout_s` overrun is a fact
+about the **kernel** — it compiled, it ran, it was too slow — and is recorded as a `bench_fail` at the watchdog's
+sentinel latency. A `bench_compile_timeout_s` overrun is a fact about **cicc and the tile's unroll size**: nothing
+about the kernel's speed was measured, so it raises `CompileBudgetExceeded` and callers record *nothing at all*
+(`search/policy/terminal_bench.py`, and `run --bench`'s pinned rows via `_failed_bench_status`). The exception class
+cannot cross the worker pipe (the protocol carries `error` as a string), so the child flags the kind as
+`compile_budget: True` and the parent rebuilds it onto `BenchWorkerJobError` — the same shape the retryable
+`cache_miss` kind already uses.
+
+`bench_wall_timeout_s` is the third, and it **must exceed the other two**, because it cannot tell them apart: on
+overrun the parent SIGKILLs the child and raises a plain `RuntimeError`, so a wall that can fire first collapses both
+honest in-child verdicts into one anonymous failure. The compile budget is checked when the compile *returns* and so
+can only fire for a compile that finished; the sweep's old wall sat ~2 s above compile+run, which meant any compile
+slower than that was killed rather than reported — and the wide register-tile family that motivates the budget is
+exactly the family that overruns it. The sweep therefore derives its wall as `compile + run + 60 s`, the same formula
+the pinned path uses; the 60 s of headroom is what lets the per-launch watchdog's first-iter grace fire in-child,
+which is what actually catches hangs. The wall is a backstop for a wedged worker, not a per-variant budget.
+
 The one-shot comparison result includes the worker's non-fatal `accuracy_error` beside timings, reference
 availability, and capture state. `tune --bench` persists that verdict per provenance reproducer instead of treating a
 successful timing response as proof of correctness.

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -20,14 +20,17 @@ Protocol (length-prefixed pickle on stdin/stdout):
 - Response: ``{"ok": True, "result": BenchmarkResult, "results": dict|None, "torch_available": bool,
   "captured": bool, "run_outputs": dict|None, "accuracy_error": str|None, "run_io": tuple|None,
   "greedy_error": str|None, "reference_run_us": float|None}``
-  or ``{"ok": False, "error": str, "traceback": str}`` on exception.
+  or ``{"ok": False, "error": str, "traceback": str, "cache_miss": bool, "compile_budget": bool}``
+  on exception — the two flags rebuild parent-side the exception kinds a pickled string loses.
 - Worker imports cupy / torch lazily on first request, writes ``<8-byte length><pickled response>``.
 - A ``worker_warmup`` request initializes CuPy and the CUDA context without consuming a candidate's wall budget.
 - EOF on stdin (or parent SIGKILL) terminates the worker.
 
 Errors raised inside ``benchmark_program`` (bench_compile_timeout_s,
 bench_run_timeout_s, per-launch ``_KERNEL_TIMEOUT_MS``) propagate back
-as ``ok: False`` and the parent surfaces them as ``RuntimeError``.
+as ``ok: False`` and the parent surfaces them as ``RuntimeError``. A
+``bench_compile_timeout_s`` overrun is the one kind the caller must tell apart — it measured
+no latency — so it rides back as ``compile_budget: True`` and the parent re-raises it as such.
 
 A failing bench may have left the CUDA context in a sticky-error state: an
 illegal / misaligned memory access corrupts the context so that *every*
@@ -294,6 +297,8 @@ def main() -> None:
             dirty = bool(result.get("_retire_worker", False))
             resp = {"ok": True, **result}
         except BaseException as exc:  # noqa: BLE001 — surface every failure mode to the parent
+            from emmy.compiler.backend.cuda.program import CompileBudgetExceeded
+
             # A bare ``SystemExit`` repr hides the cause (a CLI-style ``sys.exit`` after a
             # logged error) — point the parent at the traceback + stderr, where it lives.
             error = (
@@ -306,6 +311,7 @@ def main() -> None:
                 "error": error,
                 "traceback": traceback.format_exc(),
                 "cache_miss": isinstance(exc, InputsCacheMissError),
+                "compile_budget": isinstance(exc, CompileBudgetExceeded),
             }
             dirty = _hung(exc) or _context_dirty()
         payload = pickle.dumps(resp, protocol=pickle.HIGHEST_PROTOCOL)

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -615,6 +615,26 @@ class HungKernelError(RuntimeError):
     ``bench_fail`` unchanged."""
 
 
+class CompileBudgetExceeded(RuntimeError):
+    """The compile stage ran past ``compile_timeout_s``, before any launch happened.
+
+    Distinct from a plain ``RuntimeError`` because **nothing about the kernel's speed was
+    measured**: cicc was slow, which is a fact about the compiler and the tile's unroll size, not
+    about the kernel. Callers must record no latency for it — inventing one mislabels the config,
+    and a persisted row is worse than mislabelled, because it is then served as a cache hit and
+    the config is never re-benched. Subclasses ``RuntimeError`` so existing handlers still catch
+    it. The budget is checked when the compile RETURNS, so it can only fire for a compile that
+    finished: any wall cap over it must exceed it, or the SIGKILL pre-empts this distinction."""
+
+
+def compile_budget_overrun(exc: BaseException) -> bool:
+    """``True`` iff ``exc`` is :class:`CompileBudgetExceeded`, from either bench path — the class
+    itself in-process, or the flag :class:`BenchWorkerJobError` carries when the exception was
+    raised in the worker subprocess (the protocol pickles ``error`` as a string, losing the
+    class). Lives here, beside the two classes it bridges."""
+    return isinstance(exc, CompileBudgetExceeded) or bool(getattr(exc, "compile_budget", False))
+
+
 class GraphCaptureError(RuntimeError):
     """CUDA graph capture of the bench launch loop failed.
 
@@ -810,7 +830,7 @@ class CompiledProgram:
         descs = _prebuild_descriptors(compiled, arrays)
         elapsed = _time_module.monotonic() - t0
         if compile_timeout_s is not None and elapsed > compile_timeout_s:
-            raise RuntimeError(f"compile stage exceeded {compile_timeout_s:.1f}s budget ({elapsed:.2f}s) — variant marked bench_fail")
+            raise CompileBudgetExceeded(f"compile stage exceeded {compile_timeout_s:.1f}s budget ({elapsed:.2f}s) — nothing measured")
         logger.info(
             "[cuda] CompiledProgram.build: %d launch(es) compile+alloc=%.2fs kernels=[%s]",
             len(compiled.launches),
@@ -1533,11 +1553,15 @@ def _samples_to_result(
 class BenchWorkerJobError(RuntimeError):
     """A worker job that ran and failed (``ok: False`` response — the child is alive).
     ``cache_miss`` marks the one retryable kind: a job referenced a ``run_inputs_key``
-    a freshly-respawned child no longer holds."""
+    a freshly-respawned child no longer holds. ``compile_budget`` marks a
+    :class:`CompileBudgetExceeded` raised in the child — the exception CLASS cannot cross the
+    process boundary (the protocol carries ``error`` as a string), so the child flags the kind
+    and the parent rebuilds the distinction here."""
 
-    def __init__(self, message: str, *, cache_miss: bool = False) -> None:
+    def __init__(self, message: str, *, cache_miss: bool = False, compile_budget: bool = False) -> None:
         super().__init__(message)
         self.cache_miss = cache_miss
+        self.compile_budget = compile_budget
 
 
 class _AsyncBenchWorker:
@@ -1771,7 +1795,11 @@ class _AsyncBenchWorker:
                 # their cause before exiting) would otherwise be silently discarded.
                 if resp.get("traceback"):
                     logger.error("[bench-worker] job failed in the child; traceback:\n%s%s", resp["traceback"], self._tail_suffix())
-                raise BenchWorkerJobError(f"bench worker error: {resp.get('error', '?')}", cache_miss=bool(resp.get("cache_miss")))
+                raise BenchWorkerJobError(
+                    f"bench worker error: {resp.get('error', '?')}",
+                    cache_miss=bool(resp.get("cache_miss")),
+                    compile_budget=bool(resp.get("compile_budget")),
+                )
             if resp.pop("_retire_worker", False):
                 # The child returned a completed same-input reference after its later greedy
                 # timing hit the hung-kernel watchdog. Retire it before returning the reference:

--- a/emmy/compiler/context.py
+++ b/emmy/compiler/context.py
@@ -15,6 +15,7 @@ the signature alone.
 
 from __future__ import annotations
 
+import re
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -51,6 +52,34 @@ def _env_compile_flags() -> str:
     CLI commands (via :func:`emmy.config.set_nvcc_flags`); folded into
     :meth:`Context.structural_key` so the perf cache is partitioned by opt level."""
     return config.nvcc_flags()
+
+
+# The cicc optimization level as it is spelled on the nvcc command line, with the ``-Xcicc``
+# forwarding prefix when present. nvcc's own default is -O3, which is why an absent token reads
+# as 3 (:func:`split_opt_level`) — the compile / run default of ``""`` IS the deployable regime.
+_OPT_TOKEN = re.compile(r"(?:-Xcicc\s+)?-O(\d)")
+
+
+def split_opt_level(compile_flags: str) -> tuple[int, str]:
+    """Split extra nvcc flags into ``(cicc opt level, everything else)``.
+
+    ONE parse, shared by the two places the opt level matters: the ``H_opt`` feature
+    (:meth:`Context.features`) and the identity a measurement is stored under
+    (:meth:`Context.structural_key`). They must agree — the deploy evidence tiers gate on
+    ``H_opt`` and then look rows up by ``structural_key``, so a regime the two spell differently
+    is a row that is declared deployable and is then unreadable at a deploy.
+
+    Splitting rather than digesting the raw string is what makes ``""`` (compile / run's default)
+    and ``"-Xcicc -O3"`` ONE regime, as they physically are — keyed on the raw string they were
+    two, and every ``-O3``-pinned row was invisible to a default deploy. The residual keeps every
+    other flag verbatim, so ``--use_fast_math`` (which genuinely changes codegen) stays its own
+    partition."""
+    opt = 3
+    m = _OPT_TOKEN.search(compile_flags)
+    if m is not None:
+        opt = int(m.group(1))
+        compile_flags = compile_flags[: m.start()] + compile_flags[m.end() :]
+    return opt, " ".join(compile_flags.split())
 
 
 def _max_dynamic_smem_for(cc: tuple[int, int]) -> int:
@@ -275,10 +304,13 @@ class Context:
         As other non-derived knobs land (forced TMA on/off, splitk overrides),
         extend this method explicitly — keep ambient I/O fields out so the
         autotuning cache survives debug-flag flips.
+
+        The flags enter **split** (:func:`split_opt_level`), never raw, so that one regime has one
+        key however it is spelled.
         """
         from emmy.compiler.structural import digest  # noqa: PLC0415
 
-        return digest("Context", self.compute_capability, self.compile_flags)
+        return digest("Context", self.compute_capability, *split_opt_level(self.compile_flags))
 
     def hardware_id(self) -> str:
         """A stable per-card identity for the node-store key + ``gpu`` column: the PCIe
@@ -312,17 +344,14 @@ class Context:
           (VRAM bytes) is the one feature that distinguishes same-die SKUs the SM-only
           features can't — H100 80GB vs H200 141GB share cc + SM count.
         """
-        import re  # noqa: PLC0415
-
         from emmy.compiler.target import live_device_features  # noqa: PLC0415
 
         major, minor = self.compute_capability
-        m = re.search(r"-O(\d)", self.compile_flags)
         feats = {
             "H_cc": float(major * 10 + minor),
             "H_tc_gen": float(_TENSOR_CORE_GEN.get((major, minor), major)),
             "H_smem_optin": float(self.max_dynamic_smem),
-            "H_opt": float(m.group(1)) if m else 3.0,
+            "H_opt": float(split_opt_level(self.compile_flags)[0]),
         }
         # The memorized props of this context's card (golden reconstruction) when
         # set, else the live device's — so a golden featurizes with its own card.

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -556,7 +556,12 @@ Three definitions the list leans on:
 - **Which compile flags each tier applies under**: the reservoir tier applies only to a compile at deployable `-O3`
   flags (`H_opt=3`) — `-O3` evidence is true of the deployable settings only and must never settle an `-Xcicc -O1`
   compile. `H_opt` is read from the `-O<n>` in the compile flags; flags with no `-O<n>` at all — the `compile` /
-  `run` default — count as 3, so a default deploy is always deployable. The DB tier applies under any flags: its
+  `run` default — count as 3, so a default deploy is always deployable. The identity a measurement is *stored* under
+  agrees with that reading: `Context.structural_key` folds the flags **split** into an opt level plus the other flags
+  (`context.split_opt_level`), never the raw string, so `""` and an explicit `-Xcicc -O3` are one key for the one
+  regime they physically are. Keyed on the raw string they were two, and a row a tune wrote under an explicit `-O3`
+  pin was declared deployable by `H_opt` and then unreadable at a default deploy. The DB tier applies under any
+  flags: its
   "deployable" half means any context key that is not the `-O1` one, so an `-O3` row decides outright even under an
   `-O1` compile. The two tests are deliberately not mirror images: only `-Xcicc -O1` counts as the ranking flags,
   while anything else counts as deployable for the DB tier. An explicit `-O2` pin therefore gets DB evidence but not
@@ -1109,7 +1114,10 @@ Each `node` row also carries **label-quality columns** (additive migration; old 
 - `is_leaf` — whether this is a real measurement or a minimum over explored descendants.
 - `variance` / `n_samples` — the leaf's own bench statistics.
 - `status` — `ok` / `bench_fail`. Failed leaves ARE recorded, with the watchdog's placeholder value as `value_us`;
-  they are the negative examples a search prior needs. An `ok` row is never downgraded by a later failure.
+  they are the negative examples a search prior needs. An `ok` row is never downgraded by a later failure. A config
+  whose **compile** ran past its budget is not one of these and is not recorded at all: nothing about its speed was
+  measured, and a stored row would make it a permanent cache hit that is never re-benched (see the two bench budgets
+  in `backend/cuda/ARCHITECTURE.md`).
 - `run_id` / `measured_at` — the tune session (one id per CLI invocation) and the time that produced the CURRENT
   `value_us`; both are replaced only when that value is.
 - `feat_ver` — the `features.FEATURIZER_VERSION` the row's feature dict was written under (Part 3). Rows written
@@ -1346,7 +1354,8 @@ fresh child — no escalation modes, no `os._exit`.
   child's profiled launches), so with `--bench` those two want a separate plain `run`.
 
 Plus `--json PATH` — a machine-readable record of the whole comparison (backends / greedy kernels / pinned rows with
-their flags and a `status` field: `ok` / `pin_unmatched` / `bench_fail`; a failed greedy block carries
+their flags and a `status` field: `ok` / `pin_unmatched` / `bench_fail` / `compile_timeout` (the config's compile ran
+past its budget, so nothing about it was measured and the row is reported but never recorded); a failed greedy block carries
 `status: bench_fail` and an `error`, with null timings), so a sweep's judgments can be traced to flagged fields
 instead of to parsed terminal text. Each kernel row also carries **`record_knobs`**: the tuning knobs the compile
 actually produced, with every schedule knob family (`knob.SCHEDULE_FAMILIES`: WORK / TILE / REDUCE / STAGE / RASTER)

--- a/emmy/compiler/pipeline/search/policy/terminal_bench.py
+++ b/emmy/compiler/pipeline/search/policy/terminal_bench.py
@@ -12,6 +12,8 @@ import logging
 import statistics
 
 from emmy import config
+from emmy.compiler.backend.cuda.program import compile_budget_overrun
+from emmy.compiler.context import split_opt_level
 from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.cuda.ir import CudaOp
 from emmy.compiler.ir.kernel.ir import KernelOp
@@ -33,7 +35,7 @@ async def rebench_o3_async(cand, backend):
     median latency in µs, or ``None`` when the sweep is already at -O3 or the bench
     errors (best-effort — a re-bench hiccup must never abort the sweep). The winner
     already benched OK at -O1, so the only added cost is one -O3 compile (cubin-cached)."""
-    if "-O3" in config.nvcc_flags():
+    if split_opt_level(config.nvcc_flags())[0] == 3:  # already deployable, however it is spelled
         return None
     try:
         result = await backend.benchmark_async(cand.graph, nvcc_flags=O3_NVCC_FLAGS)
@@ -250,6 +252,18 @@ class TerminalBench:
         return "bench", None
 
     def finalize_exc(self, exc):
+        if compile_budget_overrun(exc):
+            # Nothing was measured, so nothing is recorded (see ``CompileBudgetExceeded``). The
+            # status stays in memory: ``_collect_node_records`` emits fail rows for ``bench_fail``
+            # exactly, so this writes no node row either. Loud, because a whole tile family
+            # overrunning the budget is a finding, not noise.
+            logger.warning(
+                "[tune] COMPILE BUDGET EXCEEDED for %d kernel(s) (%s) — nothing recorded; "
+                "raise bench_compile_timeout_s if this repeats on a whole tile family",
+                len(self.cuda_nodes),
+                exc,
+            )
+            return self._point_stats(0.0), "compile_timeout"
         fail_us = float(self.backend.bench_run_timeout_s) * 1_000_000.0
         logger.warning(
             "[tune] backend.benchmark failed (%s) — pinning bench_fail @ %.1f us for %d kernel(s)",

--- a/emmy/compiler/pipeline/search/strategy/two_level.py
+++ b/emmy/compiler/pipeline/search/strategy/two_level.py
@@ -37,7 +37,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from emmy.compiler.context import Context
+from emmy.compiler.context import Context, split_opt_level
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pass, Pipeline, TuningSearch
 from emmy.compiler.pipeline.knob import stamp_schedule_families
@@ -339,7 +339,7 @@ class TwoLevelStrategy(SearchStrategy):
         # The regime the deployable -O3 re-benches are keyed under in the node store — the tune
         # context with the re-bench's flags substituted, so an -O3 leaf row never collides with
         # its -O1 twin. ``None`` when the sweep itself already runs at -O3.
-        o3_ctx_key = replace(ctx, compile_flags=O3_NVCC_FLAGS).structural_key() if "-O3" not in ctx.compile_flags else None
+        o3_ctx_key = None if split_opt_level(ctx.compile_flags)[0] == 3 else replace(ctx, compile_flags=O3_NVCC_FLAGS).structural_key()
         backend_name = getattr(self.pool[0], "name", "cuda")
         # Group structurally-identical LoopOps under one ``Op.cache_key`` — insertion order =
         # first occurrence (drives the progress tail name). Ops with no cache key are

--- a/tests/compiler/backend/test_nvcc_compile.py
+++ b/tests/compiler/backend/test_nvcc_compile.py
@@ -12,7 +12,7 @@ import argparse
 
 from emmy.commands.compile import apply_nvcc_flags
 from emmy.compiler.backend.cuda import nvcc
-from emmy.compiler.context import Context
+from emmy.compiler.context import Context, split_opt_level
 
 
 def test_effective_flags_reads_env(monkeypatch) -> None:
@@ -33,16 +33,36 @@ def test_cubin_cache_key_partitions_by_flags(monkeypatch) -> None:
     assert k_o3 != k_o1
 
 
-def test_context_key_partitions_by_flags(monkeypatch) -> None:
-    """The perf cache key (Context.structural_key) must differ by opt level so
-    -O1-measured latencies never clobber -O3 ones."""
-    monkeypatch.setenv("EMMY_NVCC_FLAGS", "")
-    k_o3 = Context.from_target((8, 0)).structural_key()
-    monkeypatch.setenv("EMMY_NVCC_FLAGS", "-Xcicc -O1")
-    k_o1 = Context.from_target((8, 0)).structural_key()
-    assert k_o3 != k_o1
-    # Same flags ⇒ same key (cache hit across runs).
-    assert Context.from_target((8, 0)).structural_key() == k_o1
+def test_context_key_reads_one_regime_however_it_is_spelled(monkeypatch) -> None:
+    """``""`` (compile / run's default) and an explicit ``-Xcicc -O3`` are the SAME physical
+    regime and must key the same. Keyed on the raw flag string they did not, so every row a tune
+    wrote under an explicit -O3 pin was invisible to a default compile — declared deployable by
+    ``H_opt`` and then unreadable by ``structural_key``, the two spellings disagreeing about one
+    regime."""
+
+    def key_for(flags: str) -> str:
+        monkeypatch.setenv("EMMY_NVCC_FLAGS", flags)
+        return Context.from_target((8, 0)).structural_key()
+
+    assert key_for("") == key_for("-Xcicc -O3") == key_for("  -Xcicc   -O3  ")
+    # A ranking-only regime still keys apart — it must never answer for a deployable measurement.
+    assert key_for("-Xcicc -O1") != key_for("")
+    # Any other flag genuinely changes codegen and keeps its own partition.
+    assert key_for("--use_fast_math") != key_for("")
+    assert key_for("--use_fast_math -Xcicc -O3") == key_for("--use_fast_math")
+    assert key_for("--use_fast_math -Xcicc -O1") != key_for("--use_fast_math")
+
+
+def test_h_opt_and_context_key_agree_on_the_regime(monkeypatch) -> None:
+    """The deploy evidence tiers gate on ``H_opt`` and then look rows up by ``structural_key``,
+    so the two must never disagree about what regime a compile is in."""
+    for flags, opt in (("", 3.0), ("-Xcicc -O3", 3.0), ("-Xcicc -O1", 1.0), ("--use_fast_math", 3.0)):
+        monkeypatch.setenv("EMMY_NVCC_FLAGS", flags)
+        assert Context.from_target((8, 0)).features()["H_opt"] == opt
+    # The residual keeps every other flag, so a same-opt pair still separates on codegen.
+    assert split_opt_level("-Xcicc -O1") == (1, "")
+    assert split_opt_level("--use_fast_math -Xcicc -O3") == (3, "--use_fast_math")
+    assert split_opt_level("") == (3, "")
 
 
 def test_apply_nvcc_flags_precedence(monkeypatch) -> None:

--- a/tests/compiler/pipeline/search/policy/test_terminal_bench.py
+++ b/tests/compiler/pipeline/search/policy/test_terminal_bench.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from emmy.compiler.backend.base import BenchmarkResult, LaunchTime
+from emmy.compiler.backend.cuda.program import BenchWorkerJobError, CompileBudgetExceeded
 from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
@@ -56,3 +57,78 @@ async def test_auto_tune_uses_one_nominal_warmup_before_run_budget() -> None:
     assert measured is True
     assert status == "ok"
     assert stats.median == 750_000.0
+
+
+class _RaisingBackend:
+    """Fails every bench with ``exc``; counts how many times it was actually asked."""
+
+    name = "cuda"
+    bench_run_timeout_s = 2.0
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+        self.calls = 0
+
+    async def benchmark_async(self, _graph, *, warmup: int = 5, num_iters: int | str = 20) -> BenchmarkResult:
+        self.calls += 1
+        raise self.exc
+
+
+def _perf_row(db: SearchDB, cand):
+    return db.lookup_perf(cand.ctx.structural_key(), cand.graph.nodes["out"].op.cache_key(), backend="cuda")
+
+
+async def test_compile_budget_overrun_records_nothing() -> None:
+    """A compile-budget overrun measured no latency, so it must persist none. Recording one is
+    not merely a wrong label: ``prelude``'s cache lookup accepts any status, so the row would be
+    served as a cache hit forever after."""
+    db, cand = SearchDB(), _candidate()
+    backend = _RaisingBackend(CompileBudgetExceeded("compile stage exceeded 12.0s budget (13.4s) — nothing measured"))
+
+    stats, status, measured, per_kernel = await bench_terminal_async(cand, backend=backend, db=db)
+
+    assert status == "compile_timeout"
+    assert measured is True  # it burned real wall time; it must still spend the candidate budget
+    assert stats.median == 0.0  # no latency was measured — none is invented
+    assert per_kernel == []
+    assert _perf_row(db, cand) is None
+
+
+async def test_compile_budget_overrun_does_not_become_a_sticky_cache_hit() -> None:
+    """The regression this fix exists for: after a compile timeout the SAME config must still be
+    benchable. Previously the ``bench_fail`` sentinel row was a ``prelude`` cache hit on every
+    later terminal and every later sweep, so the config was never re-benched until ``tune
+    --clean`` — a slow compile permanently deleted it from the search."""
+    db, cand = SearchDB(), _candidate()
+    await bench_terminal_async(cand, backend=_RaisingBackend(CompileBudgetExceeded("budget")), db=db)
+
+    good = _BudgetedBackend(iter_ms=1.0)
+    stats, status, measured, _ = await bench_terminal_async(cand, backend=good, db=db)
+
+    assert good.calls == [(1, "auto")], "the retry must reach the device, not be served the earlier failure"
+    assert (status, measured) == ("ok", True)
+    assert stats.median == 1000.0
+
+
+async def test_worker_side_compile_budget_overrun_is_recognized() -> None:
+    """The sweep benches in a subprocess, where the exception CLASS cannot cross the pipe — the
+    kind rides back as a flag on ``BenchWorkerJobError`` and must be treated identically."""
+    db, cand = SearchDB(), _candidate()
+    exc = BenchWorkerJobError("bench worker error: CompileBudgetExceeded(...)", compile_budget=True)
+
+    _stats, status, _measured, _ = await bench_terminal_async(cand, backend=_RaisingBackend(exc), db=db)
+
+    assert status == "compile_timeout"
+    assert _perf_row(db, cand) is None
+
+
+async def test_a_real_bench_failure_still_records_bench_fail() -> None:
+    """The narrowing must not swallow genuine failures: a kernel that compiled and then failed
+    IS evidence about the kernel, and stays a recorded ``bench_fail`` at the watchdog sentinel."""
+    db, cand = SearchDB(), _candidate()
+
+    stats, status, _measured, _ = await bench_terminal_async(cand, backend=_RaisingBackend(RuntimeError("illegal memory access")), db=db)
+
+    assert status == "bench_fail"
+    assert stats.median == 2_000_000.0
+    assert _perf_row(db, cand).status == "bench_fail"


### PR DESCRIPTION
Two defects in how a measurement's regime and its failures are recorded. Both stand on their own; both are
prerequisites for a follow-up that makes `tune` measure only at the deployable regime.

## A compile-budget overrun was a sticky, cross-run exclusion

It raised a plain `RuntimeError`, which the sweep recorded as a `bench_fail` at the run-timeout sentinel — a fact
about cicc's compile time written down as a fact about the kernel's speed.

Worse than mislabelled. `TerminalBench.prelude`'s cache lookup accepts a row of **any** status, so that sentinel was
then served as a cache hit on every later terminal and every later sweep, and the config was never re-benched until
`tune --clean`. A slow compile permanently deleted a config from the search on that machine.

It now raises a named `CompileBudgetExceeded` and **nothing is recorded at all** — no perf row, no node row, no
durable negative in a freeze. The status stays in memory, so the existing "`bench_fail` exactly" gates exclude it
with no schema change. `run --bench`'s pinned and `--ab` rows take the same path, since they feed the same node
store the prior trains on. The exception class cannot cross the worker pipe (the protocol pickles `error` as a
string), so the child flags the kind and the parent rebuilds it, mirroring the `cache_miss` flag beside it.

The sweep's wall cap had to move with it. The compile budget is checked when the compile *returns*, so it can only
fire for a compile that finished; the wall sat ~2 s above compile+run, so any compile slower than that was SIGKILLed
into an anonymous `RuntimeError` and recorded as the sticky row instead, defeating the distinction entirely. The wall
now derives from the in-child budgets — the same formula the pinned path already uses. Hangs are still caught
in-child by the per-launch watchdog; the wall is a backstop for a wedged worker.

## `Context.structural_key` keyed on the raw nvcc flag string

`""` (compile/run's default) and `"-Xcicc -O3"` were two different keys for one physical regime, so rows written
under an explicit `-O3` pin were declared deployable by the `H_opt` feature and then unreadable at a default deploy.
The three-key union in `policy/greedy.py` papers over it today.

One shared `split_opt_level` now feeds both `H_opt` and the key, so the feature that declares a row deployable and
the key it is stored under can never disagree. The two remaining substring tests for "am I already deployable"
(`terminal_bench.rebench_o3_async`, `two_level`'s `o3_ctx_key`) were switched to it.

## Migration

Existing local tune DBs keep their rows but under superseded context keys; node rows are orphaned rather than
corrupted. **No checked-in artifact stores a context key** — the measurement freeze stores the opt level and
synthesizes its own `capX.Y-OZ`, and `group_measured` keys on the `H_opt` feature by design.

## On urgency

A compile-cost sweep run alongside this work (4,888 nvcc compiles, CUDA 13.0 and 12.8, RTX 5090) found the
compile-time blowup the `-Xcicc -O1` default exists to dodge **does not reproduce in current codegen**: paired per
config, `-O3` compiles at a median 0.96x of `-O1`, and the slowest compile anywhere in the sweep is 1.39 s against a
12 s budget. So the compile-budget path fixed here is a **guard, not a live failure mode** today. The bug is real and
the handling is wrong either way; it is simply not currently firing. The budget itself is left unchanged — it bounds
cubin load, buffer alloc and TMA descriptor prebuild as well as nvcc, and that half was not measured.

## Verification

- New: a compile-budget overrun persists no row, and the same config still benches on a retry instead of being
  served the earlier failure (the sticky-cache regression, which fails on the old behaviour).
- New: `structural_key` is equal for `""` / `-Xcicc -O3` / whitespace variants, distinct for `-Xcicc -O1` and
  `--use_fast_math`, and agrees with `H_opt` on every spelling.
- A genuine bench failure still records `bench_fail` at the sentinel — the narrowing does not swallow real negatives.
- `make test`: 3228 passed. The one failure (`test_golden_bench_2026.py::test_neptune_emmy_runner_fails_when_one_setup_is_incomplete`)
  is pre-existing and reproduces identically on a clean `main` — a shell-script test hitting exit 127 on macOS.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEbjU8cA3X7LAcWVL8gj9a