### PR TITLE
Stop load-dedup renames at a scope that re-binds the name

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -396,6 +396,15 @@ both maps renames it twice — and if the two passes form a chain (e.g.
 `x → in5` and a pre-existing `in5 → in26`) the double application
 collapses it transitively, silently wiring a gather to the wrong row.
 
+`rewrite` is also **not scope-aware**: it descends into every nested body and maps a stmt's own bindings as well as
+its reads, while `Assign` / `Load` / `Select` names bound inside a `Loop` / `Cond` body are scoped to that body. The
+two are safe together only for a whole-subtree renumbering (`rename_ssa_sequential`). When the rename instead comes
+from *dropping* a binding — load dedup, CSE — an inner scope that merely re-uses the dropped name's spelling is a
+different variable, and renaming it both redeclares the survivor inside the scope and rewires the inner arithmetic to
+the outer value. `passes.rename_free(stmt, alias)` is the hygienic form: it prunes the alias of whatever each child
+scope re-binds before descending. `normalize.dedup_loads` applies the same rule while threading its own per-scope
+environment.
+
 ### `ir/stmt/normalize.py` — structural canonicalization
 
 Pure `body → body` passes run from `LoopOp.__post_init__` so every

--- a/emmy/compiler/ir/stmt/normalize.py
+++ b/emmy/compiler/ir/stmt/normalize.py
@@ -636,7 +636,13 @@ def dedup_loads(stmts: Body) -> Body:
     name. Operates per-scope: a Load at an outer scope is reused by
     inner siblings (their identical ``index`` doesn't reference any
     inner-axis Var, so the values are equal). Loads inside a nested
-    scope are not visible to outer / sibling scopes."""
+    scope are not visible to outer / sibling scopes.
+
+    Hygienic: an inner scope that re-binds a name the outer scope
+    deduped keeps its own binding — those are different variables
+    (see :func:`~emmy.compiler.ir.stmt.passes.rename_free`)."""
+    from emmy.compiler.ir.stmt.passes import rename_free  # noqa: PLC0415
+
     stmts = Body.coerce(stmts)
 
     def walk(
@@ -649,6 +655,18 @@ def dedup_loads(stmts: Body) -> Body:
 
         def rename(n: str) -> str:
             return alias.get(n, n)
+
+        def descend(inner: Body) -> Body:
+            """Enter ``inner``'s scope, dropping every alias / kept name whose spelling ``inner``
+            re-binds. SSA names bound inside a Loop / Cond body are scoped to it, so such a name is
+            a DIFFERENT variable — following it out would rewire the inner arithmetic to the outer
+            value and redeclare the survivor."""
+            shadowed = _all_ssa_defs(inner)
+            return walk(
+                inner,
+                {k: v for k, v in local.items() if v not in shadowed},
+                {k: v for k, v in alias.items() if k not in shadowed},
+            )
 
         out: list[Stmt] = []
         for s in body:
@@ -665,14 +683,14 @@ def dedup_loads(stmts: Body) -> Body:
                     continue
                 local[key] = s.name
                 out.append(s)
-            elif isinstance(s, Loop):
-                out.append(replace(s, body=walk(s.body, local, alias)))
-            elif isinstance(s, StridedLoop):
-                out.append(replace(s, body=walk(s.body, local, alias)))
+            elif isinstance(s, Loop | StridedLoop):
+                out.append(replace(s, body=descend(s.body)))
             elif isinstance(s, Cond):
-                out.append(Cond(cond=s.cond, body=walk(s.body, local, alias), else_body=walk(s.else_body, local, alias)))
+                out.append(Cond(cond=s.cond, body=descend(s.body), else_body=descend(s.else_body)))
             else:
-                out.append(s.rewrite(rename))
+                # ``rename_free``, not ``rewrite``: identical for a leaf, but a block stmt the
+                # ladder above doesn't name (``Tile``) carries scopes the alias must stop at.
+                out.append(rename_free(s, alias))
         return tuple(out)
 
     return walk(stmts, {}, {})

--- a/emmy/compiler/ir/stmt/passes.py
+++ b/emmy/compiler/ir/stmt/passes.py
@@ -10,7 +10,7 @@ silent-drop bug).
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import fields, is_dataclass
 from functools import singledispatch
 
