### PR TITLE
Declare a shared broadcast constant once per emitted scope

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/010_materialize.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/010_materialize.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from emmy.compiler.graph import Node
 from emmy.compiler.ir.kernel import KernelOp
-from emmy.compiler.ir.stmt import Body
+from emmy.compiler.ir.stmt import Body, Load
 from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.ir.tile.ops import UnbindableProjection, reduce_plan
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
@@ -41,10 +41,51 @@ def rewrite(match: Match, root: Node) -> KernelOp | None:
     rplan = reduce_plan(tile) if tile.op is not None else None
     assert rplan is None or not rplan.needs_split, "materialize: a GRID split stage reached the kernel pass past 035_split_reduce"
     try:
-        return KernelOp(body=Body((factorize(tile, root),)), name=tile.name)
+        return KernelOp(body=_drop_repeated_declarations(Body((factorize(tile, root),))), name=tile.name)
     except UnbindableProjection as exc:
         # The offered row has no multi-root binding (e.g. it tiles two contraction operands of a
         # projection whose outputs do not partition by root). The row stays OFFERED — the
         # realization corpus pins that — and the compile declines it here: the skip is recorded,
         # the node stays a TileOp, and the greedy blocklist retry resolves onto the next row.
         raise RuleSkipped(f"kernel binder refuses this row's projection ownership: {exc}", reject=True) from exc
+
+
+def _drop_repeated_declarations(body: Body) -> Body:
+    """Drop a scalar ``Load`` re-binding a name already bound to the IDENTICAL ``(input, index)``
+    in the same scope — the emitted body's one legality guard.
+
+    Operand cones splice INDEPENDENTLY (``Fold.spliced_step``), so two sibling cones reading one
+    shared broadcast constant each carry their own copy of its ``buf[0]`` ``Load``, under the same
+    SSA name and at the same address. Flattened into one loop body those are two C declarations of
+    one name, which nvcc rejects (*already declared in the current scope* — eleven of them on
+    DeepSeek-V4's MXFP4 expert kernel, whose decode applies eleven shared constants to both halves
+    of the fused ``gate_up`` weight).
+
+    The repeat binds nothing new, so it is dropped with NO rewrite: every downstream use already
+    names the survivor. That is what keeps the guard narrow, and narrow is what makes it safe over
+    a WHOLE kernel body. The renaming forms (``_atom._dedup_loads``, ``stmt.dedup_loads``) collapse
+    two DIFFERENT names at one address, which needs the memory-effect reasoning neither does: a
+    ``Write`` or an async fill between two identical loads of a staged buffer makes the second a
+    different value. A same-name repeat cannot hide such a reload — a rebind in one C scope is
+    already illegal — so this guard needs no such analysis.
+
+    A name re-bound to a DIFFERENT address is left alone: that is an SSA fault, and it must surface
+    as one rather than be collapsed onto a stale value. Per scope, so an inner body may legally
+    shadow an outer binding."""
+
+    def scope(stmts) -> tuple:
+        bound: dict[str, tuple] = {}
+        kept = []
+        for stmt in stmts:
+            if isinstance(stmt, Load) and stmt.is_scalar:
+                address = (stmt.input, tuple(e.pretty() for e in stmt.index))
+                if bound.get(stmt.name) == address:
+                    continue
+                bound[stmt.name] = address
+            nested = stmt.nested()
+            if nested:
+                stmt = stmt.with_bodies(tuple(Body(scope(inner)) for inner in nested))
+            kept.append(stmt)
+        return tuple(kept)
+
+    return Body(scope(body))

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -7,9 +7,20 @@ afterwards.
 ## `010_materialize` — bind the schedule to threads (and expand the contraction)
 
 `010_materialize` is a thin wrapper: after the split-survivor assert it makes **one** call to
