### PR TITLE
Record the expert program the checkpoint actually stores

### DIFF
--- a/emmy/compiler/loader/quant.py
+++ b/emmy/compiler/loader/quant.py
@@ -367,14 +367,30 @@ def fp8_weight_profile(hf_config) -> tuple[str, tuple[int, int] | None, list[str
     return fmt, (None if block is None else tuple(int(b) for b in block)), _skip_patterns(qc)
 
 
+def native_mxfp4_experts(hf_config) -> bool:
+    """True when the ROUTED EXPERTS are stored as native MXFP4 under the checkpoint's own
+    declaration (``expert_dtype: fp4``), whatever the trunk's ``quant_method`` says.
+
+    DeepSeek V4 publishes an fp8 trunk beside fp4 experts, so the expert storage is named by
+    this field and by nothing in ``quantization_config``. The serving loader and the twin
+    capture both key on it, which is what keeps the recorded expert program the one serving
+    binds."""
+    return str(getattr(hf_config, "expert_dtype", "") or "") == "fp4"
+
+
 def mxfp4_weight_profile(hf_config) -> list[str] | None:
-    """MXFP4 skip patterns from a shape-only config, or ``None`` for another scheme."""
+    """MXFP4 skip patterns from a shape-only config, or ``None`` for another scheme.
+
+    Two declarations select native MXFP4: ``quant_method: mxfp4`` for a wholly-MXFP4 checkpoint
+    (gpt-oss), and :func:`native_mxfp4_experts` for one whose routed experts alone are MXFP4."""
     qc = getattr(hf_config, "quantization_config", None)
     if qc is None:
         return None
     if not isinstance(qc, dict):
         qc = {key: getattr(qc, key, None) for key in ("quant_method", *_SKIP_KEYS)}
-    return _skip_patterns(qc) if qc.get("quant_method") == "mxfp4" else None
+    if qc.get("quant_method") == "mxfp4" or native_mxfp4_experts(hf_config):
+        return _skip_patterns(qc)
+    return None
 
 
 _SKIP_KEYS = ("ignored_layers", "modules_to_not_convert", "ignore")

--- a/emmy/compiler/trace/huggingface.py
+++ b/emmy/compiler/trace/huggingface.py
@@ -1699,6 +1699,7 @@ def load_quantized_split(
         _skip_patterns,
         dequantize,
         dequantize_awq4,
+        native_mxfp4_experts,
         scale_is_reciprocal,
     )
     from emmy.compiler.loader.safetensors import _build_index  # noqa: PLC0415
@@ -1712,8 +1713,9 @@ def load_quantized_split(
 
     mxfp4_qc = _mxfp4_quant_config(model_dir)
     # DeepSeek V4 declares an fp8 TRUNK while storing its routed experts as native MXFP4: the expert
-    # storage is named by ``expert_dtype``, not by ``quant_method``.
-    native_mxfp4_experts = str(getattr(config, "expert_dtype", "") or "") == "fp4"
+    # storage is named by ``expert_dtype``, not by ``quant_method``. The twin capture reads the same
+    # predicate, so the golden records the expert program this load produces.
+    native_experts = native_mxfp4_experts(config)
     qc = _fp8_quant_config(model_dir) or mxfp4_qc or {}
     awq = _awq_quant_config(model_dir)
     patterns = _skip_patterns(qc)
@@ -1797,7 +1799,7 @@ def load_quantized_split(
                         # index 0, and the router maps global selections onto that axis at dispatch.
                         expert -= expert_range[0]
                     t = f.get_tensor(k)
-                    if native_mxfp4_experts:
+                    if native_experts:
                         # The published MXFP4 dialect: ``I8 [out, in/2]`` nibble pairs beside
                         # ``F8_E8M0 [out, in/32]`` exponents. Both are raw byte carriers, so VIEW
                         # (never cast) and give the blocks the ``(out, groups, 16)`` shape the

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -120,11 +120,10 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `…@f8e4m3` carries `w_gate_up` / `w_down` as bits + block scales tiled over the traced weight shapes), with the
   plain twin kept beside it only for a profile whose layers the quantizer left unconverted (Laguna's last four), and
   native MXFP4 from logical expert shapes (`…@mxfp4`, uint8 blocks plus uint8 E8M0 scales, in the layout the experts
-  module declares). One checkpoint escapes that rule today: DeepSeek V4 declares `quant_method: fp8` with
-  `expert_dtype: fp4`, and the format choice here keys on `quant_method` while the serving loader keys on
-  `expert_dtype` — so its expert twin records `@f8e4m3` while serving deploys `@mxfp4`, leaving its routed-expert
-  kernels out of the golden entirely (they resolve from measured or prior evidence instead). Serving is unaffected;
-  a release that warms and bakes this model would seal unqualified picks for its dominant kernel.
+  module declares). The format follows the EXPERTS, not the trunk: a checkpoint may declare an fp8 trunk beside
+  natively MXFP4 routed experts (DeepSeek V4's `expert_dtype: fp4`), and `loader.quant.native_mxfp4_experts` is the
+  one predicate both this capture and the serving loader read, so the two cannot disagree about what the expert
+  program binds.
   Query-head discovery validates the classic `q_proj` signature and DeepSeek's complete low-rank `q_a_proj` /
   `q_b_proj` plus shared-`kv_proj` layout. A DeepSeek V4 layer is captured through the attention-sublayer seam
   (`hyper_connection_seam` in `compiler/trace/huggingface.py`): the carrier is the `hc_mult` hyper-connection residual

--- a/emmy/serving/twins.py
+++ b/emmy/serving/twins.py
@@ -204,10 +204,12 @@ def capture_twin_graphs(
                 expert_name = f"expert{name}{suffix}"
                 if storage:
                     graphs.update(_spell_expert_twins(expert_name, graph, storage))
+                elif mxfp4 is not None:
+                    # BEFORE fp8: a checkpoint can declare an fp8 trunk beside natively MXFP4
+                    # routed experts (DeepSeek V4), and the experts are what this twin records.
+                    graphs.update(_spell_mxfp4_expert_twins(expert_name, graph, mxfp4, members, moe_expert_layout(parts[1])[0]))
                 elif fp8 is not None:
                     graphs.update(_spell_fp8_expert_twins(expert_name, graph, fp8, members))
-                elif mxfp4 is not None:
-                    graphs.update(_spell_mxfp4_expert_twins(expert_name, graph, mxfp4, members, moe_expert_layout(parts[1])[0]))
                 else:
                     graphs[expert_name] = graph
     return _spell_coded_twins(graphs, storage, layer_scopes=layer_scopes) if storage else graphs

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -127,13 +127,16 @@ pick lands within 0.089 of the fork's: a near-tie between two continuations the 
 both of which continue coherently. Each arm is individually deterministic — two runs of each agree on every token —
 so the single divergence is arm-to-arm numerics at a tie, not run-to-run noise.
 
-**The routed-expert kernels are not covered by this model's serving golden.** The twin capture picks the expert
-format from `quantization_config.quant_method`, which this checkpoint declares as `fp8`, while the serving loader
-picks it from `expert_dtype: fp4` — so the golden records an `@f8e4m3` expert program and serving deploys an
-`@mxfp4` one. Goldens are keyed by strict structural kernel identity, so those kernels match nothing in it and
-resolve from measured or prior evidence instead. Serving correctness is unaffected — the agreement above was
-measured on exactly this configuration — but a release that warmed and baked this model today would seal
-unqualified picks for its dominant kernel, so that mismatch is a prerequisite for the image work, not a footnote.
+**The routed-expert kernels have no golden coverage.** The committed golden is the per-layer compiler-qualification
+trace below — layers 0/2/3/4 plus the model seam, expert weights as dense values. Serving's routed-expert program is
+input-sourced instead: packed MXFP4 blocks and E8M0 scales that decode in-graph. Goldens key on strict structural
+kernel identity, so that program matches nothing in the file and resolves its forks from measured or prior evidence.
+Serving correctness is unaffected — the agreement above was measured in exactly that state — but a release that warms
+and bakes this model seals whatever those forks resolved to, unqualified.
+
+Closing it needs a *serving* golden, which this model does not have: `emmy trace --serving-twins` derives its width
+and pin matrix from `models/<slug>.env`, and that config is what the image stage's headroom sweep produces. So the
+serving golden comes with the image work rather than before it.
 
 This is what makes the output the load-bearing evidence: a transposed expert matrix or a mis-scaled MXFP4 decode
 yields fluent-looking garbage, not correct capitals, a valid Python guard clause, and 101 of the corpus's 128 token

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -253,6 +253,7 @@
  "tests/compiler/passes/test_split_fresh_kernels.py::test_finalize_keeps_projection_input_edges": 1.4,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_no_piece_inherits_the_kernel_it_replaces": 0.16,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_split_preserves_every_fused_output": 6.4,
+ "tests/compiler/passes/test_split_fresh_kernels.py::test_split_reductions_remain_fold_trees[graph0]": 5.1,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_the_split_is_consumed_by_the_kernel_that_realizes_it[g2a]": 0.22,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_the_split_is_consumed_by_the_kernel_that_realizes_it[g2k]": 0.21,
  "tests/compiler/passes/test_split_fresh_kernels.py::test_the_split_is_consumed_by_the_kernel_that_realizes_it[g4k]": 1.31,

--- a/tests/serving/test_twins_coded.py
+++ b/tests/serving/test_twins_coded.py
@@ -240,11 +240,13 @@ def test_deepseek_serving_twins_capture_the_hyper_connection_seam_weight_free(tm
     assert not token_dim.is_static and token_dim.as_atom_name() == "num_tokens"
 
 
-def test_deepseek_fp8_declaration_spells_the_expert_twin_for_the_cast_lane(tmp_path):
-    """The pinned checkpoint declares an fp8 trunk while storing its routed experts as MXFP4
-    (``expert_dtype: fp4``). The snapshot's converter casts those experts LOSSLESSLY into exactly the
-    declared fp8 [128, 128]-block form, so the ``@f8e4m3`` expert twin records the program the
-    fp8-cast serving lane deploys; the hyper-connection pre/post twins keep their value constants."""
+def test_deepseek_expert_twin_records_the_native_mxfp4_program_serving_binds(tmp_path):
+    """The pinned checkpoint declares an fp8 TRUNK while storing its routed experts as native MXFP4
+    (``expert_dtype: fp4``), and the serving loader keeps those experts packed. The expert twin has
+    to follow the experts, not the trunk declaration, or the golden records a program serving never
+    runs. ``w_down``'s packed shape also pins the layout the caller passes down: these experts are
+    ``F.linear`` parameters, so the blocks lead with ``out``; the ``x @ W`` reading would produce
+    (16, 2, 16) here instead."""
     pytest.importorskip("torch")
     transformers = pytest.importorskip("transformers")
 
@@ -252,8 +254,8 @@ def test_deepseek_fp8_declaration_spells_the_expert_twin_for_the_cast_lane(tmp_p
 
     config = transformers.DeepseekV4Config(
         vocab_size=64,
-        hidden_size=32,
-        moe_intermediate_size=16,
+        hidden_size=64,
+        moe_intermediate_size=32,
         num_hidden_layers=2,
         num_attention_heads=4,
         head_dim=8,
@@ -285,11 +287,13 @@ def test_deepseek_fp8_declaration_spells_the_expert_twin_for_the_cast_lane(tmp_p
     config.expert_dtype = "fp4"
     config.save_pretrained(tmp_path)
     graphs = capture_twin_graphs(str(tmp_path), decode_bucket=4, prefill_bucket=0)
-    assert set(graphs) == {"pre4", "pre-sym", "post4", "post-sym", "expert4@f8e4m3", "expert-sym@f8e4m3"}
-    expert = graphs["expert4@f8e4m3"]
+    assert set(graphs) == {"pre4", "pre-sym", "post4", "post-sym", "expert4@mxfp4", "expert-sym@mxfp4"}
+    expert = graphs["expert4@mxfp4"]
+    assert set(expert.inputs) >= {"w_gate_up", "w_gate_up_scale", "w_down", "w_down_scale"}
     by_id = {i: expert.nodes[i].output for i in expert.inputs}
-    assert {out.dtype.name for i, out in by_id.items() if i in ("w_gate_up", "w_down")} == {"f8e4m3"}
-    assert {i for i in expert.inputs} >= {"w_gate_up", "w_gate_up_scale", "w_down", "w_down_scale"}
+    assert {out.dtype.name for i, out in by_id.items() if i.startswith("w_")} == {"u8"}
+    shape = tuple(d.as_static() for d in by_id["w_down"].shape)
+    assert shape == (64, 1, 16), f"expected (out, in/32, 16) for an F.linear expert, got {shape}"
 
 
 @pytest.mark.skip(reason="global greedy ranking still traverses the full coded-expert schedule space")


### PR DESCRIPTION
Rebased onto main now that #665 has merged; this is its own two commits against main.

Closes the High finding from #665's review — and corrects the framing of it.

## The fix

The twin capture chose the expert format from `quantization_config.quant_method` while the serving loader chose it
from `expert_dtype`. DeepSeek V4 declares `quant_method: fp8` with `expert_dtype: fp4`, so a serving-twin capture of
this checkpoint recorded an `@f8e4m3` expert program while serving deploys `@mxfp4`. Both lanes now read one
predicate, `native_mxfp4_experts`, and the expert twin is chosen before the trunk's fp8 declaration — the experts are
what it records.

Verified against the real 43-layer config on the target host: the twin's packed inputs are now
`w_gate_up (4096, 128, 16)` and `w_down (4096, 64, 16)` uint8 — byte-for-byte the geometry the serving store binds.
Comparing the two spellings' inventories at identical widths, they share 279 targets and differ by 7 new against 6
stale, so this moves the routed-expert rows and nothing else.

The rewritten test also pins the caller's layout argument, which #665's speller tests could not: `w_down`'s packed
shape is `(64, 1, 16)` for these `F.linear` experts and would be `(16, 2, 16)` under the `x @ W` reading. That closes
the one review finding #665 left open.

## Correction to the reported gap

The review said — and #665's docs repeated — that the committed golden records `@f8e4m3` while serving deploys
`@mxfp4`. Checking the artifact, it records neither: `recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml` is the
per-layer compiler-qualification trace of layers 0/2/3/4 plus the model seam, 279 whole-layer targets whose expert
weights are dense values, with no packed inputs anywhere (`u8`, `f8e4m3`, `mxfp4` all absent).

The conclusion survives for a different reason: serving's routed-expert program is input-sourced from packed blocks
and decodes in-graph, so it is structurally a different kernel and matches nothing in a file built from dense layer
traces. The remedy changes, though. Closing it needs a *serving* golden, which this model has none of, and
`emmy trace --serving-twins` derives its matrix from `models/<slug>.env` — the config the image stage's headroom
sweep produces. **That inverts the order I gave earlier: the serving golden comes with the image work, not before
it.** The docs now say that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
