### PR TITLE
Give the torch reference one device instead of two guesses

### DIFF
--- a/emmy/compiler/backend/torch_ref.py
+++ b/emmy/compiler/backend/torch_ref.py
@@ -187,7 +187,7 @@ def _shape_ints(shape, sym_env: dict[str, int]) -> tuple[int, ...]:
     return tuple(d.as_static() if d.is_static else int(d.expr.eval(sym_env)) for d in shape)
 
 
-def _eval(node, ins: list, sym_env: dict[str, int] | None = None):
+def _eval(node, ins: list, sym_env: dict[str, int] | None = None, device=None):
     import torch  # noqa: PLC0415
     import torch.nn.functional as F  # noqa: PLC0415
 
@@ -285,7 +285,7 @@ def _eval(node, ins: list, sym_env: dict[str, int] | None = None):
         dim = next((int(i) for i in ins if not isinstance(i, torch.Tensor)), -1)
         return torch.cat(tensors, dim=dim)
     if name == "IndexMapOp":
-        return _index_map(op, ins, sym_env)
+        return _index_map(op, ins, sym_env, device)
     raise NotImplementedError(f"torch_ref: op {name!r} unmapped")
 
 
@@ -337,7 +337,7 @@ def _idx_expr(e, env: dict):
     return e.eval(env)
 
 
-def _index_map(op, ins: list, sym_env: dict[str, int] | None = None):
+def _index_map(op, ins: list, sym_env: dict[str, int] | None = None, device=None):
     """Run an ``IndexMapOp`` as a vectorized gather over output coordinates.
 
     For every output cell, the first source whose ``select`` predicate holds
@@ -352,7 +352,11 @@ def _index_map(op, ins: list, sym_env: dict[str, int] | None = None):
     # device / dtype from the first tensor-valued source (a source can be a
     # scalar constant — stored as a python float).
     base = next((ins[s.input_idx] for s in op.sources if torch.is_tensor(ins[s.input_idx])), None)
-    dev = base.device if base is not None else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    # No tensor-valued source (every source is a scalar constant) → fall back to the device the
+    # RUN is on, threaded down from ``build_callable``. Guessing from ``torch.cuda.is_available()``
+    # instead put an all-constant map on the GPU while the graph's own inputs sat on the CPU, so
+    # the two could not combine — invisible on a CPU-only host, a hard error anywhere with a GPU.
+    dev = base.device if base is not None else (device or torch.device("cpu"))
     dtype = base.dtype if base is not None else torch.float32
     # Coord / select exprs may reference symbolic extents (e.g. ``coord < seq_len``)
     # besides the output-coordinate placeholders — resolve both from one env.
@@ -438,6 +442,10 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
     # to fp16) into the declared dtype, and the CUDA backend honors it via typed
     # buffers — the torch ref must cast too, or torch's promotion silently runs
     # everything downstream of a mixed-dtype op at fp32.
+    # ONE device for the whole reference run: whatever the graph's own input tensors are on,
+    # CPU when a graph has none. Every step that has to invent a tensor (a range, an all-constant
+    # index map) uses this, so the pieces can always combine.
+    run_device = next((t.device for t in input_tensors.values() if torch.is_tensor(t)), torch.device("cpu"))
     compute_steps: list[tuple[str, Callable, list[str], torch.dtype | None]] = []
     for nid in order:
         node = graph.nodes[nid]
@@ -446,8 +454,6 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
         if type(node.op).__name__ == "ElementwiseOp":
             op_callable = _elementwise_callable(node.op.op.name)
         elif type(node.op).__name__ == "RangeOp":
-            first_input = next(iter(input_tensors.values()), None)
-            device = first_input.device if first_input is not None else torch.device("cpu")
             op_callable = (
                 lambda n, d: (
                     lambda _ins: torch.arange(
@@ -458,9 +464,9 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
                         device=d,
                     )
                 )
-            )(node, device)
+            )(node, run_device)
         else:
-            op_callable = (lambda n: lambda ins: _eval(n, ins, sym_env))(node)
+            op_callable = (lambda n, d: lambda ins: _eval(n, ins, sym_env, d))(node, run_device)
         compute_steps.append((nid, op_callable, list(node.inputs), torch_dtype(node.output.dtype)))
     out_ids = tuple(graph.outputs)
 


### PR DESCRIPTION
`build_callable` had two different answers to the same question — *what device does a tensor go on when there is
nothing to infer it from?*

- `_index_map` fell back to `cuda if torch.cuda.is_available() else cpu`
- the `RangeOp` branch fell back to `cpu`

On a CPU-only host both say `cpu` and agree, which is why this has never shown up in a local run or in CI without a
GPU. On any machine **with** a GPU they diverge: an all-constant index map lands on `cuda:0` while the graph's own
inputs sit on the CPU, and the two cannot combine.

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
  emmy/compiler/backend/torch_ref.py:117
```

`tests/compiler/loader/test_quant.py::test_spell_mxfp4_inputs_preserves_packed_feed_and_values` reaches it through
the mxfp4 reference path. It passes on a Mac and fails on any GPU box.

## The fix

Both sites now read one `run_device`, derived from the graph's own input tensors — the signal `RangeOp` already
used — falling back to CPU only when a graph has no tensor inputs at all.

Guessing from `torch.cuda.is_available()` was never right: whether a GPU *exists* says nothing about where this
run's data *is*. The reference implementation should follow its inputs.

## Verification

Measured on an RTX 5090 (CUDA 13.0):

| | before | after |
|---|---|---|
| `test_quant.py` + `test_torch_ref.py` on GPU | 1 failed, 92 passed | **93 passed** |
| same, on a CPU-only host | 92 passed, 1 skipped | 92 passed, 1 skipped |

Full suite locally: 3228 passed. The one failure
(`test_golden_bench_2026.py::test_neptune_emmy_runner_fails_when_one_setup_is_incomplete`) is pre-existing, macOS-only
(a shell-script test hitting exit 127), and passes on Linux.

## How it was found

Running the suite on a GPU box surfaced it. Worth noting for its own sake: **~500 CUDA-marked tests only execute with
a GPU** — 3747 ran on the box versus 3230 on a Mac — so a whole class of failures is invisible to a CPU-only test
lane. This was one of them. Another one found the same way (a NaN in fused causal SDPA, bisected to #631) is *not*
fixed here and is being reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEbjU8cA3X7LAcWVL8gj9a