-`_factor.factorize(tile, root)`, the entry to the recursive emitter. `factorize` builds the ambient `Ctx` and dispatches
-`tile.op` through `_factorize`, which peels projecting zero-axis `Fold`s and binds each leaf via the ONE root-binding
-pipeline (`_factor._bind`) — its form is read off the node's SCHEDULE (which axes are tiled), never a kernel kind, and
+`_factor.factorize(tile, root)`, the entry to the recursive emitter, then passes the finished body through
+`_drop_repeated_declarations` — the emitted body's one legality guard. Operand cones splice INDEPENDENTLY
+(`Fold.spliced_step`), so two sibling cones reading one shared broadcast constant each carry their own copy of its
+`buf[0]` `Load`, under the same SSA name and at the same address; flattened into one loop body that is two C
+declarations of one name, which nvcc rejects (*already declared in the current scope*). The repeat binds nothing new,
+so it is dropped with NO rewrite — which is what keeps the guard narrow enough to run over a WHOLE kernel body. The
+renaming forms (`_atom._dedup_loads`, `stmt.dedup_loads`) collapse two DIFFERENT names at one address, which needs a
+memory-effect reading neither has: a `Write` or an async fill between two identical loads of a staged buffer makes the
+second a different value. A same-name repeat cannot hide such a reload, since a rebind in one C scope is already
+illegal. A name re-bound to a DIFFERENT address is left alone: that is an SSA fault and must surface as one.
+
+`factorize` builds the ambient `Ctx` and dispatches `tile.op` through `_factorize`, which peels projecting zero-axis
+`Fold`s and binds each leaf via the ONE root-binding pipeline (`_factor._bind`) — its form is read off the node's
+SCHEDULE (which axes are tiled), never a kernel kind, and
 it seals through the one `grid_tile` finalizer (the article's "schedule separate from combine" thesis — the op tree +
 `ir/tile` `Fold.lower` are shared across kinds; only the partition changes). Its arms are points of one
 `(output-tiling) × (reduce-folding)` space:

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -42,6 +42,7 @@ tests/compiler/passes/
 ├── test_knob_pinning.py            # EMMY_KNOBS-pinned regression configs (article-reproduction tile/transport sweep)
 ├── test_warp_specialize_deadlock.py # WS=1 stranded-TMA deadlock (Qwen3 k_linear_mean_reduce) regressions
 ├── test_tile_naming.py             # provenance-driven k_<op>_<suffix> kernel naming
+├── test_shared_constant_cone.py    # one broadcast constant, two sibling cones — one declaration per scope
 └── test_pipeline_semantics.py      # full pass chain (decompose → opt → fuse) vs numpy
 ```
 

--- a/tests/compiler/passes/test_shared_constant_cone.py
+++ b/tests/compiler/passes/test_shared_constant_cone.py
@@ -1,0 +1,100 @@
+"""One broadcast constant feeding TWO sibling cones declares its load ONCE per scope.
+
+A ``Fold``'s operand edges splice independently (``Fold.spliced_step``), so two cones reading the
+same 1-element input each carry their own copy of its ``buf[0]`` ``Load`` — same SSA name, same
+``(input, index)``. Flattened into one loop body they become two C declarations of one name, which
+nvcc rejects (``"in4" has already been declared in the current scope``, 11 errors on the
+DeepSeek-V4 MXFP4 expert kernel, whose decode spells eleven shared scalar constants and applies
+them to both halves of a fused ``gate_up`` weight).
+
+The graph below is that shape minimized: one constant applied to a fused weight, sliced into the
+two channels of one contraction. Capability-independent — it reproduced identically on sm_70,
+sm_80, sm_89 and sm_120.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib import import_module
+
+import pytest
+
+from emmy.compiler.context import Context
+from emmy.compiler.dtype import F16
+from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.expr import Literal
+from emmy.compiler.ir.frontend.ir import LinearOp, SliceOp
+from emmy.compiler.ir.stmt import Body, Load
+from emmy.compiler.ir.tensor.ir import ElementwiseOp
+from emmy.compiler.pipeline import CUDA_PASSES, Pipeline
+from emmy.compiler.target import set_target
+
+materialize = import_module("emmy.compiler.pipeline.passes.lowering.kernel.010_materialize")
+
+_CAP = (8, 0)
+_M, _K, _N = 1, 32, 16  # M=1 — the decode row, whose contraction folds serially per channel
+_DECL = re.compile(r"^\s*(?:const\s+)?(?:float|double|half|__half|int|unsigned|long|bool)\s+(\w+)\s*(?:=|;)")
+
+
+def _redeclared(source: str) -> list[str]:
+    """Names declared twice within ONE brace scope — exactly what nvcc rejects."""
+    scopes: list[dict[str, int]] = [{}]
+    clashes: list[str] = []
+    for line in source.splitlines():
+        declared = _DECL.match(line)
+        if declared and declared.group(1) in scopes[-1]:
+            clashes.append(declared.group(1))
+        elif declared:
+            scopes[-1][declared.group(1)] = 1
+        for char in line:
+            if char == "{":
+                scopes.append({})
+            elif char == "}" and len(scopes) > 1:
+                scopes.pop()
+    return clashes
+
+
+def _gate_up_graph() -> Graph:
+    """``y = (x @ (w − c)[:N].T) · (x @ (w − c)[N:].T)`` — the fused gate/up shape, ``c`` shared."""
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (_M, _K), dtype=F16), node_id="x")
+    graph.add_node(InputOp(), [], Tensor("w", (2 * _N, _K), dtype=F16), node_id="w")
+    graph.add_node(InputOp(), [], Tensor("c", (1,), dtype=F16), node_id="c")
+    graph.add_node(ElementwiseOp("subtract"), ["w", "c"], Tensor("wq", (2 * _N, _K), dtype=F16), node_id="wq")
+    graph.add_node(SliceOp(shape=(_N, _K), dim=0, start=0), ["wq"], Tensor("wg", (_N, _K), dtype=F16), node_id="wg")
+    graph.add_node(SliceOp(shape=(_N, _K), dim=0, start=_N), ["wq"], Tensor("wu", (_N, _K), dtype=F16), node_id="wu")
+    graph.add_node(LinearOp(), ["x", "wg"], Tensor("yg", (_M, _N), dtype=F16), node_id="yg")
+    graph.add_node(LinearOp(), ["x", "wu"], Tensor("yu", (_M, _N), dtype=F16), node_id="yu")
+    graph.add_node(ElementwiseOp("multiply"), ["yg", "yu"], Tensor("y", (_M, _N), dtype=F16), node_id="y")
+    graph.inputs, graph.outputs = ["x", "w", "c"], ["y"]
+    return graph
+
+
+@pytest.fixture
+def _scalar_tier(monkeypatch):
+    """Pin the mma family off — the channels then fold serially in ONE loop body, the scope that clashes."""
+    monkeypatch.setenv("EMMY_TILE", "")
+    monkeypatch.setenv("EMMY_STAGE", "")
+
+
+def test_sibling_cones_share_one_declaration_of_a_broadcast_constant(_scalar_tier) -> None:
+    set_target(_CAP)
+    try:
+        lowered = Pipeline.build(CUDA_PASSES).run(_gate_up_graph(), ctx=Context(compute_capability=_CAP))
+    finally:
+        set_target(None)
+    sources = {node.op.kernel_name: node.op.kernel_source for node in lowered.nodes.values() if getattr(node.op, "kernel_source", None)}
+
+    assert sources, "the graph must lower to at least one kernel"
+    assert {name: _redeclared(src) for name, src in sources.items() if _redeclared(src)} == {}
+    # The two channels read the shared constant through ONE binding, not one per cone.
+    assert sum(src.count("= c[0]") for src in sources.values()) == 1
+
+
+def test_a_name_rebound_to_a_different_address_survives_as_the_fault_it_is() -> None:
+    """Only an exact repeat is dead. A same-name rebind of a DIFFERENT address must reach nvcc."""
+    zero = (Literal(0, "int"),)
+    body = Body((Load(name="in0", input="a", index=zero), Load(name="in0", input="b", index=zero)))
+
+    assert [stmt.input for stmt in materialize._drop_repeated_declarations(body)] == ["a", "b"]


### PR DESCRIPTION
## The bug

A `Fold`'s operand edges splice independently (`Fold.spliced_step`), so two sibling cones reading
the same 1-element input each carry their own copy of its `buf[0]` `Load` — same SSA name, same
address. Flattened into one loop body those become two C declarations of one name, which nvcc
rejects.

DeepSeek-V4-Flash-0731's MoE expert kernel hits this on every rank: the MXFP4 decode spells eleven
shared scalar constants and applies them to both halves of the fused `gate_up` weight, so
`k_linear_reduce` redeclared `in0..in11` and the serve never booted.

```
"in4" has already been declared in the current scope
    float in4 = w_gate_up_six_f32[0];
