### PR TITLE
A nix dev shell for emmy's system deps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,13 @@
           pkgs.gcc
           pkgs.cmake
           # The interpreter ``make setup`` builds the venv with (``python3.12 -m venv``), so the
-          # version has to match the Makefile's or `make setup` fails inside the shell. Keeping it
-          # in the closure is also what holds that store path alive: without it a garbage
-          # collection leaves ``venv/bin/python`` dangling, and the venv then looks present while
-          # every call through it fails.
+          # version has to match the Makefile's or `make setup` fails inside the shell.
+          #
+          # Keeping it in the closure holds THIS store path alive, which protects a venv built
+          # INSIDE the shell — and only that one. A venv built against some other 3.12 keeps
+          # pointing at that other store path, which a garbage collection is free to remove: the
+          # venv then still looks present while every call through it fails, because pip-installed
+          # wheels are not nix-managed and nothing else references the interpreter they symlink.
           pkgs.python312
           # ``pip install ruff`` puts a generic-linux binary in the venv, which NixOS cannot
           # exec. The nixpkgs build is what ``make lint`` finds on PATH here.

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,12 @@
       # per-package option: it has to be set where nixpkgs is imported. The CUDA packages are
       # unfree, so that flag rides along. Nothing else in the shell comes from here, which keeps
       # the ordinary toolchain on the cached ``legacyPackages`` instance.
+      #
+      # These packages are NOT in the official binary cache, so a first ``nix develop`` builds
+      # them from source — hours, not minutes. Adding the community CUDA cache to the HOST
+      # configuration avoids that; this flake deliberately does not, because substituters are a
+      # trust decision that belongs to whoever runs the machine, not to a checked-in dev shell:
+      # https://wiki.nixos.org/wiki/CUDA#Setting_up_CUDA_Binary_Cache
       cudaPkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,13 @@
         # venv-installed wheels (numpy, torch, ...) dlopen these at run time;
         # makeLibraryPath picks each package's lib output, so plain `zlib` is
         # correct here (no `.out` footgun).
-        LD_LIBRARY_PATH = nixpkgs.lib.makeLibraryPath [
+        # ``/run/opengl-driver/lib`` FIRST: NixOS puts the NVIDIA driver's ``libcuda.so.1`` there
+        # rather than in any store path, and nothing else on this list supplies it. Without it
+        # every CUDA program reports "Found no NVIDIA driver on your system" while the driver is
+        # loaded and ``nvidia-smi`` works — torch and cupy both see zero devices. It is a host
+        # path by necessity: the driver has to match the running kernel, so it cannot come from
+        # the flake.
+        LD_LIBRARY_PATH = "/run/opengl-driver/lib:" + nixpkgs.lib.makeLibraryPath [
           pkgs.stdenv.cc.cc
           pkgs.zlib
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "emmy dev shell: toolchain + runtime libs for venv binary wheels";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          pkg-config
+          gcc
+          cmake
+        ];
+
+        # venv-installed wheels (numpy, torch, ...) dlopen these at run time;
+        # makeLibraryPath picks each package's lib output, so plain `zlib` is
+        # correct here (no `.out` footgun).
+        LD_LIBRARY_PATH = nixpkgs.lib.makeLibraryPath [
+          pkgs.stdenv.cc.cc
+          pkgs.zlib
+        ];
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,15 @@
         # whatever ``/usr/local/cuda`` happens to be, which on NixOS is nothing.
         CUDA_HOME = "${cudaPkgs.cudatoolkit}";
 
+        # NOT covered here: the loop backend JIT-compiles kernels in-process through cppyy, whose
+        # bundled ``rootcling`` is a generic-linux executable. NixOS stubs the loader such
+        # binaries need, so Cling fails to build its precompiled header and then FAULTS — the
+        # symptom is a segfault during pytest collection ("node down: Not properly terminated"),
+        # which reads like a broken checkout rather than a missing setting. ``programs.nix-ld.enable``
+        # in the HOST configuration supplies a real loader and fixes it (verified: cppyy imports and
+        # ``tests/compiler/ir/loop/`` passes). A devShell cannot set it for its user, which is why
+        # it is named here rather than solved here.
+        #
         # venv-installed wheels (numpy, torch, ...) dlopen these at run time;
         # makeLibraryPath picks each package's lib output, so plain `zlib` is
         # correct here (no `.out` footgun).

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,13 @@
           pkg-config
           gcc
           cmake
+          # The interpreter the venv's symlinks point at. Without it in the shell's closure
+          # nothing keeps that store path alive, and a garbage collection leaves
+          # ``venv/bin/python`` dangling — the venv looks present and every call fails.
+          python313
+          # ``pip install ruff`` puts a generic-linux binary in the venv, which NixOS cannot
+          # exec. The nixpkgs build is what ``make lint`` finds on PATH here.
+          ruff
         ];
 
         # venv-installed wheels (numpy, torch, ...) dlopen these at run time;