@@ -236,6 +236,34 @@ def _(s: Cond, rename: Rename, sigma: Sigma, axis_fn: AxisFn) -> Stmt:
         body=tuple(rewrite(c, rename, sigma, axis_fn) for c in s.body),
         else_body=tuple(rewrite(c, rename, sigma, axis_fn) for c in s.else_body),
     )
+
+
+def rename_free(stmt: Stmt, alias: Mapping[str, str]) -> Stmt:
+    """:func:`rewrite` under an alias map, made **hygienic**: the rename stops at a nested scope
+    that re-binds one of the aliased names.
+
+    ``rewrite`` descends into every nested body and maps a stmt's OWN bindings as well as its
+    reads. But ``Assign`` / ``Load`` / ``Select`` names bound inside a ``Loop`` / ``Cond`` body are
+    scoped to that body (see :class:`~emmy.compiler.ir.stmt.blocks.Loop`), so an inner binding that
+    merely shares a spelling with an aliased outer name is a DIFFERENT variable. Renaming it both
+    redeclares the survivor inside the scope and rewires the inner arithmetic to the outer value.
+
+    Use this — not a bare ``rewrite`` — whenever the alias comes from dropping a binding (load
+    dedup, CSE) rather than from a whole-subtree renumbering.
+    """
+    if not alias:
+        return stmt
+    renamed = rewrite(stmt, lambda nm: alias.get(nm, nm), Sigma.IDENTITY, _axis_identity)
+    bodies = stmt.nested()
+    if not bodies:
+        return renamed
+    # ``rewrite`` just descended into the child scopes under the full alias. Redo each one with the
+    # names that scope re-binds pruned out, and put those bodies back.
+    inner = []
+    for b in bodies:
+        pruned = {k: v for k, v in alias.items() if k not in b._all_ssa_defs}
+        inner.append(Body(tuple(rename_free(c, pruned) for c in b)))
+    return renamed.with_bodies(tuple(inner))
 
 
 # ---------------------------------------------------------------------------

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -54,6 +54,7 @@ from emmy.compiler.ir.pure.fold import Channel, Fold, is_contraction, operand_bo
 from emmy.compiler.ir.schedule import Side, Stage, TilePlan
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
+from emmy.compiler.ir.stmt.passes import rename_free
 from emmy.compiler.ir.tile.ops import make_cone
 from emmy.compiler.pipeline.passes.lowering._addr import BYTE_SLAB_PAD
 from emmy.compiler.pipeline.passes.lowering._reduction import Reduction
