### PR TITLE
Keep a sweep-reading fold a projection body member: k_div_36's unbound axis was a hoist, not a rename

### DIFF
--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -120,6 +120,12 @@ canonical form is gated on byte-identity exactly as before. A write whose stored
 scope unchanged (`o[j] = acc`, broadcasting an already-reduced accumulator) has no body def to name, and is declined:
 the fusion lift-preflight turns that into "leave the region unfused".
 
+A sweep axis is bound only by the per-cell output `Loop` reconstitution wraps around the projection body — never at
+kernel scope. Canonicalization therefore keeps a non-contraction fold that reads a sweep axis a projection BODY
+member: hoisting it onto an operand edge would lower it outside the sweep loop, rendering the axis as an undefined
+identifier (DeepSeek-V4 post16's per-column sum was the live case). A contraction is exempt because post-init
+promotes a sweep its operands read into a real free axis right after normalization.
+
 A matrix row that Loop IR elided because its static extent is one remains algebraic information when every output
 specification starts with one or more literal-zero coordinates followed by the dense `n` coordinate, directly or
 split into row-major quotient/remainder coordinates by a pure reshape. The `n` coordinate may already be free or may

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -350,14 +350,11 @@ def extract_output_specs(stmts) -> tuple[tuple[Stmt, ...], tuple[OutputSpec, ...
                 results = tuple(dict.fromkeys(value for spec in child_direct for value in spec.write.values))
                 # A write may store a value captured from the enclosing scope unchanged (a sweep
                 # broadcasting an already-reduced accumulator, ``o[j] = acc``). Such a result is
-                # not a body def; spelling it as a captured param produced a kernel whose reduce
-                # body read a free axis under its pre-canonicalization name (an undefined
-                # identifier at nvcc), so the shape is DECLINED — a clean ``None`` (the merge
-                # stays unfused), not the Lambda formation crash probing it used to raise.
+                # not a body def, so probe free names with results left off, then bind captured
+                # results as params alongside the body's own free reads.
                 probe = Lambda(params=(stmt.axis.name,), body=child_body, results=())
-                if any(value not in probe.defined for value in results):
-                    return None
-                captures = tuple(sorted(probe.free_names()))
+                captured_results = tuple(value for value in results if value not in probe.defined)
+                captures = tuple(sorted(probe.free_names() | set(captured_results)))
                 region = ProjectionRegion(
                     axis=stmt.axis,
                     lift=Lambda(params=(stmt.axis.name, *captures), body=child_body, results=results),
@@ -462,13 +459,16 @@ class TileOp(Op):
     def __post_init__(self) -> None:
         scope_axes = (*self.place.free, *(store.sweep for store in self.output_specs if store.sweep is not None))
         axes = tuple(dict.fromkeys(axis.name for axis in scope_axes))
-        normalized = normalize_fold_tree(self.op, axes)
+        free_names = {axis.name for axis in self.place.free}
+        sweep_axes = frozenset(name for name in axes if name not in free_names)
+        normalized = normalize_fold_tree(self.op, axes, sweep_axes=sweep_axes)
         unit_row = _implicit_unit_row(self.output_specs, self.place.free)
         if unit_row is not None:
             candidate_free = (unit_row, *self.place.free)
             candidate_scope = (*candidate_free, *(store.sweep for store in self.output_specs if store.sweep is not None))
             candidate_axes = tuple(dict.fromkeys(axis.name for axis in candidate_scope))
-            candidate = normalize_fold_tree(self.op, candidate_axes, implicit_axes=(unit_row.name,))
+            candidate_sweeps = frozenset(name for name in candidate_axes if name not in {axis.name for axis in candidate_free})
+            candidate = normalize_fold_tree(self.op, candidate_axes, implicit_axes=(unit_row.name,), sweep_axes=candidate_sweeps)
             if any(is_contraction(site.node) for site in sites(candidate)):
                 normalized = candidate
                 self.place = replace(self.place, free=candidate_free)
@@ -508,7 +508,8 @@ class TileOp(Op):
         # different Fold tree or placement seam.
         scope_axes = (*self.place.free, *(store.sweep for store in self.output_specs if store.sweep is not None))
         final_axes = tuple(dict.fromkeys(axis.name for axis in scope_axes))
-        renormalized = normalize_fold_tree(self.op, final_axes)
+        final_sweeps = frozenset(name for name in final_axes if name not in {axis.name for axis in self.place.free})
+        renormalized = normalize_fold_tree(self.op, final_axes, sweep_axes=final_sweeps)
         if self.schedule and renormalized != self.op:
             raise ValueError("cannot canonicalize a TileOp after schedule slices have been attached")
         self.op = renormalized

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -335,24 +335,38 @@ def _canonical_semiring(fold: Fold, axes: tuple[str, ...], implicit_axes: frozen
     return replace(fold, operands=tuple(ordered), lift=lift)
 
 
-def _normalize_body(body: Body, axes: tuple[str, ...], implicit_axes: frozenset[str]) -> Body:
+def _normalize_body(body: Body, axes: tuple[str, ...], implicit_axes: frozenset[str], sweep_axes: frozenset[str]) -> Body:
     out = []
     for stmt in body:
         if isinstance(stmt, Fold):
-            out.append(_normalize_fold(stmt, axes, implicit_axes))
+            out.append(_normalize_fold(stmt, axes, implicit_axes, sweep_axes))
             continue
         nested = stmt.nested()
         if not nested:
             out.append(stmt)
             continue
         child_axes = (*axes, *stmt.binds_axes())
-        out.append(stmt.with_bodies(tuple(_normalize_body(child, child_axes, implicit_axes) for child in nested)))
+        out.append(stmt.with_bodies(tuple(_normalize_body(child, child_axes, implicit_axes, sweep_axes) for child in nested)))
     return Body(out)
 
 
-def _hoist_closed_folds(root: Fold, axes: tuple[str, ...]) -> Fold:
-    """Move closed child Folds from a zero-axis body onto operand edges."""
-    candidates = [stmt for stmt in root.body if isinstance(stmt, Fold) and not (set(stmt.lift.free_names()) - set(axes))]
+def _hoist_closed_folds(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[str]) -> Fold:
+    """Move closed child Folds from a zero-axis body onto operand edges.
+
+    A non-contraction fold that reads a SWEEP axis is never hoisted: a sweep axis is bound only by
+    the per-cell output ``Loop`` reconstitution wraps around the projection body
+    (``apply_output_specs``), so a body member re-enters that scope while an operand edge lowers
+    at kernel scope, where the axis is an undefined identifier (``head``'s sweep case — the fold
+    must stay the projection's body member; found live on DeepSeek-V4 post16's per-column sum,
+    ``k_div_36``). A CONTRACTION is exempt: ``TileOp.__post_init__`` promotes a sweep its operands
+    read into a real free axis right after normalization, so the hoisted edge stays bound."""
+    candidates = [
+        stmt
+        for stmt in root.body
+        if isinstance(stmt, Fold)
+        and not (set(stmt.lift.free_names()) - set(axes))
+        and (is_contraction(stmt) or not any(edge_refs_axis(stmt, name) for name in sweep_axes))
+    ]
     if not candidates:
         return root
     candidate_ids = {id(candidate) for candidate in candidates}
@@ -383,7 +397,7 @@ def _edge_free_names(edge) -> frozenset[str]:
     return frozenset(edge.deps()) if isinstance(edge, Fold) else frozenset()
 
 
-def _close_projection(root: Fold, axes: tuple[str, ...]) -> Fold:
+def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[str]) -> Fold:
     """Move an enclosing projection's dependencies onto captured contraction operands."""
     assert root.axis is None
     provider_order = tuple(
@@ -409,7 +423,7 @@ def _close_projection(root: Fold, axes: tuple[str, ...]) -> Fold:
             return None
         moved_members.update(id(stmt) for stmt in cone.members)
         moved_edges.update(id(edge) for edge in edges)
-        hoisted = _hoist_closed_folds(Fold.projection(operands=edges, body=Body(cone.members), results=names), axes)
+        hoisted = _hoist_closed_folds(Fold.projection(operands=edges, body=Body(cone.members), results=names), axes, sweep_axes)
         return _passthrough(hoisted) or hoisted
 
     def close(node: Fold) -> Fold:
@@ -459,7 +473,7 @@ def _close_projection(root: Fold, axes: tuple[str, ...]) -> Fold:
     return Fold.projection(operands=remaining_operands, body=remaining_body, results=root.lift.results)
 
 
-def _close_reduce_body(root: Fold, axes: tuple[str, ...]) -> Fold:
+def _close_reduce_body(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[str]) -> Fold:
     """Move a reducing fold's body-resident producer chain onto a captured contraction operand.
 
     :func:`_close_projection` closes contraction operands against a zero-axis root, but a chain
@@ -483,7 +497,7 @@ def _close_reduce_body(root: Fold, axes: tuple[str, ...]) -> Fold:
         if not set(names) <= defined:
             return None
         moved.update(id(stmt) for stmt in cone.members)
-        return _hoist_closed_folds(Fold.projection(body=Body(cone.members), results=names), axes)
+        return _hoist_closed_folds(Fold.projection(body=Body(cone.members), results=names), axes, sweep_axes)
 
     def close(node: Fold) -> Fold:
         operands = tuple(close(edge) if isinstance(edge, Fold) else edge for edge in node.operands)
@@ -711,28 +725,31 @@ def _hoist_decode_operands(root: Fold) -> Fold:
     return Fold.projection(operands=root.operands, body=Body(tuple(members)), results=root.lift.results)
 
 
-def _normalize_fold(fold: Fold, axes: tuple[str, ...], implicit_axes: frozenset[str]) -> Fold:
-    operands = tuple(_normalize_fold(edge, axes, implicit_axes) if isinstance(edge, Fold) else edge for edge in fold.operands)
+def _normalize_fold(fold: Fold, axes: tuple[str, ...], implicit_axes: frozenset[str], sweep_axes: frozenset[str]) -> Fold:
+    operands = tuple(_normalize_fold(edge, axes, implicit_axes, sweep_axes) if isinstance(edge, Fold) else edge for edge in fold.operands)
     node = replace(fold, operands=operands) if operands != fold.operands else fold
     if node.axis is None and (collapsed := _passthrough(node)) is not None:
         return collapsed
     body_axes = (*axes, node.axis.name) if node.axis is not None else axes
-    body = _normalize_body(node.lift.body, body_axes, implicit_axes)
+    body = _normalize_body(node.lift.body, body_axes, implicit_axes, sweep_axes)
     if body != node.lift.body:
         node = node.with_bodies((body,))
     node = _canonical_semiring(node, axes, implicit_axes)
     if node.axis is not None:
-        return _close_reduce_body(node, body_axes)
+        return _close_reduce_body(node, body_axes, sweep_axes)
     node = _hoist_decode_operands(node)
-    node = _close_projection(node, axes)
-    return _hoist_closed_folds(node, axes)
+    node = _close_projection(node, axes, sweep_axes)
+    return _hoist_closed_folds(node, axes, sweep_axes)
 
 
-def normalize_fold_tree(root, axes: Iterable[str] = (), implicit_axes: Iterable[str] = ()):
-    """Normalize a complete Tile IR tree bottom-up; ``None`` placeholders pass through."""
+def normalize_fold_tree(root, axes: Iterable[str] = (), implicit_axes: Iterable[str] = (), sweep_axes: Iterable[str] = ()):
+    """Normalize a complete Tile IR tree bottom-up; ``None`` placeholders pass through.
+
+    ``sweep_axes`` names the axes bound only by output-sweep reconstitution (never kernel scope);
+    :func:`_hoist_closed_folds` keeps a fold reading one as a projection body member."""
     if not isinstance(root, Fold):
         return root
-    normalized = _normalize_fold(root, tuple(axes), frozenset(implicit_axes))
+    normalized = _normalize_fold(root, tuple(axes), frozenset(implicit_axes), frozenset(sweep_axes))
     # A contraction reached as the whole tree has no projection to host hoisted factors, so the
     # hoist creates one here. Nested contractions are handled by their own projection, which keeps
     # the common shape flat.

--- a/tests/compiler/ir/tile/test_effect_boundary.py
+++ b/tests/compiler/ir/tile/test_effect_boundary.py
@@ -235,13 +235,11 @@ def test_sweep_body_out_of_canonical_order_still_extracts() -> None:
     assert extract_output_specs(rebuilt) is not None
 
 
-def test_sweep_write_of_a_captured_accumulator_declines_cleanly() -> None:
+def test_sweep_write_of_a_captured_accumulator_extracts() -> None:
     """A sweep may store an enclosing scope's value unchanged — ``o[j] = acc`` broadcasting an
-    already-reduced accumulator. The result is not a body def; spelling it as a captured param
-    produced a kernel reading a free axis under its pre-canonicalization name (an undefined
-    identifier at nvcc), so the shape is DECLINED — a clean ``None`` the fusion preflight turns
-    into "leave the region unfused", not the Lambda formation crash probing it used to raise
-    ("Lambda results ['acc'] are not defined")."""
+    already-reduced accumulator. The result is not a body def, so the region's Lambda must bind
+    it as a captured param; building the capture probe WITH results raised the formation error
+    instead ("Lambda results ['acc'] are not defined"), a crash on a legitimate stream."""
     first = Loop(
         axis=_ax("a1", 8),
         body=Body(
@@ -256,4 +254,10 @@ def test_sweep_write_of_a_captured_accumulator_declines_cleanly() -> None:
         axis=_ax("a2", 4),
         body=Body((Write(output="o2", index=(Var("a2"),), value="acc"),)),
     )
-    assert extract_output_specs([first, second]) is None
+    split = extract_output_specs([first, second])
+    assert split is not None
+    pure, stores = split
+    assert [store.write.output for store in stores] == ["o1", "o2"]
+    region = pure[-1]
+    assert isinstance(region, ProjectionRegion) and "acc" in region.lift.params
+    assert extract_output_specs(apply_output_specs(pure, stores)) is not None

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -364,6 +364,28 @@ def test_reduced_qk_attention_offers_the_statistic_arm_b_seams_idempotently() ->
     assert TileOp(op=tile.op, name=tile.name, place=tile.place, output_specs=tile.output_specs).op is tile.op
 
 
+def test_a_fold_reading_a_sweep_axis_stays_a_body_member() -> None:
+    """A per-column reduce whose streamed load reads the boundary store's sweep axis must stay a
+    projection BODY member: reconstitution re-wraps body stmts inside the sweep ``Loop``, but an
+    operand edge lowers at kernel scope, where the sweep axis is unbound (found live: DeepSeek-V4
+    post16's ``k_div_36`` column sum rendered its sweep column as an undefined identifier at nvcc)."""
+    k = Axis("k", Dim(4))
+    j = Axis("j", Dim(4))
+    body = Body((Load(name="xin", input="x", index=(Var("m"), Var("k"), Var("j"))),))
+    init, combine = M(ElementwiseImpl("add"), names=("acc",))
+    fold = Fold(axis=k, lift=Lambda(params=("k",), body=body, results=("xin",)), init=init, combine=combine)
+    epilogue = Assign(name="v", op="relu", args=("acc",))
+
+    tile = TileOp(
+        op=Fold.projection(body=Body((fold, epilogue))),
+        place=Placement(free=(Axis("m", 8),)),
+        output_specs=(OutputSpec(write=Write(output="out", index=(Var("m"), Var("j")), value="v"), sweep=j),),
+    )
+
+    assert not tile.op.operands
+    assert any(isinstance(stmt, Fold) for stmt in tile.op.body)
+
+
 def test_contraction_clusters_alpha_equivalent_shared_operands() -> None:
     axis = Axis("k", Dim(32))
     body = Body(


### PR DESCRIPTION
Rebased onto `main` (`374a912dc`) — one commit, no #676 duplicates. **The bug is still live on main**, on the default
greedy row.

## The failure

#676 landed a KNOWN LIMITATION: DeepSeek-V4-Flash-0731's post16 kernel `k_div_36_reduce` renders an unbound sweep
axis. It was read as schedule-dependent (only the live V100's row) and as coming from the captured-result sweep
shape, which that PR therefore DECLINED in `extract_output_specs` as containment. Both readings were wrong, and the
decline was containing something it did not cause — on today's `main` the kernel still miscompiles, with no pins at
all:

```c
// main @ 374a912dc, default greedy row, k_div_36_reduce
int a0 = _gid / 16;
int a1 = (_gid / 4) % 4;
int a16_co = (_gid) % 4;
for (int a16 = a16_co; a16 < 4; a16 += 8) {
    float in26 = div_31[a0 * 16 + a16 * 4 + a15];   // a15 is undefined here
```

## Root cause: the hoist, not a rename

`TileOp.__post_init__` hands `normalize_fold_tree` its free axes **and its store sweeps** as scope axes.
`_hoist_closed_folds` then reads a fold whose loads reference only `(free ∪ sweep)` names as *closed* and moves it out
of the projection body onto an operand edge.

That position is the bug. A sweep axis is bound **only** by the per-cell output `Loop` that `apply_output_specs` wraps
around the projection **body**. An operand edge lowers at kernel scope — outside that wrap — so the hoisted fold's
sweep reads dangle. `ops.head` and `035_split_reduce`'s projection refusal both already document the body-member
spelling as the sweep case's invariant; the hoist was quietly violating it.

`a15` and `a1` are two different axes here, not one axis under two spellings: `place.free = (a0, a1)`, both outputs
sweep on `a15`, and no canonicalization rename was ever missed.

## Two corrections to the record

- **Not schedule-dependent.** The "off-GPU emission is correct" reading came from a scan that treated a declaration
  anywhere in the source as covering every use. Scanning position-aware (first use before first declaration), main's
  greedy off-GPU emission carries the same defect. The V100 row only made it loud.
- **Not the captured-param path.** The decline contained the symptom indirectly, by leaving the region unfused — which
  is also why the on-card limitation survived it.

## The fix

- `_hoist_closed_folds` no longer hoists a **non-contraction** fold that reads a sweep axis (`edge_refs_axis`, deep, so
  operand edges count). `sweep_axes` threads from post-init through `_normalize_fold` / `_normalize_body` /
  `_close_projection` / `_close_reduce_body`, and through all three post-init `normalize_fold_tree` calls — the initial
  one, the unit-row candidate, and #678's post-promotion renormalize.
- A **contraction** stays exempt: post-init promotes a sweep its operands read into a real free axis immediately after
  normalization, so its hoisted edge stays bound and contraction kernel identities are untouched.
- The `extract_output_specs` decline reverts to the enabling spelling — captured results bind as region `Lambda` params.

## Verification

Driven off the standalone merged `div_36` region (the Sinkhorn mean cone) extracted from post16, which compiles in
seconds and lets every schedule row be swept:

| | main @ `374a912dc` | this PR |
|---|---|---|
| greedy (default) | `a15` used before declaration | bound inside its sweep loop |
| `coop` / `r2` / `coop/r2` | same defect | bound |
| pinned `g2k` / `g4k` | `k_div_36__partial` emits undefined `a15` | row not offered; a pin raises the recorded refusal |
| **full post16** | **56 kernels, 1 miscompiled** | **43 kernels, 0 axis vars used before declaration** |

- `make test`: **3931 passed**. The two `tests/serving` failures are the known local Transformers drift — verified
  failing identically on `374a912dc` itself.
- `make lint`: clean. No realization-corpus staleness.
- Tests: the pinned decline test flips back to `test_sweep_write_of_a_captured_accumulator_extracts` (#676's own
  enabled-behavior assertions), plus a new `test_a_fold_reading_a_sweep_axis_stays_a_body_member` pinning the invariant
  directly, red without the normalize fix.

## Note for the on-card boot

Because the cross-CTA split row is no longer offered for such kernels, a stored V100 tune-DB row or ambient pin that
previously selected `g2k` on one will now raise the recorded pin refusal rather than silently degrade. The next boot on
the card will show whether any stored evidence trips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)