--- a/flake.nix
+++ b/flake.nix
@@ -28,10 +28,12 @@
           pkgs.pkg-config
           pkgs.gcc
           pkgs.cmake
-          # The interpreter the venv's symlinks point at. Without it in the shell's closure
-          # nothing keeps that store path alive, and a garbage collection leaves
-          # ``venv/bin/python`` dangling — the venv looks present and every call fails.
-          pkgs.python313
+          # The interpreter ``make setup`` builds the venv with (``python3.12 -m venv``), so the
+          # version has to match the Makefile's or `make setup` fails inside the shell. Keeping it
+          # in the closure is also what holds that store path alive: without it a garbage
+          # collection leaves ``venv/bin/python`` dangling, and the venv then looks present while
+          # every call through it fails.
+          pkgs.python312
           # ``pip install ruff`` puts a generic-linux binary in the venv, which NixOS cannot
           # exec. The nixpkgs build is what ``make lint`` finds on PATH here.
           pkgs.ruff

--- a/flake.nix
+++ b/flake.nix
@@ -7,20 +7,35 @@
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
+      # A second instance, because ``cudaSupport`` is an evaluation-time config rather than a
+      # per-package option: it has to be set where nixpkgs is imported. The CUDA packages are
+      # unfree, so that flag rides along. Nothing else in the shell comes from here, which keeps
+      # the ordinary toolchain on the cached ``legacyPackages`` instance.
+      cudaPkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+        config.cudaSupport = true;
+      };
     in {
       devShells.${system}.default = pkgs.mkShell {
-        packages = with pkgs; [
-          pkg-config
-          gcc
-          cmake
+        packages = [
+          pkgs.pkg-config
+          pkgs.gcc
+          pkgs.cmake
           # The interpreter the venv's symlinks point at. Without it in the shell's closure
           # nothing keeps that store path alive, and a garbage collection leaves
           # ``venv/bin/python`` dangling — the venv looks present and every call fails.
-          python313
+          pkgs.python313
           # ``pip install ruff`` puts a generic-linux binary in the venv, which NixOS cannot
           # exec. The nixpkgs build is what ``make lint`` finds on PATH here.
-          ruff
+          pkgs.ruff
+          # ``nvcc``, which the CUDA backend shells out to for every kernel it compiles.
+          cudaPkgs.cudatoolkit
         ];
+
+        # The compiler reads this to find the toolkit root; without it a CUDA build falls back to
+        # whatever ``/usr/local/cuda`` happens to be, which on NixOS is nothing.
+        CUDA_HOME = "${cudaPkgs.cudatoolkit}";
 
         # venv-installed wheels (numpy, torch, ...) dlopen these at run time;
         # makeLibraryPath picks each package's lib output, so plain `zlib` is


### PR DESCRIPTION
A `nix develop` shell carrying the system dependencies emmy's `venv` needs on NixOS: libstdc++ and zlib for the binary wheels, the interpreter the venv's symlinks point at, ruff, and `nvcc` for the CUDA backend.

Relevant only to NixOS users, everyone else can safely disregard it. Applies only when you run `nix develop`, and makes `make setup` / `make test` / `make lint` behave exactly as it does for, say, an Ubuntu user with the right system deps installed.

Two things the shell names but cannot set, because they are host configuration: the CUDA binary cache (without it, a first `nix develop` builds the CUDA packages from source) and `programs.nix-ld.enable` (without it, cppyy segfaults during pytest collection). Both are commented at the point they matter in `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SWsPwiCdMHkz4Q3huMDYL
