### PR TITLE
Un-skip the anticipatory scan tests; ambient pins cannot mean a scan

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -683,13 +683,12 @@ def _reduce_moves(state: _State, node, key: str | None) -> list[ReducePlan]:
     if node.observed:
         # An observer makes the stream order-visible: every partitioned combine — cooperative
         # band, ILP register partials, the cross-CTA split — changes which prefixes exist, so a
-        # scan offers exactly the serial fold. A pin naming a partition is a recorded refusal,
-        # never a silent drop.
-        if pin is not None and ReducePlan.parse(pin, state.work_pin).stages:
-            raise PinRefused(
-                f"REDUCE pin {pin!r} at {key or 'REDUCE'} names a partition, but an observed fold "
-                f"(a scan) preserves its stream order — only the serial fold realizes"
-            )
+        # scan offers exactly the serial fold. A pin naming a partition DROPS to serial (the same
+        # adaptation as the consumed ``g``-half strip: an ambient pin fans out to every kernel,
+        # and refusing here would fail whole-model sweeps on any scan); a pinned replay still
+        # fails loudly at the offered oracle, whose membership check sees the pin unsatisfied.
+        if pin is not None and ReducePlan.parse(pin, state.work_pin).stages and logger.isEnabledFor(logging.DEBUG):
+            logger.debug("REDUCE pin %r names a partition; an observed fold (a scan) realizes the serial fold only", pin)
         return [ReducePlan()]
     if pin is None:
         return [ReducePlan(), *(p for p in coop_reduce_moves() if _band_refusal(p, extent, state.transposed_ok) is None)]
@@ -737,11 +736,6 @@ def _contraction_reduces(state: _State, node, key: str | None, tiled: bool) -> l
     if node.observed:
         # Same stream-order gate as the plain fold's (:func:`_reduce_moves`) — defensive here:
         # nothing builds an observed contraction yet.
-        if pin is not None and ReducePlan.parse(pin, state.work_pin).stages:
-            raise PinRefused(
-                f"REDUCE pin {pin!r} at {key or 'REDUCE'} names a partition, but an observed fold "
-                f"(a scan) preserves its stream order — only the serial fold realizes"
-            )
         return [ReducePlan()]
     if pin is not None:
         pinned = _parsed_reduce_pin(state, pin, key)
@@ -1301,6 +1295,13 @@ class _State:
         inventory."""
         return not self.work_pinned or work == self.work_pin
 
+    @property
+    def observed(self) -> bool:
+        """Whether this kernel's tree holds an observed fold — a scan. Its one row is the serial
+        fold, so an ambient ``WORK``/``REDUCE`` pin fanning out over the graph cannot mean it: the
+        leaf keeps the decided-empty row instead of dropping the kernel to unmapped."""
+        return any(isinstance(s.node, Fold) and s.node.axis is not None and s.node.observed for s in self.sched._all_sites())
+
 
 def _off(sched: Sched, root) -> dict:
     """Every slice key the stored tree spells, at the codec families' declared OFF — the empty
@@ -1384,7 +1385,7 @@ def _step(state: _State, stack: tuple, ctx: Ctx, knobs: dict) -> list[Fork]:
             knobs, stack = _spelled(knobs, option, ctx), children
             continue  # a level with one option is no choice at all — collapse it
         return [_Branch(state, children, below, _spelled(knobs, o, below)) for o, below in offers]
-    if not state.honors_work_pin(ctx.work):
+    if not state.honors_work_pin(ctx.work) and not state.observed:
         return []  # the walk finished without ever claiming the pinned inventory
     return [_Leaf(state, {**state.off, **knobs, WORK.name: _work_spelling(ctx.work) if ctx.work is not None else ""})]
 

--- a/tests/compiler/passes/test_pipeline_semantics.py
+++ b/tests/compiler/passes/test_pipeline_semantics.py
@@ -116,7 +116,6 @@ def test_reduce_sum():
     assert any(lb.op.name == "add" for lb in loop.body.accums)
 
 
-@pytest.mark.skip(reason="scan lowering needs the planned pure Fold observer representation")
 def test_scan_sum_lifts_and_preserves_prefix_values():
     def make_graph():
         graph = Graph()
@@ -139,7 +138,6 @@ def test_scan_sum_lifts_and_preserves_prefix_values():
     assert source.index("+=") < source.index("out[")
 
 
-@pytest.mark.skip(reason="scan lowering needs the planned pure Fold observer representation")
 def test_scan_after_pointwise_keeps_the_write_inside_its_reduce_loop():
     """Fusion must not rebuild an ordered prefix as one full reduce plus an output sweep."""
 
@@ -180,7 +178,9 @@ def test_scan_after_pointwise_keeps_the_write_inside_its_reduce_loop():
     )
     lines = source.splitlines()
     update = next(i for i, line in enumerate(lines) if "acc0 +=" in line)
-    write = next(i for i, line in enumerate(lines) if "out[a0 * 4 + a1] = acc0;" in line)
+    # The stored value is the observer's fresh name (``acc0__obs``), never the raw accumulator —
+    # the boundary distinguishes a streamed store from a post-fold store by exactly that name.
+    write = next(i for i, line in enumerate(lines) if "out[a0 * 4 + a1] = acc0__obs;" in line)
     loop_open = max(i for i in range(update) if lines[i].lstrip().startswith("for ("))
     loop_indent = len(lines[loop_open]) - len(lines[loop_open].lstrip())
     loop_close = next(

--- a/tests/compiler/passes/test_pipeline_semantics.py
+++ b/tests/compiler/passes/test_pipeline_semantics.py
@@ -12,7 +12,6 @@ preserves semantics without needing a GPU.
 """
 
 import numpy as np
-import pytest
 
 from emmy.compiler.backend.numpy import NumpyBackend
 from emmy.compiler.context import Context


### PR DESCRIPTION
Follow-up to #673 — the fix that landed on the old branch after the squash-merge.

Two pipeline-semantics tests were skipped waiting on exactly the observer feature ("scan lowering needs the planned pure Fold observer representation"). The direct scan test passes as written. The fusion-boundary test is the spec for pinned behavior and reverses #673's draft gate:

- An ambient `WORK`/`REDUCE` pin fans out to every kernel of the graph and cannot mean a scan — its one row is the serial fold. An observed fold now **drops** such a pin and keeps its decided-empty serial row (`REDUCE: ''`, `WORK: ''`) — the same adaptation as the consumed `g`-half strip — instead of raising `PinRefused` in `_reduce_moves` or falling to unmapped at the leaf's pinned-inventory check.
- A pinned replay still fails loudly at the realization corpus's `offered` oracle, whose membership check sees the pin unsatisfied.
- The one speculative assertion is updated to the landed design: the streamed store reads the observer's fresh name (`acc0__obs`), never the raw accumulator — that name is how the boundary distinguishes a streamed store from a post-fold store.

Verification: `tests/compiler/passes/` + `tests/compiler/realization/` green on top of main (1359 passed; the two un-skipped tests included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UakkJhZzw2ovXPr24x8iSX