```

The two chains are the gate and up channels of one contraction, in one `for (int a3 …)` scope:

```c
float in4 = w_gate_up_six_f32[0];   // acc0's cone
float v21 = v17 - in4;
...
float in4 = w_gate_up_six_f32[0];   // acc1's cone — same name, same address
float v43 = v39 - in4;
```

## The fix

Drop the repeat at the single `TileOp -> KernelOp` funnel. The repeat binds nothing new, so it goes
with **no rewrite**: every downstream use already names the survivor.

That is what keeps the guard narrow enough to run over a *whole* kernel body. The renaming forms
(`_atom._dedup_loads`, `stmt.dedup_loads`) collapse two **different** names at one address, which
needs a memory-effect reading neither has — a `Write` or an async fill between two identical loads
of a staged buffer makes the second a different value. A same-name repeat cannot hide such a
reload, since a rebind in one C scope is already illegal.

A name re-bound to a *different* address is left alone — that is an SSA fault, and it must surface
as one rather than be collapsed onto a stale value.

## Verification

- **V100 (sm_70)**, the reported failure: the expert program goes from **11 redeclarations to 0**,
  and nvcc compiles the kernel (`compiled 1/1`). The kernel identity hash is unchanged
  (`k_linear_reduce_8beaa5` before and after), so no golden or corpus churn. Re-run on this base.
- **`make test`**: 3856 passed. The two `tests/serving` failures on this branch also fail on `main`
  with this file reverted — Transformers API drift (`LagunaAttention.gate_per_head`), unrelated,
  and both pass in CI.
- **`make lint`**: clean.

Two tests, both failing without the fix: the minimized sibling-cone reproducer (no GPU, reproduced
identically on sm_70 / sm_80 / sm_89 / sm_120), and the different-address rebind that must survive.

Rebased onto #672, which landed the hygiene fix for the renaming helpers found while reviewing this
one. The capture case this PR originally carried a test for is now owned there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)