@@ -1036,7 +1037,12 @@ def _cell_varying(body, side: Side | None) -> bool:
 def _dedup_loads(stmts: list[Stmt]) -> list[Stmt]:
     """Collapse syntactically-identical scalar ``Load``s (same buffer + index) to one binding,
     rewriting the dropped names to the survivor — the operand reuse a register tile exists for (a
-    load not referencing the ``m`` cell axis is shared across the ``n`` cells, and vice versa)."""
+    load not referencing the ``m`` cell axis is shared across the ``n`` cells, and vice versa).
+
+    Dedup itself is per-``stmts`` (this list only); the rewrite reaches nested scopes, since an
+    epilogue cell's output sweep consumes the loads hoisted above it. It goes through
+    :func:`~emmy.compiler.ir.stmt.passes.rename_free` so a nested scope re-binding a dropped
+    name keeps its own binding."""
     seen: dict = {}
     rename: dict[str, str] = {}
     kept: list[Stmt] = []
@@ -1049,7 +1055,7 @@ def _dedup_loads(stmts: list[Stmt]) -> list[Stmt]:
             seen[sig] = s.names[0]
         kept.append(s)
     if rename:
-        kept = [s.rewrite(lambda nm: rename.get(nm, nm)) for s in kept]
+        kept = [rename_free(s, rename) for s in kept]
     return kept
 
 

--- a/tests/compiler/ir/stmt/test_dedup_loads.py
+++ b/tests/compiler/ir/stmt/test_dedup_loads.py
@@ -1,11 +1,11 @@
 """Tests for Load deduplication during body normalization."""
 
 from emmy.compiler.ir.axis import Axis
-from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.expr import Literal, Var
 from emmy.compiler.ir.stmt.blocks import Loop
 from emmy.compiler.ir.stmt.body import Body
 from emmy.compiler.ir.stmt.leaves import Assign, Load, Write
-from emmy.compiler.ir.stmt.normalize import normalize_body
+from emmy.compiler.ir.stmt.normalize import dedup_loads, normalize_body
 
 
 def test_normalize_body_dedups_loads_and_rewires_gather_indices() -> None:
@@ -32,3 +32,46 @@ def test_normalize_body_dedups_loads_and_rewires_gather_indices() -> None:
         Load(name="in1", input="values", index=(Var("in0"),)),
     ]
     assert loop.body[-2] == Assign(name="v0", op="add", args=("in1", "in1"))
+
+
+ZERO = (Literal(0, "int"),)
+
+
+def test_dedup_loads_does_not_capture_a_rebinding_inner_scope() -> None:
+    """A nested scope re-binding a deduped name binds a DIFFERENT variable — the outer alias must
+    stop there, or the loop is handed a redeclaration of the survivor and the wrong arithmetic."""
+    inner = Body(
+        (
+            Load(name="in0", input="x", index=ZERO),
+            Load(name="in1", input="y", index=ZERO),
+            Assign(name="v", op="add", args=("in0", "in1")),
+        )
+    )
+    body = Body(
+        (
+            Load(name="in0", input="const", index=ZERO),
+            Load(name="in1", input="const", index=ZERO),  # duplicate -> dropped, alias in1 -> in0
+            Loop(axis=Axis("a", 4), body=inner),
+        )
+    )
+
+    out = dedup_loads(body)
+
+    assert out[0] == Load(name="in0", input="const", index=ZERO)
+    assert out[1].body == inner
+
+
+def test_dedup_loads_still_rewires_an_inner_use_of_the_dropped_name() -> None:
+    """The mirror case: the loop only *reads* the dropped name, so the alias must reach inside."""
+    body = Body(
+        (
+            Load(name="in0", input="const", index=ZERO),
+            Load(name="in1", input="const", index=ZERO),
+            Loop(axis=Axis("a", 4), body=Body((Assign(name="v", op="add", args=("in0", "in1")),))),
+        )
+    )
+
+    out = dedup_loads(body)
+
+    assert [s.name for s in out if isinstance(s, Load)] == ["in0"]
+    assert out[-1].body == Body((Assign(name="v", op="add", args=("in0", "in0")),))

--- a/tests/compiler/pipeline/test_scalar_load_dedup.py
+++ b/tests/compiler/pipeline/test_scalar_load_dedup.py
@@ -1,0 +1,57 @@
+"""Scope hygiene for the register-tile scalar ``Load`` dedup.
+
+``_dedup_loads`` collapses identical scalar ``Load``\\ s in one statement list and rewires the
+dropped names to the survivor. The rewrite has to reach *into* nested scopes — an epilogue cell's
+output sweep consumes the loads hoisted above it — but ``Stmt.rewrite`` renames a stmt's own
+bindings as well as its reads and descends unconditionally, while SSA names bound inside a ``Loop``
+body are scoped to that body.
+
+So an inner scope that merely re-uses the *spelling* of a dropped outer name used to be captured:
+its binding was renamed to the survivor, redeclaring it inside the loop and rewiring the inner
+arithmetic to the outer buffer's value. The two production call sites (the scalar drain, the
+register-tile epilogue cell) pass flat-ish bodies, but the epilogue cell can carry nested output
+sweeps or conditions, so the capture was reachable in principle.
+"""
+
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Literal
+from emmy.compiler.ir.stmt import Assign, Body, Load, Loop
+from emmy.compiler.pipeline.passes.lowering.kernel._atom import _dedup_loads
+
+ZERO = (Literal(0, "int"),)
+
+
+def test_dedup_loads_does_not_capture_a_rebinding_inner_scope() -> None:
+    """The loop re-binds both ``in0`` and ``in1`` from different buffers — its own bindings and its
+    arithmetic must survive the outer ``in1`` -> ``in0`` alias untouched."""
+    inner = Body(
+        (
+            Load(name="in0", input="x", index=ZERO),
+            Load(name="in1", input="y", index=ZERO),
+            Assign(name="v", op="add", args=("in0", "in1")),
+        )
+    )
+    body = [
+        Load(name="in0", input="const", index=ZERO),
+        Load(name="in1", input="const", index=ZERO),  # duplicate -> dropped, alias in1 -> in0
+        Loop(axis=Axis("a", 4), body=inner),
+    ]
+
+    kept = _dedup_loads(body)
+
+    assert kept[0] == Load(name="in0", input="const", index=ZERO)
+    assert kept[1].body == inner
+
+
+def test_dedup_loads_still_rewires_an_inner_use_of_the_dropped_name() -> None:
+    """The mirror case: the loop only *reads* the dropped name, so the rewrite must descend."""
+    body = [
+        Load(name="in0", input="const", index=ZERO),
+        Load(name="in1", input="const", index=ZERO),
+        Loop(axis=Axis("a", 4), body=Body((Assign(name="v", op="add", args=("in0", "in1")),))),
+    ]
+
+    kept = _dedup_loads(body)
+
+    assert [s.name for s in kept if isinstance(s, Load)] == ["in0"]
+    assert kept[-1].body == Body((Assign(name="v", op="add", args=("in0", "in0")),))


### PR DESCRIPTION
Fixes a latent variable-capture bug in both load-dedup helpers. Predates #671 and is on `main`.

## The bug

`Stmt.rewrite` descends into every nested body and maps a stmt's OWN bindings as well as its reads. But
`Assign` / `Load` / `Select` names bound inside a `Loop` / `Cond` body are scoped to that body. That pairing
is safe for a whole-subtree renumbering (`rename_ssa_sequential`) and wrong for a rename that comes from
**dropping** a binding: an inner scope re-using the dropped name's spelling is a *different* variable, so it
got redeclared as the survivor and its arithmetic rewired to the outer buffer's value.

Both helpers had it, with byte-identical wrong output:

```
in0 = load const[0]           in0 = load const[0]
for a in 0..4          ->     for a in 0..4
    in0 = load x[0]               in0 = load x[0]
    in1 = load y[0]               in0 = load y[0]     <- inner binding captured
    v = add(in0, in1)             v = add(in0, in0)   <- wrong arithmetic
```

- `_atom._dedup_loads` — reported case. Its two call sites (scalar drain, register-tile epilogue cell) pass
  flat-ish bodies, which is why this never fired in production; the epilogue cell can carry nested output
  sweeps or conditions, so it was reachable in principle.
- `normalize.dedup_loads` — same weakness, found by checking the sibling. It threads a `parent_alias` down
  through scopes but never pruned it.

## The fix

Hygiene, **not** narrowing. The epilogue call site genuinely needs the rewrite to descend, since an epilogue
cell's output sweep consumes the loads hoisted above it — so each helper gets that mirror case as a test
alongside the capture case, and the descent cannot be removed later to "fix" this.

`passes.rename_free(stmt, alias)` is the hygienic form: rewrite, then redo each child scope under an alias
pruned of what that scope re-binds. It lives next to `rewrite`, where the footgun is, so the next caller sees
the warning.

- `_atom._dedup_loads` switches to it (one line).
- `normalize.dedup_loads` already threaded scopes, so it prunes its alias and kept-name environment on entry
  instead. Its fall-through branch also moves from bare `rewrite` to `rename_free`, which closes the same hole
  for a block stmt its isinstance ladder never named (`Tile`).

The scoping invariant is documented in `emmy/compiler/ir/ARCHITECTURE.md`, in the existing section on
`rewrite`'s rename channels.

## Verification

5 tests across `tests/compiler/ir/stmt/test_dedup_loads.py` and `tests/compiler/pipeline/test_scalar_load_dedup.py`
— the capture case plus its mirror, per helper. Reverting the source fix was confirmed to fail both capture
tests; the two mirror tests pass either way, which is the point (they guard against over-pruning).

`make test` — 3825 passed, 960 skipped, 5 xfailed, exit 0. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)