### PR TITLE
Retune child schedules and fix corpus replay

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -214,10 +214,10 @@ to the ordinary compile: the structural target is part of the requested working 
 unverified schedule knobs remain free for the normal deploy evidence hierarchy. Different input-pin regimes under the
 same name leave the ordinary target unpinned rather than choosing one. Canonical selection never gets this
 working-file behavior. Embedded Loop IR stores stable algebra rather than derived structural stamps. Registered
-Boolean values in an explicit `--ab` row
-remain input pins, so false values are not dropped with kernel pass markers and the JSON record identifies the inputs
-that were compiled. A scoped schedule-key OFF beside a non-OFF bare family pin also remains explicit: it is the
-site-specific exception to that bare pin, not a redundant declined-site stamp. A failed row with
+Boolean values in an explicit `--ab` row remain input pins, so false values are not dropped with kernel pass markers
+and the JSON record identifies the inputs that were compiled. A scoped schedule-key OFF beside a non-OFF bare family
+pin also remains explicit: it is the site-specific exception to that bare pin, not a redundant declined-site stamp
+(`replay_pin_spelling` in `compiler/pipeline/knob.py` owns the rule). A failed row with
 no realized graph reports the precision lane requested by those parsed input pins, including explicit false
 overrides, rather than defaulting every failure to the standard lane. `run --golden` replays it through the full
 compiler pipeline. When that replay has

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -216,7 +216,8 @@ same name leave the ordinary target unpinned rather than choosing one. Canonical
 working-file behavior. Embedded Loop IR stores stable algebra rather than derived structural stamps. Registered
 Boolean values in an explicit `--ab` row
 remain input pins, so false values are not dropped with kernel pass markers and the JSON record identifies the inputs
-that were compiled. A failed row with
+that were compiled. A scoped schedule-key OFF beside a non-OFF bare family pin also remains explicit: it is the
+site-specific exception to that bare pin, not a redundant declined-site stamp. A failed row with
 no realized graph reports the precision lane requested by those parsed input pins, including explicit false
 overrides, rather than defaulting every failure to the standard lane. `run --golden` replays it through the full
 compiler pipeline. When that replay has

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -208,9 +208,15 @@ process unless `--target` narrows the file to one exact or unambiguous substring
 `--json DIR` writes one readable JSON record per target; there is no repeat or child-process orchestration layer.
 Invoke `emmy run` again when independent process observations are required. Inventory and proposal rows select the
 graph but are not trusted as automatic A/B pins; only verified rows with paired measurements auto-pin, while a
-proposal is tested explicitly with `run --bench --ab 'KNOBS…'`. Embedded Loop IR stores stable algebra rather than
-derived structural stamps. Registered Boolean values in an explicit `--ab` row remain input pins, so false values are
-not dropped with kernel pass markers and the JSON record identifies the inputs that were compiled. A failed row with
+proposal is tested explicitly with `run --bench --ab 'KNOBS…'`. One explicit working target whose matching
+realizations share an identical input-pin regime containing `PLACE` also applies the placement pins from that regime
+to the ordinary compile: the structural target is part of the requested working slice, while its other input pins and
+unverified schedule knobs remain free for the normal deploy evidence hierarchy. Different input-pin regimes under the
+same name leave the ordinary target unpinned rather than choosing one. Canonical selection never gets this
+working-file behavior. Embedded Loop IR stores stable algebra rather than derived structural stamps. Registered
+Boolean values in an explicit `--ab` row
+remain input pins, so false values are not dropped with kernel pass markers and the JSON record identifies the inputs
+that were compiled. A failed row with
 no realized graph reports the precision lane requested by those parsed input pins, including explicit false
 overrides, rather than defaulting every failure to the standard lane. `run --golden` replays it through the full
 compiler pipeline. When that replay has

--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -156,9 +156,11 @@ def resolve_golden_arg(args) -> None:
     Canonical selection retains every measured sibling on ``args.golden_configs``
     for pinned A/B reporting. ``--golden-file`` instead resolves only inside that
     working document and retains its verified siblings, or its one valid direct tune winner, as automatic pins;
-    inventory/proposal siblings still select the target graph. No Python snippet
-    is generated and dynamic shapes need no CLI reconstruction: they are already
-    in the decoded program.
+    inventory/proposal siblings still select the target graph. When every matching
+    realization in an explicit working file shares one input-pin regime containing
+    ``PLACE``, that regime selects the ordinary compile's structural target without
+    promoting any unverified schedule knobs. No Python snippet is generated and
+    dynamic shapes need no CLI reconstruction: they are already in the decoded program.
 
     ``NAME`` matches the same way ``emmy eval --kernel`` filters goldens: an exact
     golden name first, else a name **substring** — so the identifier used to inspect
@@ -170,6 +172,7 @@ def resolve_golden_arg(args) -> None:
     name = getattr(args, "golden", None)
     golden_file = getattr(args, "golden_file", None)
     args.golden_configs = []
+    args.golden_target_pins = {}
     if golden_file and not name:
         logger.error("--golden-file requires --golden NAME")
         sys.exit(2)
@@ -235,6 +238,18 @@ def resolve_golden_arg(args) -> None:
     if len(targets) != 1:
         logger.error("golden %r resolves to %d different embedded program targets", name, len(targets))
         sys.exit(2)
+    if document is not None:
+        # An explicit working target's shared placement regime is part of the target,
+        # not unverified schedule evidence. Apply it to the ordinary compile while the
+        # remaining schedule families stay free for the normal deploy hierarchy. If
+        # same-name realizations disagree on any input pin, leave the target unpinned:
+        # choosing one regime would silently change which realization was requested.
+        pin_regimes = {match.pins for match in matches}
+        if len(pin_regimes) == 1:
+            shared_pins = dict(pin_regimes.pop())
+            from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
+
+            args.golden_target_pins = {key: value for key, value in shared_pins.items() if family_of(key) == "PLACE"}
     args._golden_graph = matches[0].target_program.copy()
     from emmy.compiler.pipeline.search.data import Sample  # noqa: PLC0415
 
@@ -265,6 +280,20 @@ def resolve_golden_arg(args) -> None:
         len(pinned),
         "" if len(pinned) == 1 else "s",
     )
+    if args.golden_target_pins:
+        logger.info("[golden] applying shared structural target pins: %s", args.golden_target_pins)
+
+
+def _golden_target_pin_context(args):
+    """Publish one explicit working target's shared structural input regime."""
+    from contextlib import nullcontext
+
+    pins = getattr(args, "golden_target_pins", None) or {}
+    if not pins:
+        return nullcontext()
+    from emmy.compiler.pipeline.search.pins import pinned_knobs  # noqa: PLC0415
+
+    return pinned_knobs(pins)
 
 
 def add_diagnostics_args(parser) -> None:
@@ -443,7 +472,8 @@ def handle_compile(args):
     else:
         logger.debug("No tuning DB at %s — using rule defaults", tune_db_path)
 
-    result = Pipeline.build(passes).run(graph, db=db, dump=dump)
+    with _golden_target_pin_context(args):
+        result = Pipeline.build(passes).run(graph, db=db, dump=dump)
 
     n_compute = sum(1 for n in result.nodes.values() if not _is_boundary(n.op))
     logger.info("Lowered: %d graph nodes -> %d kernels", initial_count, n_compute)

--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -195,6 +195,7 @@ def resolve_golden_arg(args) -> None:
         goldens_for_live_gpu,
         load_golden_file,
         load_golden_records,
+        shared_placement_pins,
     )
 
     # Canonical replay scopes to the live card as before. An explicit working file is
@@ -239,17 +240,7 @@ def resolve_golden_arg(args) -> None:
         logger.error("golden %r resolves to %d different embedded program targets", name, len(targets))
         sys.exit(2)
     if document is not None:
-        # An explicit working target's shared placement regime is part of the target,
-        # not unverified schedule evidence. Apply it to the ordinary compile while the
-        # remaining schedule families stay free for the normal deploy hierarchy. If
-        # same-name realizations disagree on any input pin, leave the target unpinned:
-        # choosing one regime would silently change which realization was requested.
-        pin_regimes = {match.pins for match in matches}
-        if len(pin_regimes) == 1:
-            shared_pins = dict(pin_regimes.pop())
-            from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
-
-            args.golden_target_pins = {key: value for key, value in shared_pins.items() if family_of(key) == "PLACE"}
+        args.golden_target_pins = shared_placement_pins(matches)
     args._golden_graph = matches[0].target_program.copy()
     from emmy.compiler.pipeline.search.data import Sample  # noqa: PLC0415
 
@@ -282,18 +273,6 @@ def resolve_golden_arg(args) -> None:
     )
     if args.golden_target_pins:
         logger.info("[golden] applying shared structural target pins: %s", args.golden_target_pins)
-
-
-def _golden_target_pin_context(args):
-    """Publish one explicit working target's shared structural input regime."""
-    from contextlib import nullcontext
-
-    pins = getattr(args, "golden_target_pins", None) or {}
-    if not pins:
-        return nullcontext()
-    from emmy.compiler.pipeline.search.pins import pinned_knobs  # noqa: PLC0415
-
-    return pinned_knobs(pins)
 
 
 def add_diagnostics_args(parser) -> None:
@@ -472,7 +451,9 @@ def handle_compile(args):
     else:
         logger.debug("No tuning DB at %s — using rule defaults", tune_db_path)
 
-    with _golden_target_pin_context(args):
+    from emmy.compiler.pipeline.search.pins import pinned_knobs  # noqa: PLC0415
+
+    with pinned_knobs(args.golden_target_pins):
         result = Pipeline.build(passes).run(graph, db=db, dump=dump)
 
     n_compute = sum(1 for n in result.nodes.values() if not _is_boundary(n.op))

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -959,11 +959,19 @@ def _sample_replay_knobs(sample) -> dict:
     row the realization stamps. A stored spelling may still carry a declined scoped key
     (``STAGE@a1: ''``); pinning it verbatim contradicts the row's own bare value (a bare pin fans
     out across every eligible site) and the realized kernel — which stamps nothing at a declined
-    site — can never satisfy it. The family-level OFF fill is deliberately NOT applied here: a
-    partial working row leaves a family unmentioned meaning "unpinned", not "pinned OFF"."""
-    from emmy.compiler.pipeline.knob import drop_uninformative_scopes  # noqa: PLC0415
+    site — can never satisfy it. A scoped OFF beside a non-OFF bare pin is different: it explicitly
+    overrides the bare pin at that site and must survive replay. The family-level OFF fill is
+    deliberately NOT applied here: a partial working row leaves a family unmentioned meaning
+    "unpinned", not "pinned OFF"."""
+    from emmy.compiler.pipeline.knob import drop_uninformative_scopes, family_of, is_off_value  # noqa: PLC0415
 
-    return {**getattr(sample, "pins", {}), **drop_uninformative_scopes(sample.knobs)}
+    replay = drop_uninformative_scopes(sample.knobs)
+    for name, value in sample.knobs.items():
+        family = family_of(name)
+        bare = sample.knobs.get(family)
+        if "@" in name and is_off_value(family, value) and bare is not None and not is_off_value(family, bare):
+            replay[name] = value
+    return {**getattr(sample, "pins", {}), **replay}
 
 
 def _failed_bench_status(exc: BaseException) -> str:

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -2208,6 +2208,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     """Run path: load JSON IR (any stage), finish lowering, execute, bench."""
     import json
 
+    from emmy.commands.compile import _golden_target_pin_context
     from emmy.compiler.backend import torch_ref
     from emmy.compiler.graph import Graph
     from emmy.compiler.pipeline import Pipeline
@@ -2251,7 +2252,8 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         # prior (uniform PUCT → emission-order, option-0) and does not replay tuned
         # variants from the DB; ``db=`` is kept for perf recording only. Wiring a
         # warm-started prior into single-shot compile is a deferred follow-up.
-        graph = Pipeline.build(tail).run(graph, db=db, dump=dump)
+        with _golden_target_pin_context(args):
+            graph = Pipeline.build(tail).run(graph, db=db, dump=dump)
 
     if not args.bench:
         # No bench: one in-process run + non-fatal accuracy vs the torch reference

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -954,24 +954,14 @@ def _ab_samples(specs, dynamic=None):
 
 
 def _sample_replay_knobs(sample) -> dict:
-    """All knob pins needed to reproduce a golden winner or explicit A/B row, with the
-    no-information spellings dropped (:func:`drop_uninformative_scopes`) so replay pins exactly the
-    row the realization stamps. A stored spelling may still carry a declined scoped key
-    (``STAGE@a1: ''``); pinning it verbatim contradicts the row's own bare value (a bare pin fans
-    out across every eligible site) and the realized kernel — which stamps nothing at a declined
-    site — can never satisfy it. A scoped OFF beside a non-OFF bare pin is different: it explicitly
-    overrides the bare pin at that site and must survive replay. The family-level OFF fill is
-    deliberately NOT applied here: a partial working row leaves a family unmentioned meaning
+    """All knob pins needed to reproduce a golden winner or explicit A/B row: the record's input
+    pins plus its knobs in the replay spelling (:func:`replay_pin_spelling` — no-information
+    spellings dropped, scoped OFF exceptions to a non-OFF bare pin kept). The family-level OFF fill
+    is deliberately NOT applied here: a partial working row leaves a family unmentioned meaning
     "unpinned", not "pinned OFF"."""
-    from emmy.compiler.pipeline.knob import drop_uninformative_scopes, family_of, is_off_value  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import replay_pin_spelling  # noqa: PLC0415
 
-    replay = drop_uninformative_scopes(sample.knobs)
-    for name, value in sample.knobs.items():
-        family = family_of(name)
-        bare = sample.knobs.get(family)
-        if "@" in name and is_off_value(family, value) and bare is not None and not is_off_value(family, bare):
-            replay[name] = value
-    return {**getattr(sample, "pins", {}), **replay}
+    return {**getattr(sample, "pins", {}), **replay_pin_spelling(sample.knobs)}
 
 
 def _failed_bench_status(exc: BaseException) -> str:
@@ -2216,7 +2206,6 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     """Run path: load JSON IR (any stage), finish lowering, execute, bench."""
     import json
 
-    from emmy.commands.compile import _golden_target_pin_context
     from emmy.compiler.backend import torch_ref
     from emmy.compiler.graph import Graph
     from emmy.compiler.pipeline import Pipeline
@@ -2260,7 +2249,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         # prior (uniform PUCT → emission-order, option-0) and does not replay tuned
         # variants from the DB; ``db=`` is kept for perf recording only. Wiring a
         # warm-started prior into single-shot compile is a deferred follow-up.
-        with _golden_target_pin_context(args):
+        with pinned_knobs(getattr(args, "golden_target_pins", None) or {}):
             graph = Pipeline.build(tail).run(graph, db=db, dump=dump)
 
     if not args.bench:

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -397,6 +397,7 @@ def _stmt_eval_scope() -> dict:
     # back. Auto-populate every public class from these modules (``setdefault`` so the
     # explicit stmt/expr entries above win on any name clash) — a new node/knob field
     # needs no edit here.
+    import emmy.compiler.ir.atom as _atom_mod  # noqa: PLC0415
     import emmy.compiler.ir.axis as _axis_mod  # noqa: PLC0415
     import emmy.compiler.ir.cuda.ir as _cuda_mod  # noqa: PLC0415
     import emmy.compiler.ir.kernel.ir as _kernel_mod  # noqa: PLC0415
@@ -404,7 +405,7 @@ def _stmt_eval_scope() -> dict:
     import emmy.compiler.ir.schedule as _sched_mod  # noqa: PLC0415
     import emmy.compiler.ir.tile.ir as _tile_mod  # noqa: PLC0415
 
-    for _mod in (_axis_mod, _sched_mod, _fold_mod, _tile_mod, _kernel_mod, _cuda_mod):
+    for _mod in (_atom_mod, _axis_mod, _sched_mod, _fold_mod, _tile_mod, _kernel_mod, _cuda_mod):
         for _nm in dir(_mod):
             _obj = getattr(_mod, _nm)
             if isinstance(_obj, type):

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -538,13 +538,13 @@ splicer refuses that shape whether it is the merged root or a producer edge: dep
 the reduce loop and move the `Write` after it, changing every prefix value into the final reduction. Such an
 effectful inner loop is not valid input to total lift.
 
-An `Accum` stores its value into the producing tensor before a distinct frontend operation loads that tensor. When the
-declared tensor dtype differs from the accumulator dtype (implicitly f32 until Kernel IR), `splice_graph` keeps that
-boundary as a typed `copy` alias. Nodes created by decomposing and rewriting one frontend operation share the ultimate
-`Op.source` object and may reconstruct their private edge directly. A private output stays recognizable even when its
-consumer fragment already mixes origins: it is absent from the ultimate frontend source's declared outputs. Missing
-or unrelated source chains preserve the conversion. Equal-dtype reductions and non-`Accum` producers keep the
-ordinary untyped alias, so fusion does not duplicate a conversion already carried by the defining statement.
+Before splicing, `loop/lifting/090_spell_store_rounding` turns a public store that narrows an `Accum` into an ordinary
+typed `copy` statement. A decomposition may route that accumulator through one transient, shape-only buffer before a
+pass-through LoopOp writes the public buffer; that direct load retains the accumulator's implicit f32 dtype, so the
+same rule spells its public conversion. An actual `Assign` computation over private reduction state remains untyped:
+normalization and softmax therefore retain f32 internal state rather than narrowing it at an inferred projection edge.
+`splice_graph` then preserves the explicit conversion through its ordinary statement path and reconstructs no dtype
+boundary from source provenance or graph topology.
 
 Construction is bounded per statement: the dedup table shares each `(stmt, emit scope, σ)` binding, and in
 every legitimate splice no single statement takes more than a handful of distinct bindings. A recurrence-shaped

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -390,6 +390,9 @@ recurse via `pretty_body`).
 CUDA scalar rendering goes through `stmt.base.op_to_expr`. Boolean masks retain the historical f32 SSA convention,
 so Torch's `bitwise_not` spelling renders as logical zero-test (`mask == 0`); explicitly bool-stamped values use the
 same semantics. Integer complement is not inferred from that name and fails closed until it has a typed consumer.
+The optional readable-source fold keeps a single-use `Assign` named when any argument's stamped dtype differs from
+the result dtype, so the target-aware `Assign.render` path remains responsible for conversions such as
+`__half2float`.
 
 Dependence cones (`ir/stmt/body.py`): `Body.backward_cone(roots)` / `Body.forward_cone(seeds)` build a `Cone` —
 the subset of the body's immediate stmts closed under SSA dependence (a wrapper joins as a unit; internally-bound

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -70,11 +70,13 @@ the argument for `Stmt`-hood: it has to appear at a POSITION in the emitted step
 need to be a statement to get there. The tree already carries it: a composed node is an entry in
 `operands`, and its position is produced by the derivation — `_twisted_derived_step` PLACES each
 inline-node edge before the first stmt that reads its bound name (lift body or merge), and
-`splice_operands` applies the same first-use rule to every other edge. Placement, not prepending, is
-what lets a step whose pure prologue precedes its producer (a loop-invariant scale `Load` ahead of
-attention's score contraction) re-derive to the program it was read from. `Fold.loop` passes that
-mixed term/stmt sequence to `_flatten_nodes` as a plain tuple; the only place terms become statements
-is `Fold.lower()`.
+`splice_operands` applies the same first-use rule to every other edge. A sibling edge that provides a
+value to another operand inherits that consumer's insertion point and precedes it; otherwise the
+provider could land after its only use when the projection body reads only the consumer. Placement,
+not prepending, is what lets a step whose pure prologue precedes its producer (a loop-invariant scale
+`Load` ahead of attention's score contraction) re-derive to the program it was read from. `Fold.loop`
+passes that mixed term/stmt sequence to `_flatten_nodes` as a plain tuple; the only place terms become
+statements is `Fold.lower()`.
 
 `Fold` does keep a small structural protocol whose names it shares with `Stmt` — `nested()` for its
 children, `rewrite()` for α-renaming, and `defines()` for its result names.

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -22,6 +22,7 @@ alone.
 
 from __future__ import annotations
 
+import heapq
 from dataclasses import dataclass, field, replace
 from functools import cached_property
 
@@ -38,18 +39,51 @@ from emmy.compiler.ir.stmt.base import _axis_identity
 
 def splice_operands(operands: tuple, stmts: tuple[Stmt, ...]) -> tuple[Stmt, ...]:
     """Splice each operand edge's producing stmts into ``stmts`` immediately BEFORE the first stmt
-    that reads the operand's bound name (appended when nothing reads it), ties resolved in operand
-    TUPLE order. This is the one lowering rule that turns the stored operands + derived step back
-    into the flat loop body — deterministic, so the derived loop (and with it ``Op.cache_key``)
-    depends only on the stored params."""
+    that reads the operand's bound name, directly or through another operand. A provider inherits
+    its dependent's insertion point and precedes it; otherwise an unread edge appends. Independent
+    ties retain operand TUPLE order. This is the one lowering rule that turns the stored operands +
+    derived step back into the flat loop body — deterministic, so the derived loop (and with it
+    ``Op.cache_key``) depends only on the stored params."""
     operands = _unique_edges(operands)
     if not operands:
         return stmts
-    at: dict[int, list] = {}
-    for edge in operands:  # first-use indexes against the ORIGINAL stmts — ties keep tuple order
+
+    results = tuple(frozenset(_operand_result_names(edge)) for edge in operands)
+    dependencies = []
+    for index, edge in enumerate(operands):
+        body = Body(operand_body(edge))
+        external = body.backward_cone(_operand_result_names(edge)).external_reads
+        dependencies.append(tuple(provider for provider, names in enumerate(results) if provider != index and names & external))
+
+    incoming = [set(providers) for providers in dependencies]
+    outgoing: list[list[int]] = [[] for _ in operands]
+    for dependent, providers in enumerate(dependencies):
+        for provider in providers:
+            outgoing[provider].append(dependent)
+    ready = [index for index, providers in enumerate(incoming) if not providers]
+    heapq.heapify(ready)
+    order: list[int] = []
+    while ready:
+        index = heapq.heappop(ready)
+        order.append(index)
+        for dependent in outgoing[index]:
+            incoming[dependent].remove(index)
+            if not incoming[dependent]:
+                heapq.heappush(ready, dependent)
+    if len(order) != len(operands):
+        raise ValueError("operand edges form a cyclic provider dependency")
+
+    indexes = []
+    for edge in operands:
         names = set(_operand_result_names(edge))
-        idx = next((i for i, st in enumerate(stmts) if names & deep_reads([st])), len(stmts))
-        at.setdefault(idx, []).append(edge)
+        indexes.append(next((i for i, st in enumerate(stmts) if names & deep_reads([st])), len(stmts)))
+    for dependent in reversed(order):
+        for provider in dependencies[dependent]:
+            indexes[provider] = min(indexes[provider], indexes[dependent])
+
+    at: dict[int, list] = {}
+    for index in order:
+        at.setdefault(indexes[index], []).append(operands[index])
     out: list[Stmt] = []
     for i, st in enumerate((*stmts, None)):
         for edge in at.get(i, ()):

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -70,8 +70,7 @@ def splice_operands(operands: tuple, stmts: tuple[Stmt, ...]) -> tuple[Stmt, ...
             incoming[dependent].remove(index)
             if not incoming[dependent]:
                 heapq.heappush(ready, dependent)
-    if len(order) != len(operands):
-        raise ValueError("operand edges form a cyclic provider dependency")
+    assert len(order) == len(operands), "operand edges are acyclic SSA cones — a cyclic provider dependency is not constructible"
 
     indexes = []
     for edge in operands:

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -165,6 +165,24 @@ def _operand_binding(fold: Fold) -> dict:
     return out
 
 
+def _expectation_bindings(fold: Fold) -> tuple[tuple[str, str, object], ...]:
+    """The twisted carrier's ``(state, injected term, operand edge)`` expectation channels.
+
+    This is the one structural reading shared by derived evaluation and placement: every named
+    non-pivot lift result bound to an operand becomes a synthesized expectation contraction when
+    that edge is materialized as a :class:`Load`. A computed edge is the same future contraction
+    operand before placement cuts it.
+    """
+    if fold.axis is None or not fold.family.twisted:
+        return ()
+    by_param = _operand_binding(fold)
+    return tuple(
+        (state, term, by_param[term])
+        for state, term in zip(fold.combine.results[1:], fold.lift.results[1:], strict=True)
+        if isinstance(term, str) and term in by_param
+    )
+
+
 def _twisted_derived_step(fold: Fold) -> tuple[Stmt, ...]:
     """The DERIVED blocked evaluation of a λ-spelled TWISTED fold: the INLINE-NODE operand edges
     at the head in operand order (flash's ``Σ_dd Q·K`` score, ahead of the lift body), the lift
@@ -177,11 +195,7 @@ def _twisted_derived_step(fold: Fold) -> tuple[Stmt, ...]:
     names = tuple(fold.combine.results)
     terms = tuple(lam.results)
     merge = list(exp_merge(names, terms, key=names[0]))
-    by_param = _operand_binding(fold)
-    for i, (nm, term) in enumerate(zip(names, terms, strict=True)):
-        if i == 0 or not isinstance(term, str):
-            continue  # the pivot / a literal denominator — only EXPECTATION components split
-        edge = by_param.get(term)
+    for nm, term, edge in _expectation_bindings(fold):
         if isinstance(edge, Load):
             merge = _split_expect(merge, nm, term, edge)
     # The inline-node edges are PLACED, not prepended: each lands immediately before the first
@@ -636,12 +650,9 @@ class Fold:
         twice."""
         consumed = {id(s) for s in self.step_stmts()}
         if self.family.twisted and not _identity_lift(self):
-            by_param = _operand_binding(self)
-            for term in self.lift.results[1:]:  # EXPECTATION components: a str-injected non-pivot
-                if isinstance(term, str):
-                    edge = by_param.get(term)
-                    if isinstance(edge, Load):
-                        consumed.add(id(edge))
+            for _, _, edge in _expectation_bindings(self):
+                if isinstance(edge, Load):
+                    consumed.add(id(edge))
         return _unique_edges(tuple(e for e in self.operands if id(e) not in consumed))
 
     @cached_property

--- a/emmy/compiler/ir/stmt/base.py
+++ b/emmy/compiler/ir/stmt/base.py
@@ -710,6 +710,10 @@ def render_body(body: Body, ctx: RenderCtx) -> list[str]:
 
     inlined: set[str] = set()
     if _readable():
+        # The readability scan runs before this body's Loads / Assigns render, so their dtypes are
+        # not in ``ctx.ssa_dtypes`` yet. Keep their stamped types locally: folding an expression
+        # that needs a target conversion would bypass ``Assign.render`` and drop that conversion.
+        local_dtypes = {name: s.dtype.name for s in body if isinstance(s, (Load, Assign)) and s.dtype is not None for name in s.defines()}
         from emmy.compiler.ir.expr import BinaryExpr, TernaryExpr, Var  # local — avoid cycle
 
         total = _read_counts(body, {})
@@ -734,6 +738,13 @@ def render_body(body: Body, ctx: RenderCtx) -> list[str]:
             # without substituting it, leaving an undefined reference.
             ri = next((j for j, r in enumerate(stmts) if s.name in r.deps()), None)
             if ri is None or not isinstance(stmts[ri], Assign):
+                continue
+            result_dt = s.dtype.name if s.dtype is not None else "f32"
+            arg_dtypes = [local_dtypes.get(arg, ctx.ssa_dtypes.get(arg, "f32")) for arg in s.args]
+            if any(dtype != result_dt for dtype in arg_dtypes):
+                # The named Assign's target-aware renderer inserts conversions (for example
+                # ``__half2float``). The readability-only fold renders a bare Expr tree, so keep
+                # the Assign named rather than silently changing its type semantics.
                 continue
             # Straddle guard: the fold moves this computation from its def site to the read site, so
             # every base operand — transitively, through already-inlined temps — must not be redefined

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -56,7 +56,11 @@ boundary. Unsupported non-canonical Loop IR fails loudly. Kernel placement is a 
 pure body receives a dependency-safe order and commutative `Assign` arguments are sorted before it reaches a Fold.
 Structural identity therefore reads the stored order directly. Contraction canonicalization first orders product
 arguments by geometry, then places the one argument shared by every product in the Fold's shared operand slot.
-Physical M/N orientation remains a placement fact rather than part of the Fold algebra.
+For a broadcast-batched product whose batch axis occurs in only one operand, the placement's trailing output pair
+still supplies that geometry. If its geometric first operand reads the reduction axis non-contiguously and the other
+materialized operand reads it contiguously, the commutative product puts the contiguous operand in the shared A slot;
+placement then derives the corresponding physical M/N orientation from the operand axes. Physical M/N orientation
+remains a placement fact rather than part of the Fold algebra.
 
 `normalize.py` owns only the idempotent, bottom-up rules that need Tile context: scoped lambda alpha-equivalence and
 clustering, semiring contraction canonicalization, and closed child-Fold extraction from a root projection. The

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -212,6 +212,10 @@ placement before scheduling; a scoped cut carries the consumed placement decisio
 directly to scheduling. Synthesized evaluation nodes are not cut sites, and the rule neither recognizes operation
 families nor filters legal cuts by profitability.
 
+A computed edge injected into a twisted expectation is already the operand of the derived contraction that appears
+when placement materializes it. Its workspace therefore uses the consumer's public store dtype, not the producer's
+f32 reduction-carrier dtype; otherwise the materialized B slab would make every f16 tensor-core atom ineligible.
+
 Scheduling sees only the rewritten stored Fold tree. Every Fold is an addressable schedule site; the scheduler does
 not derive alternate classified views or suppress a child because its parent may realize it. A derived unit-axis
 contraction inherits its enclosing Fold's reduction domain through the parent/child scheduling interface, while its

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -84,6 +84,15 @@ its defining scope. Straight-line chains still close normally, and a reducing ro
 domain. A stored fold left capturing by this rule remains placeable: the placement fork resolves its captures outward
 through the occurrence's lexical environment at offer time, without moving the stored tree.
 
+Three walks compute a capture's provider cone, at three stages, and each is allowed to move something different.
+Normalization's closing rules (`normalize.py`, above) are the only walk that REWRITES the stored tree, and only for
+straight-line providers within one evaluation domain. The placement fork's provider closure
+(`lowering/tile/_cut.py`) moves nothing: it proves every occurrence resolves to equal sources and offers the closed
+value as a seam, recording fold producers as the seam's requirements. Kernel lowering's per-cell closure
+(`lowering/kernel/_factor.py`) moves sibling providers into a computed operand's compute fill of the one kernel being
+emitted — a codegen fact that exists only inside that realization. A new capture-resolution need belongs in one of
+these three, not a fourth walk.
+
 An identity pass-through — a projection that only re-exposes its single operand's results — dissolves wherever a
 projection is formed or revisited. That is not cosmetic: a pass-through is what makes two occurrences of the same
 computation compare unequal, and the placement fork's value clustering (`lowering/tile/_cut.py`) relies on

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -76,9 +76,13 @@ exclusive consumption (every moved definition dies into the closed edges), so th
 duplicated. Both rules measure an edge's captures with `Fold.deps` — scope-aware, so a name a sibling operand binds
 inside the edge is not a capture and an already-closed edge never re-fires the rewrite. A cone closed at its axes is
 what the placement fork can offer as a workspace seam, which is how a computed operand (the RMSNorm'd, RoPE'd K
-vector) becomes materializable once per key instead of recomputed per query row. A body-member fold these rules
-leave capturing host names is not lost to placement: the fork closes it at offer time through provider closure
-(`lowering/tile/_cut.py`), without moving anything in the stored tree.
+vector) becomes materializable once per key instead of recomputed per query row.
+
+An iteration never crosses into a new evaluation domain. Attaching an iteration-bearing provider to a contraction
+operand would evaluate it once per step of every intervening binder; normalization therefore leaves that provider at
+its defining scope. Straight-line chains still close normally, and a reducing root's own axis counts as its existing
+domain. A stored fold left capturing by this rule remains placeable: the placement fork resolves its captures outward
+through the occurrence's lexical environment at offer time, without moving the stored tree.
 
 An identity pass-through — a projection that only re-exposes its single operand's results — dissolves wherever a
 projection is formed or revisited. That is not cosmetic: a pass-through is what makes two occurrences of the same

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -430,6 +430,14 @@ def _edge_free_names(edge) -> frozenset[str]:
     return frozenset(edge.deps()) if isinstance(edge, Fold) else frozenset()
 
 
+def _carries_iteration(node) -> bool:
+    """Whether a provider chain contains a Fold axis rather than only straight-line code."""
+    if getattr(node, "axis", None) is not None:
+        return True
+    children = (*node.operands, *node.lift.body) if isinstance(node, Fold) else tuple(stmt for body in node.nested() for stmt in body)
+    return any(_carries_iteration(child) for child in children)
+
+
 def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[str]) -> Fold:
     """Move an enclosing projection's dependencies onto captured contraction operands."""
     assert root.axis is None
@@ -446,7 +454,7 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
     moved_members: set[int] = set()
     moved_edges: set[int] = set()
 
-    def provider(names: tuple[str, ...]):
+    def provider(names: tuple[str, ...], binders: tuple[str, ...]):
         cone = root.body.backward_cone(names)
         required = set(cone.external_reads) | set(names)
         edges = tuple(dict.fromkeys(edge_by_name[name] for name in provider_order if name in required and name in edge_by_name))
@@ -454,14 +462,21 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
         defined.update(name for edge in edges for name in _operand_result_names(edge))
         if not set(names) <= defined:
             return None
+        # Attaching a provider to a nested operand evaluates it inside every binder crossed by
+        # the move. An iteration-bearing chain therefore stays at its defining scope; straight-
+        # line chains still close normally. A whole operand edge is likewise kept when any part
+        # of it iterates, because closure cannot split that edge without changing its value.
+        if any(_carries_iteration(edge) for edge in edges) or (binders and any(_carries_iteration(stmt) for stmt in cone.members)):
+            return None
         moved_members.update(id(stmt) for stmt in cone.members)
         moved_edges.update(id(edge) for edge in edges)
         hoisted = _hoist_closed_folds(Fold.projection(operands=edges, body=Body(cone.members), results=names), axes, sweep_axes)
         return _passthrough(hoisted) or hoisted
 
-    def close(node: Fold) -> Fold:
-        operands = tuple(close(edge) if isinstance(edge, Fold) else edge for edge in node.operands)
-        body = Body(close(stmt) if isinstance(stmt, Fold) else stmt for stmt in node.body)
+    def close(node: Fold, binders: tuple[str, ...] = ()) -> Fold:
+        inner = (*binders, node.axis.name) if node.axis is not None else binders
+        operands = tuple(close(edge, inner) if isinstance(edge, Fold) else edge for edge in node.operands)
+        body = Body(close(stmt, inner) if isinstance(stmt, Fold) else stmt for stmt in node.body)
         current = replace(node, operands=operands) if operands != node.operands else node
         if body != current.body:
             current = current.with_bodies((body,))
@@ -475,7 +490,7 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
                 closed.append(edge)
                 continue
             needed = tuple(name for name in provider_order if name in (_edge_free_names(edge) & provider_names))
-            source = provider(needed) if needed else None
+            source = provider(needed, binders) if needed else None
             if source is None:
                 closed.append(edge)
                 continue
@@ -524,20 +539,24 @@ def _close_reduce_body(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[
     provider_names = frozenset(provider_order)
     moved: set[int] = set()
 
-    def source(names: tuple[str, ...]) -> Fold | None:
+    def source(names: tuple[str, ...], binders: tuple[str, ...]) -> Fold | None:
         cone = body.backward_cone(names)
         defined = {name for stmt in cone.members for name in stmt.defines()}
         if not set(names) <= defined:
             return None
+        if binders and any(_carries_iteration(member) for member in cone.members):
+            return None
         moved.update(id(stmt) for stmt in cone.members)
         return _hoist_closed_folds(Fold.projection(body=Body(cone.members), results=names), axes, sweep_axes)
 
-    def close(node: Fold) -> Fold:
-        operands = tuple(close(edge) if isinstance(edge, Fold) else edge for edge in node.operands)
-        inner = Body(close(stmt) if isinstance(stmt, Fold) else stmt for stmt in node.lift.body)
+    def close(node: Fold, binders: tuple[str, ...] = ()) -> Fold:
+        # ``root`` already evaluates inside its own axis; only descendants add a new domain.
+        inner = (*binders, node.axis.name) if node.axis is not None else binders
+        operands = tuple(close(edge, inner) if isinstance(edge, Fold) else edge for edge in node.operands)
+        stmts = Body(close(stmt, inner) if isinstance(stmt, Fold) else stmt for stmt in node.lift.body)
         current = replace(node, operands=operands) if operands != node.operands else node
-        if inner != current.lift.body:
-            current = current.with_bodies((inner,))
+        if stmts != current.lift.body:
+            current = current.with_bodies((stmts,))
         if not is_contraction(current):
             return current
 
@@ -548,7 +567,7 @@ def _close_reduce_body(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[
                 closed.append(edge)
                 continue
             needed = tuple(name for name in provider_order if name in (_edge_free_names(edge) & provider_names))
-            provided = source(needed) if needed else None
+            provided = source(needed, binders) if needed else None
             if provided is None:
                 closed.append(edge)
                 continue

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, replace
 
 from emmy.compiler.ir.axis import Axis
-from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.expr import Var, affine_form
 from emmy.compiler.ir.pure import (
     Channel,
     Fold,
@@ -119,6 +119,14 @@ def _operand_lambda(operand, axes: tuple[str, ...]) -> tuple[Lambda, tuple[str, 
 
 def _operand_roles(operand, axes: tuple[str, ...]) -> frozenset[str]:
     return frozenset(axis for axis in axes if edge_refs_axis(operand, axis))
+
+
+def _loads_axis_contiguously(operand, axis: str) -> bool:
+    """Whether a materialized operand carries ``axis`` only in its trailing index component."""
+    if not isinstance(operand, Load) or not operand.index or any(axis in index.free_vars() for index in operand.index[:-1]):
+        return False
+    form = affine_form(operand.index[-1], {axis})
+    return form is not None and form[1].get(axis) == 1
 
 
 def _ordered_projection(members: Iterable, results: tuple[str, ...]) -> Fold:
@@ -283,14 +291,30 @@ def _canonical_semiring(fold: Fold, axes: tuple[str, ...], implicit_axes: frozen
         left_roles, right_roles = _operand_roles(left, axes), _operand_roles(right, axes)
         left_only, right_only = left_roles - right_roles, right_roles - left_roles
         unused_implicit = implicit_axes - left_roles - right_roles
+        broadcast_batch = False
         if not left_only and len(right_only) == 1 and len(unused_implicit) == 1:
             left_only = unused_implicit
         elif not right_only and len(left_only) == 1 and len(unused_implicit) == 1:
             right_only = unused_implicit
+        one_sided_batch = (len(left_only) > 1 and len(right_only) == 1) or (len(right_only) > 1 and len(left_only) == 1)
+        if one_sided_batch:
+            # A broadcast batch axis may occur in only one operand. The placement's trailing pair
+            # still identifies the contraction's m/n roles; earlier free axes remain ordinary
+            # grid dimensions and do not change that orientation.
+            matrix_axes = frozenset(axes[-2:])
+            left_matrix = left_only & matrix_axes
+            right_matrix = right_only & matrix_axes
+            if len(left_matrix) == 1 and len(right_matrix) == 1:
+                left_only, right_only = left_matrix, right_matrix
+                broadcast_batch = True
         if len(left_only) != 1 or len(right_only) != 1:
             return fold
         left_axis, right_axis = next(iter(left_only)), next(iter(right_only))
         pair = (left, right) if axis_position[left_axis] < axis_position[right_axis] else (right, left)
+        if broadcast_batch and form.product.commutative:
+            first, second = pair
+            if _loads_axis_contiguously(second, fold.axis.name) and not _loads_axis_contiguously(first, fold.axis.name):
+                pair = (second, first)
         pairs.append(pair)  # A (earlier output axis), B (later output axis)
 
     pairs = _orient_shared(pairs, form.product, all_axes)

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -122,7 +122,11 @@ def _operand_roles(operand, axes: tuple[str, ...]) -> frozenset[str]:
 
 
 def _loads_axis_contiguously(operand, axis: str) -> bool:
-    """Whether a materialized operand carries ``axis`` only in its trailing index component."""
+    """Whether a materialized operand carries ``axis`` only in its trailing index component.
+
+    The same unit-stride reading one position over is ``reads_declared_rows`` in the lowering
+    layer's ``_addr``; it cannot be shared because ``ir/tile`` sits below ``pipeline/passes``.
+    This is the ONE layout fact canonicalization reads — see the caller's precedence note."""
     if not isinstance(operand, Load) or not operand.index or any(axis in index.free_vars() for index in operand.index[:-1]):
         return False
     form = affine_form(operand.index[-1], {axis})
@@ -312,6 +316,13 @@ def _canonical_semiring(fold: Fold, axes: tuple[str, ...], implicit_axes: frozen
         left_axis, right_axis = next(iter(left_only)), next(iter(right_only))
         pair = (left, right) if axis_position[left_axis] < axis_position[right_axis] else (right, left)
         if broadcast_batch and form.product.commutative:
+            # Physical M/N orientation stays a placement fact; this swap decides only which
+            # commutative argument SPELLS the shared A slot when the batch axis breaks the
+            # symmetric geometry, preferring the operand that reads the reduction axis
+            # contiguously so placement can derive a tensor-core-eligible orientation.
+            # Precedence with ``_orient_shared`` below: a broadcast-batched product is
+            # single-channel, where ``_orient_shared`` is a no-op; with two or more channels its
+            # shared-argument rule wins and its tie-break retains the orientation chosen here.
             first, second = pair
             if _loads_axis_contiguously(second, fold.axis.name) and not _loads_axis_contiguously(first, fold.axis.name):
                 pair = (second, first)
@@ -464,8 +475,14 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
             return None
         # Attaching a provider to a nested operand evaluates it inside every binder crossed by
         # the move. An iteration-bearing chain therefore stays at its defining scope; straight-
-        # line chains still close normally. A whole operand edge is likewise kept when any part
-        # of it iterates, because closure cannot split that edge without changing its value.
+        # line chains still close normally. The two arms deliberately differ: a whole operand
+        # EDGE that iterates is kept unconditionally — the enclosing projection evaluates it
+        # once, so even the depth-0 move into a contraction operand's per-cell fill multiplies
+        # it, and closure cannot split the edge without changing its value — while an iterating
+        # body MEMBER is blocked only past a new binder (``_close_reduce_body`` states the
+        # mirror convention: a reducing root's own axis is its existing domain). A fold this
+        # rule leaves capturing stays placeable through provider closure at offer time
+        # (``lowering/tile/_cut.py``).
         if any(_carries_iteration(edge) for edge in edges) or (binders and any(_carries_iteration(stmt) for stmt in cone.members)):
             return None
         moved_members.update(id(stmt) for stmt in cone.members)

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -70,7 +70,10 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict
     """Infer an edge's result dtypes in the lexical scope where the edge occurs.
 
     A capturing Fold cannot be typed in an empty environment. Starting this walk at the root and
-    threading each enclosing environment produces one dtype table for every stored edge.
+    threading each enclosing environment produces one dtype table for every stored edge. The
+    ``cache`` is keyed by object identity, so a SHARED node keeps the dtypes of the first
+    environment reached — sound for placement's consumers because provider closure only offers a
+    capturing seam whose occurrences resolve to equal providers, and equal providers type equally.
     """
     cache = {} if cache is None else cache
     if id(edge) in cache:

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -66,8 +66,12 @@ def cone_seam(cone, k_name: str) -> tuple[tuple, tuple, tuple[str, ...]]:
     return (pro, cell, stats) if stats else ((), cell, ())
 
 
-def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None) -> tuple:
-    """Infer a pure operand edge's result dtypes from its typed leaves and SSA program."""
+def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict | None = None) -> tuple:
+    """Infer an edge's result dtypes in the lexical scope where the edge occurs.
+
+    A capturing Fold cannot be typed in an empty environment. Starting this walk at the root and
+    threading each enclosing environment produces one dtype table for every stored edge.
+    """
     cache = {} if cache is None else cache
     if id(edge) in cache:
         return cache[id(edge)]
@@ -81,15 +85,15 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None) -> tuple:
         cache[id(edge)] = result
         return result
 
-    env = {}
+    env = dict(scope or {})
     for operand in edge.operands:
-        env.update(zip(_operand_result_names(operand), edge_dtypes(operand, inputs, cache), strict=True))
+        env.update(zip(_operand_result_names(operand), edge_dtypes(operand, inputs, cache, env), strict=True))
     for stmt in edge.lift.body:
         if isinstance(stmt, Load):
             tensor = inputs.get(stmt.input) if inputs else None
             env.update((name, tensor.dtype if tensor is not None else None) for name in stmt.names)
         elif isinstance(stmt, Fold):
-            env.update(zip(_operand_result_names(stmt), edge_dtypes(stmt, inputs, cache), strict=True))
+            env.update(zip(_operand_result_names(stmt), edge_dtypes(stmt, inputs, cache, env), strict=True))
         elif isinstance(stmt, Assign):
             args = [env.get(name) for name in stmt.args]
             env[stmt.name] = stmt.dtype or (get_dtype(dtype_promote(stmt.op.name, [dtype.name for dtype in args])) if all(args) else None)
@@ -102,7 +106,11 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None) -> tuple:
             env.update((name, None) for name in stmt.defines())
 
     lifted = tuple(env.get(result) if isinstance(result, str) else F32 for result in edge.lift.results)
-    result = lifted if edge.axis is None else lifted[: len(edge.combine.results)]
+    if edge.axis is None:
+        result = lifted
+    else:
+        carried = lifted[: len(edge.combine.results)]
+        result = carried + tuple(env.get(name) for name in _operand_result_names(edge)[len(carried) :])
     cache[id(edge)] = result
     return result
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1281,11 +1281,13 @@ child kernel's deploy identity stored in `identity`. A stored identity is author
 (`kernel_identity` returns it as-is — the target's own lift stops at the pre-cut kernel and cannot name a child), and
 the join stays fail-closed: a stale identity matches no live fork and decides nothing. The strict decode is stricter —
 the stored identity must equal one kernel resolved under the record's pins, and the spelled row must equal one of
-THAT kernel's enumerated rows, so a sibling child's row never vouches. At deploy the pin-regime check skips PLACE
-pins (the route is the routing consult's decision; the identity join guarantees a receipt only decorates a
-structurally identical kernel), and validation rejects a realization that schedules behind pinned cuts without a
-stored identity. A stored identity equal to the target's own lift is the corpus's derived stamp, not a receipt, and
-keeps the pooled decode.
+THAT kernel's enumerated rows, so a sibling child's row never vouches. Ordinary records must still select exactly one
+pre-cut kernel, but a receipt may outlive target-boundary drift that makes its regenerated target lower to several:
+the stored identity selects one bucket from the kernels resolved under its pins, without first requiring the legacy
+one-kernel lift. At deploy the pin-regime check skips PLACE pins (the route is the routing consult's decision; the
+identity join guarantees a receipt only decorates a structurally identical kernel), and validation rejects a
+realization that schedules behind pinned cuts without a stored identity. A stored identity equal to the target's own
+lift is the corpus's derived stamp, not a receipt, and keeps the pooled decode.
 
 The preferred reference is the runnable Torch slice (`torch-eager`) or the applicable library kernel (`cublas`). A
 Loop IR fallback has no frontend callable by construction; an origin slice can also have synthetic boundaries whose

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -852,7 +852,10 @@ predicted to be cheaper first.
 
 **Separable scoring** (`TwoLevelStrategy._evaluate_terminal`) tunes each finalized kernel **independently** in
 its own single-node slice (`single_node_graph`, `slice.py`) with a plain `TuningSearch` over the lowering passes
-only (`tile → kernel → cuda`), and returns the Σ once ALL Loop kernels are measured:
+only (`tile → kernel → cuda`), and returns the Σ once all kernel roots are measured. A serialized post-cut child is
+already Tile IR: an unscheduled Tile root enters this same per-kernel search directly and records ordinary
+child-identity evidence that a later parent cut can consume. A Tile root whose worker inventory is sealed is already
+scheduled; it remains lowering-only and is never enrolled or scheduled again.
 
 - The slice keeps the root kernel + its leaf-op closure and turns every other kernel-input into a synthetic `InputOp`.
   The root op is shared **by reference**, so its body — and thus `Op.cache_key` — is byte-for-byte the full-graph op's.

--- a/emmy/compiler/pipeline/knob.py
+++ b/emmy/compiler/pipeline/knob.py
@@ -689,6 +689,23 @@ def drop_uninformative_scopes(knobs: dict) -> dict[str, str]:
     return dict(sorted(out.items(), key=lambda kv: knob_sort_key(kv[0])))
 
 
+def replay_pin_spelling(knobs: dict) -> dict[str, str]:
+    """A stored row as replay pins: the no-information spellings dropped
+    (:func:`drop_uninformative_scopes`), except that a scoped OFF beside a NON-OFF bare family pin
+    survives — it is the site-specific exception to that bare pin (a bare pin fans out across every
+    eligible site), not a redundant declined-site stamp. The exception is replay-only and stays out
+    of :func:`schedule_row_key`: the realized kernel stamps nothing at the declined site, so row
+    identity must keep normalizing the scoped OFF away on both sides or every such recording would
+    read as drift."""
+    out = drop_uninformative_scopes(knobs)
+    for name, value in knobs.items():
+        family = family_of(name)
+        bare = knobs.get(family)
+        if "@" in name and is_off_value(family, value) and bare is not None and not is_off_value(family, bare):
+            out[name] = value
+    return out
+
+
 def stamp_schedule_families(knobs: dict) -> dict[str, str]:
     """The ready-to-record knob map for one realized kernel: its tuning knobs
     (:func:`tuning_knob_items`) plus an explicit OFF value for every :data:`SCHEDULE_FAMILIES`

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -82,16 +82,17 @@ whose workspace dtypes stay undetermined).
 A contraction-operand seam stands for a VALUE, not only an object: closed cones that are alpha-equivalent up to
 their captured axis names (attention's normalized K cone, once per score contraction) fold into one seam, each
 duplicate carried as a sibling with its capture correspondence, and the cut replaces every one with workspace loads
-spelled through its own axes. A body-member fold capturing host-provided names is cuttable through PROVIDER
-CLOSURE: a capture whose producer chain is pure `Load`/`Assign` stmts joins the produced piece verbatim, and a
-capture only a sibling fold defines makes the seam DEPENDENT — its piece reads the name back through that producer's
-workspace, so cutting it composes the producer's cut in (attention's second softmax-statistics pass reading the
-first's accumulator; a pinned dependent cut pulls its producers in transitively, and pinning a producer `fuse`
-beside it is an error). This is what lets the row statistics materialize once per query row instead of once per
-output weight. Provider-closed and dependent seams are SCOPED-PIN-ONLY: the unpinned fork and bare `PLACE=cut`
-never select them, because nearly every kernel — and every fresh cut piece, which copies its providers — hosts
-some, so offering them would make recursive placement inexhaustible and the candidate walk explode. A route through
-them is spelled by authored or golden-decoded pins.
+spelled through its own axes. Any stored fold capturing enclosing-scope names — operand edge or body member — is
+cuttable through PROVIDER CLOSURE. Each occurrence resolves captures outward through its lexical environment,
+nearest scope first; every occurrence must resolve to equal straight-line providers and the same Fold producers. A
+pure `Load`/`Assign` chain joins the produced piece verbatim, while a Fold producer makes the seam DEPENDENT: its piece
+reads the name through that producer's workspace, so cutting it composes the producer's cut in. Dtypes for capturing
+seams come from inference rooted at the Tile tree, where the enclosing bindings are visible. This is what lets row
+statistics materialize once per query row instead of being copied into a contraction's evaluation domain.
+Provider-closed and dependent seams are SCOPED-PIN-ONLY: the unpinned fork and bare `PLACE=cut` never select them,
+because nearly every kernel — and every fresh cut piece, which copies its providers — hosts some, so offering them
+would make recursive placement inexhaustible and the candidate walk explode. A route through them is spelled by
+authored or golden-decoded pins.
 Scoped `PLACE@path=cut` pins are authoritative and COMPOSE: every pin that resolves on
 one kernel joins a single realization — one producer per seam, one consumer, a producer reading another seam's
 workspace when its value nests inside (attention's statistics cone contains the score dots whose operand cones are

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -303,6 +303,12 @@ Multi-source `IndexMapOp` lifting preserves predicate dtype: an explicit source 
 and an unconditional fallback is a boolean `Literal(True, "bool")`. The rendered CUDA condition remains `1`, while
 Loop IR persistence and vectorized reference evaluation retain the boolean type required by `Select`.
 
+Before fusion, `090_spell_store_rounding` turns a public narrowing reduction store into a typed `copy` value. A
+decomposition may place one transient, shape-only buffer between the accumulator and its public pass-through store;
+that direct private copy inherits the same accumulator dtype. Actual computation over private reduction state remains
+untyped, so normalization and softmax keep their f32 state until their own public result store. Fusion and placement
+then preserve the typed `copy` as an ordinary statement rather than reconstructing a boundary from graph topology.
+
 Loop fusion is maximal and schedule-blind: every structurally legal merge is taken to fixpoint before lowering
 considers a kernel boundary. Fusion never asks whether the merged body is recognized, schedulable by an optimized
 tier, or faster than its parts. Nested reductions and multi-statistic compounds are therefore not fusion gates. A

--- a/emmy/compiler/pipeline/passes/loop/lifting/090_spell_store_rounding.py
+++ b/emmy/compiler/pipeline/passes/loop/lifting/090_spell_store_rounding.py
@@ -11,10 +11,13 @@ this pass the rounding is a VALUE fact, and every later transform preserves it f
 splicer inlines the conversion through its ordinary plain-stmt path, total lift carries it into the
 projection epilogue, and no pass needs a private channel for "this edge also converts".
 
-**Which stores round.** Only a store whose value is an ``Accum``: a reduce accumulates in f32 until
-``030_stamp_types`` stamps a dtype, so its value is provably wider than a 16-bit destination. An
-``Assign`` chain already carries its inputs' width, so narrowing it here would introduce a rounding
-the reference never performed.
+**Which stores round.** A store whose value is an ``Accum``: a reduce accumulates in f32 until
+``030_stamp_types`` stamps a dtype, so its value is provably wider than a 16-bit destination. The
+same boundary can appear one node later when a decomposition writes the accumulator to a transient
+shape buffer and a pass-through LoopOp copies it to the public buffer. The transient never stored,
+so that direct load still carries the accumulator's width and the public copy performs the source
+program's rounding. An ``Assign`` chain already carries its inputs' width, so narrowing it here
+would introduce a rounding the reference never performed.
 
 **Which stores need it spelled.** Only one whose buffer something READS. The rounding has to
 survive fusion, and fusion is what deletes the store — but a buffer with no consumer is never
@@ -37,10 +40,29 @@ from dataclasses import replace
 
 from emmy.compiler.dtype import F32
 from emmy.compiler.graph import Node
-from emmy.compiler.ir.loop import Accum, Assign, LoopOp, Write
+from emmy.compiler.ir.loop import Accum, Assign, Load, LoopOp, Write
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
 
 PATTERN = [Pattern("root", LoopOp)]
+
+
+def _accum_dtype(graph, meta, write: Write):
+    """The accumulator dtype reaching ``write`` directly or through one private copy."""
+    value = meta.defs.get(write.value)
+    if isinstance(value, Accum):
+        return value.dtype or F32
+    if not isinstance(value, Load):
+        return None
+    source = graph.buffer(value.input)
+    producer = graph.producer(value.input)
+    if source is None or not source.transient or producer is None or not isinstance(producer.op, LoopOp):
+        return None
+    producer_meta = producer.op.analyze()
+    produced = [candidate for candidate, _scope in producer_meta.writes if candidate.output == value.input]
+    if len(produced) != 1 or not produced[0].is_scalar:
+        return None
+    accumulated = producer_meta.defs.get(produced[0].value)
+    return (accumulated.dtype or F32) if isinstance(accumulated, Accum) else None
 
 
 def rewrite(match: Match, root: Node) -> LoopOp:
@@ -53,13 +75,11 @@ def rewrite(match: Match, root: Node) -> LoopOp:
     for write, _scope in meta.writes:
         if not write.is_scalar:
             continue
-        value = meta.defs.get(write.value)
-        if not isinstance(value, Accum):
+        value_dtype = _accum_dtype(graph, meta, write)
+        if value_dtype is None:
             continue
         buffer = graph.buffer(write.output)
-        # ``value.dtype or F32``: an Accum is unstamped in canonical Loop IR, and unstamped IS
-        # f32 — the accumulation dtype, not a missing value.
-        if buffer is None or buffer.transient or buffer.dtype == (value.dtype or F32):
+        if buffer is None or buffer.transient or buffer.dtype == value_dtype:
             continue
         if not graph.buffer_users(write.output):
             continue  # nothing reads it, so no fusion can delete the store that rounds

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -215,9 +215,12 @@ an `EMMY_STAGE` pin stays authoritative.
 
 **Computed operands and nested Folds.** Every computed edge remains a schedule site. Scalar rows evaluate a pure
 producer in registers. Warp rows place a producer either in a synchronous shared-memory slab or, when the child is a
-scheduled contraction, directly in fragments before storing the slab consumed by `ldmatrix`. Materialized peers keep
-using the ordinary vectorized copy transports. These are residence choices over the same Fold tree; the scheduler and
-materializer do not recognize operation families.
+scheduled contraction, directly in fragments. At a static reduce extent, a child and value contraction with the same
+m16n8k16 f16/bf16 atom and M-side lane map can keep those fragments live under a single-buffer value stage:
+`FragmentRepack` converts each pair of adjacent f32 C fragments into one A fragment, while the materialized B operand
+retains its ordinary staged transport. A symbolic reduce extent, another atom or lane map, or register ping-pong
+stores the computed operand in the slab consumed by `ldmatrix`. These are residence choices over the same Fold tree;
+the scheduler and materializer do not recognize operation families.
 
 The fragment Fold evaluator assigns each live value one of three residences: CTA-cell uniform, one scalar per fragment
 row, or one C fragment. It interprets the stored `Lambda` directly. `Assign` broadcasts to the highest input residence,

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -215,12 +215,9 @@ an `EMMY_STAGE` pin stays authoritative.
 
 **Computed operands and nested Folds.** Every computed edge remains a schedule site. Scalar rows evaluate a pure
 producer in registers. Warp rows place a producer either in a synchronous shared-memory slab or, when the child is a
-scheduled contraction, directly in fragments. At a static reduce extent, a child and value contraction with the same
-m16n8k16 f16/bf16 atom and M-side lane map can keep those fragments live under a single-buffer value stage:
-`FragmentRepack` converts each pair of adjacent f32 C fragments into one A fragment, while the materialized B operand
-retains its ordinary staged transport. A symbolic reduce extent, another atom or lane map, or register ping-pong
-stores the computed operand in the slab consumed by `ldmatrix`. These are residence choices over the same Fold tree;
-the scheduler and materializer do not recognize operation families.
+scheduled contraction, directly in fragments before storing the slab consumed by `ldmatrix`. Materialized peers keep
+using the ordinary vectorized copy transports. These are residence choices over the same Fold tree; the scheduler and
+materializer do not recognize operation families.
 
 The fragment Fold evaluator assigns each live value one of three residences: CTA-cell uniform, one scalar per fragment
 row, or one C fragment. It interprets the stored `Lambda` directly. `Assign` broadcasts to the highest input residence,

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -41,6 +41,7 @@ from emmy.compiler.ir.kernel.ir import (
     EpilogueLoad,
     FragmentApply,
     FragmentPromote,
+    FragmentRepack,
     FragmentRowReduce,
     LdmatrixLoad,
     MmaSyncPtx,
@@ -332,6 +333,7 @@ def _staged_inner_atom_loop(
     byte_slabs=None,
     pads=None,
     frag_ns: str = "",
+    resident_a: tuple[tuple[str, ...], ...] | None = None,
 ) -> list[Stmt]:
     """The inner atom-K drain shared by every staged path: read the A/B ``slabs`` via
     ``LdmatrixLoad(staged=True)`` + ``MmaSyncPtx``. The leaf uses modern ``ldmatrix`` instructions
@@ -364,6 +366,10 @@ def _staged_inner_atom_loop(
     ``ldm = bk_elems``) and drains via the plain (no ``.trans``) ldmatrix — the
     ``LdmatrixLoad(b_trans=True)`` staged path. Always ``False`` for A.
 
+    ``resident_a`` replaces the A-slab load with the m16n8k16 C→A register repack. Each row carries
+    two adjacent C fragments per inner atom-K step. This is deliberately narrower than staging:
+    the producer and consumer already proved the common lane map before entering this leaf.
+
     ``byte_slabs`` (per-slab, aligned with ``slabs``): a 1-byte (fp8) slab — ldmatrix is b16-only
     below sm_100a, so its drain is the cooperative per-lane byte gather instead
     (``LdmatrixLoad(byte_slab=True)`` — the gmem fragment-loader lane map pointed at the slab; a
@@ -382,21 +388,23 @@ def _staged_inner_atom_loop(
     # atom dim, slot row off, swizzle, byte flag). A stacks the tile axis on the slab row (K the
     # col); B swaps (K the row, tile the col) — unless its slab is transposed (N-major: tile the
     # row, K the col, like A); the slot offset always lands on the ROW. All share ONE emission loop.
-    specs = [
-        (
-            lambda x: f"{frag_ns}_a{x}",
-            "a",
-            a_slab,
-            bk_elems + pads[0],
-            True,
-            m.reg,
-            m.unit,
-            atom_m,
-            offs[0],
-            swizzles[0],
-            byte_slabs[0],
+    specs = []
+    if resident_a is None:
+        specs.append(
+            (
+                lambda x: f"{frag_ns}_a{x}",
+                "a",
+                a_slab,
+                bk_elems + pads[0],
+                True,
+                m.reg,
+                m.unit,
+                atom_m,
+                offs[0],
+                swizzles[0],
+                byte_slabs[0],
+            )
         )
-    ]
     for f, bs in enumerate(b_slabs):
         frag_of = (lambda ff: lambda x: _fold_frag(f"{frag_ns}_b{x}", ff))(f)
         tr = trans[1 + f]
@@ -443,6 +451,22 @@ def _staged_inner_atom_loop(
             for i in range(m.reg)
             for j in range(n.reg)
         ]
+
+    if resident_a is not None:
+        assert reg_depth == 1, "the register-resident A seam has one fragment buffer"
+        stmts: list[Stmt] = []
+        for step in range(n_steps):
+            stmts.extend(
+                FragmentRepack(
+                    frag=f"{frag_ns}_a{i}",
+                    srcs=(row[2 * step], row[2 * step + 1]),
+                    ab_dtype=atom.ab_dtype,
+                )
+                for i, row in enumerate(resident_a)
+            )
+            stmts.extend(ldms(Literal(step * atom_k, "int"), ""))
+            stmts.extend(mmas(""))
+        return stmts
 
     if reg_depth < 2 or n_steps < 2:  # single-buffer: the inline fragment-load → mma loop
         body = ldms(Var(ki), "") + mmas("")
@@ -1261,7 +1285,7 @@ class _MmaOps(_AtomOps):
             out.append(t.dtype if t is not None and t.dtype.nbytes == 1 else dt)
         return tuple(out)
 
-    def staged_drain(self, operands, slot, cells, offset, mn):
+    def staged_drain(self, operands, slot, cells, offset, mn, resident_a=None):
         """The mma slab drain — the fragment-load + ``mma.sync`` leaf reading ring ``slot``
         (:func:`_staged_inner_atom_loop`; the cells ride ``mn``'s reg counts, so ``cells`` /
         ``offset`` are unused here). Each slab's swizzle mode rides its operand (``NONE`` on the
@@ -1270,19 +1294,36 @@ class _MmaOps(_AtomOps):
         instead of ldmatrix, its row pad riding the drain ``ldm``. An f16-accumulate
         atom promote-folds its packed f16 fragments into the f32 shadows once per drain — the
         bk chunk IS the promote cadence (the last chunk's fold doubles as the final one)."""
+        if resident_a is None:
+            slabs = tuple(op.slab for op in operands)
+            offs = tuple(op.slot_row(slot) for op in operands)
+            swizzles = tuple(getattr(op, "swizzle", "NONE") for op in operands)
+            trans = tuple(getattr(op, "trans", False) for op in operands)
+            byte_slabs = tuple((getattr(op, "elem_bytes", None) or self.tile.atom.operand_dtype("a").nbytes) == 1 for op in operands)
+            pads = tuple(getattr(op, "pad_cols", 0) for op in operands)
+        else:
+            assert len(operands) == 1, "the register-resident A seam stages only the B operand"
+            (b_op,) = operands
+            slabs = (None, b_op.slab)
+            offs = (None, b_op.slot_row(slot))
+            swizzles = ("NONE", getattr(b_op, "swizzle", "NONE"))
+            trans = (False, getattr(b_op, "trans", False))
+            byte_slabs = (False, (getattr(b_op, "elem_bytes", None) or self.tile.atom.operand_dtype("b").nbytes) == 1)
+            pads = (0, getattr(b_op, "pad_cols", 0))
         stmts = _staged_inner_atom_loop(
-            slabs=tuple(op.slab for op in operands),
-            offs=tuple(op.slot_row(slot) for op in operands),
+            slabs=slabs,
+            offs=offs,
             mn=mn,
             atom=self.tile.atom,
             bk_elems=self.stage.bk_elems,
             ki="_ki",
             reg_depth=self.stage.reg_depth,
-            swizzles=tuple(getattr(op, "swizzle", "NONE") for op in operands),
-            trans=tuple(getattr(op, "trans", False) for op in operands),
-            byte_slabs=tuple((getattr(op, "elem_bytes", None) or self.tile.atom.operand_dtype("a").nbytes) == 1 for op in operands),
-            pads=tuple(getattr(op, "pad_cols", 0) for op in operands),
+            swizzles=swizzles,
+            trans=trans,
+            byte_slabs=byte_slabs,
+            pads=pads,
             frag_ns=self.frag_ns,
+            resident_a=resident_a,
         )
         if _f16acc(self.tile.atom):
             stmts = [*stmts, *_f16acc_promotes(mn[0].reg, mn[1].reg, len(self.channels), self.frag_ns)]
@@ -1728,6 +1769,38 @@ def _projection_finalize(tail: tuple, carried: dict[str, Value], target: Value) 
     return body
 
 
+def _repacked_a_fragments(
+    weight: Value,
+    *,
+    producer_tile: TilePlan,
+    consumer_tile: TilePlan,
+    stage: Stage,
+    static_k: bool,
+) -> tuple[tuple[str, ...], ...] | None:
+    """Return the fragment rows for the exact legal C-to-A register handoff."""
+    producer, consumer = producer_tile.atom, consumer_tile.atom
+    if (
+        weight.kind != FRAG
+        or not isinstance(producer, AtomKind)
+        or not isinstance(consumer, AtomKind)
+        or producer != consumer
+        or not producer.c_to_a_repack
+        or producer.operand_dtype("c") != F32
+        or producer.ab_dtype not in ("f16", "bf16")
+        or producer_tile.m != consumer_tile.m
+        or not static_k
+        or stage.reg_depth != 1
+        or stage.bk_elems < consumer.atom_k
+        or stage.bk_elems % consumer.atom_k
+    ):
+        return None
+    n_steps = stage.bk_elems // consumer.atom_k
+    rows = weight.data
+    if len(rows) != consumer_tile.m.reg or any(len(row) != 2 * n_steps for row in rows):
+        return None
+    return rows
+
+
 def _fold_staged(
     ops: _AtomOps,
     fold: Fold,
@@ -1917,32 +1990,40 @@ def _fold_staged(
         names = tuple(tuple(f"_fold_partial_{index}_{i}_{r}" for r in range(lay.rows_per_lane)) for i in range(active_tile.m.reg))
         reduced, partial[stmt.name] = _row_value(value, stmt.op, names, lay.reduce_group)
         producer_body.extend(reduced)
-    producer_body.extend(
-        RegStore(
-            dst_buffer="_a_smem",
-            dst_index=(
-                BinaryExpr("-", bases[i][j][0], row_base),
-                BinaryExpr("-", bases[i][j][1], k0),
-            ),
-            frag=weight.data[i][j],
-            shape=active_tile.atom.shape,
-            ldm=bk,
-            swizzle=swizzles[0],
-            fragment_layout=active_tile.atom.fragment_layout,
-            row_dim=0,
-            col_dim=1,
-        )
-        for i in range(len(weight.data))
-        for j in range(len(weight.data[i]))
+    resident_a = _repacked_a_fragments(
+        weight,
+        producer_tile=active_tile,
+        consumer_tile=tile,
+        stage=stage,
+        static_k=fold.axis.extent.is_static,
     )
+    if resident_a is None:
+        producer_body.extend(
+            RegStore(
+                dst_buffer="_a_smem",
+                dst_index=(
+                    BinaryExpr("-", bases[i][j][0], row_base),
+                    BinaryExpr("-", bases[i][j][1], k0),
+                ),
+                frag=weight.data[i][j],
+                shape=active_tile.atom.shape,
+                ldm=bk,
+                swizzle=swizzles[0],
+                fragment_layout=active_tile.atom.fragment_layout,
+                row_dim=0,
+                col_dim=1,
+            )
+            for i in range(len(weight.data))
+            for j in range(len(weight.data[i]))
+        )
 
     def unreachable(_k0, _row, _col):
         raise AssertionError("a whole-slab scheduled producer has no scalar value callback")
 
     a_op = SyncOperand(tag="a", shape=(m.tile, bk), value=unreachable, producer=lambda _k0: producer_body, swizzle=swizzles[0])
-    operands = (a_op, b_op)
+    operands = (a_op, b_op) if resident_a is None else (b_op,)
     transport = SyncTransport(
-        operands=(a_op,),
+        operands=(a_op,) if resident_a is None else (),
         copy_operands=(b_op,),
         invariant_operands=(invariant_op,) if invariant_op is not None else (),
         slab_dtype=cuda_name(elem),
@@ -1963,7 +2044,7 @@ def _fold_staged(
             **{param: partial[name] for param, name in zip(fold.combine.params[len(carried) :], fold.combine.results, strict=True)},
         }
         merged, _, _ = evaluate(fold.combine, bindings, targets=carried)
-        return [*block_ops.state(cells), *block_ops.staged_drain(operands, slot, cells, offset, mn), *merged]
+        return [*block_ops.state(cells), *block_ops.staged_drain(operands, slot, cells, offset, mn, resident_a), *merged]
 
     extent = fold.axis.extent.as_static() if fold.axis.extent.is_static else fold.axis.extent
     n_chunks = (

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -41,7 +41,6 @@ from emmy.compiler.ir.kernel.ir import (
     EpilogueLoad,
     FragmentApply,
     FragmentPromote,
-    FragmentRepack,
     FragmentRowReduce,
     LdmatrixLoad,
     MmaSyncPtx,
@@ -333,7 +332,6 @@ def _staged_inner_atom_loop(
     byte_slabs=None,
     pads=None,
     frag_ns: str = "",
-    resident_a: tuple[tuple[str, ...], ...] | None = None,
 ) -> list[Stmt]:
     """The inner atom-K drain shared by every staged path: read the A/B ``slabs`` via
     ``LdmatrixLoad(staged=True)`` + ``MmaSyncPtx``. The leaf uses modern ``ldmatrix`` instructions
@@ -366,10 +364,6 @@ def _staged_inner_atom_loop(
     ``ldm = bk_elems``) and drains via the plain (no ``.trans``) ldmatrix — the
     ``LdmatrixLoad(b_trans=True)`` staged path. Always ``False`` for A.
 
-    ``resident_a`` replaces the A-slab load with the m16n8k16 C→A register repack. Each row carries
-    two adjacent C fragments per inner atom-K step. This is deliberately narrower than staging:
-    the producer and consumer already proved the common lane map before entering this leaf.
-
     ``byte_slabs`` (per-slab, aligned with ``slabs``): a 1-byte (fp8) slab — ldmatrix is b16-only
     below sm_100a, so its drain is the cooperative per-lane byte gather instead
     (``LdmatrixLoad(byte_slab=True)`` — the gmem fragment-loader lane map pointed at the slab; a
@@ -388,23 +382,21 @@ def _staged_inner_atom_loop(
     # atom dim, slot row off, swizzle, byte flag). A stacks the tile axis on the slab row (K the
     # col); B swaps (K the row, tile the col) — unless its slab is transposed (N-major: tile the
     # row, K the col, like A); the slot offset always lands on the ROW. All share ONE emission loop.
-    specs = []
-    if resident_a is None:
-        specs.append(
-            (
-                lambda x: f"{frag_ns}_a{x}",
-                "a",
-                a_slab,
-                bk_elems + pads[0],
-                True,
-                m.reg,
-                m.unit,
-                atom_m,
-                offs[0],
-                swizzles[0],
-                byte_slabs[0],
-            )
+    specs = [
+        (
+            lambda x: f"{frag_ns}_a{x}",
+            "a",
+            a_slab,
+            bk_elems + pads[0],
+            True,
+            m.reg,
+            m.unit,
+            atom_m,
+            offs[0],
+            swizzles[0],
+            byte_slabs[0],
         )
+    ]
     for f, bs in enumerate(b_slabs):
         frag_of = (lambda ff: lambda x: _fold_frag(f"{frag_ns}_b{x}", ff))(f)
         tr = trans[1 + f]
@@ -451,22 +443,6 @@ def _staged_inner_atom_loop(
             for i in range(m.reg)
             for j in range(n.reg)
         ]
-
-    if resident_a is not None:
-        assert reg_depth == 1, "the register-resident A seam has one fragment buffer"
-        stmts: list[Stmt] = []
-        for step in range(n_steps):
-            stmts.extend(
-                FragmentRepack(
-                    frag=f"{frag_ns}_a{i}",
-                    srcs=(row[2 * step], row[2 * step + 1]),
-                    ab_dtype=atom.ab_dtype,
-                )
-                for i, row in enumerate(resident_a)
-            )
-            stmts.extend(ldms(Literal(step * atom_k, "int"), ""))
-            stmts.extend(mmas(""))
-        return stmts
 
     if reg_depth < 2 or n_steps < 2:  # single-buffer: the inline fragment-load → mma loop
         body = ldms(Var(ki), "") + mmas("")
@@ -1285,7 +1261,7 @@ class _MmaOps(_AtomOps):
             out.append(t.dtype if t is not None and t.dtype.nbytes == 1 else dt)
         return tuple(out)
 
-    def staged_drain(self, operands, slot, cells, offset, mn, resident_a=None):
+    def staged_drain(self, operands, slot, cells, offset, mn):
         """The mma slab drain — the fragment-load + ``mma.sync`` leaf reading ring ``slot``
         (:func:`_staged_inner_atom_loop`; the cells ride ``mn``'s reg counts, so ``cells`` /
         ``offset`` are unused here). Each slab's swizzle mode rides its operand (``NONE`` on the
@@ -1294,36 +1270,19 @@ class _MmaOps(_AtomOps):
         instead of ldmatrix, its row pad riding the drain ``ldm``. An f16-accumulate
         atom promote-folds its packed f16 fragments into the f32 shadows once per drain — the
         bk chunk IS the promote cadence (the last chunk's fold doubles as the final one)."""
-        if resident_a is None:
-            slabs = tuple(op.slab for op in operands)
-            offs = tuple(op.slot_row(slot) for op in operands)
-            swizzles = tuple(getattr(op, "swizzle", "NONE") for op in operands)
-            trans = tuple(getattr(op, "trans", False) for op in operands)
-            byte_slabs = tuple((getattr(op, "elem_bytes", None) or self.tile.atom.operand_dtype("a").nbytes) == 1 for op in operands)
-            pads = tuple(getattr(op, "pad_cols", 0) for op in operands)
-        else:
-            assert len(operands) == 1, "the register-resident A seam stages only the B operand"
-            (b_op,) = operands
-            slabs = (None, b_op.slab)
-            offs = (None, b_op.slot_row(slot))
-            swizzles = ("NONE", getattr(b_op, "swizzle", "NONE"))
-            trans = (False, getattr(b_op, "trans", False))
-            byte_slabs = (False, (getattr(b_op, "elem_bytes", None) or self.tile.atom.operand_dtype("b").nbytes) == 1)
-            pads = (0, getattr(b_op, "pad_cols", 0))
         stmts = _staged_inner_atom_loop(
-            slabs=slabs,
-            offs=offs,
+            slabs=tuple(op.slab for op in operands),
+            offs=tuple(op.slot_row(slot) for op in operands),
             mn=mn,
             atom=self.tile.atom,
             bk_elems=self.stage.bk_elems,
             ki="_ki",
             reg_depth=self.stage.reg_depth,
-            swizzles=swizzles,
-            trans=trans,
-            byte_slabs=byte_slabs,
-            pads=pads,
+            swizzles=tuple(getattr(op, "swizzle", "NONE") for op in operands),
+            trans=tuple(getattr(op, "trans", False) for op in operands),
+            byte_slabs=tuple((getattr(op, "elem_bytes", None) or self.tile.atom.operand_dtype("a").nbytes) == 1 for op in operands),
+            pads=tuple(getattr(op, "pad_cols", 0) for op in operands),
             frag_ns=self.frag_ns,
-            resident_a=resident_a,
         )
         if _f16acc(self.tile.atom):
             stmts = [*stmts, *_f16acc_promotes(mn[0].reg, mn[1].reg, len(self.channels), self.frag_ns)]
@@ -1769,38 +1728,6 @@ def _projection_finalize(tail: tuple, carried: dict[str, Value], target: Value) 
     return body
 
 
-def _repacked_a_fragments(
-    weight: Value,
-    *,
-    producer_tile: TilePlan,
-    consumer_tile: TilePlan,
-    stage: Stage,
-    static_k: bool,
-) -> tuple[tuple[str, ...], ...] | None:
-    """Return the fragment rows for the exact legal C-to-A register handoff."""
-    producer, consumer = producer_tile.atom, consumer_tile.atom
-    if (
-        weight.kind != FRAG
-        or not isinstance(producer, AtomKind)
-        or not isinstance(consumer, AtomKind)
-        or producer != consumer
-        or not producer.c_to_a_repack
-        or producer.operand_dtype("c") != F32
-        or producer.ab_dtype not in ("f16", "bf16")
-        or producer_tile.m != consumer_tile.m
-        or not static_k
-        or stage.reg_depth != 1
-        or stage.bk_elems < consumer.atom_k
-        or stage.bk_elems % consumer.atom_k
-    ):
-        return None
-    n_steps = stage.bk_elems // consumer.atom_k
-    rows = weight.data
-    if len(rows) != consumer_tile.m.reg or any(len(row) != 2 * n_steps for row in rows):
-        return None
-    return rows
-
-
 def _fold_staged(
     ops: _AtomOps,
     fold: Fold,
@@ -1990,40 +1917,32 @@ def _fold_staged(
         names = tuple(tuple(f"_fold_partial_{index}_{i}_{r}" for r in range(lay.rows_per_lane)) for i in range(active_tile.m.reg))
         reduced, partial[stmt.name] = _row_value(value, stmt.op, names, lay.reduce_group)
         producer_body.extend(reduced)
-    resident_a = _repacked_a_fragments(
-        weight,
-        producer_tile=active_tile,
-        consumer_tile=tile,
-        stage=stage,
-        static_k=fold.axis.extent.is_static,
-    )
-    if resident_a is None:
-        producer_body.extend(
-            RegStore(
-                dst_buffer="_a_smem",
-                dst_index=(
-                    BinaryExpr("-", bases[i][j][0], row_base),
-                    BinaryExpr("-", bases[i][j][1], k0),
-                ),
-                frag=weight.data[i][j],
-                shape=active_tile.atom.shape,
-                ldm=bk,
-                swizzle=swizzles[0],
-                fragment_layout=active_tile.atom.fragment_layout,
-                row_dim=0,
-                col_dim=1,
-            )
-            for i in range(len(weight.data))
-            for j in range(len(weight.data[i]))
+    producer_body.extend(
+        RegStore(
+            dst_buffer="_a_smem",
+            dst_index=(
+                BinaryExpr("-", bases[i][j][0], row_base),
+                BinaryExpr("-", bases[i][j][1], k0),
+            ),
+            frag=weight.data[i][j],
+            shape=active_tile.atom.shape,
+            ldm=bk,
+            swizzle=swizzles[0],
+            fragment_layout=active_tile.atom.fragment_layout,
+            row_dim=0,
+            col_dim=1,
         )
+        for i in range(len(weight.data))
+        for j in range(len(weight.data[i]))
+    )
 
     def unreachable(_k0, _row, _col):
         raise AssertionError("a whole-slab scheduled producer has no scalar value callback")
 
     a_op = SyncOperand(tag="a", shape=(m.tile, bk), value=unreachable, producer=lambda _k0: producer_body, swizzle=swizzles[0])
-    operands = (a_op, b_op) if resident_a is None else (b_op,)
+    operands = (a_op, b_op)
     transport = SyncTransport(
-        operands=(a_op,) if resident_a is None else (),
+        operands=(a_op,),
         copy_operands=(b_op,),
         invariant_operands=(invariant_op,) if invariant_op is not None else (),
         slab_dtype=cuda_name(elem),
@@ -2044,7 +1963,7 @@ def _fold_staged(
             **{param: partial[name] for param, name in zip(fold.combine.params[len(carried) :], fold.combine.results, strict=True)},
         }
         merged, _, _ = evaluate(fold.combine, bindings, targets=carried)
-        return [*block_ops.state(cells), *block_ops.staged_drain(operands, slot, cells, offset, mn, resident_a), *merged]
+        return [*block_ops.state(cells), *block_ops.staged_drain(operands, slot, cells, offset, mn), *merged]
 
     extent = fold.axis.extent.as_static() if fold.axis.extent.is_static else fold.axis.extent
     n_chunks = (

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -301,10 +301,10 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         projection_reads = op.body.backward_cone(_operand_result_names(op)).external_reads
         siblings = []
         for edge in other:
-            required = set(_operand_result_names(edge)) & projection_reads
-            projection_edge = _provider_slice(edge, required) if id(edge) in consumed and required else edge
-            if id(edge) not in consumed or required:
-                siblings.extend(_emit(projection_edge, ctx).body)
+            if id(edge) not in consumed:
+                siblings.extend(_emit(edge, ctx).body)
+            elif required := set(_operand_result_names(edge)) & projection_reads:
+                siblings.extend(_emit(_provider_slice(edge, required), ctx).body)
         proj = [*siblings, *_emit_body(op.body, ctx, output_specs)]
         region_results = _projection_results(op.body)
         root_specs = tuple(spec for spec in output_specs if not set(spec.write.values) <= region_results)
@@ -321,8 +321,9 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
     if output_specs and isinstance(op, Fold) and op.axis is None:
         # A zero-axis root with no operand edge still owns a real projection body. Reconstitute
         # its output specifications only after that body is emitted so an output sweep wraps every stmt
-        # that reads the sweep coordinate.
-        return _bind(op, ctx, tail, out_val, store, output_specs=output_specs, cell_op=cell_op)
+        # that reads the sweep coordinate. ``cell_op`` cannot reach this branch: it is only set when
+        # recursing into a tiled contraction root, whose axis is never ``None``.
+        return _bind(op, ctx, tail, out_val, store, output_specs=output_specs)
     if output_specs:
         # A non-projection flat root can carry plain root ``Write``\\ s only. A STREAMED store
         # (its values an observer's results) stays a spec so the scalar arm splices it into the
@@ -435,6 +436,9 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
         projection = tail
         tail = fold_store_tail(tail, op, c)
     else:
+        # ``cell_op`` is the provider-closed rewrite of ``op``: the emitted per-cell value carries
+        # the sibling providers its computed operands read, while every schedule lookup stays keyed
+        # on the STORED node — ``ctx.sched`` is identity-keyed, so a rewritten node has no schedule.
         c, value_child, projection = cell_op or op, None, ()
         tile = ctx.sched.tile_of(op) if is_contraction(op) else None
         stage = ctx.sched.get("STAGE", op) if tile is not None else None

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -299,12 +299,12 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         other = tuple(edge for edge in op.operands if edge is not root)
         closed_root, consumed = _close_cell_providers(root, other) if tiled else (None, frozenset())
         projection_reads = op.body.backward_cone(_operand_result_names(op)).external_reads
-        siblings = [
-            stmt
-            for edge in other
-            if id(edge) not in consumed or set(_operand_result_names(edge)) & projection_reads
-            for stmt in _emit(edge, ctx).body
-        ]
+        siblings = []
+        for edge in other:
+            required = set(_operand_result_names(edge)) & projection_reads
+            projection_edge = _provider_slice(edge, required) if id(edge) in consumed and required else edge
+            if id(edge) not in consumed or required:
+                siblings.extend(_emit(projection_edge, ctx).body)
         proj = [*siblings, *_emit_body(op.body, ctx, output_specs)]
         region_results = _projection_results(op.body)
         root_specs = tuple(spec for spec in output_specs if not set(spec.write.values) <= region_results)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -53,7 +53,7 @@ from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.kernel import Tile
 from emmy.compiler.ir.kernel.ir import Smem, Sync, TreeHalve, WarpShuffle
-from emmy.compiler.ir.pure.fold import Fold, _unique_edges, is_contraction
+from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, _unique_edges, is_contraction, operand_body
 from emmy.compiler.ir.schedule import Raster
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
@@ -236,7 +236,54 @@ def factorize(tile, root, store=None) -> Tile:
     return _factorize(op, ctx, tail=(), out_val=out_val, store=store, output_specs=tuple(tile.output_specs))
 
 
-def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs: tuple = ()) -> Tile:
+def _cell_provider_closure(edge, siblings: tuple) -> tuple[object, frozenset[int]]:
+    """Close one computed contraction operand over sibling providers that its result cone reads."""
+    body = Body(operand_body(edge))
+    needed = set(body.backward_cone(_operand_result_names(edge)).external_reads)
+    required: dict[int, set[str]] = {}
+    while True:
+        added = False
+        for provider in siblings:
+            results = set(_operand_result_names(provider))
+            prior = required.get(id(provider), set())
+            if not ((results & needed) - prior):
+                continue
+            required[id(provider)] = prior | (results & needed)
+            provider_body = Body(operand_body(provider))
+            ordered = tuple(result for result in _operand_result_names(provider) if result in required[id(provider)])
+            needed.update(provider_body.backward_cone(ordered).external_reads)
+            added = True
+        if not added:
+            break
+    if not required:
+        return edge, frozenset()
+    selected = tuple(_provider_slice(provider, required[id(provider)]) for provider in siblings if id(provider) in required)
+    return Fold.projection(operands=(*selected, edge), results=_operand_result_names(edge)), frozenset(required)
+
+
+def _provider_slice(provider, required: set[str]):
+    """Narrow a projection provider to the result cone its cell consumer needs."""
+    results = _operand_result_names(provider)
+    if not isinstance(provider, Fold) or provider.axis is not None or required == set(results):
+        return provider
+    ordered = tuple(result for result in results if result in required)
+    cone = provider.body.backward_cone(ordered)
+    operands = tuple(edge for edge in provider.operands if set(_operand_result_names(edge)) & cone.external_reads)
+    return Fold.projection(operands=operands, body=Body(cone.members), results=ordered)
+
+
+def _close_cell_providers(contraction: Fold, siblings: tuple) -> tuple[Fold, frozenset[int]]:
+    """Move sibling providers read by computed operands into their per-cell fill."""
+    operands = []
+    consumed: set[int] = set()
+    for edge in contraction.operands:
+        closed, used = _cell_provider_closure(edge, siblings)
+        operands.append(closed)
+        consumed.update(used)
+    return replace(contraction, operands=tuple(operands)), frozenset(consumed)
+
+
+def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs: tuple = (), cell_op=None) -> Tile:
     """The recursive root walk — peel the projecting zero-axis ``Fold``\\ s, then bind each leaf to the grid via
     the ONE binding pipeline. A zero-axis :class:`Fold` with an operand recurses: its ``body`` (the projection /
     epilogue) is walked (:func:`_emit_body`, reaching any nested node), the kernel-boundary
@@ -249,7 +296,15 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         if len(tiled) > 1:
             return _bind_roots(op, ctx, output_specs)
         root = tiled[0] if tiled else op.operands[0]
-        siblings = [stmt for edge in op.operands if edge is not root for stmt in _emit(edge, ctx).body]
+        other = tuple(edge for edge in op.operands if edge is not root)
+        closed_root, consumed = _close_cell_providers(root, other) if tiled else (None, frozenset())
+        projection_reads = op.body.backward_cone(_operand_result_names(op)).external_reads
+        siblings = [
+            stmt
+            for edge in other
+            if id(edge) not in consumed or set(_operand_result_names(edge)) & projection_reads
+            for stmt in _emit(edge, ctx).body
+        ]
         proj = [*siblings, *_emit_body(op.body, ctx, output_specs)]
         region_results = _projection_results(op.body)
         root_specs = tuple(spec for spec in output_specs if not set(spec.write.values) <= region_results)
@@ -262,12 +317,12 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         plain = tuple(spec for spec in root_specs if id(spec) not in streamed_ids)
         if plain:
             proj = apply_output_specs(proj, plain)
-        return _factorize(root, ctx, tail=(*proj, *tail), out_val=out_val, store=store, output_specs=streamed)
+        return _factorize(root, ctx, tail=(*proj, *tail), out_val=out_val, store=store, output_specs=streamed, cell_op=closed_root)
     if output_specs and isinstance(op, Fold) and op.axis is None:
         # A zero-axis root with no operand edge still owns a real projection body. Reconstitute
         # its output specifications only after that body is emitted so an output sweep wraps every stmt
         # that reads the sweep coordinate.
-        return _bind(op, ctx, tail, out_val, store, output_specs=output_specs)
+        return _bind(op, ctx, tail, out_val, store, output_specs=output_specs, cell_op=cell_op)
     if output_specs:
         # A non-projection flat root can carry plain root ``Write``\\ s only. A STREAMED store
         # (its values an observer's results) stays a spec so the scalar arm splices it into the
@@ -277,8 +332,8 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         streamed = tuple(st for st in output_specs if set(st.write.values) <= observed)
         streamed_ids = {id(st) for st in streamed}
         tail = (*tail, *(st.write for st in output_specs if id(st) not in streamed_ids))
-        return _bind(op, ctx, tail, out_val, store, output_specs=streamed)
-    return _bind(op, ctx, tail, out_val, store)
+        return _bind(op, ctx, tail, out_val, store, output_specs=streamed, cell_op=cell_op)
+    return _bind(op, ctx, tail, out_val, store, cell_op=cell_op)
 
 
 def _merge_root_tiles(tiles: tuple[Tile, ...]) -> Tile:
@@ -348,7 +403,7 @@ def with_store(stmts: list[Stmt], output: str, grid, value: str) -> list[Stmt]:
     return [*stmts, Write(output=output, index=index, value=value)]
 
 
-def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: tuple = (), frag_ns: str = "") -> Tile:
+def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: tuple = (), frag_ns: str = "", cell_op=None) -> Tile:
     """The ONE root binder — every kernel binds through the same pipeline: read WHICH AXES the
     schedule tiles off the node, build the fold region, and seal through the one :func:`grid_tile`
     finalizer. The cases are points of one ``(output-tiling) × (reduce-folding)`` space, selected by
@@ -380,7 +435,7 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
         projection = tail
         tail = fold_store_tail(tail, op, c)
     else:
-        c, value_child, projection = op, None, ()
+        c, value_child, projection = cell_op or op, None, ()
         tile = ctx.sched.tile_of(op) if is_contraction(op) else None
         stage = ctx.sched.get("STAGE", op) if tile is not None else None
     if tile is not None and tile.axes is not None and len(grid) >= 2:

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -481,6 +481,27 @@ def _requires_order(seams) -> tuple:
     return tuple(ordered)
 
 
+def _producer_order(pieces) -> list:
+    """Topologically order cut producers by the workspaces their stored Fold reads.
+
+    Containment can make one produced piece read another even when the corresponding seams have
+    no provider requirement. Dependency COUNT is not an order: two pieces may each read one
+    workspace while one of those workspaces is produced by the other piece.
+    """
+    workspaces = {buffer for *_, buffers in pieces for buffer in buffers}
+    remaining = list(pieces)
+    ordered = []
+    available: set[str] = set()
+    while remaining:
+        ready = [piece for piece in remaining if {load.input for load in Body.coerce(piece[1].lower()).loads} & workspaces <= available]
+        if not ready:
+            raise ValueError("cyclic cut-workspace dependency cannot arise from strict Fold containment")
+        ordered.extend(ready)
+        available.update(buffer for *_, buffers in ready for buffer in buffers)
+        remaining = [piece for piece in remaining if not any(piece is chosen for chosen in ready)]
+    return ordered
+
+
 def realize(
     match: Match,
     root: Node,
@@ -558,10 +579,10 @@ def realize(
 
     fragment = _input_fragment(match, root)
     all_buffers = [buffer for *_, buffers in produced_pieces for buffer in buffers]
-    # A producer reading another seam's workspace must follow the node that writes it, so pieces
-    # are added in dependency order (containment is strict, so the order exists).
-    produced_pieces.sort(key=lambda piece: len({load.input for load in Body.coerce(piece[1].lower()).loads} & set(all_buffers)))
-    for seam, produced, axes, index, token, names, buffers in produced_pieces:
+    # A producer reading another seam's workspace must follow the node that writes it. Strict
+    # containment makes this dependency graph acyclic, including chains whose members have the
+    # same number of direct workspace reads.
+    for seam, produced, axes, index, token, names, buffers in _producer_order(produced_pieces):
         producer = TileOp(
             op=produced,
             # The seam token keeps recursive pieces' kernel names distinct — the one-name-one-source

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -518,8 +518,7 @@ def _producer_order(pieces) -> list:
     available: set[str] = set()
     while remaining:
         ready = [piece for piece in remaining if {load.input for load in Body.coerce(piece[1].lower()).loads} & workspaces <= available]
-        if not ready:
-            raise ValueError("cyclic cut-workspace dependency cannot arise from strict Fold containment")
+        assert ready, "strict Fold containment makes the cut-workspace dependency graph acyclic"
         ordered.extend(ready)
         available.update(buffer for *_, buffers in ready for buffer in buffers)
         remaining = [piece for piece in remaining if not any(piece is chosen for chosen in ready)]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -180,7 +180,7 @@ def _fed_store_dtype(tile: TileOp, consumer: Fold):
     return fed.pop() if len(fed) == 1 else None
 
 
-def _workspace_dtypes(node: Fold, tile: TileOp, consumer: Fold | None) -> tuple | None:
+def _workspace_dtypes(node: Fold, tile: TileOp, consumer: Fold | None, table: dict[int, tuple]) -> tuple | None:
     """The cut workspace's per-component dtypes, or ``None`` when they cannot be determined.
     Reduction carrier precision is a Kernel IR policy — every Fold state is f32 until lowering
     stamps the concrete Accum/Init pair; a zero-axis value has no carrier and is inferred from its
@@ -194,68 +194,62 @@ def _workspace_dtypes(node: Fold, tile: TileOp, consumer: Fold | None) -> tuple 
     if consumer is not None:
         dtype = _fed_store_dtype(tile, consumer)
         return None if dtype is None else (dtype,) * len(names)
-    dtypes = (F32,) * len(names) if node.axis is not None else edge_dtypes(node, tile.inputs)
+    dtypes = (F32,) * len(names) if node.axis is not None else table.get(id(node), ())
     if len(dtypes) != len(names) or any(dtype is None for dtype in dtypes):
         return None
     return dtypes
 
 
-def _member_hosts(root: Fold) -> dict[int, list[Fold]]:
-    """Each stored fold's hosting folds — every enclosing fold whose lift body holds it as a
-    member. A shared cone (normalization guarantees structurally identical cones are one object)
-    records every host, which is what lets provider closure demand the hosts agree."""
-    hosts: dict[int, list[Fold]] = {}
-    visited: set[int] = set()
+def _environments(root: Fold) -> dict[int, list[tuple[Fold, ...]]]:
+    """Each stored Fold occurrence's lexical environment, innermost scope first.
 
-    def visit(node: Fold) -> None:
-        if id(node) in visited:
-            return
-        visited.add(id(node))
-        for edge in node.operands:
-            if isinstance(edge, Fold):
-                visit(edge)
-        for stmt in node.lift.body:
-            if isinstance(stmt, Fold):
-                hosts.setdefault(id(stmt), []).append(node)
-                visit(stmt)
+    Operand edges and body members have the same lexical scoping. The walk follows every tree
+    occurrence, including shared nodes, because provider closure must prove that all occurrences
+    resolve to the same sources before one placement seam may represent them.
+    """
+    environments: dict[int, list[tuple[Fold, ...]]] = {}
 
-    visit(root)
-    return hosts
+    def visit(node: Fold, outer: tuple[Fold, ...]) -> None:
+        inner = (node, *outer)
+        for child in (*node.operands, *node.lift.body):
+            if isinstance(child, Fold):
+                environments.setdefault(id(child), []).append(inner)
+                visit(child, inner)
+
+    visit(root, ())
+    return environments
 
 
-def _provider_closure(node: Fold, scopes, hosts: list[Fold]) -> tuple[tuple, tuple] | None:
-    """The ``(providers, requires)`` that close an SSA-capturing body-member seam, or ``None``.
-
-    A member fold may read names its hosting body provides — attention's softmax statistics
-    capture the mask/scale scalars, and the second statistics pass reads the first pass's
-    accumulator. A capture whose producer chain is pure ``Load``/``Assign`` stmts joins the
-    produced piece verbatim (``providers``); a capture only a sibling or host-operand Fold
-    defines becomes a ``requires`` pair, realizable only when that producer is cut beside this
-    seam. Every hosting body must agree — structurally equal providers, the same producer
-    objects — and the closed piece must capture nothing but scope axes at every occurrence."""
-    if not hosts:
-        return None
-    axis_names = {axis.name for scope in scopes for axis in scope}
-    closures = []
-    for host in hosts:
+def _closed_in(node: Fold, environment: tuple[Fold, ...], axis_names: set[str]) -> tuple[tuple, tuple] | None:
+    """Resolve one occurrence's captures outward through its lexical environment."""
+    needed = set(_external_reads(node)) - axis_names
+    levels: list[tuple] = []
+    requires: list = []
+    for scope in environment:
+        if not needed:
+            break
         defined: dict[str, object] = {}
-        for stmt in host.lift.body:
+        for stmt in scope.lift.body:
             for name in stmt.defines():
                 defined[name] = stmt
-        for edge in host.operands:
+        for edge in scope.operands:
             for name in _operand_result_names(edge):
                 defined.setdefault(name, edge)
+        order = {id(stmt): position for position, stmt in enumerate(scope.lift.body)}
         providers: list = []
-        requires: list = []
-        queue = sorted(set(_external_reads(node)) - axis_names)
+        outward: set[str] = set()
         resolved: set[str] = set()
+        queue = sorted(needed)
         while queue:
             name = queue.pop()
             if name in resolved:
                 continue
             resolved.add(name)
             producer = defined.get(name)
-            if producer is None or producer is node:
+            if producer is None:
+                outward.add(name)
+                continue
+            if producer is node:
                 return None
             if isinstance(producer, Fold):
                 requires.append((name, producer))
@@ -265,16 +259,33 @@ def _provider_closure(node: Fold, scopes, hosts: list[Fold]) -> tuple[tuple, tup
             if not any(chosen is producer for chosen in providers):
                 providers.append(producer)
             queue.extend(sorted(deep_reads([producer]) - axis_names - resolved))
-        order = {id(stmt): position for position, stmt in enumerate(host.lift.body)}
         providers.sort(key=lambda stmt: order.get(id(stmt), -1))
-        closures.append((tuple(providers), tuple(sorted(requires, key=lambda pair: pair[0]))))
+        levels.append(tuple(providers))
+        needed = outward
+    if needed:
+        return None
+    providers = tuple(stmt for level in reversed(levels) for stmt in level)
+    return providers, tuple(sorted(requires, key=lambda pair: pair[0]))
+
+
+def _provider_closure(node: Fold, scopes, environments: list[tuple[Fold, ...]]) -> tuple[tuple, tuple] | None:
+    """Close a capturing seam identically at every stored occurrence, or return ``None``."""
+    if not environments:
+        return None
+    axis_names = {axis.name for scope in scopes for axis in scope}
+    closures = []
+    for environment in environments:
+        closure = _closed_in(node, environment, axis_names)
+        if closure is None:
+            return None
+        closures.append(closure)
     first_providers, first_requires = closures[0]
     for providers, requires in closures[1:]:
         aligned = providers == first_providers and len(requires) == len(first_requires)
         if not aligned or any(
             a != b or producer_a is not producer_b for (a, producer_a), (b, producer_b) in zip(requires, first_requires, strict=True)
         ):
-            return None  # the hosts spell different closures — one seam cannot read two sources
+            return None  # occurrences resolving to different sources cannot share one seam
     provided = {name for stmt in first_providers for name in stmt.defines()}
     provided.update(name for name, _ in first_requires)
     outside = (set(_external_reads(node)) | {name for stmt in first_providers for name in deep_reads([stmt])}) - provided
@@ -312,7 +323,11 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     occurrence_axes: dict[int, list[tuple]] = {}
     for node, available in islice(walk(tile.op, outer), 1, None):
         occurrence_axes.setdefault(id(node), []).append(available)
-    hosts = _member_hosts(tile.op) if isinstance(tile.op, Fold) else {}
+    environments: dict[int, list[tuple[Fold, ...]]] = {}
+    dtype_table: dict[int, tuple] = {}
+    if isinstance(tile.op, Fold):
+        environments = _environments(tile.op)
+        edge_dtypes(tile.op, tile.inputs, dtype_table)
     out: list[CutSite] = []
     seen: set[int] = set()
     for site in family_sites("PLACE", all_sites):
@@ -323,7 +338,7 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
         providers: tuple = ()
         requires: tuple = ()
         if not all(_closed_at(node, scope) for scope in scopes):
-            closure = _provider_closure(node, scopes, hosts.get(id(node), []))
+            closure = _provider_closure(node, scopes, environments.get(id(node), []))
             if closure is None:
                 continue
             providers, requires = closure
@@ -337,7 +352,7 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
         # re-rounded) and footprint (storage width vs store width), so there is no trade for the
         # evidence to decide — one site stays one decision.
         frontier = storage_frontier(node) if consumer is not None else None
-        dtypes = (frontier.dtype,) if frontier is not None else _workspace_dtypes(node, tile, consumer)
+        dtypes = (frontier.dtype,) if frontier is not None else _workspace_dtypes(node, tile, consumer, dtype_table)
         if dtypes is None:
             continue
         seen.add(id(node))

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -19,7 +19,7 @@ from emmy.compiler.dtype import get as get_dtype
 from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
-from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, deep_defines, deep_reads, is_contraction
+from emmy.compiler.ir.pure.fold import Fold, _expectation_bindings, _operand_result_names, deep_defines, deep_reads, is_contraction
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.normalize import _operand_lambda, lambda_equivalent_clusters
@@ -292,13 +292,22 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     (:func:`_provider_closure`); one whose closure needs another seam's workspace is offered as a
     dependent seam and drops out unless that producer is offered too."""
     all_sites = sites(tile.op)
-    contraction_operands = {
+    store_dtype_consumers = {
         id(edge): site.node
         for site in all_sites
         if is_contraction(site.node)
         for edge in (site.node.a, *(channel.b for channel in site.node.channels))
         if isinstance(edge, Fold)
     }
+    # A computed twisted expectation edge becomes a synthesized contraction operand as soon as
+    # this placement fork materializes it. Preserve the same public store dtype the derived
+    # contraction needs instead of exposing the producer's f32 reduction carrier as its B slab.
+    for site in all_sites:
+        if not isinstance(site.node, Fold):
+            continue
+        for _, _, edge in _expectation_bindings(site.node):
+            if isinstance(edge, Fold):
+                store_dtype_consumers[id(edge)] = site.node
     outer = (*tile.place.free, *(store.sweep for store in tile.output_specs if store.sweep is not None))
     occurrence_axes: dict[int, list[tuple]] = {}
     for node, available in islice(walk(tile.op, outer), 1, None):
@@ -322,7 +331,7 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
             # An observed fold's per-step results exist only inside its stream — a cut would
             # separate the scan from its streamed boundary store, which no piece can then spell.
             continue
-        consumer = contraction_operands.get(id(node))
+        consumer = store_dtype_consumers.get(id(node))
         # A frontier REPLACES the fed-store realization at this seam rather than joining the
         # offer: the raw bits dominate the fed-store workspace on both precision (exact vs
         # re-rounded) and footprint (storage width vs store width), so there is no trade for the
@@ -352,7 +361,7 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
         if len(kept) == len(out):
             break
         out = kept
-    return _cluster_value_seams(out, {id(seam.node): seam.frontier is None and contraction_operands.get(id(seam.node)) for seam in out})
+    return _cluster_value_seams(out, {id(seam.node): seam.frontier is None and store_dtype_consumers.get(id(seam.node)) for seam in out})
 
 
 def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) -> tuple[CutSite, ...]:

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -743,24 +743,27 @@ def _lifted_target(record: GoldenRecord):
 def decode_record(record: GoldenRecord) -> str | None:
     """STRICTLY decode one record against the current compiler — ``None`` on success, else the
     failure reason. This is the replayability contract the nightly onboarding job gates: the persisted
-    program selects exactly one kernel; a routing record names a legal closed Fold seam; a SCHEDULE record's spelled row
-    equals one enumerated
-    leaf (``canonical_row_key`` equality under the record's own pins) — no prefix matching, no
-    any-of, no classified shape. A child-identity schedule receipt (a stored identity that is not
-    the target's own lift) is stricter still: its identity must equal one kernel resolved under the
-    record's pins, and the spelled row must equal one of THAT kernel's rows — a sibling child's row
-    must not vouch for it."""
+    program selects exactly one kernel, except that a child-identity schedule receipt may select its
+    kernel from a multi-kernel target by stored identity; a routing record names a legal closed Fold
+    seam; a SCHEDULE record's spelled row equals one enumerated leaf (``canonical_row_key`` equality
+    under the record's own pins) — no prefix matching, no any-of, no classified shape. A receipt's
+    identity must equal one kernel resolved under the record's pins, and the spelled row must equal
+    one of THAT kernel's rows — a sibling child's row must not vouch for it."""
     from emmy.compiler.pipeline.knob import schedule_row_key  # noqa: PLC0415
 
-    try:
-        tile = _lifted_target(record)
-    except Exception as exc:  # noqa: BLE001 — the reason IS the product here
-        return f"{type(exc).__name__}: {exc}"
     verdict_key = digest(_record_fingerprint(record), str(sorted(record.knobs.items())), str(record.pins), record.identity or "")
     store = _identity_store()
     verdicts = store.setdefault("verdicts", {})
     if verdict_key in verdicts:
         return verdicts[verdict_key]
+    pinned_cut = any(str(name).split("@", 1)[0] == "PLACE" and str(value) == "cut" for name, value in record.pins)
+    is_receipt = record.identity is not None and pinned_cut and not record.is_routing
+    tile = None
+    try:
+        tile = _lifted_target(record)
+    except Exception as exc:  # noqa: BLE001 — the reason IS the product here
+        if not is_receipt:
+            return _remember_verdict(verdict_key, f"{type(exc).__name__}: {exc}")
     if record.is_routing:
         from dataclasses import replace  # noqa: PLC0415
 
@@ -786,7 +789,7 @@ def decode_record(record: GoldenRecord) -> str | None:
         return _remember_verdict(verdict_key, None)
     candidates = _candidate_rows(record)
     row = schedule_row_key(record.knobs)
-    if record.identity is not None and record.identity != deploy_identity(tile):
+    if is_receipt and (tile is None or record.identity != deploy_identity(tile)):
         child_rows = candidates.get(record.identity)
         if child_rows is None:
             reason = f"stored identity equals none of the {len(candidates)} kernel identities resolved under the record's pins"

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -144,6 +144,14 @@ def precision_trading_pins(pins: Mapping) -> bool:
     return any(bool(pins.get(name, umbrella)) for name in ("FAST_EXP", "F16_MMA_F32_ACC", "FP8_MMA"))
 
 
+def pins_freeze_cut(pins: Mapping) -> bool:
+    """Whether the input pins freeze any placement cut (a ``PLACE…=cut`` pin) — the ONE spelling
+    of the predicate behind both the loader's receipt validation and :attr:`GoldenRecord.is_receipt`."""
+    from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
+
+    return any(family_of(str(name)) == "PLACE" and str(value) == "cut" for name, value in pins.items())
+
+
 def golden_entry_state(entry: Mapping) -> GoldenEntryState:
     has_knobs = "knobs" in entry
     has_measurements = "measurements" in entry
@@ -195,6 +203,12 @@ class GoldenRecord:
     def is_routing(self) -> bool:
         """Whether this row records a kernel-placement decision rather than a kernel schedule."""
         return bool(self.knobs) and all(str(key).split("@", 1)[0] == "PLACE" for key in self.knobs)
+
+    @property
+    def is_receipt(self) -> bool:
+        """Whether this row is a child-identity schedule receipt: a schedule row recorded behind
+        pinned cut(s), whose stored ``identity`` names the child kernel the row decorates."""
+        return self.identity is not None and not self.is_routing and pins_freeze_cut(dict(self.pins))
 
     @cached_property
     def pool_key(self) -> tuple:
@@ -501,8 +515,7 @@ def validate_golden_file(
                 families = {str(key).split("@", 1)[0] for key in realization["knobs"]}
                 if "PLACE" in families and families != {"PLACE"}:
                     raise ValueError(f"{realization_where} mixes PLACE routing knobs with schedule knobs")
-                pins_cut = any(str(name).split("@", 1)[0] == "PLACE" and str(value) == "cut" for name, value in pins.items())
-                if families and "PLACE" not in families and pins_cut and "identity" not in realization:
+                if families and "PLACE" not in families and pins_freeze_cut(pins) and "identity" not in realization:
                     raise ValueError(
                         f"{realization_where} schedules a kernel behind pinned cut(s) without naming it; "
                         "a child-identity schedule receipt must store the child kernel's identity"
@@ -580,6 +593,22 @@ def load_golden_records(document: Mapping) -> list[GoldenRecord]:
     return [
         golden_record_from_entry(document, entry, realization) for entry in document["configs"] for realization in entry["realizations"]
     ]
+
+
+def shared_placement_pins(matches: list[GoldenRecord]) -> dict:
+    """The placement pins every matching working-file realization shares, or ``{}``.
+
+    An explicit working target's shared placement regime is part of the target, not unverified
+    schedule evidence: the ordinary compile applies it while the remaining schedule families stay
+    free for the normal deploy evidence hierarchy. When same-name realizations disagree on any
+    input pin the target stays unpinned — choosing one regime would silently change which
+    realization was requested."""
+    from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
+
+    regimes = {match.pins for match in matches}
+    if len(regimes) != 1:
+        return {}
+    return {key: value for key, value in regimes.pop() if family_of(key) == "PLACE"}
 
 
 _STRUCTURAL_CACHE: dict[tuple, tuple[tuple[str, float], ...]] = {}
@@ -756,13 +785,11 @@ def decode_record(record: GoldenRecord) -> str | None:
     verdicts = store.setdefault("verdicts", {})
     if verdict_key in verdicts:
         return verdicts[verdict_key]
-    pinned_cut = any(str(name).split("@", 1)[0] == "PLACE" and str(value) == "cut" for name, value in record.pins)
-    is_receipt = record.identity is not None and pinned_cut and not record.is_routing
     tile = None
     try:
         tile = _lifted_target(record)
     except Exception as exc:  # noqa: BLE001 — the reason IS the product here
-        if not is_receipt:
+        if not record.is_receipt:
             return _remember_verdict(verdict_key, f"{type(exc).__name__}: {exc}")
     if record.is_routing:
         from dataclasses import replace  # noqa: PLC0415
@@ -789,7 +816,7 @@ def decode_record(record: GoldenRecord) -> str | None:
         return _remember_verdict(verdict_key, None)
     candidates = _candidate_rows(record)
     row = schedule_row_key(record.knobs)
-    if is_receipt and (tile is None or record.identity != deploy_identity(tile)):
+    if record.is_receipt and (tile is None or record.identity != deploy_identity(tile)):
         child_rows = candidates.get(record.identity)
         if child_rows is None:
             reason = f"stored identity equals none of the {len(candidates)} kernel identities resolved under the record's pins"

--- a/emmy/compiler/pipeline/search/golden_eval.py
+++ b/emmy/compiler/pipeline/search/golden_eval.py
@@ -44,7 +44,7 @@ def enumerate_graph(graph, ctx: Context, *, family: str = "") -> Candidates:
     sample the rows are every kernel's fork rows and ``total`` is ``len(rows)``, so a caller that
     reports both prints today's numbers unchanged."""
     from emmy.compiler.pipeline import TILE_PASSES, Pipeline  # noqa: PLC0415
-    from emmy.compiler.pipeline.fork import Fork, iter_leaves, leaf_knobs  # noqa: PLC0415
+    from emmy.compiler.pipeline.fork import iter_leaves, leaf_knobs  # noqa: PLC0415
     from emmy.compiler.pipeline.knob import family_of  # noqa: PLC0415
     from emmy.compiler.pipeline.pipeline import Run  # noqa: PLC0415
     from emmy.compiler.pipeline.search.space import WORK  # noqa: PLC0415
@@ -80,18 +80,12 @@ def enumerate_graph(graph, ctx: Context, *, family: str = "") -> Candidates:
         return _first(fp.options)
 
     def _first(options):
-        # A pin that admits nothing at this fork leaves no option to walk into. Say so: the bare
-        # `IndexError` this used to raise names neither the pin nor the fork, and it reaches
-        # callers that are asking a perfectly ordinary question — "is this schedule offered?" —
-        # for which "no" is a legitimate answer rather than a crash.
-        if not options:
+        # A pin may empty an early lazy branch while leaving a later sibling live. Walk to the
+        # first complete leaf across the whole sibling set, matching the resolver's own traversal;
+        # only an entirely empty fork means the schedule is not offered.
+        option = next(iter_leaves(options), None)
+        if option is None:
             raise ValueError("the live pins admit no option at this fork, so no candidate row can be enumerated")
-        option = options[0]
-        while isinstance(option, Fork) and not option.is_leaf:
-            expanded = option.expand()
-            if not expanded:
-                raise ValueError("the live pins admit no option at this fork, so no candidate row can be enumerated")
-            option = expanded[0]
         return option
 
     Run(pipeline=Pipeline.build(TILE_PASSES), ctx=ctx).resolve(graph, decide)

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -631,15 +631,16 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
     if not recs and _AUDIT_SINK is None:
         return None
 
-    def find_recorded(options, record, target):
+    def find_recorded(options, target):
         """Descend only branches compatible with one recorded row."""
+        record = dict(target)
         for option in options:
             if _is_structural_option(option):
                 return None
             if isinstance(option, Fork) and not option.is_leaf:
                 branch = drop_uninformative_scopes(option.knobs)
                 if all(key in record and values_equal(key, record[key], value) for key, value in branch.items()):
-                    found = find_recorded(option.expand(), record, target)
+                    found = find_recorded(option.expand(), target)
                     if found is not None:
                         return found
                 continue
@@ -650,8 +651,7 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
 
     if recs and _AUDIT_SINK is None:
         for rec in recs:
-            target = schedule_row_key(rec.knobs)
-            if (hit := find_recorded(fp.options, dict(target), target)) is not None:
+            if (hit := find_recorded(fp.options, schedule_row_key(rec.knobs))) is not None:
                 return hit[0], float(rec.emmy_us or 0.0), dict(hit[1])
         logger.warning(
             "deploy: node %r matches %d recorded golden(s) by structural identity, but none equals an enumerated row — "

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -635,7 +635,7 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
         """Descend only branches compatible with one recorded row."""
         for option in options:
             if _is_structural_option(option):
-                continue
+                return None
             if isinstance(option, Fork) and not option.is_leaf:
                 branch = drop_uninformative_scopes(option.knobs)
                 if all(key in record and values_equal(key, record[key], value) for key, value in branch.items()):
@@ -671,7 +671,7 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
     live_count = 0
     for leaf in iter_leaves(fp.options):
         if _is_structural_option(leaf):
-            continue
+            return None
         knobs = leaf_knobs(leaf)
         if node_blocked is not None and _tile_blocked(knobs, node_blocked):
             continue

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -619,7 +619,7 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
     Under an active :func:`golden_audit` sink every SCHEDULE consultation also appends its verdict
     (MATCH / DRIFT / GAP) — the drift audit's only reading of this tier."""
     from emmy.compiler.ir.tile import TileOp  # noqa: PLC0415
-    from emmy.compiler.pipeline.knob import schedule_row_key, values_equal  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import drop_uninformative_scopes, schedule_row_key, values_equal  # noqa: PLC0415
     from emmy.compiler.pipeline.pipeline import _is_structural_option  # noqa: PLC0415
 
     root = fp.root_op
@@ -635,9 +635,10 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
         """Descend only branches compatible with one recorded row."""
         for option in options:
             if _is_structural_option(option):
-                return None
+                continue
             if isinstance(option, Fork) and not option.is_leaf:
-                if all(key in record and values_equal(key, record[key], value) for key, value in option.knobs.items()):
+                branch = drop_uninformative_scopes(option.knobs)
+                if all(key in record and values_equal(key, record[key], value) for key, value in branch.items()):
                     found = find_recorded(option.expand(), record, target)
                     if found is not None:
                         return found
@@ -649,7 +650,8 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
 
     if recs and _AUDIT_SINK is None:
         for rec in recs:
-            if (hit := find_recorded(fp.options, rec.knobs, schedule_row_key(rec.knobs))) is not None:
+            target = schedule_row_key(rec.knobs)
+            if (hit := find_recorded(fp.options, dict(target), target)) is not None:
                 return hit[0], float(rec.emmy_us or 0.0), dict(hit[1])
         logger.warning(
             "deploy: node %r matches %d recorded golden(s) by structural identity, but none equals an enumerated row — "
@@ -669,7 +671,7 @@ def _verified_pick(fp: ForkPoint, sched_idx: dict, blocked) -> tuple[object, flo
     live_count = 0
     for leaf in iter_leaves(fp.options):
         if _is_structural_option(leaf):
-            return None
+            continue
         knobs = leaf_knobs(leaf)
         if node_blocked is not None and _tile_blocked(knobs, node_blocked):
             continue

--- a/emmy/compiler/pipeline/search/prior/base.py
+++ b/emmy/compiler/pipeline/search/prior/base.py
@@ -433,6 +433,8 @@ class Prior(ABC):
         elif self._since_fit < self._refit_interval():
             return False
         self.fit()
+        if not self.fitted:
+            return False
         self._since_fit = 0
         self._note_fit()
         # Calibration gate input: can the fresh model rank its own reservoir? A

--- a/emmy/compiler/pipeline/search/prior/online.py
+++ b/emmy/compiler/pipeline/search/prior/online.py
@@ -72,6 +72,8 @@ class OnlinePrior(Prior):
             return
         x = np.array([[f.get(c, np.nan) for c in cols] for f in feats], dtype=float)
         y = np.log(np.array([lab for _, lab in rows], dtype=float))
+        if np.ptp(y) == 0:
+            return
         model = CatBoostRegressor(
             iterations=self._iterations,
             depth=self.DEPTH,

--- a/emmy/compiler/pipeline/search/strategy/two_level.py
+++ b/emmy/compiler/pipeline/search/strategy/two_level.py
@@ -168,8 +168,11 @@ def _kernel_nodes(graph: Graph) -> list[tuple[str, object]]:
     A normal outer terminal sits at the loop dialect's end (:func:`outer_pipeline`), so its
     kernels are finalized ``LoopOp`` instances. A direct post-cut reproducer instead starts at an
     unscheduled ``TileOp``; it enters the same inner search so its rows keep the child identity
-    ordinary parent-route replay already consumes. A sealed Tile root is already scheduled and
-    stays lowering-only."""
+    ordinary parent-route replay already consumes. A Tile root whose worker inventory is sealed
+    (``work`` set) is already scheduled and stays lowering-only. ``work`` is the only sealed
+    signal today, and it is ``None`` for the per-cell / pure-reduce forms too — such a root
+    re-enters the per-kernel search and re-decides its schedule from the same evidence, which is
+    redundant but not wrong; a dedicated scheduled marker on ``TileOp`` would tighten this."""
     return [(nid, n.op) for nid, n in graph.nodes.items() if isinstance(n.op, LoopOp) or (isinstance(n.op, TileOp) and n.op.work is None)]
 
 

--- a/emmy/compiler/pipeline/search/strategy/two_level.py
+++ b/emmy/compiler/pipeline/search/strategy/two_level.py
@@ -6,7 +6,9 @@
 - **Outer**: drive the graph-changing passes (``OUTER_PASSES`` — ``frontend`` + ``loop``, the
   strategy's OWN boundary config, never an engine parameter). The outer never ventures into
   Tile IR; a terminal is the fused graph of finalized ``LoopOp``\\ s. Today the outer tree is a
-  chain — fusion offers no multi-option forks yet — and nothing here depends on that.
+  chain — fusion offers no multi-option forks yet — and nothing here depends on that. A direct
+  unscheduled ``TileOp`` target passes through that boundary unchanged and joins the inner
+  per-kernel search; an already scheduled ``TileOp`` stays lowering-only.
 - **Scoring is DECLARED SEPARABLE**: an outer terminal's reward is the Σ of its unique kernels'
   bests, each kernel measured independently in its own single-node slice
   (:func:`single_node_graph`) by a plain :class:`TuningSearch` (MCTS) over ``INNER_PASSES``.
@@ -38,6 +40,7 @@ from uuid import uuid4
 
 from emmy.compiler.context import Context
 from emmy.compiler.ir.loop import LoopOp
+from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pass, Pipeline, TuningSearch
 from emmy.compiler.pipeline.knob import stamp_schedule_families
 from emmy.compiler.pipeline.passes.identity import IdentityStrategy
@@ -140,7 +143,7 @@ class InnerReward:
 class TwoLevelResult:
     """Outcome of :meth:`TwoLevelStrategy.run`."""
 
-    best_fused: Graph | None  # winning fused graph (finalized LoopOps)
+    best_fused: Graph | None  # winning outer terminal (normally finalized LoopOps)
     best_reward: InnerReward | None  # its Σ-per-op breakdown
     n_terminals: int  # outer terminals evaluated (1 today)
     assembled: Graph | None  # greedy DB-best Graph[CudaOp] assembled from the bests
@@ -162,9 +165,12 @@ def _mint_run_id() -> str:
 def _kernel_nodes(graph: Graph) -> list[tuple[str, object]]:
     """Post-fusion kernel nodes — ``(node_id, op)`` for every kernel-bearing op.
 
-    An outer terminal sits at the loop dialect's end (:func:`outer_pipeline`), so every kernel is a
-    finalized ``LoopOp`` and each gets its own inner slice."""
-    return [(nid, n.op) for nid, n in graph.nodes.items() if isinstance(n.op, LoopOp)]
+    A normal outer terminal sits at the loop dialect's end (:func:`outer_pipeline`), so its
+    kernels are finalized ``LoopOp`` instances. A direct post-cut reproducer instead starts at an
+    unscheduled ``TileOp``; it enters the same inner search so its rows keep the child identity
+    ordinary parent-route replay already consumes. A sealed Tile root is already scheduled and
+    stays lowering-only."""
+    return [(nid, n.op) for nid, n in graph.nodes.items() if isinstance(n.op, LoopOp) or (isinstance(n.op, TileOp) and n.op.work is None)]
 
 
 @dataclass
@@ -334,7 +340,7 @@ class TwoLevelStrategy(SearchStrategy):
     async def _evaluate_terminal(self, fused_graph: Graph, ctx: Context) -> InnerReward:
         """The separable scoring function: tune every post-fusion kernel of ``fused_graph`` in
         its own single-node slice and return ``Σ best-per-op time`` — the outer terminal reward
-        — once ALL Loop kernels are measured. Kernels minted inside the inner loops are enrolled
+        — once all kernel roots are measured. Kernels minted inside the inner loops are enrolled
         in waves (evidence, never reward terms).
 
         One coroutine per work item over a slot queue of ``len(pool)`` device-pinned backends
@@ -346,7 +352,7 @@ class TwoLevelStrategy(SearchStrategy):
         identity = _identity()
         ctx_key = ctx.structural_key()
         backend_name = getattr(self.pool[0], "name", "cuda")
-        # Group structurally-identical LoopOps under one ``Op.cache_key`` — insertion order =
+        # Group structurally-identical kernel roots under one ``Op.cache_key`` — insertion order =
         # first occurrence (drives the progress tail name). Ops with no cache key are
         # unreachable through the bench path so they don't enter the dedup map at all.
         unique: OrderedDict[str, tuple[str, object, int]] = OrderedDict()

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -9,8 +9,8 @@ direct correctness where a timing was admissible. The retained A100 VM stayed ru
 ### A100 corpus
 
 The exact sm80 lane collected 201 tests and found six applicable cases. It completed in 189 seconds with five passes,
-one independent stat-fill watchdog failure, and 195 skips. The result JSON and full log are preserved under
-`_tune/a100-corpus-857ba7e9/evidence/full-corpus/`.
+one independent stat-fill watchdog failure, and 195 skips. The result JSON and full log are retained host-local on the retained A100 VM (untracked
+`_tune/a100-corpus-857ba7e9/evidence/full-corpus/`; `_tune/` is not in the repository).
 
 | A100 case | Emmy | `torch.compile` | launches | result |
 | --- | ---: | ---: | ---: | --- |
@@ -49,7 +49,7 @@ sibling operands by dependency, closing tiled provider cones, and retaining comp
 authored fused schedule is nevertheless about 0.28 seconds per iteration and trips the benchmark watchdog. A correct
 six-seam route reached 3,342 µs versus 17.238 µs for `torch.compile`; its best measured factor-16 child was 184.525 µs.
 The parent instead selected an unmeasured factor-32 split, so a 206.592 µs parent canary is not qualified evidence.
-The remaining storage gap is an ordered structural receipt: record the split choice first, then join the identities
+The remaining storage gap is ordering in the child-identity schedule receipts: record the split choice first, then join the identities
 and measured schedules of the children that choice creates.
 
 ### Other exact platforms
@@ -75,7 +75,8 @@ A/B replay. It promotes the GQA, PV, workspace-chain, and V100 schedules. The co
 Parity is not achieved: A100 has two wins, three measurable losses, and one watchdog; V100 has one correct loss and
 one correctness failure; RTX 4090 has no exact corpus coverage. No large serving experiment was started while those
 kernel-level gaps remain. The next compiler work is structural reuse/materialization for attention, transpose-aware
-PV stores, a cross-CTA completion/reset primitive for split-K, ordered structural receipts for stat-fill, and a Volta
+PV stores, a cross-CTA completion/reset primitive for split-K, split-first ordering for stat-fill's child-identity
+schedule receipts, and a Volta
 producer/consumer staging primitive.
 
 ## Cut-pinned attention qualification after the computed-B changes (main through `d2950079`, 2026-08-28)

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,87 +1,82 @@
 # Golden-bench kernel corpus
 
-## Latest-main corpus and affected-kernel requalification after #684 (2026-08-29)
+## Current-head corpus requalification (2026-08-29)
 
-The draft was rebased through current main `b88763fa`; #685 changes only a DeepSeek V4 working plan. V100, A100, and
-RTX 4090 runs used deployable O3, exact GPUs, task-owned empty evidence state, strict direct eager correctness, and the
-repository CLI. No temporary repository golden remained installed after a run, and the retained A100 VM stayed
-running.
+The draft is based on current main `b88763fa`; the exact combined source for this pass is `857ba7e9`. Every hardware
+run used deployable O3, the exact GPU capability, task-owned tuning and cubin state, the repository CLI, and strict
+direct correctness where a timing was admissible. The retained A100 VM stayed running.
 
-### Current A100 corpus result
+### A100 corpus
 
-The stock lane collected 200 tests and found five closed sm80 corpus cases. The first pass produced three measured
-losses, one two-second kernel watchdog, and one A/B pin-integrity failure. The integrity failure was in the perf
-harness: a case's placement pins selected the ordinary compile but were omitted from the independently re-lowered A/B
-row. The harness now repeats both input pins and schedule knobs in the explicit row. The exact current-source fixture
-then passed and turned that broken measurement into a real corpus win. The final full run completed in 119.87 s with
-four passes, one watchdog failure, and 195 skips. Its missing-duration warning concerns worker bucketing, not a kernel
-result; no host-specific duration file was copied from the remote run.
+The exact sm80 lane collected 201 tests and found six applicable cases. It completed in 189 seconds with five passes,
+one independent stat-fill watchdog failure, and 195 skips. The result JSON and full log are preserved under
+`_tune/a100-corpus-857ba7e9/evidence/full-corpus/`.
 
-| A100 case | Emmy | `torch.compile` | latest result |
-| --- | ---: | ---: | --- |
-| `attention/sdpa-computed-value-cut-mma.yaml` | 6.2 µs | 8.0 µs | Correct, two launches, 1.29x faster than `torch.compile` |
-| `matmul/f16-cut-splitk-unit-row.yaml` | 9.1 µs | 2.9 µs | Correct after the public-rounding fix; 3.14x slower |
-| `attention/rmsnorm-gqa-b-cut.yaml` | 38.1 µs | 10.1 µs | Exact strict finalist reached 28.644 µs; still a loss |
-| `matmul/f16-mma-broadcast-batched-pv-transpose.yaml` | 79.0 µs | 12.0 µs | Exact strict finalist reached 19.777 µs; still a loss |
-| `attention/rmsnorm-gqa-sdpa-stat-fill.yaml` | — | — | Greedy kernel exceeded the two-second per-iteration watchdog |
+| A100 case | Emmy | `torch.compile` | launches | result |
+| --- | ---: | ---: | ---: | --- |
+| `attention/rmsnorm-gqa-b-cut.yaml` | 6.907 µs | 10.026 µs | 2 | Correct; 1.45x faster |
+| `attention/sdpa-computed-value-cut-mma.yaml` | 6.193 µs | 8.039 µs | 2 | Correct; 1.30x faster |
+| `attention/rmsnorm-qk-sdpa-workspace-chain.yaml` | 75.855 µs | 11.469 µs | 1 | Correct; 6.61x slower |
+| `matmul/f16-cut-splitk-unit-row.yaml` | 9.183 µs | 2.839 µs | 3 | Correct; 3.23x slower |
+| `matmul/f16-mma-broadcast-batched-pv-transpose.yaml` | 17.664 µs | 11.894 µs | 1 | Correct; 1.49x slower |
+| `attention/rmsnorm-gqa-sdpa-stat-fill.yaml` | about 280 ms/iteration | 19.456 µs | — | Pinned row exceeds the aggregate 10-second watchdog |
 
-The two bounded improvements are search observations, not promoted timings. The PV finalist repeated at 19.784 and
-19.777 µs versus 12.009 µs for `torch.compile`. It launches 64 CTAs with 256 threads, 48 KiB shared memory, 126
-registers per thread, and 25% theoretical occupancy. Its eight f32 accumulator fragments end in 32 scalar stores per
-thread because the algebraic output axis has physical stride 512; alternate geometry and deeper-pipeline canaries were
-slower. Closing the remaining 7.77 µs requires a shared transpose epilogue or contraction-orientation change, not
-another ordinary schedule row. The GQA finalist measured 28.644 µs versus 10.075 µs for `torch.compile`; its 64-CTA,
-four-thread consumer recomputes Q RMSNorm state inside the score and value loops and softmax statistics across output
-lanes. It needs a reuse or materialization redesign.
+The GQA win required both a better route and one replay fix. Materializing the clustered normalized-K value produces
+one cooperative producer and one consumer. The A/B path then incorrectly dropped scoped OFF exceptions such as
+`REDUCE@a7=''`, allowing bare `REDUCE=coop` to fan out and change the consumer source. Replay now preserves a scoped
+OFF when it overrides a non-OFF bare family. The unchanged perf command fell from 10.193 to 6.857-7.100 µs and uses
+the same fast source as direct full-row replay.
 
-The split-K search had previously found a 3.26 µs kernel row that failed strict correctness on 3/64 elements. After
-the compiler fix, the authored three-launch case passes strict correctness; its canonical 100-iteration perf result is
-the 9.1 µs row above, so it still loses.
+The PV golden now carries the strict `w8x1`, `f1x8/k8`, `d1/smem-async` schedule. This is about four times faster than
+the prior checked row, but an eight-row neighbour search found no further schedule gain. The kernel uses 48 KiB shared
+memory, 126 registers per thread, and 25% occupancy. Its transpose epilogue emits 32 stride-512 scalar stores per
+thread; toggling vector stores produces byte-identical CUDA. Parity therefore needs a transpose-aware store path or a
+different contraction orientation.
 
-The watchdog is a separate compiler-quality gap. Stage 07 duplicates the Q RMSNorm work that Stage 06 shares: the Fold
-count grows from two to five and the `rsqrt` count from five to eight when a provider with iteration-bearing axes is
-sunk across contraction and sweep binders. A guard-only change breaks four neighbouring attention cases, while the
-known complete correction spans projection closure, lexical provider environments, root-scoped dtype inference, and
-affected schedule identities. No unsafe local patch was retained.
+The workspace-chain golden improved 13.5% by using `WORK=t8` and cooperative reductions, with the combined lane
+reaching 75.855 µs. Its CUDA still recomputes Q RMSNorm within output-key work, K RMSNorm within each dot product, and
+the softmax score scan across value-output lanes. No offered schedule changes that structure; reuse or materialization
+must move those cones outside the repeated loops.
 
-### Affected model targets
+The split-K case remains a launch-structure gap. Its fastest strict forced row with a genuine split used `g2k+w1x1`
+at 4.681 µs versus 2.761 µs for `torch.compile`, but the corpus row remains the repeatable authored 9.183 µs result.
+Deferred split-K requires partial, finalize, and cut-consumer kernels. Atomic split-K removes the finalize kernel but
+needs a runtime accumulator reset because its first kernel has no predecessor to own zero initialization. A safe
+improvement needs a cross-CTA last-arriver primitive or a proved consumer-side reset protocol.
 
-| platform | affected target | latest bounded result | decision |
-| --- | --- | --- | --- |
-| A100 | s512 P×V target, `PLACE@a8=cut` | Two strict 5-warmup/20-iteration repeats: Emmy 67.038 µs versus `torch.compile` 52.224 µs; child kernels 24.55 and 40.83 µs | Correct, 1.284x slower; no promotion |
-| RTX 4090 | t16, `PLACE@a=cut` | Emmy 7.864 µs versus `torch.compile` 7.143 µs and eager 10.168 µs; three launches | Correct, 10.1% slower; no promotion |
-| RTX 4090 | t17, `PLACE@map=cut` | Emmy 10.047 µs versus `torch.compile` 8.433 µs and eager 90.823 µs; four launches | Correct, 19.1% slower; no promotion |
-| V100 | s512 down-projection plus residual | Typed public rounding: cut route 333 µs versus eager 75 µs; fused route about 512 µs versus eager 83 µs; both have 364/524,288 mismatches | Correctness gate still fails; no promotion |
+The stat-fill case now builds and passes strict correctness after preserving provider evaluation domains, ordering
+sibling operands by dependency, closing tiled provider cones, and retaining computed-B projection providers. Its
+authored fused schedule is nevertheless about 0.28 seconds per iteration and trips the benchmark watchdog. A correct
+six-seam route reached 3,342 µs versus 17.238 µs for `torch.compile`; its best measured factor-16 child was 184.525 µs.
+The parent instead selected an unmeasured factor-32 split, so a 206.592 µs parent canary is not qualified evidence.
+The remaining storage gap is an ordered structural receipt: record the split choice first, then join the identities
+and measured schedules of the children that choice creates.
 
-The A100 cut is a real 4.5x improvement over the 303 µs one-cut greedy result, but its exact child schedules do not
-assemble from repository receipts. The current receipt resolves a child before later kernel-set-changing feature
-choices. On RTX 4090 t16, for example, `PLACE@a=cut` reaches one OFF child and one pre-split child; a later
-`REDUCE=g32k` choice replaces the latter with a partial and a finalize kernel. Ambient `REDUCE` pins are not a safe
-encoding: they also reach the unsplit sibling, and one combined value would force a common schedule across children
-that need different rows. The durable representation must record the exact parent identity and structural choice in
-sequence, then join each resulting child identity to its exact schedule row. Reusing the pre-split identity or
-skipping structural forks would weaken the existing fail-closed contract, so the experimental replay change was
-reverted. A follow-up atomic-receipt prototype rejected an incomplete child set correctly, but the tune DB and online
-writer cannot emit the ordered parent-to-final-children join; retaining only its decoder would create a hand-authored
-verified-only path. A bounded V100 retune confirms the impact: it can select `PLACE=cut`, but cannot express schedules
-for the resulting children and stops at a 282.702 µs placement-only row.
+### Other exact platforms
 
-The A100 consumer remains limited by code generation rather than ordinary schedule selection. Its qualified row uses
-128 threads, 155 registers per thread, and 48 KiB shared memory. A narrow register-repack prototype removed the 8 KiB
-softmax-weight slab and reduced the consumer to 146 registers and 40 KiB, but CTA occupancy stayed at 19% and the
-consumer canary was 41.6 µs rather than the prior 40.83 µs. The prototype was reverted. Beating 52.224 µs requires a
-fragment-liveness design that drops below the next register-residency boundary, not just removal of the shared slab.
+| platform | exact corpus coverage | current result |
+| --- | --- | --- |
+| V100 sm70 | 2 cases | Volta MMA is correct at 3,130.368 µs versus 757.760 µs; linear-cut latency is inadmissible because strict correctness still has 26,418/524,288 mismatches |
+| RTX 4090 sm89 | 0 cases | 201 collected, 201 skipped; no exact sm89 closed case and therefore no parity claim |
 
-The retained compiler fix preserves a public f16 store/load conversion across one transient loop buffer while leaving
-deliberate f32 internal workspaces unchanged. It closes strict correctness for the sm80 split-K corpus case. On V100 it
-halves the down-projection target's mean absolute error to about 0.00011, but does not close correctness: both fused and
-cut routes still have 364 mismatches, maximum absolute error 0.00390625. The remaining difference is contraction
-accumulation and reduction order rather than the now-preserved public rounding boundary.
+The promoted V100 row uses `WORK=w4x2` and a single `d1/smem` stage. It shares A tiles across two N warps and B tiles
+across four M warps, reducing shared-memory requests, but remains 4.13x behind `torch.compile`. Volta lacks
+`ldmatrix` and `cp.async`; the next useful schedule primitive is a producer/consumer warp band with named barriers,
+not another depth or geometry row. The linear-cut target still differs in contraction accumulation order after the
+public f16 boundary is restored, so its perf-harness number is reported only as diagnostic output.
 
-No golden row was promoted and no large serving experiment was started. Current sm80 corpus coverage has one win and
-three losses among the four measurable cases; one case still exceeds the watchdog. The next shared bottleneck is
-ordered child-schedule receipts, followed by projection multiplicity and register liveness in the remaining hard
-attention kernels.
+### Retained fixes and conclusion
+
+This pass retains small, separately tested fixes for provider evaluation domains, dependency-ordered operand splicing,
+scalar-atom dump replay, direct tuning of persisted unscheduled Tile children, provider-cone closure, and scoped-OFF
+A/B replay. It promotes the GQA, PV, workspace-chain, and V100 schedules. The combined local gate is 3,981 passed,
+1,012 skipped, and five expected failures; lint is clean.
+
+Parity is not achieved: A100 has two wins, three measurable losses, and one watchdog; V100 has one correct loss and
+one correctness failure; RTX 4090 has no exact corpus coverage. No large serving experiment was started while those
+kernel-level gaps remain. The next compiler work is structural reuse/materialization for attention, transpose-aware
+PV stores, a cross-CTA completion/reset primitive for split-K, ordered structural receipts for stat-fill, and a Volta
+producer/consumer staging primitive.
 
 ## Cut-pinned attention qualification after the computed-B changes (main through `d2950079`, 2026-08-28)
 

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,6 +1,6 @@
 # Golden-bench kernel corpus
 
-## Cut-pinned attention qualification after the computed-B changes (main through `a597f15d`, 2026-08-28)
+## Cut-pinned attention qualification after the computed-B changes (main through `d2950079`, 2026-08-28)
 
 ### Corrected protocol
 
@@ -70,20 +70,53 @@ sm120 realization case proves offered, realized, built, and correct. The repaire
 at t32, 72,405 µs at t64, 71,969 µs at t128, 73,936 µs at t256, and 73,362 µs at t512. This closes compilation but
 does not change the repeated 512×128 work.
 
-`torch.compile` produced no positive latency for these score/statistics strict replays, so no parity ratio is claimed.
+### Statistics-sharing replay after #682
+
+PR #682 (`d2950079`) directly closes the repeated-statistics gap identified above: Tile normalization restores object
+sharing between structurally equal cones, and two provider-closed statistics seams make the shared row state
+materializable. On the exact Qwen s512 target, adding those two cuts to the prior four-cut route produces six launches.
+The statistics producer writes max and normalization state once per `(head, query)` row; the softmax-weight child
+loads that workspace and no longer contains the 512-key scan. The consumer also loads the shared state rather than
+recomputing it.
+
+The retained A100 was replayed at exact branch source `31e7e629` (PR #682 plus this draft's receipt and readable-CUDA
+fixes), deployable O3, isolated DB/prior/cubin state, five warmups, and 20 iterations. Both standard repeats passed the
+strict direct eager check.
+
+| lane | eager (µs) | Emmy route (µs) | dominant statistics child (µs) | result |
+| --- | ---: | ---: | ---: | --- |
+| standard repeat 1 | 744.653 | 11,717.632 | 11,501.568 | correct; 6 launches |
+| standard repeat 2 | 744.795 | 11,720.704 | 11,505.664 | correct; 6 launches |
+| `FAST_MATH` | 744.590 | 11,704.320 | 11,501.568 | correct; noise-scale 0.1% change |
+
+The prior four-cut full replay was 110,723 µs, so the shared-statistics route is 9.45x faster. The old c3d child falls
+from about 110,780 µs to 65-66 µs; the consumer is 81 µs and the other three producers are 7-37 µs. This is a real
+algorithmic improvement, but the route remains 15.7x slower than eager. The matched `torch.compile` request again
+produced no positive timing for this embedded target, so it still cannot supply a parity ratio.
+
+The new bottleneck is the one correctly shared statistics producer, not duplicated work. Its greedy row is
+`TILE@a4=f1x2, WORK=t32x8` and takes 11.50 ms. A bounded MCTS-only follow-up measured
+`TILE@a4=f4x6, WORK=t32x16` at 11.535 ms and found no improvement; after 2m55s the next candidate remained in CPU
+descent with the GPU idle, so the arm was stopped. The remaining performance work is to make the nested 128-channel
+score contraction inside the online 512-key statistics reduction eligible for an efficient tensor-core schedule,
+then reduce the still-large candidate descent. No receipt was promoted. Raw host-local evidence is retained under
+`_tune/pr682-a100/remote/`; the task-owned remote scratch was removed while the A100 VM stayed running.
+
+`torch.compile` produced no positive latency for these score/statistics strict replays, including the post-#682
+attempt, so no parity ratio is claimed.
 The earlier output-projection strict result remains a valid separate finding: 1,594,544 µs for Emmy versus 52.6 µs
 for `torch.compile` on RTX 4090. The V100 down-projection also remains a direct correctness failure and was not
 admitted as a performance result.
 
 ### Bottleneck and receipt-aware replay
 
-The correction changes the diagnosis. Placement works, and resulting kernels are independently schedulable. On A100
-and RTX 4090, four children tune into the tens-of-microseconds range; materializing the softmax weight isolates one
-producer that remains about 100-111 ms. Its lowered loop has free query and output-key axes and, for every output
-weight, recomputes the complete 512-key reduction whose body performs a 128-channel score contraction. Ordinary
-`WORK` and `REDUCE` choices change the constant factor but preserve that repeated scan. The missing optimization is to
-compute and share the row statistics once across its output keys, not to give all split children one shared schedule.
-On V100, even the K-cut consumer did not complete a candidate inside the original search wall.
+Before #682, the correction changed the diagnosis. Placement worked, and resulting kernels were independently
+schedulable. On A100 and RTX 4090, four children tuned into the tens-of-microseconds range; materializing the softmax
+weight isolated one producer that remained about 100-111 ms. Its lowered loop had free query and output-key axes and,
+for every output weight, recomputed the complete 512-key reduction whose body performs a 128-channel score
+contraction. Ordinary `WORK` and `REDUCE` choices changed the constant factor but preserved that repeated scan. PR #682
+closes that reuse gap; the statistics-sharing replay above supersedes this performance state. On V100, even the K-cut
+consumer did not complete a candidate inside the original search wall.
 
 The earlier cold-replay drift was a separate persistence gap: the DB keyed different rows by child structural
 identity, but the old flat realization could not serialize conflicting child-global `WORK`, `TILE`, `REDUCE`, `STAGE`,

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -21,18 +21,28 @@ result; no host-specific duration file was copied from the remote run.
 | --- | ---: | ---: | --- |
 | `attention/sdpa-computed-value-cut-mma.yaml` | 6.2 µs | 8.0 µs | Correct, two launches, 1.29x faster than `torch.compile` |
 | `matmul/f16-cut-splitk-unit-row.yaml` | 9.1 µs | 2.9 µs | Correct after the public-rounding fix; 3.14x slower |
-| `attention/rmsnorm-gqa-b-cut.yaml` | 38.1 µs | 10.1 µs | Bounded search reached about 24.3 µs; still a loss |
-| `matmul/f16-mma-broadcast-batched-pv-transpose.yaml` | 79.0 µs | 12.0 µs | Bounded search reached 19.845 µs; still a loss |
+| `attention/rmsnorm-gqa-b-cut.yaml` | 38.1 µs | 10.1 µs | Exact strict finalist reached 28.644 µs; still a loss |
+| `matmul/f16-mma-broadcast-batched-pv-transpose.yaml` | 79.0 µs | 12.0 µs | Exact strict finalist reached 19.777 µs; still a loss |
 | `attention/rmsnorm-gqa-sdpa-stat-fill.yaml` | — | — | Greedy kernel exceeded the two-second per-iteration watchdog |
 
-The two bounded improvements are search observations, not promoted timings. The split-K search had previously found a
-3.26 µs kernel row that failed strict correctness on 3/64 elements. After the compiler fix, the authored three-launch
-case passes strict correctness; its canonical 100-iteration perf result is the 9.1 µs row above, so it still loses.
+The two bounded improvements are search observations, not promoted timings. The PV finalist repeated at 19.784 and
+19.777 µs versus 12.009 µs for `torch.compile`. It launches 64 CTAs with 256 threads, 48 KiB shared memory, 126
+registers per thread, and 25% theoretical occupancy. Its eight f32 accumulator fragments end in 32 scalar stores per
+thread because the algebraic output axis has physical stride 512; alternate geometry and deeper-pipeline canaries were
+slower. Closing the remaining 7.77 µs requires a shared transpose epilogue or contraction-orientation change, not
+another ordinary schedule row. The GQA finalist measured 28.644 µs versus 10.075 µs for `torch.compile`; its 64-CTA,
+four-thread consumer recomputes Q RMSNorm state inside the score and value loops and softmax statistics across output
+lanes. It needs a reuse or materialization redesign.
+
+The split-K search had previously found a 3.26 µs kernel row that failed strict correctness on 3/64 elements. After
+the compiler fix, the authored three-launch case passes strict correctness; its canonical 100-iteration perf result is
+the 9.1 µs row above, so it still loses.
 
 The watchdog is a separate compiler-quality gap. Stage 07 duplicates the Q RMSNorm work that Stage 06 shares: the Fold
 count grows from two to five and the `rsqrt` count from five to eight when a provider with iteration-bearing axes is
 sunk across contraction and sweep binders. A guard-only change breaks four neighbouring attention cases, while the
-known complete correction spans the projection-closing design. No unsafe local patch was retained.
+known complete correction spans projection closure, lexical provider environments, root-scoped dtype inference, and
+affected schedule identities. No unsafe local patch was retained.
 
 ### Affected model targets
 
@@ -51,8 +61,10 @@ encoding: they also reach the unsplit sibling, and one combined value would forc
 that need different rows. The durable representation must record the exact parent identity and structural choice in
 sequence, then join each resulting child identity to its exact schedule row. Reusing the pre-split identity or
 skipping structural forks would weaken the existing fail-closed contract, so the experimental replay change was
-reverted. A bounded V100 retune confirms the impact: it can select `PLACE=cut`, but cannot express schedules for the
-resulting children and stops at a 282.702 µs placement-only row.
+reverted. A follow-up atomic-receipt prototype rejected an incomplete child set correctly, but the tune DB and online
+writer cannot emit the ordered parent-to-final-children join; retaining only its decoder would create a hand-authored
+verified-only path. A bounded V100 retune confirms the impact: it can select `PLACE=cut`, but cannot express schedules
+for the resulting children and stops at a 282.702 µs placement-only row.
 
 The A100 consumer remains limited by code generation rather than ordinary schedule selection. Its qualified row uses
 128 threads, 155 registers per thread, and 48 KiB shared memory. A narrow register-repack prototype removed the 8 KiB

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,6 +1,6 @@
 # Golden-bench kernel corpus
 
-## Cut-pinned attention qualification after the computed-B changes (main @ `6e6181d5`, 2026-08-28)
+## Cut-pinned attention qualification after the computed-B changes (main through `a597f15d`, 2026-08-28)
 
 ### Corrected protocol
 
@@ -15,10 +15,12 @@ The full route has four distinct value seams: shared statistics (`PLACE@map.fold
 spellings resolve to three different Fold occurrences, but value clustering groups them into one K-value `CutSite`;
 pinning any occurrence replaces all three. They are one cut, not three composed cuts.
 
-Every lane used exact `6e6181d5` source, deployable `-O3`, isolated tuning state, seed 0, at most 12 candidates per
-independent kernel, patience 4, and an outer wall bound. A fresh trace still produces one maximal whole-layer target,
-so these diagnostics use untrusted copies of the checked self-contained score/statistics slice. They are host-local
-compiler qualification, not replacement publication evidence; no results archive was changed.
+The first measurement lanes used exact `6e6181d5` source, deployable `-O3`, isolated tuning state, seed 0, at most 12
+candidates per independent kernel, patience 4, and an outer wall bound. The receipt-aware follow-up rebased the draft
+onto exact `a597f15d` and regenerated the working files before inspecting or measuring any schedule. A fresh trace
+still produces one maximal whole-layer target, so these diagnostics use untrusted copies of the checked self-contained
+score/statistics slice. They are host-local compiler qualification, not replacement publication evidence; no results
+archive was changed.
 
 ### Hardware result
 
@@ -30,25 +32,67 @@ compiler qualification, not replacement publication evidence; no results archive
 | RTX 4090 | add softmax weight; five launches | The consumer fell to 19-31 µs, but the new producer's best row was 100,416 µs; replay was 101,233 µs versus 504 µs eager and passed direct correctness. |
 | RTX 5090 | statistics + Q + K + softmax weight; structural replay only | Exact lowering produced the expected five children. Timing was deferred because an unrelated task owned the host's only compatible GPU; it was not interrupted. |
 
+### Receipt-aware current-main retune
+
+The follow-up regenerated the working targets after rebasing. V100, A100, and RTX 4090 measurements used exact
+`043f1f25`, which adds only the route-contract test to `a597f15d`; RTX 5090 used exact `5ddf7816`, whose receipt
+decoder change does not alter kernel source. All rows used deployable O3 and bounded candidate or explicit-row
+budgets.
+
+| platform | child | best bounded row | result |
+| --- | --- | --- | --- |
+| V100 | K-cut cast producer | `TILE=f2`; other schedule families off | 2.924 µs |
+| V100 | K-cut pointwise producer | `TILE=f4`; other schedule families off | 2.686 µs |
+| V100 | K-cut attention consumer | only offered row: all schedule families off | exceeded the 15 s watchdog; no accepted latency |
+| A100 | softmax materialization (`c3d`) | `WORK=t128, REDUCE@a3=coop, REDUCE@a4=coop` | qualifying repeats 110,768 and 110,786 µs |
+| RTX 4090 | softmax materialization (`c3d`) | `WORK=t128, REDUCE@a3=coop, REDUCE@a4=coop` | search observations 100,351 and 100,335 µs; a noise-scale tie with the prior 100,416 µs row |
+| RTX 4090 | other four-cut children | per-child rows: statistic `t32/coop`, Q all-off, K `t128/coop`, consumer f2x8 MMA with async stage | 4.15-27.89 µs |
+| RTX 5090 | softmax materialization (`c3d`) | `WORK=t128, REDUCE@a3=coop, REDUCE@a4=coop` | after the compiler fix, qualifying repeats 72,380 and 71,966 µs |
+
+The A100 c3d candidate-pool bound is 1,094,745,632 rows and the consumer bound is 1,066,670,432. Whole-target MCTS
+spent 8m30s in first-candidate CPU descent without measuring a row. On RTX 4090, the 24-live-candidate MCTS-only arm
+took 407.5 s and the equally bounded evidence-seeded refinement reached its 600 s wall; neither found a different c3d
+schedule. Exhaustive child-row listing and strict receipt decoding were each stopped at 60 s. The useful schedules
+are visible by deploy identity, but flattening these pools is not a usable listing or validation algorithm.
+
+Current main's child-identity schedule receipts close the representation gap, and `5ddf7816` fixes strict decoding
+when a regenerated target lowers to several kernels. Exact deployment is not closed yet. On RTX 4090 the canonical
+t128 receipt joined the correct c3d identity but reported row DRIFT and fell back to t8: 397,303 µs for c3d and
+397,477 µs for the four-cut route versus 480 µs eager, with direct correctness passing. The explicit working-file
+path also treats receipt siblings as independent flat A/B rows rather than installing them together for base
+lowering. No receipt was promoted; the remaining work is a child-directed exact-row descent shared by strict decode
+and the verified tier, plus grouped working-file replay.
+
+RTX 5090 exposed one independent built-stage gap: every screened row initially emitted ambiguous `float * __half`
+expressions under readable CUDA rendering. The readability fold had inlined a mixed-dtype single-use `Assign` before
+the target-aware renderer could insert `__half2float`. The compiler now keeps such assignments named; the new closed
+sm120 realization case proves offered, realized, built, and correct. The repaired explicit rows measured 72,488 µs
+at t32, 72,405 µs at t64, 71,969 µs at t128, 73,936 µs at t256, and 73,362 µs at t512. This closes compilation but
+does not change the repeated 512×128 work.
+
 `torch.compile` produced no positive latency for these score/statistics strict replays, so no parity ratio is claimed.
 The earlier output-projection strict result remains a valid separate finding: 1,594,544 µs for Emmy versus 52.6 µs
 for `torch.compile` on RTX 4090. The V100 down-projection also remains a direct correctness failure and was not
 admitted as a performance result.
 
-### Bottleneck and replay gap
+### Bottleneck and receipt-aware replay
 
 The correction changes the diagnosis. Placement works, and resulting kernels are independently schedulable. On A100
 and RTX 4090, four children tune into the tens-of-microseconds range; materializing the softmax weight isolates one
-producer that remains about 100-111 ms. On V100, even the cut consumer did not complete a candidate inside the search
-wall. These are child-kernel schedule/code-generation gaps, not evidence that the cut route must keep one shared
-schedule.
+producer that remains about 100-111 ms. Its lowered loop has free query and output-key axes and, for every output
+weight, recomputes the complete 512-key reduction whose body performs a 128-channel score contraction. Ordinary
+`WORK` and `REDUCE` choices change the constant factor but preserve that repeated scan. The missing optimization is to
+compute and share the row statistics once across its output keys, not to give all split children one shared schedule.
+On V100, even the K-cut consumer did not complete a candidate inside the original search wall.
 
-Exact portability is a second, independent gap. The tuning DB can key schedules by child structural identity, and the
-RTX 4090 assembly replayed those rows. A realization has only one flat `knobs` map, however, so it cannot serialize
-conflicting child-global `WORK`, `TILE`, `REDUCE`, `STAGE`, or `RASTER` values. The A100 cold replay also found two
-stored child rows whose keys no longer intersected the currently offered candidates and fell back to the model. A
-durable golden therefore needs an ordered child-identity schedule receipt; copying the rows into the parent flat map
-would be ambiguous.
+The earlier cold-replay drift was a separate persistence gap: the DB keyed different rows by child structural
+identity, but the old flat realization could not serialize conflicting child-global `WORK`, `TILE`, `REDUCE`, `STAGE`,
+or `RASTER` values. Main `a597f15d` resolves that representation gap with child-identity schedule receipts. Each
+sibling realization carries the route cuts in `pins`, one child's row in `knobs`, and that child's `deploy_identity`
+in `identity`; strict decoding checks the row only against that child's candidate pool. Copying child rows into the
+parent flat map remains invalid, but the sibling receipts make exact per-child replay representable in the schema.
+The current-main retune above shows that strict enumeration and deploy equality still need a child-directed descent
+before those receipts are promotion-ready for this large route.
 
 No realization was promoted. Offered, realized, built, and correctness stages are closed for the composed route, so
 there was no small compiler failure or new realization-corpus gap to patch. `FAST_MATH` was not promoted because the

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,46 +1,58 @@
 # Golden-bench kernel corpus
 
-## Affected-kernel qualification after the computed-B cut changes (main @ `6e6181d5`, 2026-08-28)
+## Cut-pinned attention qualification after the computed-B changes (main @ `6e6181d5`, 2026-08-28)
 
-### Scope
+### Corrected protocol
 
-This bounded follow-up re-traced Qwen3-0.6B layer 0 at sequence length 512 and re-tuned the three attention targets
-whose placement or schedule could change after #678: score/statistics (`k_sdpa_mean_reduce_29d3df`), softmax times V
-(`k_sdpa_linear_reduce_c0a378`), and output projection plus residual (`k_linear_sdpa_reduce_e24efe`). The V100 lane
-also rechecked the already incorrect down-projection target. Every lane used the exact `6e6181d5` source, isolated
-tuning state, deployable `-O3`, at most 12 candidates, patience 4, and a per-target wall bound.
+The first screen put `PLACE` choices in proposal `knobs`. That measured one structural candidate whose new kernels
+kept greedy schedules; it did not test the route the compiler is designed to tune. This follow-up instead froze the
+kernel set in realization `pins`, ran the normal two-level tuner on every minted kernel identity, and replayed the
+assembled route from the same isolated evidence state. A CPU regression test now protects that exact contract: a
+pinned placement cut enrolls both children and the assembly replays different `WORK` and `STAGE` rows.
 
-A fresh trace on all four cards now produces one maximal whole-layer target,
-`k_sdpa_linear_mean_reduce_ad2ade.060608ea1479`, instead of the checked nine-target inventory. That changes the
-denominator, so the bounded comparison used untrusted copies of the three checked self-contained provenance slices.
-The whole-layer target was recorded but not substituted into the historical comparison. An RTX 4090 control trace at
-the immediate parent `b4efe436` is byte-identical, so the inventory change predates #678.
+The full route has four distinct value seams: shared statistics (`PLACE@map.fold.a21`), Q
+(`PLACE@a.map.a`), K (`PLACE@a.map.b`), and softmax weight (`PLACE@map.fold.a1`). The three previously tested K
+spellings resolve to three different Fold occurrences, but value clustering groups them into one K-value `CutSite`;
+pinning any occurrence replaces all three. They are one cut, not three composed cuts.
 
-This is a host-local compiler qualification, not a new `emmy bench` experiment snapshot. No results archive was
-replaced, and none of these numbers is publication evidence.
+Every lane used exact `6e6181d5` source, deployable `-O3`, isolated tuning state, seed 0, at most 12 candidates per
+independent kernel, patience 4, and an outer wall bound. A fresh trace still produces one maximal whole-layer target,
+so these diagnostics use untrusted copies of the checked self-contained score/statistics slice. They are host-local
+compiler qualification, not replacement publication evidence; no results archive was changed.
 
-### Result
+### Hardware result
 
-| platform | score/statistics | softmax times V | output projection plus residual |
-| --- | --- | --- | --- |
-| V100 | 455,132 µs versus 1,975 µs eager; direct eager check passed, but `torch.compile` was unavailable | strict pass: 457,662 µs versus 531 µs eager and 274 µs `torch.compile` | exact historical pins take about 6.1-6.5 s per first launch and exceed the benchmark watchdog |
-| A100 | the exact three-cut proposal builds, then its main kernel exceeds the 60 s launch watchdog | three bounded candidates take about 3.92 s per main launch | exact historical pins are consumed, but the main kernel takes about 2.15 s and exceeds the benchmark-stage budget |
-| RTX 4090 | one cold candidate and the exact cut proposal each exceed the 60 s launch watchdog | fused and placed candidates take about 1.85 s per launch | strict pass: 1,594,544 µs versus 49 µs eager and 53 µs `torch.compile` |
-| RTX 5090 | one cold candidate and all three current scoped cut proposals exceed the 60 s launch watchdog | three candidates take about 1.30-1.36 s per launch | exact historical pins take about 1.49-1.54 s; eight more variants remain about 0.97-1.99 s |
+| platform | frozen route | result |
+| --- | --- | --- |
+| V100 | K-value cut; two children | Correct replay: 595,101 µs versus 1,920 µs eager. No child candidate finished inside the bounded search, so replay correctly used the offline fallback. |
+| A100 | statistics + Q + K + softmax weight; five primary children plus one recursive statistics split | 67 clean benches in 219 s. Best children were 7-37 µs except the softmax-weight producer at 110,744 µs; tuned route 110,882 µs. Fresh replay was 110,723 µs versus 758 µs eager and passed direct correctness. |
+| RTX 4090 | statistics + Q + K; four launches | Per-identity DB replay used different child schedules: 4,561 µs versus 494 µs eager, direct correctness passed. The remaining consumer was 4,396 µs. |
+| RTX 4090 | add softmax weight; five launches | The consumer fell to 19-31 µs, but the new producer's best row was 100,416 µs; replay was 101,233 µs versus 504 µs eager and passed direct correctness. |
+| RTX 5090 | statistics + Q + K + softmax weight; structural replay only | Exact lowering produced the expected five children. Timing was deferred because an unrelated task owned the host's only compatible GPU; it was not interrupted. |
 
-The V100 down-projection diagnostic remains incorrect: current greedy execution is about 511 µs versus 84 µs eager
-and 76 µs `torch.compile`, with 40 of 524,288 outputs outside tolerance (`max_abs=0.00391`). It was not admitted as a
-performance result.
+`torch.compile` produced no positive latency for these score/statistics strict replays, so no parity ratio is claimed.
+The earlier output-projection strict result remains a valid separate finding: 1,594,544 µs for Emmy versus 52.6 µs
+for `torch.compile` on RTX 4090. The V100 down-projection also remains a direct correctness failure and was not
+admitted as a performance result.
 
-No realization qualified for promotion. #678 closes the placement legality gap: the scoped computed-B cuts are
-offered, realized, built, and consume their exact pins. It does not yet close the performance gap. On the output
-projection target, generated code recomputes the complete attention expression inside each output-projection
-contraction step; local schedule knobs cannot remove that asymptotic duplication. The score/statistics cuts likewise
-need deployable child schedules after materialization. These are placement and schedule-design gaps, not small
-offered, realized, built, or correctness failures, so this pass made no compiler or canonical-golden change.
+### Bottleneck and replay gap
 
-`FAST_MATH` was not promoted. None of the affected standard rows reached the performance and strict-correctness gate,
-and changing contraction math cannot remove the duplicated attention work diagnosed above.
+The correction changes the diagnosis. Placement works, and resulting kernels are independently schedulable. On A100
+and RTX 4090, four children tune into the tens-of-microseconds range; materializing the softmax weight isolates one
+producer that remains about 100-111 ms. On V100, even the cut consumer did not complete a candidate inside the search
+wall. These are child-kernel schedule/code-generation gaps, not evidence that the cut route must keep one shared
+schedule.
+
+Exact portability is a second, independent gap. The tuning DB can key schedules by child structural identity, and the
+RTX 4090 assembly replayed those rows. A realization has only one flat `knobs` map, however, so it cannot serialize
+conflicting child-global `WORK`, `TILE`, `REDUCE`, `STAGE`, or `RASTER` values. The A100 cold replay also found two
+stored child rows whose keys no longer intersected the currently offered candidates and fell back to the model. A
+durable golden therefore needs an ordered child-identity schedule receipt; copying the rows into the parent flat map
+would be ambiguous.
+
+No realization was promoted. Offered, realized, built, and correctness stages are closed for the composed route, so
+there was no small compiler failure or new realization-corpus gap to patch. `FAST_MATH` was not promoted because the
+standard route remained far behind eager and changing contraction math does not remove the isolated producer cost.
 
 ## Host-local exact-card qualification checkpoint (2026-08-28)
 

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,5 +1,47 @@
 # Golden-bench kernel corpus
 
+## Affected-kernel qualification after the computed-B cut changes (main @ `6e6181d5`, 2026-08-28)
+
+### Scope
+
+This bounded follow-up re-traced Qwen3-0.6B layer 0 at sequence length 512 and re-tuned the three attention targets
+whose placement or schedule could change after #678: score/statistics (`k_sdpa_mean_reduce_29d3df`), softmax times V
+(`k_sdpa_linear_reduce_c0a378`), and output projection plus residual (`k_linear_sdpa_reduce_e24efe`). The V100 lane
+also rechecked the already incorrect down-projection target. Every lane used the exact `6e6181d5` source, isolated
+tuning state, deployable `-O3`, at most 12 candidates, patience 4, and a per-target wall bound.
+
+A fresh trace on all four cards now produces one maximal whole-layer target,
+`k_sdpa_linear_mean_reduce_ad2ade.060608ea1479`, instead of the checked nine-target inventory. That changes the
+denominator, so the bounded comparison used untrusted copies of the three checked self-contained provenance slices.
+The whole-layer target was recorded but not substituted into the historical comparison. An RTX 4090 control trace at
+the immediate parent `b4efe436` is byte-identical, so the inventory change predates #678.
+
+This is a host-local compiler qualification, not a new `emmy bench` experiment snapshot. No results archive was
+replaced, and none of these numbers is publication evidence.
+
+### Result
+
+| platform | score/statistics | softmax times V | output projection plus residual |
+| --- | --- | --- | --- |
+| V100 | 455,132 µs versus 1,975 µs eager; direct eager check passed, but `torch.compile` was unavailable | strict pass: 457,662 µs versus 531 µs eager and 274 µs `torch.compile` | exact historical pins take about 6.1-6.5 s per first launch and exceed the benchmark watchdog |
+| A100 | the exact three-cut proposal builds, then its main kernel exceeds the 60 s launch watchdog | three bounded candidates take about 3.92 s per main launch | exact historical pins are consumed, but the main kernel takes about 2.15 s and exceeds the benchmark-stage budget |
+| RTX 4090 | one cold candidate and the exact cut proposal each exceed the 60 s launch watchdog | fused and placed candidates take about 1.85 s per launch | strict pass: 1,594,544 µs versus 49 µs eager and 53 µs `torch.compile` |
+| RTX 5090 | one cold candidate and all three current scoped cut proposals exceed the 60 s launch watchdog | three candidates take about 1.30-1.36 s per launch | exact historical pins take about 1.49-1.54 s; eight more variants remain about 0.97-1.99 s |
+
+The V100 down-projection diagnostic remains incorrect: current greedy execution is about 511 µs versus 84 µs eager
+and 76 µs `torch.compile`, with 40 of 524,288 outputs outside tolerance (`max_abs=0.00391`). It was not admitted as a
+performance result.
+
+No realization qualified for promotion. #678 closes the placement legality gap: the scoped computed-B cuts are
+offered, realized, built, and consume their exact pins. It does not yet close the performance gap. On the output
+projection target, generated code recomputes the complete attention expression inside each output-projection
+contraction step; local schedule knobs cannot remove that asymptotic duplication. The score/statistics cuts likewise
+need deployable child schedules after materialization. These are placement and schedule-design gaps, not small
+offered, realized, built, or correctness failures, so this pass made no compiler or canonical-golden change.
+
+`FAST_MATH` was not promoted. None of the affected standard rows reached the performance and strict-correctness gate,
+and changing contraction math cannot remove the duplicated attention work diagnosed above.
+
 ## Host-local exact-card qualification checkpoint (2026-08-28)
 
 ### Question and scope

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,5 +1,76 @@
 # Golden-bench kernel corpus
 
+## Latest-main corpus and affected-kernel requalification after #684 (2026-08-29)
+
+The draft was rebased through current main `b88763fa`; #685 changes only a DeepSeek V4 working plan. V100, A100, and
+RTX 4090 runs used deployable O3, exact GPUs, task-owned empty evidence state, strict direct eager correctness, and the
+repository CLI. No temporary repository golden remained installed after a run, and the retained A100 VM stayed
+running.
+
+### Current A100 corpus result
+
+The stock lane collected 200 tests and found five closed sm80 corpus cases. The first pass produced three measured
+losses, one two-second kernel watchdog, and one A/B pin-integrity failure. The integrity failure was in the perf
+harness: a case's placement pins selected the ordinary compile but were omitted from the independently re-lowered A/B
+row. The harness now repeats both input pins and schedule knobs in the explicit row. The exact current-source fixture
+then passed and turned that broken measurement into a real corpus win. The final full run completed in 119.87 s with
+four passes, one watchdog failure, and 195 skips. Its missing-duration warning concerns worker bucketing, not a kernel
+result; no host-specific duration file was copied from the remote run.
+
+| A100 case | Emmy | `torch.compile` | latest result |
+| --- | ---: | ---: | --- |
+| `attention/sdpa-computed-value-cut-mma.yaml` | 6.2 µs | 8.0 µs | Correct, two launches, 1.29x faster than `torch.compile` |
+| `matmul/f16-cut-splitk-unit-row.yaml` | 9.1 µs | 2.9 µs | Correct after the public-rounding fix; 3.14x slower |
+| `attention/rmsnorm-gqa-b-cut.yaml` | 38.1 µs | 10.1 µs | Bounded search reached about 24.3 µs; still a loss |
+| `matmul/f16-mma-broadcast-batched-pv-transpose.yaml` | 79.0 µs | 12.0 µs | Bounded search reached 19.845 µs; still a loss |
+| `attention/rmsnorm-gqa-sdpa-stat-fill.yaml` | — | — | Greedy kernel exceeded the two-second per-iteration watchdog |
+
+The two bounded improvements are search observations, not promoted timings. The split-K search had previously found a
+3.26 µs kernel row that failed strict correctness on 3/64 elements. After the compiler fix, the authored three-launch
+case passes strict correctness; its canonical 100-iteration perf result is the 9.1 µs row above, so it still loses.
+
+The watchdog is a separate compiler-quality gap. Stage 07 duplicates the Q RMSNorm work that Stage 06 shares: the Fold
+count grows from two to five and the `rsqrt` count from five to eight when a provider with iteration-bearing axes is
+sunk across contraction and sweep binders. A guard-only change breaks four neighbouring attention cases, while the
+known complete correction spans the projection-closing design. No unsafe local patch was retained.
+
+### Affected model targets
+
+| platform | affected target | latest bounded result | decision |
+| --- | --- | --- | --- |
+| A100 | s512 P×V target, `PLACE@a8=cut` | Two strict 5-warmup/20-iteration repeats: Emmy 67.038 µs versus `torch.compile` 52.224 µs; child kernels 24.55 and 40.83 µs | Correct, 1.284x slower; no promotion |
+| RTX 4090 | t16, `PLACE@a=cut` | Emmy 7.864 µs versus `torch.compile` 7.143 µs and eager 10.168 µs; three launches | Correct, 10.1% slower; no promotion |
+| RTX 4090 | t17, `PLACE@map=cut` | Emmy 10.047 µs versus `torch.compile` 8.433 µs and eager 90.823 µs; four launches | Correct, 19.1% slower; no promotion |
+| V100 | s512 down-projection plus residual | Typed public rounding: cut route 333 µs versus eager 75 µs; fused route about 512 µs versus eager 83 µs; both have 364/524,288 mismatches | Correctness gate still fails; no promotion |
+
+The A100 cut is a real 4.5x improvement over the 303 µs one-cut greedy result, but its exact child schedules do not
+assemble from repository receipts. The current receipt resolves a child before later kernel-set-changing feature
+choices. On RTX 4090 t16, for example, `PLACE@a=cut` reaches one OFF child and one pre-split child; a later
+`REDUCE=g32k` choice replaces the latter with a partial and a finalize kernel. Ambient `REDUCE` pins are not a safe
+encoding: they also reach the unsplit sibling, and one combined value would force a common schedule across children
+that need different rows. The durable representation must record the exact parent identity and structural choice in
+sequence, then join each resulting child identity to its exact schedule row. Reusing the pre-split identity or
+skipping structural forks would weaken the existing fail-closed contract, so the experimental replay change was
+reverted. A bounded V100 retune confirms the impact: it can select `PLACE=cut`, but cannot express schedules for the
+resulting children and stops at a 282.702 µs placement-only row.
+
+The A100 consumer remains limited by code generation rather than ordinary schedule selection. Its qualified row uses
+128 threads, 155 registers per thread, and 48 KiB shared memory. A narrow register-repack prototype removed the 8 KiB
+softmax-weight slab and reduced the consumer to 146 registers and 40 KiB, but CTA occupancy stayed at 19% and the
+consumer canary was 41.6 µs rather than the prior 40.83 µs. The prototype was reverted. Beating 52.224 µs requires a
+fragment-liveness design that drops below the next register-residency boundary, not just removal of the shared slab.
+
+The retained compiler fix preserves a public f16 store/load conversion across one transient loop buffer while leaving
+deliberate f32 internal workspaces unchanged. It closes strict correctness for the sm80 split-K corpus case. On V100 it
+halves the down-projection target's mean absolute error to about 0.00011, but does not close correctness: both fused and
+cut routes still have 364 mismatches, maximum absolute error 0.00390625. The remaining difference is contraction
+accumulation and reduction order rather than the now-preserved public rounding boundary.
+
+No golden row was promoted and no large serving experiment was started. Current sm80 corpus coverage has one win and
+three losses among the four measurable cases; one case still exceeds the watchdog. The next shared bottleneck is
+ordered child-schedule receipts, followed by projection multiplicity and register liveness in the remaining hard
+attention kernels.
+
 ## Cut-pinned attention qualification after the computed-B changes (main through `d2950079`, 2026-08-28)
 
 ### Corrected protocol

--- a/tests/compiler/cli/test_golden_file_replay.py
+++ b/tests/compiler/cli/test_golden_file_replay.py
@@ -1,14 +1,20 @@
 """Explicit working-golden replay for ``compile`` / ``run``."""
 
+import argparse
 import asyncio
 import copy
+from contextlib import redirect_stdout
+from io import StringIO
 from types import SimpleNamespace
 
 import pytest
 
 from emmy.compiler.context import Context
+from emmy.compiler.dim import Dim
+from emmy.compiler.dtype import F16
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import ConstantOp, InputOp
+from emmy.compiler.ir.frontend.ir import MatmulOp, RmsNormOp
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
 from emmy.compiler.loop_wire import loop_graph_from_wire, loop_graph_to_wire
@@ -16,7 +22,7 @@ from emmy.compiler.pipeline.search.golden import dump_golden_file, load_golden_f
 from emmy.compiler.pipeline.search.working_golden import write_trace_inventory
 
 
-def _working_loop(path, *, state="inventory"):
+def _working_loop(path, *, state="inventory", pins=None):
     graph = Graph()
     graph.add_node(InputOp(), [], Tensor("x", (16,)), node_id="x")
     graph.add_node(ElementwiseOp("relu"), ["x"], Tensor("y", (16,)), node_id="y")
@@ -31,6 +37,8 @@ def _working_loop(path, *, state="inventory"):
     entry = document["configs"][0]
     realization = entry["realizations"][0]
     realization["name"] = "working.relu"
+    if pins is not None:
+        realization["pins"] = pins
     if state in {"proposal", "tuned", "verified"}:
         realization["knobs"] = {"WORK": "w1x1"}
     if state == "tuned":
@@ -53,6 +61,33 @@ def _working_loop(path, *, state="inventory"):
     return document
 
 
+def _working_placement_route(path):
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (Dim(1), Dim(2), Dim(16)), dtype=F16), node_id="x")
+    graph.add_node(InputOp(), [], Tensor("wn", (Dim(16),), dtype=F16), node_id="wn")
+    graph.add_node(InputOp(), [], Tensor("w", (Dim(16), Dim(16)), dtype=F16), node_id="w")
+    graph.add_node(
+        RmsNormOp(),
+        ["x", "wn"],
+        Tensor("xn", (Dim(1), Dim(2), Dim(16)), dtype=F16),
+        node_id="xn",
+    )
+    graph.add_node(
+        MatmulOp(),
+        ["xn", "w"],
+        Tensor("y", (Dim(1), Dim(2), Dim(16)), dtype=F16),
+        node_id="y",
+    )
+    graph.inputs, graph.outputs = ["x", "wn", "w"], ["y"]
+    write_trace_inventory(graph, path, ctx=Context.from_target((8, 9)), force_loop_targets=True)
+    document = load_golden_file(path)
+    realization = document["configs"][0]["realizations"][0]
+    realization["name"] = "working.route"
+    realization["pins"] = {"FAST_MATH": False, "PLACE@a": "cut"}
+    dump_golden_file(document, path, overwrite=True)
+    return document
+
+
 def _args(path, **overrides):
     values = {
         "golden": "working.relu",
@@ -64,6 +99,23 @@ def _args(path, **overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def _compile_output(*args):
+    from emmy.commands.compile import register_compile_command
+    from emmy.compiler.target import set_target
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    register_compile_command(subparsers)
+    parsed = parser.parse_args(["compile", *args])
+    stdout = StringIO()
+    try:
+        with redirect_stdout(stdout):
+            parsed.func(parsed)
+    finally:
+        set_target(None)
+    return stdout.getvalue()
 
 
 def test_compile_working_file_uses_exact_loop_target(run_cli, tmp_path):
@@ -190,6 +242,67 @@ def test_working_proposal_supplies_graph_but_is_not_automatically_pinned(tmp_pat
     (manual,) = _pinned_samples_for_ir(args, args._golden_graph)
     assert manual.name == "ab WORK=w2x2"
     assert manual.knobs == {"WORK": "w2x2"}
+
+
+@pytest.mark.parametrize("explicit", [False, True], ids=["ordinary", "explicit"])
+def test_working_shared_placement_pins_select_the_exact_compile_target(tmp_path, monkeypatch, explicit):
+    path = tmp_path / "working-route.yaml"
+    _working_placement_route(path)
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.setenv("EMMY_NVCC_FLAGS", "")
+    monkeypatch.setenv("EMMY_READABLE", "1")
+    monkeypatch.setenv("EMMY_TUNE_DB", str(tmp_path / "tune.db"))
+    if explicit:
+        monkeypatch.setenv("EMMY_KNOBS", "PLACE@a=cut")
+
+    stdout = _compile_output(
+        "--golden-file",
+        str(path),
+        "--golden",
+        "working.route",
+        "--target",
+        "sm_89",
+        "--ir",
+        "tile",
+    )
+
+    assert tuple(line for line in stdout.splitlines() if line.startswith("=== ")) == (
+        "=== 0: k_rms_norm_matmul_reduce_3ac0aa__place_a4b222d654 ===",
+        "=== 1: y__partial -> y__partial ===",
+        "=== 2: y -> y ===",
+    )
+
+
+def test_working_ambiguous_placement_pin_regimes_leave_the_target_unpinned(tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    document = _working_loop(path, pins={"FAST_MATH": False, "PLACE@a": "cut"})
+    second = copy.deepcopy(document["configs"][0]["realizations"][0])
+    second["pins"]["FAST_MATH"] = True
+    document["configs"][0]["realizations"].append(second)
+    dump_golden_file(document, path, overwrite=True)
+    args = _args(path)
+
+    resolve_golden_arg(args)
+
+    assert args.golden_target_pins == {}
+
+
+def test_canonical_golden_does_not_select_structural_target_pins(monkeypatch, tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+    from emmy.compiler.pipeline.search import golden
+
+    path = tmp_path / "canonical-like.yaml"
+    document = _working_loop(path, pins={"FAST_MATH": False, "PLACE@a": "cut"})
+    records = golden.load_golden_records(document)
+    monkeypatch.setattr(golden, "goldens_for_live_gpu", lambda: records)
+    monkeypatch.setattr(golden, "GOLDEN_RECORDS", records)
+    args = _args(path, golden_file=None)
+
+    resolve_golden_arg(args)
+
+    assert args.golden_target_pins == {}
 
 
 def test_working_verified_row_is_automatically_pinned(tmp_path):

--- a/tests/compiler/cli/test_golden_file_replay.py
+++ b/tests/compiler/cli/test_golden_file_replay.py
@@ -1,10 +1,7 @@
 """Explicit working-golden replay for ``compile`` / ``run``."""
 
-import argparse
 import asyncio
 import copy
-from contextlib import redirect_stdout
-from io import StringIO
 from types import SimpleNamespace
 
 import pytest
@@ -99,23 +96,6 @@ def _args(path, **overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
-
-
-def _compile_output(*args):
-    from emmy.commands.compile import register_compile_command
-    from emmy.compiler.target import set_target
-
-    parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    register_compile_command(subparsers)
-    parsed = parser.parse_args(["compile", *args])
-    stdout = StringIO()
-    try:
-        with redirect_stdout(stdout):
-            parsed.func(parsed)
-    finally:
-        set_target(None)
-    return stdout.getvalue()
 
 
 def test_compile_working_file_uses_exact_loop_target(run_cli, tmp_path):
@@ -245,7 +225,7 @@ def test_working_proposal_supplies_graph_but_is_not_automatically_pinned(tmp_pat
 
 
 @pytest.mark.parametrize("explicit", [False, True], ids=["ordinary", "explicit"])
-def test_working_shared_placement_pins_select_the_exact_compile_target(tmp_path, monkeypatch, explicit):
+def test_working_shared_placement_pins_select_the_exact_compile_target(run_cli, tmp_path, monkeypatch, explicit):
     path = tmp_path / "working-route.yaml"
     _working_placement_route(path)
     monkeypatch.delenv("EMMY_KNOBS", raising=False)
@@ -255,7 +235,8 @@ def test_working_shared_placement_pins_select_the_exact_compile_target(tmp_path,
     if explicit:
         monkeypatch.setenv("EMMY_KNOBS", "PLACE@a=cut")
 
-    stdout = _compile_output(
+    rc, stdout, stderr = run_cli(
+        "compile",
         "--golden-file",
         str(path),
         "--golden",
@@ -266,11 +247,13 @@ def test_working_shared_placement_pins_select_the_exact_compile_target(tmp_path,
         "tile",
     )
 
-    assert tuple(line for line in stdout.splitlines() if line.startswith("=== ")) == (
-        "=== 0: k_rms_norm_matmul_reduce_3ac0aa__place_a4b222d654 ===",
-        "=== 1: y__partial -> y__partial ===",
-        "=== 2: y -> y ===",
-    )
+    # The shared PLACE regime selects the routed target: the cut fires and splits the compile
+    # into the placed producer plus its partial/final consumers. Kernel names carry volatile
+    # identity digests, so assert the kernel set's shape, not the spelled names.
+    assert rc == 0, stderr
+    headers = [line for line in stdout.splitlines() if line.startswith("=== ")]
+    assert len(headers) == 3, stdout
+    assert sum("__place_" in line for line in headers) == 1, stdout
 
 
 def test_working_ambiguous_placement_pin_regimes_leave_the_target_unpinned(tmp_path):

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -290,6 +290,19 @@ def test_ab_samples_parse_label_and_shape():
     }
 
 
+def test_ab_replay_retains_scoped_off_exception_to_bare_pin():
+    """A scoped OFF overrides a non-OFF bare pin at that exact site."""
+    from emmy.commands.run import _ab_samples, _sample_replay_knobs
+
+    (sample,) = _ab_samples(["REDUCE=coop,REDUCE@a.fold.a3=,REDUCE@a7="])
+
+    assert _sample_replay_knobs(sample) == {
+        "REDUCE": "coop",
+        "REDUCE@a.fold.a3": "",
+        "REDUCE@a7": "",
+    }
+
+
 def test_ir_ab_replay_retains_boolean_input_pins(tmp_path, monkeypatch):
     """The re-lowered IR path must use the same merged input-and-schedule pin map."""
     import contextlib

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -254,6 +254,65 @@ def test_fragment_lift_declines_nonuniform_select_branches():
             )
 
 
+def test_fragment_softmax_value_seam_reuses_score_fragments():
+    """The matching score/value lane map repacks C fragments while B keeps its slab."""
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline import CUDA_PASSES, Pipeline  # noqa: PLC0415
+    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
+
+    q, k, v = (torch.randn(1, 2, 64, 16, dtype=torch.float16) for _ in range(3))
+    graph = trace_module(_Sdpa(), (q, k, v))
+    knobs = {
+        "PLACE": "fuse",
+        "WORK": "w2x1",
+        "TILE@a3": "mma_m16n8k16_f16_f32/f2x4",
+        "TILE@pj": "mma_m16n8k16_f16_f32/f2x2/k2",
+        "STAGE@a3": "d1/smem-async",
+        "STAGE@pj": "d1/smem",
+        "REDUCE": "",
+        "RASTER": "",
+    }
+    with pinned_knobs(knobs):
+        lowered = Pipeline.build(CUDA_PASSES).run(graph, ctx=Context.from_target((8, 0)))
+    srcs = [node.op.kernel_source for node in lowered.nodes.values() if getattr(node.op, "kernel_source", None)]
+    assert len(srcs) == 1
+    src = srcs[0]
+    assert "__half _b_smem[" in src, "the value operand must retain its ordinary staged transport"
+    assert src.count("emmy_c_to_a_f16(_partial_a") == 4
+    assert "__half _a_smem[" not in src
+
+
+def test_fragment_softmax_value_seam_requires_exact_lane_map_and_single_buffer():
+    """The register handoff declines a different output map or register ping-pong."""
+    from emmy.compiler.ir.axis import Axis  # noqa: PLC0415
+    from emmy.compiler.ir.schedule import Stage, TilePlan, Workers  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.lowering.kernel._atom import _repacked_a_fragments  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.lowering.kernel._eval import Value  # noqa: PLC0415
+
+    work = Workers.parse("w2x1")
+    assert work is not None
+    m, score, value = Axis("m", 64), Axis("score", 64), Axis("value", 16)
+    producer = TilePlan.parse("mma_m16n8k16_f16_f32/f2x4", work).at(m, score)
+    consumer = TilePlan.parse("mma_m16n8k16_f16_f32/f2x2/k2", work).at(m, value)
+    fragments = Value.frag((("p00", "p01", "p02", "p03"), ("p10", "p11", "p12", "p13")))
+    stage = Stage(bk_elems=32)
+
+    assert _repacked_a_fragments(fragments, producer_tile=producer, consumer_tile=consumer, stage=stage, static_k=True) == fragments.data
+    different_map = consumer.at(Axis("other", 64), value)
+    assert _repacked_a_fragments(fragments, producer_tile=producer, consumer_tile=different_map, stage=stage, static_k=True) is None
+    assert _repacked_a_fragments(fragments, producer_tile=producer, consumer_tile=consumer, stage=stage, static_k=False) is None
+    assert (
+        _repacked_a_fragments(
+            fragments,
+            producer_tile=producer,
+            consumer_tile=consumer,
+            stage=Stage(reg_depth=2, bk_elems=32),
+            static_k=True,
+        )
+        is None
+    )
+
+
 # =========================================================================== #
 # Scalar-tier flash (the FLASH knob).
 # =========================================================================== #

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -254,65 +254,6 @@ def test_fragment_lift_declines_nonuniform_select_branches():
             )
 
 
-def test_fragment_softmax_value_seam_reuses_score_fragments():
-    """The matching score/value lane map repacks C fragments while B keeps its slab."""
-    from emmy.compiler.context import Context  # noqa: PLC0415
-    from emmy.compiler.pipeline import CUDA_PASSES, Pipeline  # noqa: PLC0415
-    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
-
-    q, k, v = (torch.randn(1, 2, 64, 16, dtype=torch.float16) for _ in range(3))
-    graph = trace_module(_Sdpa(), (q, k, v))
-    knobs = {
-        "PLACE": "fuse",
-        "WORK": "w2x1",
-        "TILE@a3": "mma_m16n8k16_f16_f32/f2x4",
-        "TILE@pj": "mma_m16n8k16_f16_f32/f2x2/k2",
-        "STAGE@a3": "d1/smem-async",
-        "STAGE@pj": "d1/smem",
-        "REDUCE": "",
-        "RASTER": "",
-    }
-    with pinned_knobs(knobs):
-        lowered = Pipeline.build(CUDA_PASSES).run(graph, ctx=Context.from_target((8, 0)))
-    srcs = [node.op.kernel_source for node in lowered.nodes.values() if getattr(node.op, "kernel_source", None)]
-    assert len(srcs) == 1
-    src = srcs[0]
-    assert "__half _b_smem[" in src, "the value operand must retain its ordinary staged transport"
-    assert src.count("emmy_c_to_a_f16(_partial_a") == 4
-    assert "__half _a_smem[" not in src
-
-
-def test_fragment_softmax_value_seam_requires_exact_lane_map_and_single_buffer():
-    """The register handoff declines a different output map or register ping-pong."""
-    from emmy.compiler.ir.axis import Axis  # noqa: PLC0415
-    from emmy.compiler.ir.schedule import Stage, TilePlan, Workers  # noqa: PLC0415
-    from emmy.compiler.pipeline.passes.lowering.kernel._atom import _repacked_a_fragments  # noqa: PLC0415
-    from emmy.compiler.pipeline.passes.lowering.kernel._eval import Value  # noqa: PLC0415
-
-    work = Workers.parse("w2x1")
-    assert work is not None
-    m, score, value = Axis("m", 64), Axis("score", 64), Axis("value", 16)
-    producer = TilePlan.parse("mma_m16n8k16_f16_f32/f2x4", work).at(m, score)
-    consumer = TilePlan.parse("mma_m16n8k16_f16_f32/f2x2/k2", work).at(m, value)
-    fragments = Value.frag((("p00", "p01", "p02", "p03"), ("p10", "p11", "p12", "p13")))
-    stage = Stage(bk_elems=32)
-
-    assert _repacked_a_fragments(fragments, producer_tile=producer, consumer_tile=consumer, stage=stage, static_k=True) == fragments.data
-    different_map = consumer.at(Axis("other", 64), value)
-    assert _repacked_a_fragments(fragments, producer_tile=producer, consumer_tile=different_map, stage=stage, static_k=True) is None
-    assert _repacked_a_fragments(fragments, producer_tile=producer, consumer_tile=consumer, stage=stage, static_k=False) is None
-    assert (
-        _repacked_a_fragments(
-            fragments,
-            producer_tile=producer,
-            consumer_tile=consumer,
-            stage=Stage(reg_depth=2, bk_elems=32),
-            static_k=True,
-        )
-        is None
-    )
-
-
 # =========================================================================== #
 # Scalar-tier flash (the FLASH knob).
 # =========================================================================== #

--- a/tests/compiler/ir/stmt/test_readable_chain_fold.py
+++ b/tests/compiler/ir/stmt/test_readable_chain_fold.py
@@ -9,10 +9,11 @@ across the redefinition.
 
 from __future__ import annotations
 
-from emmy.compiler.dtype import I32, U32
+from emmy.compiler.dtype import F16, F32, I32, U32
+from emmy.compiler.ir.expr import Literal
 from emmy.compiler.ir.stmt.base import RenderCtx, render_body
 from emmy.compiler.ir.stmt.body import Body
-from emmy.compiler.ir.stmt.leaves import Accum, Assign
+from emmy.compiler.ir.stmt.leaves import Accum, Assign, Load
 
 
 def _render(*stmts) -> list[str]:
@@ -55,6 +56,26 @@ def test_fold_preserves_integer_dtype_for_bitwise_consumer(monkeypatch) -> None:
         ctx,
     )
     assert lines == ["    int nibble = (packed >> shift) & mask;"]
+
+
+def test_fold_keeps_mixed_dtype_conversion_named(monkeypatch) -> None:
+    """A readability fold must not bypass the target-aware conversion in ``Assign.render``."""
+    monkeypatch.setenv("EMMY_READABLE", "1")
+    lines = render_body(
+        Body(
+            (
+                Load(name="scale", input="scale_buffer", index=(Literal(0, "int"),), dtype=F16),
+                Assign(name="scaled", op="multiply", args=("acc", "scale"), dtype=F32),
+                Assign(name="out", op="add", args=("bias", "scaled"), dtype=F32),
+            )
+        ),
+        RenderCtx(ssa_dtypes={"acc": "f32", "bias": "f32"}, shapes={"scale_buffer": (1,)}),
+    )
+    assert lines == [
+        "    __half scale = scale_buffer[0];",
+        "    float scaled = acc * __half2float(scale);",
+        "    float out = bias + scaled;",
+    ]
 
 
 def test_fold_declines_across_operand_redefinition(monkeypatch) -> None:

--- a/tests/compiler/ir/test_graph.py
+++ b/tests/compiler/ir/test_graph.py
@@ -217,6 +217,31 @@ def test_kernel_op_windowed_axis_roundtrip():
     assert op.smem_bytes() == 128 * 32 * 2
 
 
+def test_tile_op_scalar_atom_schedule_roundtrip():
+    """A dumped tile-stage graph must rehydrate the scalar output-tile schedule."""
+    import json
+
+    from emmy.compiler.ir.atom import ScalarAtom
+    from emmy.compiler.ir.pure import Fold
+    from emmy.compiler.ir.schedule import TilePlan
+    from emmy.compiler.ir.tile import TileOp
+
+    g = Graph()
+    x = g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (1,), "f16"), node_id="x")
+    g.add_node(
+        op=TileOp(op=Fold.projection(results=(0.0,)), schedule={"TILE": TilePlan()}),
+        inputs=[x],
+        output=Tensor("out", (1,), "f16"),
+        node_id="out",
+    )
+    g.inputs, g.outputs = [x], ["out"]
+
+    loaded = Graph.from_dict(json.loads(json.dumps(g.to_dict(), default=str)))
+    plan = loaded.nodes["out"].op.schedule["TILE"]
+    assert isinstance(plan, TilePlan)
+    assert isinstance(plan.atom, ScalarAtom)
+
+
 def test_stmt_eval_scope_reads_non_finite_literals():
     """``repr(float('-inf'))`` is the bare token ``-inf``, which does not eval without a name.
 

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -415,6 +415,75 @@ def test_reduced_qk_attention_offers_the_statistic_arm_b_seams_idempotently() ->
     assert TileOp(op=tile.op, name=tile.name, place=tile.place, output_specs=tile.output_specs).op is tile.op
 
 
+def _statistic_under_two_binders() -> TileOp:
+    """A row statistic feeding a contraction nested under a separate fold binder."""
+    r, k, t = Axis("r", Dim(16)), Axis("k", Dim(16)), Axis("t", Dim(4))
+    stat_init, stat_combine = M(ElementwiseImpl("add"), names=("ss",))
+    stat = Fold(
+        axis=r,
+        lift=Lambda(
+            params=("r",),
+            body=Body(
+                (
+                    Load(name="xr", input="x", index=(Var("m"), Var("r"))),
+                    Assign(name="sq", op="multiply", args=("xr", "xr")),
+                )
+            ),
+            results=("sq",),
+        ),
+        init=stat_init,
+        combine=stat_combine,
+    )
+    inv = Assign(name="inv", op="rsqrt", args=("ss",))
+    b_cone = Fold.projection(
+        body=Body(
+            (
+                Load(name="wv", input="w", index=(Var("t"), Var("k"))),
+                Assign(name="wn", op="multiply", args=("wv", "inv")),
+            )
+        ),
+        results=("wn",),
+    )
+    score = Fold.contraction(
+        k_axis=k,
+        a=Load(name="qv", input="q", index=(Var("m"), Var("k"))),
+        channels=(Channel(b=b_cone, acc="acc"),),
+    )
+    sweep_init, sweep_combine = M(ElementwiseImpl("maximum"), names=("mx",))
+    sweep = Fold(
+        axis=t,
+        lift=Lambda(params=("t",), body=Body((score,)), results=("acc",)),
+        init=sweep_init,
+        combine=sweep_combine,
+    )
+    return TileOp(op=Fold.projection(body=Body((stat, inv, sweep))), place=Placement(free=(Axis("m", 4),)))
+
+
+def _loop_scopes(stmts, enclosing: tuple[str, ...] = ()) -> list[tuple[str, tuple[str, ...]]]:
+    """Each synthesized loop axis paired with its enclosing loop axes."""
+    out: list[tuple[str, tuple[str, ...]]] = []
+    for stmt in stmts:
+        axis = getattr(stmt, "axis", None)
+        inner = (*enclosing, axis.name) if axis is not None else enclosing
+        if axis is not None:
+            out.append((axis.name, enclosing))
+        for body in stmt.nested():
+            out.extend(_loop_scopes(list(body), inner))
+    return out
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="projection closure does not preserve an iteration-bearing provider's evaluation domain",
+)
+def test_a_statistic_is_not_sunk_beneath_new_binders() -> None:
+    """Projection closure must preserve the statistic's evaluation multiplicity."""
+    tile = _statistic_under_two_binders()
+
+    scopes = [enclosing for name, enclosing in _loop_scopes(tile.op.lower()) if name == "r"]
+    assert scopes == [()], scopes
+
+
 def test_a_fold_reading_a_sweep_axis_stays_a_body_member() -> None:
     """A per-column reduce whose streamed load reads the boundary store's sweep axis must stay a
     projection BODY member: reconstitution re-wraps body stmts inside the sweep ``Loop``, but an

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -52,6 +52,28 @@ def test_tile_post_init_canonicalizes_contraction() -> None:
     assert TileOp(op=tile.op, place=tile.place).op == tile.op
 
 
+def test_tile_post_init_canonicalizes_broadcast_batched_contraction() -> None:
+    axis = Axis("k", Dim(32))
+    body = Body(
+        (
+            Load(name="left", input="x", index=(Var("k"), Var("batch") * 8 + Var("m"))),
+            Load(name="right", input="w", index=(Var("n"), Var("k"))),
+            Assign(name="product", op="multiply", args=("left", "right")),
+        )
+    )
+    init, combine = M(ElementwiseImpl("add"), names=("acc",))
+    planar = Fold(axis=axis, lift=Lambda(params=("k",), body=body, results=("product",)), init=init, combine=combine)
+
+    tile = TileOp(
+        op=planar,
+        place=Placement(free=(Axis("batch", 4), Axis("m", 8), Axis("n", 16))),
+    )
+
+    assert tile.op.role is AxisRole.CONTRACTION
+    assert tile.op.a.input == "w"
+    assert tile.op.b.input == "x"
+
+
 def test_tile_post_init_recovers_an_elided_unit_contraction_row() -> None:
     axis = Axis("k", Dim(16))
     body = Body(

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -14,7 +14,7 @@ from emmy.compiler.ir.pure import Channel, Fold, Lambda, M, is_contraction
 from emmy.compiler.ir.schedule import TilePlan
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp, lambda_equivalent_clusters
-from emmy.compiler.ir.tile.path import family_sites, resolve, sites
+from emmy.compiler.ir.tile.path import family_sites, sites
 from emmy.compiler.pipeline import Pipeline
 from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams
 from emmy.compiler.pipeline.search.golden import _lifted_target, load_golden_file, load_golden_records
@@ -288,11 +288,11 @@ def test_promoted_attention_output_sweep_closes_the_a100_b_seam_idempotently() -
     assert tuple(axis.name for axis in tile.place.free) == ("a0", "a1", "a6")
     assert all(spec.sweep is None for spec in tile.output_specs)
     assert reconstructed.op is tile.op
-    # The previously offered edge is still addressable: its cone folded into the value cluster,
-    # so the seam that covers it names it among the representative's siblings.
-    site = resolve(tile.op, "PLACE@map.fold.a.fold.b1")
-    covered = {id(node) for seam in cuttable_seams(tile) for node in (seam.node, *(sibling for sibling, _ in seam.siblings))}
-    assert site is not None and id(site.node) in covered
+    # The authored seam carries the lexical provider closure needed to cut the input projection
+    # without duplicating the statistic.
+    seams = {seam.spelling: seam for seam in cuttable_seams(tile)}
+    seam = seams["PLACE@map.fold.a.fold.b1"]
+    assert seam.requires
 
 
 def _key_swept_score(shared_reader: bool = False) -> TileOp:
@@ -405,11 +405,10 @@ def test_reduced_qk_attention_offers_the_statistic_arm_b_seams_idempotently() ->
     tile = _lifted_target(record)
     seams = {seam.spelling: seam for seam in cuttable_seams(tile)}
     seam = seams["PLACE@map.fold.a.map.fold.fold.b1"]
-    # The score contractions' K cones are one VALUE. Name-identical copies (the second-path
-    # duplicates of each statistic arm) collapse into shared objects at normalization, so only
-    # the copies captured under DIFFERENT axis names — the sum arm and the softmax-V arm — remain
-    # clustering siblings, each with its capture correspondence.
-    assert len(seam.siblings) == 2
+    # The score contractions' K cones are one VALUE. Retaining the shared statistic at its
+    # defining scope lets normalization collapse one more duplicate, leaving one sibling whose
+    # differently named key axis is recorded by the capture correspondence.
+    assert len(seam.siblings) == 1
     assert all(dict(pairs).keys() == dict(seam.siblings[0][1]).keys() for _, pairs in seam.siblings)
     assert "PLACE@map.fold.a.map.fold.fold.b2" not in seams
     assert TileOp(op=tile.op, name=tile.name, place=tile.place, output_specs=tile.output_specs).op is tile.op
@@ -472,10 +471,6 @@ def _loop_scopes(stmts, enclosing: tuple[str, ...] = ()) -> list[tuple[str, tupl
     return out
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="projection closure does not preserve an iteration-bearing provider's evaluation domain",
-)
 def test_a_statistic_is_not_sunk_beneath_new_binders() -> None:
     """Projection closure must preserve the statistic's evaluation multiplicity."""
     tile = _statistic_under_two_binders()

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from emmy.compiler.ir.axis import Axis, AxisRole
 from emmy.compiler.ir.expr import Var
-from emmy.compiler.ir.pure.fold import Channel, Fold, operand_body, operand_name
+from emmy.compiler.ir.pure.fold import Channel, Fold, operand_body, operand_name, splice_operands
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
 from emmy.compiler.ir.stmt.passes import rewrite
@@ -85,6 +85,18 @@ def test_single_channel_node_is_the_plain_matmul() -> None:
 
 
 # --- inline computed operands ------------------------------------------------------------------- #
+
+
+def test_splice_orders_a_sibling_provider_before_its_consumer() -> None:
+    """A provider used only by another operand still precedes that dependent operand."""
+    provider = Fold.projection(body=Body((Load(name="raw", input="x", index=()), Assign(name="scale", op="rsqrt", args=("raw",)))))
+    consumer = Fold.projection(body=Body((Assign(name="weighted", op="multiply", args=("value", "scale")),)))
+    independent = Fold.projection(body=Body((Assign(name="offset", op="copy", args=("bias",)),)))
+    projection = (Assign(name="out", op="add", args=("weighted", "offset")),)
+
+    lowered = splice_operands((consumer, independent, provider), projection)
+
+    assert [stmt.defines()[-1] for stmt in lowered] == ["offset", "raw", "scale", "weighted", "out"]
 
 
 def test_a_computed_operand_is_stored_inline_and_flattens_on_the_edge() -> None:

--- a/tests/compiler/ir/tile/test_structural_reduction.py
+++ b/tests/compiler/ir/tile/test_structural_reduction.py
@@ -399,16 +399,17 @@ def test_computed_b_factorizes_at_the_scalar_tier() -> None:
     assert exps, "the computed B operand (exp of the weight) must survive into the scalar kernel body"
 
 
-def test_output_tiled_contraction_keeps_a_sibling_provider_for_its_computed_b() -> None:
+def test_output_tiled_contraction_keeps_a_sibling_provider_for_its_computed_b(monkeypatch) -> None:
     """Selecting an output-tiled contraction from a projection must retain a sibling Fold whose
     result its computed B edge reads. The sibling varies over the contraction's output column, so
     it belongs inside the per-cell compute fill; treating it as a post-contraction projection
     leaves the fill reading an undefined scalar."""
     from emmy.compiler.dtype import F16
     from emmy.compiler.graph import Tensor
+    from emmy.compiler.ir.kernel.ir import RegStore
     from emmy.compiler.ir.schedule import Placement, Stage, Workers
     from emmy.compiler.ir.tile.ops import sched_of
-    from emmy.compiler.pipeline.passes.lowering.kernel._factor import factorize
+    from emmy.compiler.pipeline.passes.lowering.kernel import _factor
 
     m, n, k, r = Axis("m", 16), Axis("n", 32), Axis("k", 16), Axis("r", 16)
     statistic = Fold(
@@ -477,13 +478,28 @@ def test_output_tiled_contraction_keeps_a_sibling_provider_for_its_computed_b() 
     sched.put("TILE", contraction, plan)
     sched.put("STAGE", contraction, Stage(depth=1, transport="smem", smem=("scaled",), bk_elems=16))
 
-    lowered = factorize(tile, root=None)
+    sliced_results = []
+    provider_slice = _factor._provider_slice
+
+    def track_slice(edge, required):
+        sliced_results.append(frozenset(required))
+        return provider_slice(edge, required)
+
+    monkeypatch.setattr(_factor, "_provider_slice", track_slice)
+    lowered = _factor.factorize(tile, root=None)
     stmts = tuple(lowered.body.iter())
     first_def = {name: index for index, stmt in reversed(tuple(enumerate(stmts))) for name in stmt.defines()}
     norm_reads = [(index, name) for index, stmt in enumerate(stmts) for name in stmt.deps() if name.startswith("norm")]
     assert norm_reads
     assert all(first_def.get(name, len(stmts)) < index for index, name in norm_reads)
     assert all("m" not in expr.free_vars() for stmt in stmts for expr in stmt.exprs())
+    stat_loads = [stmt for stmt in stmts if isinstance(stmt, Load) and stmt.name.startswith("stat_in")]
+    assert len(stat_loads) == 8, "the statistic belongs only to the eight-column computed-B fill"
+    definitions = [name for stmt in stmts for name in stmt.defines()]
+    assert sum(name.startswith("norm") for name in definitions) == 8
+    bias_loads = [load for stmt in stmts if isinstance(stmt, RegStore) for load in stmt.epilogue.loads if load.name == "row_bias"]
+    assert len(bias_loads) == 4, "the unrelated provider result belongs only to the four output fragments"
+    assert sliced_results == [frozenset(("norm",)), frozenset(("row_bias",))]
 
 
 def test_both_edges_may_be_computed_at_once() -> None:

--- a/tests/compiler/ir/tile/test_structural_reduction.py
+++ b/tests/compiler/ir/tile/test_structural_reduction.py
@@ -399,6 +399,93 @@ def test_computed_b_factorizes_at_the_scalar_tier() -> None:
     assert exps, "the computed B operand (exp of the weight) must survive into the scalar kernel body"
 
 
+def test_output_tiled_contraction_keeps_a_sibling_provider_for_its_computed_b() -> None:
+    """Selecting an output-tiled contraction from a projection must retain a sibling Fold whose
+    result its computed B edge reads. The sibling varies over the contraction's output column, so
+    it belongs inside the per-cell compute fill; treating it as a post-contraction projection
+    leaves the fill reading an undefined scalar."""
+    from emmy.compiler.dtype import F16
+    from emmy.compiler.graph import Tensor
+    from emmy.compiler.ir.schedule import Placement, Stage, Workers
+    from emmy.compiler.ir.tile.ops import sched_of
+    from emmy.compiler.pipeline.passes.lowering.kernel._factor import factorize
+
+    m, n, k, r = Axis("m", 16), Axis("n", 32), Axis("k", 16), Axis("r", 16)
+    statistic = Fold(
+        axis=r,
+        lift=Lambda(
+            params=("r",),
+            body=Body(
+                (
+                    Load(name="stat_in", input="W", index=(Var("n"), Var("r"))),
+                    Assign(name="square", op="multiply", args=("stat_in", "stat_in")),
+                )
+            ),
+            results=("square",),
+        ),
+        init=(0.0,),
+        combine=Lambda(
+            params=("stat", "stat__o"),
+            body=Body((Assign(name="stat", op="add", args=("stat", "stat__o")),)),
+            results=("stat",),
+        ),
+    )
+    provider = Fold.projection(
+        operands=(statistic,),
+        body=Body(
+            (
+                Assign(name="norm", op="rsqrt", args=("stat",)),
+                Load(name="row_bias", input="Bias", index=(Var("m"),)),
+            )
+        ),
+        results=("norm", "row_bias"),
+    )
+    computed_b = Fold.projection(
+        body=Body(
+            (
+                Load(name="weight", input="W", index=(Var("n"), Var("k"))),
+                Assign(name="scaled", op="multiply", args=("weight", "norm")),
+            )
+        ),
+        results=("scaled",),
+    )
+    contraction = Fold.contraction(
+        k_axis=k,
+        a=Load(name="activation", input="A", index=(Var("m"), Var("k"))),
+        channels=(Channel(b=computed_b, acc="out"),),
+    )
+    root = Fold.projection(
+        operands=(provider, contraction),
+        body=Body((Assign(name="biased", op="add", args=("out", "row_bias")),)),
+        results=("biased",),
+    )
+    workers = Workers.parse("w1x1")
+    plan = TilePlan.parse("mma_m16n8k16_f16_f32/f1x4/k1", workers).at(m, n)
+    tile = TileOp(
+        op=root,
+        name="out",
+        place=Placement(free=(m, n), grid=(m, n), mapped=True),
+        output_specs=(OutputSpec(Write(output="out", index=(Var("m"), Var("n")), value="biased")),),
+    )
+    tile.inputs = {
+        "A": Tensor("A", (16, 16), F16),
+        "Bias": Tensor("Bias", (16,), F16),
+        "W": Tensor("W", (32, 16), F16),
+    }
+    tile.outputs = {"out": Tensor("out", (16, 32), F16)}
+    sched = sched_of(tile)
+    sched.put("TILE", contraction, plan)
+    sched.put("STAGE", contraction, Stage(depth=1, transport="smem", smem=("scaled",), bk_elems=16))
+
+    lowered = factorize(tile, root=None)
+    stmts = tuple(lowered.body.iter())
+    first_def = {name: index for index, stmt in reversed(tuple(enumerate(stmts))) for name in stmt.defines()}
+    norm_reads = [(index, name) for index, stmt in enumerate(stmts) for name in stmt.deps() if name.startswith("norm")]
+    assert norm_reads
+    assert all(first_def.get(name, len(stmts)) < index for index, name in norm_reads)
+    assert all("m" not in expr.free_vars() for stmt in stmts for expr in stmt.exprs())
+
+
 def test_both_edges_may_be_computed_at_once() -> None:
     """Nothing privileges one side: a contraction of two computed operands lowers too."""
     c = _computed_b_contraction(a_load=False)

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -90,6 +90,7 @@ lowering.
 | `loop/lifting/025_lift_scan.py`        | `ScanOp` → `LoopOp`        | `test_pipeline_semantics.py::test_scan_*`                                          |
 | `loop/lifting/030_lift_indexmap.py`    | `IndexMapOp` → `LoopOp`    | `test_optimization_rules.py::test_matmul_with_transpose_fuses_to_one_kernel` (e2e) |
 | `loop/lifting/040_lift_gather.py`      | `GatherOp` → `LoopOp`      | `test_torch_ops.py::test_gather`                                                   |
+| `loop/lifting/090_spell_store_rounding.py` | public narrowing boundary → typed `copy` | `test_spell_store_rounding.py`                             |
 | `loop/fusion/010_merge_loop_ops.py`    | `LoopOp → LoopOp` (splice) | `test_fusion_rules.py` (fixpoint)                                                  |
 
 Numerical correctness for lifted + merged kernels runs through the

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -122,7 +122,8 @@ widths and unit counts match on the physical output axes, and that f32 computed-
 output-tile rows when no MMA atom applies. `test_cut_forks.py` checks fused and closed Fold-edge choices for SDPA score
 production, causal SDPA, and multi-output roots, then pins each representative cut through CUDA lowering, and proves
 child-identity schedule receipts round-trip: under a pinned cut each child's stored identity decodes only its own
-kernel's schedule rows and joins the verified tier as-is. Direct
+kernel's schedule rows and joins the verified tier as-is, including when target-boundary drift makes the regenerated
+Loop target contain several kernels and the stored identity must select one. Direct
 contraction-operand cuts remain strict xfails until Tile IR represents their materialized workspace dtype.
 The generated carrier's numerical laws are covered
 independently by `tests/compiler/ir/pure/test_carrier_gen.py` and `test_lambda_monoid.py`; end-to-end softmax and

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -23,7 +23,7 @@ from emmy.compiler.ir.tile.identity import deploy_identity
 from emmy.compiler.loop_wire import loop_graph_to_wire
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule, RuleSkipped
 from emmy.compiler.pipeline.fork import Fork
-from emmy.compiler.pipeline.passes.lowering.tile._cut import CutSite, _workspace_axes, cuttable_seams
+from emmy.compiler.pipeline.passes.lowering.tile._cut import CutSite, _producer_order, _workspace_axes, cuttable_seams
 from emmy.compiler.pipeline.pipeline import Run, _is_structural_option
 from emmy.compiler.pipeline.search.golden import (
     GoldenRecord,
@@ -188,6 +188,19 @@ def test_cut_workspace_retains_static_unit_axes() -> None:
     )
 
     assert _workspace_axes(seam, produced) == (unit, column)
+
+
+def test_composed_cut_topologically_orders_equal_degree_workspace_chain() -> None:
+    """Counting direct workspace reads cannot order A->C->B when A and C each read one."""
+
+    def piece(name: str, source: str | None):
+        body = Body((Load(name=f"{name}_value", input=source or "input", index=()),))
+        produced = Fold.projection(body=body, results=(f"{name}_value",))
+        return (None, produced, (), (), name, (f"{name}_value",), (name,))
+
+    pieces = [piece("a", "c"), piece("c", "b"), piece("b", None)]
+
+    assert [buffers[0] for *_, buffers in _producer_order(pieces)] == ["b", "c", "a"]
 
 
 def test_pinned_fusion_lowers_one_computed_operand_kernel() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -20,7 +20,8 @@ from emmy.compiler.ir.pure.fold import Channel, Fold
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.identity import deploy_identity
-from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Match, Pipeline, Rule, RuleSkipped
+from emmy.compiler.loop_wire import loop_graph_to_wire
+from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule, RuleSkipped
 from emmy.compiler.pipeline.fork import Fork
 from emmy.compiler.pipeline.passes.lowering.tile._cut import CutSite, _workspace_axes, cuttable_seams
 from emmy.compiler.pipeline.pipeline import Run, _is_structural_option
@@ -450,6 +451,30 @@ def test_child_identity_receipts_decode_per_child_and_join_by_stored_identity() 
     stale = GoldenRecord(knobs=dict(row_a), identity="0" * 64, **fields)
     reason = decode_record(stale)
     assert reason is not None and "equals none" in reason
+
+
+def test_child_identity_receipt_selects_one_kernel_from_multi_kernel_loop_target() -> None:
+    """A stored child identity is the selector when a regenerated target now lowers to several
+    kernels; strict decoding must consult that identity's rows before requiring a one-kernel lift."""
+    graph = _sdpa_graph(False)
+    _input(graph, "x", (4, 32))
+    graph.add_node(SoftmaxOp(axis=-1), ["x"], Tensor("softmax", (4, 32), "f16"), node_id="softmax")
+    graph.inputs.append("x")
+    graph.outputs.append("softmax")
+    loop = Pipeline.build(LOOP_PASSES).run(graph.copy(), ctx=_CTX)
+    fields = {
+        **_receipt_fields(),
+        "program_wire": graph_to_wire(graph),
+        "origins": (),
+        "loop_index": 0,
+        "loop_wire": loop_graph_to_wire(loop),
+    }
+    parent = GoldenRecord(knobs={}, **fields)
+    with pytest.raises(ValueError, match="target lowers to 2 kernels"):
+        _lifted_target(parent)
+    identity, rows = next((identity, rows) for identity, rows in _candidate_rows(parent).items() if identity is not None)
+    receipt = GoldenRecord(knobs=dict(next(iter(rows))), identity=identity, **fields)
+    assert decode_record(receipt) is None
 
 
 def test_receipt_validation_requires_child_identity_and_place_pins_stay_live() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -418,16 +418,15 @@ _STAT_PINS = {
 
 
 def test_statistics_seams_close_via_providers_and_declare_requirements() -> None:
-    """The softmax-statistics folds capture host-provided scalars and each other's accumulator;
-    provider closure offers them anyway, with the chain recorded as a requirement."""
+    """Provider closure records every fold-produced capture as a requirement."""
     match, graph = _composed_case_match()
     tile = next(node.op for node in graph.nodes.values() if isinstance(node.op, TileOp))
     seams = {seam.spelling: seam for seam in cuttable_seams(tile)}
+    norm = seams["PLACE@map.fold.a21"]
     first = seams["PLACE@map.fold.a.map.fold.a31"]
     second = seams["PLACE@map.fold.a.map.fold.a32"]
-    assert first.providers and not first.requires
-    assert second.providers and len(second.requires) == 1
-    assert second.requires[0][1] is first.node
+    assert first.providers and [producer for _, producer in first.requires] == [norm.node]
+    assert second.providers and [producer for _, producer in second.requires] == [norm.node, first.node]
 
 
 def test_dependent_seam_pins_pull_their_producer_into_the_composed_cut() -> None:
@@ -437,7 +436,11 @@ def test_dependent_seam_pins_pull_their_producer_into_the_composed_cut() -> None
     node = next(node for node in graph.nodes.values() if isinstance(node.op, TileOp))
     with pinned_knobs({"PLACE@map.fold.a.map.fold.a32": "cut", **_OFF}):
         fork = _CUT.rewrite(match, node)
-    assert set(fork.knobs) == {"PLACE@map.fold.a.map.fold.a32", "PLACE@map.fold.a.map.fold.a31"}
+    assert set(fork.knobs) == {
+        "PLACE@map.fold.a.map.fold.a32",
+        "PLACE@map.fold.a.map.fold.a31",
+        "PLACE@map.fold.a21",
+    }
 
 
 def test_statistics_route_shares_the_row_reduction_across_output_keys() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -10,13 +10,14 @@ import pytest
 
 from emmy.compiler.backend.cuda.backend import CudaBackend
 from emmy.compiler.context import Context
-from emmy.compiler.dtype import F16
+from emmy.compiler.dtype import F16, F32
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.frontend.ir import SdpaOp, SoftmaxOp
-from emmy.compiler.ir.pure.fold import Channel, Fold
+from emmy.compiler.ir.pure.carrier import exp_combine_states
+from emmy.compiler.ir.pure.fold import Channel, Fold, Lambda
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.identity import deploy_identity
@@ -125,6 +126,52 @@ def _softmax_graph() -> Graph:
     graph.add_node(SoftmaxOp(axis=-1), ["x"], Tensor("out", (4, 32), "f16"), node_id="out")
     graph.inputs, graph.outputs = ["x"], ["out"]
     return graph
+
+
+def _computed_value_expectation_tile() -> TileOp:
+    """A twisted expectation whose value is a stored contraction until placement cuts it."""
+    query, column, key, inner = Axis("q", 4), Axis("n", 16), Axis("j", 8), Axis("k", 16)
+    value = Fold.contraction(
+        k_axis=inner,
+        a=Load(name="xv", input="x", index=(Var("j"), Var("k"))),
+        channels=(Channel(b=Load(name="wv", input="w", index=(Var("n"), Var("k"))), acc="vacc"),),
+    )
+    states = ("maximum", "denominator", "expectation")
+    other = tuple(f"{name}__o" for name in states)
+    carrier = Fold(
+        axis=key,
+        operands=(value,),
+        lift=Lambda(
+            params=("j", "vacc"),
+            body=Body((Load(name="score", input="scores", index=(Var("q"), Var("j"))),)),
+            results=("score", 1.0, "vacc"),
+        ),
+        init=(float("-inf"), 0.0, 0.0),
+        combine=Lambda(params=states + other, body=Body(exp_combine_states(states, other)), results=states),
+    )
+    root = Fold.projection(
+        operands=(carrier,),
+        body=Body(
+            (
+                Assign(name="inverse", op="reciprocal", args=("denominator",)),
+                Assign(name="out", op="multiply", args=("expectation", "inverse")),
+            )
+        ),
+        results=("out",),
+    )
+    tile = TileOp(
+        op=root,
+        name="out",
+        place=Placement(free=(query, column)),
+        output_specs=(OutputSpec(Write(output="out", index=(Var("q"), Var("n")), value="out")),),
+    )
+    tile.inputs = {
+        "x": Tensor("x", (8, 16), F16),
+        "w": Tensor("w", (16, 16), F16),
+        "scores": Tensor("scores", (4, 8), F16),
+    }
+    tile.outputs = {"out": Tensor("out", (4, 16), F16)}
+    return tile
 
 
 def _offered(graph: Graph, *, frontend: bool = False) -> list[dict]:
@@ -267,6 +314,14 @@ def test_softmax_state_cut_is_offered_and_pinned_cut_lowers() -> None:
     shifted = values.astype(np.float32) - values.max(axis=-1, keepdims=True).astype(np.float32)
     expected = np.exp(shifted) / np.exp(shifted).sum(axis=-1, keepdims=True)
     np.testing.assert_allclose(got, expected, rtol=2e-3, atol=2e-3)
+
+
+def test_twisted_expectation_value_cut_uses_the_public_store_dtype() -> None:
+    """Cutting a computed expectation value turns it into the derived contraction's B slab."""
+    seams = {tuple(seam.node.defines()): seam for seam in cuttable_seams(_computed_value_expectation_tile())}
+
+    assert seams[("vacc",)].dtypes == (F16,)
+    assert seams[("maximum", "denominator", "expectation")].dtypes == (F32, F32, F32)
 
 
 def test_mimo_cut_preserves_both_outputs_and_lowers_both_pieces() -> None:

--- a/tests/compiler/passes/test_spell_store_rounding.py
+++ b/tests/compiler/passes/test_spell_store_rounding.py
@@ -11,13 +11,17 @@ from dataclasses import replace
 
 import pytest
 
+from emmy.compiler.context import Context
 from emmy.compiler.dtype import F16, F32, DataType
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.loop import Accum, Assign, Axis, Load, Loop, LoopOp, Write
+from emmy.compiler.ir.stmt import Body
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
-from emmy.compiler.pipeline import Pipeline
+from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.pipeline import TILE_PASSES, Pipeline
+from emmy.compiler.pipeline.search.pins import pinned_knobs
 
 _RULE = "090_spell_store_rounding"
 A0 = Axis("a0", 4)
@@ -59,6 +63,67 @@ def _pointwise_kernel() -> LoopOp:
             ),
         ),
     )
+
+
+def _copy_kernel(source: str, output: str) -> LoopOp:
+    return LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Load(name="value", input=source, index=(Var("a0"),)),
+                    Write(output=output, index=(Var("a0"),), value="value"),
+                ),
+            ),
+        ),
+    )
+
+
+def _add_kernel(left: str, right: str, output: str) -> LoopOp:
+    return LoopOp(
+        body=(
+            Loop(
+                axis=A0,
+                body=(
+                    Load(name="left", input=left, index=(Var("a0"),)),
+                    Load(name="right", input=right, index=(Var("a0"),)),
+                    Assign(name="sum", op="add", args=("left", "right")),
+                    Write(output=output, index=(Var("a0"),), value="sum"),
+                ),
+            ),
+        ),
+    )
+
+
+def _private_reduction_graph(*, public_copy: bool) -> Graph:
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (4, 16), F16), node_id="x")
+    graph.add_node(InputOp(), [], Tensor("residual", (4,), F16), node_id="residual")
+    graph.add_node(
+        _reduce_kernel().rename_buffers({"out": "stage"}),
+        ["x"],
+        Tensor("stage", (4,), F16, transient=True),
+        node_id="stage",
+    )
+    if public_copy:
+        graph.add_node(_copy_kernel("stage", "rounded"), ["stage"], Tensor("rounded", (4,), F16), node_id="rounded")
+        graph.add_node(
+            _add_kernel("rounded", "residual", "out"),
+            ["rounded", "residual"],
+            Tensor("out", (4,), F16),
+            node_id="out",
+        )
+    else:
+        graph.add_node(
+            _add_kernel("stage", "residual", "rounded"),
+            ["stage", "residual"],
+            Tensor("rounded", (4,), F16),
+            node_id="rounded",
+        )
+        graph.add_node(ElementwiseOp("negative"), ["rounded"], Tensor("out", (4,), F16), node_id="out")
+    graph.inputs = ["x", "residual"]
+    graph.outputs = ["out"]
+    return graph
 
 
 def _run(kernel: LoopOp, out: Tensor, *, input_shape: tuple = (4, 16), consumed: bool = True) -> LoopOp:
@@ -123,3 +188,27 @@ def test_unconsumed_store_spells_nothing() -> None:
     """
     op = _run(_reduce_kernel(), Tensor("out", (4,), F16), consumed=False)
     assert _conversions(op) == []
+
+
+def test_public_copy_of_private_reduction_keeps_its_rounding_through_placement() -> None:
+    """A decomposition's private accumulator reaches its public f16 boundary through a copy."""
+    graph = _private_reduction_graph(public_copy=True)
+
+    fused = Pipeline.build(["loop/lifting", "loop/fusion"]).run(graph)
+    kernel = next(node.op for node in fused.nodes.values() if isinstance(node.op, LoopOp))
+    assert _conversions(kernel) == [F16]
+
+    with pinned_knobs({"PLACE": "cut"}):
+        placed = Pipeline.build(TILE_PASSES).run(graph, ctx=Context.from_target((7, 0)))
+    tiles = [node.op for node in placed.nodes.values() if isinstance(node.op, TileOp)]
+    consumer = next(tile for tile in tiles if "out" in tile.outputs)
+    copies = [stmt.dtype for stmt in Body(consumer.op.lower()).iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert len(tiles) == 2
+    assert copies == [F16]
+
+
+def test_public_computation_from_private_reduction_stays_full_width() -> None:
+    """A private reduction used by public computation is not itself a rounding boundary."""
+    fused = Pipeline.build(["loop/lifting", "loop/fusion"]).run(_private_reduction_graph(public_copy=False))
+    kernel = next(node.op for node in fused.nodes.values() if isinstance(node.op, LoopOp))
+    assert _conversions(kernel) == []

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -57,7 +57,7 @@ def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:
     assert materialized == []
 
 
-def test_verified_pick_skips_structural_sibling_before_recorded_schedule(monkeypatch) -> None:
+def test_verified_pick_ignores_feature_keys_in_schedule_branches(monkeypatch) -> None:
     rows = [
         {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "slow"},
         {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "recorded"},
@@ -71,9 +71,8 @@ def test_verified_pick_skips_structural_sibling_before_recorded_schedule(monkeyp
         ),
         materialize=lambda _row: None,
     )
-    structural = DeferredFork(materialize=lambda: None, structural=True)
     point = SimpleNamespace(
-        options=[structural, tree],
+        options=[tree],
         node_id="node",
         root_op=TileOp(op=Fold.projection(body=Body())),
     )
@@ -93,6 +92,19 @@ def test_verified_pick_skips_structural_sibling_before_recorded_schedule(monkeyp
     assert audited_price == 1.25
     assert schedule_row_key(audited_knobs) == schedule_row_key(record.knobs)
     assert audit[0]["verdict"] == "MATCH"
+
+
+def test_verified_pick_defers_a_structural_fork(monkeypatch) -> None:
+    structural = DeferredFork(materialize=lambda: None, structural=True)
+    point = SimpleNamespace(
+        options=[structural],
+        node_id="node",
+        root_op=TileOp(op=Fold.projection(body=Body())),
+    )
+    record = SimpleNamespace(name="recorded-golden", knobs={"TILE": "recorded"}, emmy_us=1.25)
+    monkeypatch.setattr(greedy, "deploy_identity", lambda _op: "identity")
+
+    assert _verified_pick(point, {"identity": [record]}, None) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -4,10 +4,20 @@ from types import SimpleNamespace
 
 import pytest
 
+from emmy.compiler.ir.pure import Fold
+from emmy.compiler.ir.stmt import Body
+from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.pipeline.fork import DeferredFork, Level, build_fork_tree, flatten_leaves, leaf_knobs
-from emmy.compiler.pipeline.knob import canonical_row_key
+from emmy.compiler.pipeline.knob import canonical_row_key, schedule_row_key
 from emmy.compiler.pipeline.search.policy import greedy
-from emmy.compiler.pipeline.search.policy.greedy import _db_measured_index_build, _direct_measured_pick, _stream_tiers, tile_identity
+from emmy.compiler.pipeline.search.policy.greedy import (
+    _db_measured_index_build,
+    _direct_measured_pick,
+    _stream_tiers,
+    _verified_pick,
+    golden_audit,
+    tile_identity,
+)
 
 
 @pytest.mark.parametrize("route", ({"PLACE": "cut"}, {"PLACE@a": "cut"}, {"PLACE@a": "cut", "WORK": "t32"}))
@@ -45,6 +55,44 @@ def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:
     assert leaf.knobs == knobs
     assert price == 1.25
     assert materialized == []
+
+
+def test_verified_pick_skips_structural_sibling_before_recorded_schedule(monkeypatch) -> None:
+    rows = [
+        {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "slow"},
+        {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "recorded"},
+        {"S_warp_eligible": 1.0, "RASTER": "gm8", "TILE": "other"},
+    ]
+    tree = build_fork_tree(
+        params=rows,
+        levels=(
+            Level(("S_warp_eligible", "RASTER"), lambda row: (row["S_warp_eligible"], row["RASTER"])),
+            Level(("TILE",), lambda row: (row["TILE"],)),
+        ),
+        materialize=lambda _row: None,
+    )
+    structural = DeferredFork(materialize=lambda: None, structural=True)
+    point = SimpleNamespace(
+        options=[structural, tree],
+        node_id="node",
+        root_op=TileOp(op=Fold.projection(body=Body())),
+    )
+    record = SimpleNamespace(name="recorded-golden", knobs={"RASTER": "", "TILE": "recorded"}, emmy_us=1.25)
+    monkeypatch.setattr(greedy, "deploy_identity", lambda _op: "identity")
+
+    leaf, price, knobs = _verified_pick(point, {"identity": [record]}, None)
+
+    assert schedule_row_key(leaf_knobs(leaf)) == schedule_row_key(record.knobs)
+    assert price == 1.25
+    assert schedule_row_key(knobs) == schedule_row_key(record.knobs)
+
+    audit = []
+    with golden_audit(audit):
+        audited_leaf, audited_price, audited_knobs = _verified_pick(point, {"identity": [record]}, None)
+    assert schedule_row_key(leaf_knobs(audited_leaf)) == schedule_row_key(record.knobs)
+    assert audited_price == 1.25
+    assert schedule_row_key(audited_knobs) == schedule_row_key(record.knobs)
+    assert audit[0]["verdict"] == "MATCH"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/search/prior/test_score_rows.py
+++ b/tests/compiler/pipeline/search/prior/test_score_rows.py
@@ -86,6 +86,20 @@ def test_an_unfit_online_half_answers_a_constant_rather_than_failing():
     assert OnlinePrior().score_rows(_group([{"D_a": 1.0}, {"D_a": 2.0}])).tolist() == [0.0, 0.0]
 
 
+def test_the_online_half_waits_for_label_variation_before_fitting():
+    """One equal-latency batch cannot rank anything; keep it pending until another measurement adds information."""
+    prior = OnlinePrior(iterations=5, min_rows=2, refit_every=1)
+    prior.add_rows([(_stamp() | {"BM": 8.0}, 10.0)] * 2)
+
+    assert not prior.maybe_refit()
+    assert not prior.fitted
+
+    prior.add_rows([(_stamp() | {"BM": 64.0}, 5.0)])
+
+    assert prior.maybe_refit()
+    assert prior.fitted
+
+
 def test_the_composite_answers_with_the_half_that_owns_deploys():
     """``FallbackPrior`` forwards to whichever half is live, exactly as its other scoring surfaces do — so a
     report over the deployed prior decomposes the model that actually makes decisions."""

--- a/tests/compiler/pipeline/search/test_golden_eval.py
+++ b/tests/compiler/pipeline/search/test_golden_eval.py
@@ -1,0 +1,33 @@
+"""Focused tests for program-backed golden enumeration."""
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+from emmy.compiler.context import Context
+from emmy.compiler.graph import Graph
+from emmy.compiler.pipeline.fork import DeferredFork, Fork
+from emmy.compiler.pipeline.search.golden_eval import enumerate_graph
+
+
+@dataclass(frozen=True)
+class _EmptyBranch(Fork):
+    knobs: dict = field(default_factory=dict)
+    is_leaf = False
+
+    def expand(self):
+        return []
+
+
+def test_enumeration_skips_an_empty_pinned_branch(monkeypatch) -> None:
+    row = {"WORK": "w1x1", "TILE": "mma"}
+    live = DeferredFork(materialize=lambda: None, knobs=row)
+
+    def resolve(_self, graph, decide):
+        assert decide(SimpleNamespace(options=[_EmptyBranch(), live])) is live
+        return graph, []
+
+    monkeypatch.setattr("emmy.compiler.pipeline.pipeline.Run.resolve", resolve)
+
+    candidates = enumerate_graph(Graph(), Context.from_target((8, 0)))
+
+    assert candidates.rows == [row]

--- a/tests/compiler/pipeline/search/test_two_level_strategy.py
+++ b/tests/compiler/pipeline/search/test_two_level_strategy.py
@@ -4,7 +4,8 @@ Pins the strategy's contract with a fake counting backend (no GPU): the outer ne
 into Tile IR and its scoring is DECLARED SEPARABLE (each unique Loop kernel measured in its own
 slice, Σ once all are measured); structurally identical kernels dedup with multiplicity; kernels
 minted during the inner loops (a pinned cross-CTA split's pieces) are ENROLLED as first-class
-tuning targets with their own identity — evidence, never reward terms.
+tuning targets with their own identity — evidence, never reward terms. A direct unscheduled Tile
+child enters that same per-kernel path, while a scheduled child stays lowering-only.
 
 Target forced to sm_80 so lowering is deterministic and GPU-independent — the fake backend never
 launches anything, it hands back per-launch latencies keyed off each CudaOp's structural key.
@@ -12,6 +13,7 @@ launches anything, it hands back per-launch latencies keyed off each CudaOp's st
 
 from __future__ import annotations
 
+import json
 import logging
 import zlib
 
@@ -27,10 +29,12 @@ from emmy.compiler.ir.cuda.ir import CudaOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
+from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pipeline
 from emmy.compiler.pipeline.search.db import SearchDB
+from emmy.compiler.pipeline.search.pins import pinned_knobs
 from emmy.compiler.pipeline.search.slice import single_node_graph
-from emmy.compiler.pipeline.search.strategy.two_level import InnerReward, OpResult, _KernelInventory
+from emmy.compiler.pipeline.search.strategy.two_level import InnerReward, OpResult, _kernel_nodes, _KernelInventory
 from tests.compiler.helpers import run_inner_reward, run_two_level
 
 # Moderate patience: each kernel explores several variants then stops on stagnation (the fake
@@ -101,6 +105,21 @@ class _RouteBackend(_CountingBackend):
             for i, node in enumerate(cuda)
         ]
         return BenchmarkResult(time_ms=sum(item.time_ms for item in per), num_launches=len(per), per_launch=per)
+
+
+class _ChildScheduleBackend(_CountingBackend):
+    """Prefer one exact schedule for a directly tuned post-cut child."""
+
+    def benchmark(self, graph, num_iters="auto") -> BenchmarkResult:  # noqa: ARG002
+        self.calls += 1
+        (cuda,) = [node.op for node in graph.nodes.values() if isinstance(node.op, CudaOp)]
+        fast = cuda.knobs.get("WORK") == "t16x8" and cuda.knobs.get("STAGE") == "d1/smem-async"
+        us = 0.25 if fast else 10.0
+        return BenchmarkResult(
+            time_ms=us / 1000.0,
+            num_launches=1,
+            per_launch=(LaunchTime(idx=0, kernel_name=cuda.kernel_name, time_ms=us / 1000.0, samples=(us / 1000.0,)),),
+        )
 
 
 def _matmul(g: Graph, prefix: str, M: int, K: int, N: int) -> str:
@@ -209,6 +228,76 @@ def _placement_route_graph() -> Graph:
     return graph
 
 
+def _persisted_placement_child() -> Graph:
+    """Return one unscheduled child as a Tile dump round-trip would load it."""
+    fused = Pipeline.build(LOOP_PASSES).run(_placement_route_graph(), ctx=Context.from_target((8, 0)), db=SearchDB())
+    with pinned_knobs({"PLACE": "cut"}):
+        pieces = Pipeline.build(["lowering/tile"], select={"lift", "cut"}).run(fused, ctx=Context.from_target((8, 0)), db=SearchDB())
+    producer = next(node.id for node in pieces.nodes.values() if isinstance(node.op, TileOp) and "__place_" in node.op.name)
+    child = single_node_graph(pieces, producer)
+    return Graph.from_dict(json.loads(json.dumps(child.to_dict(), default=str)))
+
+
+def test_persisted_unscheduled_tile_child_tunes_and_replays_in_parent_cut(tmp_path) -> None:
+    """A direct post-cut Tile target records ordinary child evidence, which the same child
+    consumes when its parent route is compiled later."""
+    ctx = Context.from_target((8, 0))
+    db = SearchDB(tmp_path / "child.db")
+    child = _persisted_placement_child()
+    backend = _ChildScheduleBackend()
+
+    with pinned_knobs({"REDUCE": ""}):
+        direct = run_two_level(
+            child,
+            ctx=ctx,
+            db=db,
+            backend=backend,
+            patience=24,
+            max_candidates=32,
+            prior=None,
+            manage_prior=False,
+        )
+    with pinned_knobs({"PLACE": "cut", "REDUCE": ""}):
+        parent = Pipeline.build(CUDA_PASSES).run(_placement_route_graph(), ctx=ctx, db=db)
+
+    assert direct.best_reward is not None and direct.best_reward.ok
+    assert len(direct.best_reward.per_op) == 1
+    direct_cuda = [node.op for node in direct.assembled.nodes.values() if isinstance(node.op, CudaOp)]
+    assert len(direct_cuda) == 1
+    assert direct_cuda[0].knobs["WORK"] == "t16x8"
+    assert direct_cuda[0].knobs["STAGE"] == "d1/smem-async"
+    parent_cuda = [node.op for node in parent.nodes.values() if isinstance(node.op, CudaOp)]
+    producer = next(op for op in parent_cuda if "__place_" in op.kernel_name)
+    assert producer.knobs["WORK"] == "t16x8"
+    assert producer.knobs["STAGE"] == "d1/smem-async"
+    db.close()
+
+
+def test_scheduled_tile_child_is_not_reenrolled_or_rescheduled() -> None:
+    """A Tile root whose worker inventory is sealed is already decided."""
+    child = _persisted_placement_child()
+    with pinned_knobs({"WORK": "t16x8", "STAGE": "d1/smem-async", "REDUCE": ""}):
+        scheduled = Pipeline.build(["lowering/tile"]).run(child, ctx=Context.from_target((8, 0)), db=SearchDB())
+    tile = next(node.op for node in scheduled.nodes.values() if isinstance(node.op, TileOp))
+    assert tile.work is not None
+    assert _kernel_nodes(scheduled) == []
+
+    backend = _ChildScheduleBackend()
+    result = run_two_level(
+        scheduled,
+        ctx=Context.from_target((8, 0)),
+        db=SearchDB(),
+        backend=backend,
+        patience=_PATIENCE,
+        prior=None,
+        manage_prior=False,
+    )
+    assert backend.calls == 0
+    (cuda,) = [node.op for node in result.assembled.nodes.values() if isinstance(node.op, CudaOp)]
+    assert cuda.knobs["WORK"] == "t16x8"
+    assert cuda.knobs["STAGE"] == "d1/smem-async"
+
+
 def test_placement_route_total_is_not_persisted_without_a_child_schedule_receipt(monkeypatch, tmp_path) -> None:
     """A measured route stays search evidence until its exact child tree can replay."""
     monkeypatch.setenv("EMMY_REDUCE", "")
@@ -237,8 +326,6 @@ def test_placement_route_total_is_not_persisted_without_a_child_schedule_receipt
 def test_pinned_placement_route_tunes_and_assembles_child_schedules(monkeypatch, caplog) -> None:
     """A pinned cut freezes the kernel set; every minted child is then tuned independently and
     the assembled route reads each child's own schedule evidence."""
-    from emmy.compiler.pipeline.search.pins import pinned_knobs
-
     monkeypatch.setenv("EMMY_REDUCE", "")
     backend = _RouteBackend()
     with caplog.at_level(logging.INFO, logger="emmy.compiler.pipeline.search.strategy.two_level"):

--- a/tests/compiler/pipeline/search/test_two_level_strategy.py
+++ b/tests/compiler/pipeline/search/test_two_level_strategy.py
@@ -200,14 +200,19 @@ def test_run_drives_outer_scores_separably_and_assembles() -> None:
     assert any(isinstance(n.op, CudaOp) for n in result.assembled.nodes.values())
 
 
-def test_placement_route_total_is_not_persisted_without_a_child_schedule_receipt(monkeypatch, tmp_path) -> None:
-    """A measured route stays search evidence until its exact child tree can replay."""
-    monkeypatch.setenv("EMMY_REDUCE", "")
+def _placement_route_graph() -> Graph:
     graph = _graph(("x", 64, 128, 48))
     graph.add_node(InputOp(), [], Tensor("residual", (64, 48)), node_id="residual")
     graph.add_node(ElementwiseOp("add"), ["xc", "residual"], Tensor("out", (64, 48)), node_id="out")
     graph.inputs.append("residual")
     graph.outputs = ["out"]
+    return graph
+
+
+def test_placement_route_total_is_not_persisted_without_a_child_schedule_receipt(monkeypatch, tmp_path) -> None:
+    """A measured route stays search evidence until its exact child tree can replay."""
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    graph = _placement_route_graph()
     ctx = Context.from_target((8, 0))
     path = tmp_path / "route.db"
     db = SearchDB(path)
@@ -227,6 +232,32 @@ def test_placement_route_total_is_not_persisted_without_a_child_schedule_receipt
     route_rows = [row for row in db.iter_perf(ctx.structural_key(), backend="cuda") if row.knobs.get("PLACE") == "cut"]
     assert route_rows == []
     db.close()
+
+
+def test_pinned_placement_route_tunes_and_assembles_child_schedules(monkeypatch, caplog) -> None:
+    """A pinned cut freezes the kernel set; every minted child is then tuned independently and
+    the assembled route reads each child's own schedule evidence."""
+    from emmy.compiler.pipeline.search.pins import pinned_knobs
+
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    backend = _RouteBackend()
+    with caplog.at_level(logging.INFO, logger="emmy.compiler.pipeline.search.strategy.two_level"):
+        with pinned_knobs({"PLACE": "cut"}):
+            result = run_two_level(
+                _placement_route_graph(),
+                ctx=Context.from_target((8, 0)),
+                db=SearchDB(),
+                backend=backend,
+                patience=_PATIENCE,
+                prior=None,
+                manage_prior=False,
+            )
+
+    assembled = [node.op for node in result.assembled.nodes.values() if isinstance(node.op, CudaOp)]
+    assert len(assembled) == 2
+    assert sum("enrolled minted kernel" in record.message for record in caplog.records) >= 2
+    assert assembled[0].knobs["WORK"] == "t16x8" and assembled[0].knobs["STAGE"] == "d1/smem-async"
+    assert assembled[1].knobs["WORK"] == assembled[1].knobs["STAGE"] == ""
 
 
 def test_minted_kernels_are_enrolled_as_first_class_targets(monkeypatch, caplog) -> None:

--- a/tests/compiler/realization/ARCHITECTURE.md
+++ b/tests/compiler/realization/ARCHITECTURE.md
@@ -162,6 +162,11 @@ answer it and nowhere else. That asymmetry is deliberate: the derived-half check
 fires everywhere and its fix works everywhere, while a timing can only be produced on the machine
 holding the card.
 
+The perf command repeats both the realization's input `pins` and schedule `knobs` in its explicit
+A/B row. The working-file target context selects the ordinary compile; each A/B variant re-lowers
+under its own pin context, so a placement cut omitted from the row would silently benchmark a
+different kernel set and reject the child schedule.
+
 ## Staleness: regeneration, not stamps
 
 Kernel identity and schedule codec spellings change often, so a stored case rots. The failure mode that matters is

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
@@ -73,4 +73,4 @@ configs:
       REDUCE: coop
       STAGE: ''
       RASTER: ''
-    identity: 4b19684899ef6e89de01f2500058a17a014bb0ff1831d92c12fa6c2c4ffd18ec
+    identity: fbae7e1f4741b8016b470477c8f3ef8b7ac51d8cd00cab0268bf84bb460abc7d

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
@@ -1,9 +1,8 @@
 # Reduced Qwen3 decoder attention: fp16 RMSNorm feeding causal grouped-query attention.
 #
-# evidence: experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml carries
-# PLACE@b=cut for the same RMSNorm-fed GQA B-operand structure on sm80, with a correct measured
-# k_sdpa_mean_reduce_29d3df realization. The current canonical spelling
-# PLACE@map.fold.a.fold.b1 must still address that previously offered Fold edge.
+# evidence: repeated strict O3 A100 measurements materialize the clustered normalized-K value
+# through PLACE@map.fold.a.map.fold.fold.b1 in one cooperative producer plus one consumer,
+# reaching 6.91-7.01 us against torch.compile's 10.09 us for this exact target.
 compute_cap:
 - 8
 - 0
@@ -65,12 +64,14 @@ configs:
   - name: k_sdpa_rms_norm_reduce_ca42d0.08888c314a71
     bindings: {}
     pins:
-      FAST_MATH: false
-      PLACE@map.fold.a.fold.b1: cut
+      FAST_MATH: true
+      PLACE@map.fold.a.map.fold.fold.b1: cut
     knobs:
       TILE: ''
-      WORK: t128
+      WORK: t8
       REDUCE: coop
+      REDUCE@a.fold.a3: ''
+      REDUCE@a7: ''
       STAGE: ''
       RASTER: ''
     identity: fbae7e1f4741b8016b470477c8f3ef8b7ac51d8cd00cab0268bf84bb460abc7d

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-sdpa-stat-fill.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-sdpa-stat-fill.yaml
@@ -63,12 +63,12 @@ configs:
       REDUCE@map.fold.a.map.fold.fold.a41: ''
       REDUCE@a.b.fold.a4: ''
       REDUCE@map.fold.a.fold.a81: ''
-      REDUCE@b.fold.a8: ''
+      REDUCE@a.map.fold.a8: ''
       STAGE@map.fold.a21: ''
       STAGE@a7: d1/smem
       STAGE@a.fold.a3: ''
       STAGE@map.fold.a.map.fold.fold.a41: d1/smem
       STAGE@a.b.fold.a4: ''
       STAGE@map.fold.a.fold.a81: ''
-      STAGE@b.fold.a8: ''
-    identity: 5ddf1772501faa05906fce50274ec678cfb78a51d14cb9793d6b2b65971b8b70
+      STAGE@a.map.fold.a8: ''
+    identity: b00596538d55f1f309c780a2ecafee155bb2cd1b48d0eec46c9e1b7bdf4bac37

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml
@@ -60,4 +60,4 @@ configs:
       REDUCE: coop
       STAGE: ''
       RASTER: ''
-    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f
+    identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-output-axis.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-output-axis.yaml
@@ -57,4 +57,4 @@ configs:
       REDUCE@a7: ''
       STAGE: ''
       RASTER: ''
-    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f
+    identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml
@@ -58,4 +58,4 @@ configs:
       REDUCE: coop
       STAGE: ''
       RASTER: ''
-    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f
+    identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-cut.yaml
@@ -55,4 +55,4 @@ configs:
       REDUCE: ''
       STAGE: ''
       RASTER: ''
-    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f
+    identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-route.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-route.yaml
@@ -64,4 +64,4 @@ configs:
       REDUCE: ''
       STAGE: ''
       RASTER: ''
-    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f
+    identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-workspace-chain.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-workspace-chain.yaml
@@ -59,4 +59,4 @@ configs:
       REDUCE: ''
       STAGE: ''
       RASTER: ''
-    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f
+    identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-workspace-chain.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-workspace-chain.yaml
@@ -54,9 +54,15 @@ configs:
       PLACE@map.fold.a.map.fold.fold.b.map3: cut
       PLACE@a.b.fold.a5: cut
     knobs:
+      REDUCE@a.b.fold.a4: coop
+      REDUCE@a.fold.a3: coop
+      REDUCE@a.map.fold.a8: coop
+      REDUCE@map.fold.a.fold.a81: coop
+      REDUCE@map.fold.a.map.fold.fold.a41: coop
+      REDUCE@map.fold.a21: coop
+      WORK: t8
       TILE: ''
-      WORK: ''
-      REDUCE: ''
       STAGE: ''
+      LOOPIFY: '0'
       RASTER: ''
     identity: e267aa546e0e3a8e1ee869044715c12667dbf883e16152a337771d3e6fcb4076

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-workspace-chain.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-workspace-chain.yaml
@@ -1,0 +1,62 @@
+# A composed attention cut may create a workspace chain whose members have the same number of
+# direct dependencies. The producers must follow the chain, not sort by dependency count.
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [q, k, v, qw, kw]
+  outputs: [out]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 2, 8, 16]]]
+  - id: kw
+    op: input
+    outputs: [[kw, f16, [16]]]
+  - id: kn
+    op: torch.rms_norm
+    attrs: {eps: 1.0e-06}
+    inputs: [k, kw]
+    outputs: [[kn, f16, [1, 2, 8, 16]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 2, 8, 16]]]
+  - id: qw
+    op: input
+    outputs: [[qw, f16, [16]]]
+  - id: qn
+    op: torch.rms_norm
+    attrs: {eps: 1.0e-06}
+    inputs: [q, qw]
+    outputs: [[qn, f16, [1, 2, 8, 16]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 2, 8, 16]]]
+  - id: out
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [qn, kn, v]
+    outputs: [[out, f16, [1, 2, 8, 16]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - kn
+    - out
+    - qn
+  realizations:
+  - name: k_sdpa_rms_norm_reduce_dd476e.6741552db729
+    bindings: {}
+    pins:
+      FAST_MATH: false
+      PLACE@map.fold.a.map.fold.a32: cut
+      PLACE@map.fold.a.map.fold.fold.a51: cut
+      PLACE@map.fold.a.map.fold.fold.b.map3: cut
+      PLACE@a.b.fold.a5: cut
+    knobs:
+      TILE: ''
+      WORK: ''
+      REDUCE: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f

--- a/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma.yaml
@@ -1,0 +1,51 @@
+# A linear projection supplies SDPA's value operand. Cutting that stored Fold edge must preserve
+# the public f16 tensor dtype so the resulting attention consumer can offer tensor-core schedules.
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [x0, x1, x2, x3]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: x0
+    op: input
+    outputs: [[x0, f16, [1, 1, 32, 16]]]
+  - id: x1
+    op: input
+    outputs: [[x1, f16, [1, 1, 32, 16]]]
+  - id: x2
+    op: input
+    outputs: [[x2, f16, [1, 1, 32, 16]]]
+  - id: x3
+    op: input
+    outputs: [[x3, f16, [16, 16]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [x2, x3]
+    outputs: [[linear, f16, [1, 1, 32, 16]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [x0, x1, linear]
+    outputs: [[scaled_dot_product_attention, f16, [1, 1, 32, 16]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - linear
+    - scaled_dot_product_attention
+  realizations:
+  - name: k_sdpa_linear_reduce_8aa445.6f3c8a02965f
+    bindings: {}
+    pins:
+      FAST_MATH: false
+      PLACE@a7: cut
+    knobs:
+      TILE@a2: mma_m16n8k16_f16_f32/f1x2
+      TILE@pj: mma_m16n8k16_f16_f32/f1x1
+      STAGE@pj: d1/smem
+      WORK: w1x1
+      REDUCE: ''
+      RASTER: ''
+    identity: 0de4c13b26cb92059accc77fe36d87455e5a28845e1381625752b57171d17bc6

--- a/tests/compiler/realization/cases/fused/gate-up-distinct-a_xfail_realized.yaml
+++ b/tests/compiler/realization/cases/fused/gate-up-distinct-a_xfail_realized.yaml
@@ -56,7 +56,7 @@ configs:
     - sg
     - up
   realizations:
-  - name: k_linear_reduce_e6d376.dcfef1a9b9c8
+  - name: k_linear_reduce_e89d0b.2e6490d760e8
     bindings: {}
     pins:
       FAST_MATH: false
@@ -64,4 +64,4 @@ configs:
     knobs:
       WORK: w2x2
       TILE: mma_m16n8k16_f16_f32/f2x2/k2
-    identity: c1c5e4f2e252739223679856d774744278596955b42b18202a6463e4ec28cd85
+    identity: 551431aea126969fcdd336ca08bd23772401de670974139b3e97a1973e670aa5

--- a/tests/compiler/realization/cases/fused/gate-up-shared-a.yaml
+++ b/tests/compiler/realization/cases/fused/gate-up-shared-a.yaml
@@ -43,7 +43,7 @@ configs:
     - sg
     - up
   realizations:
-  - name: k_linear_reduce_f0c139.84af9a3c2335
+  - name: k_linear_reduce_d1cd72.2de6eeaa910f
     bindings: {}
     pins:
       FAST_MATH: false
@@ -51,7 +51,7 @@ configs:
     knobs:
       WORK: w2x2
       TILE: mma_m16n8k16_f16_f32/f2x2/k2
-    identity: 8ede64c06e50b998a4d924aaa6d23520d7df4e476e9f1a4e7f5b46259cdb624d
+    identity: 1f791fec715a3c1fbfb8da3b43c467b6b6ec2bb35a7a108758819f492b660bad
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 9.945600032806396

--- a/tests/compiler/realization/cases/fused/linear-add-place-cut-sm70.yaml
+++ b/tests/compiler/realization/cases/fused/linear-add-place-cut-sm70.yaml
@@ -32,10 +32,10 @@ configs:
     - add_7
     - linear_6
   realizations:
-  - name: k_linear_d10f5f.f961b725c533
+  - name: k_linear_86a1f4.9c286907da15
     bindings: {}
     pins:
       FAST_MATH: false
       PLACE: cut
     knobs: {}
-    identity: 9439d95f8d8f6965e134a79af0a2765cec0ce54e6c27ee46488ff6a671afb06f
+    identity: 12da4cbab843ff02ff03f468087903583c9a9fbd6241818936ff9f90caabb04c

--- a/tests/compiler/realization/cases/matmul/f16-cut-splitk-unit-row.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-cut-splitk-unit-row.yaml
@@ -32,7 +32,7 @@ configs:
     - add
     - linear
   realizations:
-  - name: k_linear_da67b3.90f9d0366a1a
+  - name: k_linear_6b4f7f.db287da7abde
     bindings: {}
     pins:
       FAST_MATH: false
@@ -49,4 +49,4 @@ configs:
       INTERLEAVE_LOADS: 'True'
       PAIR_LDMATRIX: 'True'
       LOOPIFY: '0'
-    identity: e5a291968474e3517cdd078c6b0ca9af0a0c1d57220b16cd062b0b341de801f8
+    identity: 4df37b68546c328098e8d9ba117f462554936e9ca551a1d4e3b8c8a9161c9325

--- a/tests/compiler/realization/cases/matmul/f16-matvec-reshaped-output-tma.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-matvec-reshaped-output-tma.yaml
@@ -48,7 +48,7 @@ configs:
     - reshape
     - to
   realizations:
-  - name: k_linear_80faa4.27d0694f92a0
+  - name: k_linear_ecdd53.8d333bc50be9
     bindings: {}
     pins:
       FAST_MATH: false
@@ -59,4 +59,4 @@ configs:
       STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: ''
-    identity: a26e68ecd1d6f4f73d15e3b83288e980abafeab0e73ce40fe91691d3698b05cc
+    identity: d213e30ac1eb8c25ad95af9746f6d54a1aa5d55caf37a191de70a9a2ae3de11e

--- a/tests/compiler/realization/cases/matmul/f16-mma-broadcast-batched-pv-transpose.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-mma-broadcast-batched-pv-transpose.yaml
@@ -1,0 +1,66 @@
+# A transposed broadcast-batched projection carries its batch axis only in the strided operand.
+# The contiguous reduction operand must become contraction A so the tensor-core schedule can bind.
+compute_cap:
+- 8
+- 0
+programs:
+- inputs: [x0, x1]
+  outputs: [transpose]
+  nodes:
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: -1.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c1, f16, [1]]]
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: -2.0
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[transpose_c2, f16, [1]]]
+  - id: x0
+    op: input
+    outputs: [[x0, f16, [1, 512, 1024]]]
+  - id: x1
+    op: input
+    outputs: [[x1, f16, [8, 1024, 128]]]
+  - id: matmul
+    op: torch.matmul
+    attrs: {has_bias: false}
+    inputs: [x0, x1]
+    outputs: [[matmul, f16, [8, 512, 128]]]
+  - id: transpose
+    op: torch.transpose
+    attrs: {axes: {__tuple__: [-1, -2]}}
+    inputs: [matmul]
+    outputs: [[transpose, f16, [8, 128, 512]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - matmul
+    - transpose
+  realizations:
+  - name: k_matmul_8ceacc.afa60f6b06c8
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      WORK: w2x2
+    identity: 1f3d5e942468de2db6d9713cb2c8d709da09eeee28d71169c2484915f5bd399f

--- a/tests/compiler/realization/cases/matmul/f16-mma-broadcast-batched-pv-transpose.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-mma-broadcast-batched-pv-transpose.yaml
@@ -1,5 +1,7 @@
 # A transposed broadcast-batched projection carries its batch axis only in the strided operand.
 # The contiguous reduction operand must become contraction A so the tensor-core schedule can bind.
+# On an NVIDIA A100 80GB, deployable-O3 strict W5/I20 repeats measured 17.588-19.784 us versus
+# torch.compile at 10.854-11.894 us: a material improvement, not parity.
 compute_cap:
 - 8
 - 0
@@ -61,6 +63,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      TILE: mma_m16n8k16_f16_f32/f4x8/k8
-      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      WORK: w8x1
+      REDUCE: ''
+      STAGE: d1/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
     identity: 1f3d5e942468de2db6d9713cb2c8d709da09eeee28d71169c2484915f5bd399f

--- a/tests/compiler/realization/cases/matmul/f16-symbolic-m-residual-cp.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-symbolic-m-residual-cp.yaml
@@ -31,7 +31,7 @@ configs:
     - mm
     - o
   realizations:
-  - name: k_matmul_760735.169489f7e743
+  - name: k_matmul_5dc0b6.5bd6a0dc0ea7
     bindings: {}
     pins:
       FAST_MATH: false
@@ -40,7 +40,7 @@ configs:
       WORK: w2x2
       STAGE: d2/smem-async
       REDUCE: ''
-    identity: 8ec205cc1806162cf7f6297b3e762539c210de0fa35c1c73fa5775ac5451dee3
+    identity: 490b2ad2b1aa51557fe884066ebcbdb8052c33f57f33006084fd98c36b4cb18d
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 7.623816719491973

--- a/tests/compiler/realization/cases/matmul/f16-volta-warp-mma-sm70.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-volta-warp-mma-sm70.yaml
@@ -33,8 +33,8 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w1x1
+      WORK: w4x2
       TILE: mma_m8n8k4_f16_f32/f2x2/k8
-      STAGE: d2/smem
+      STAGE: d1/smem
       REDUCE: ''
     identity: 0dea019b122e91e51eebb12f63ee59ed77496f83b56e8922a6b7a1ca5bce7a7f

--- a/tests/compiler/realization/cases/reduce/mixed-f16-scale-readable-inline-sm120.yaml
+++ b/tests/compiler/realization/cases/reduce/mixed-f16-scale-readable-inline-sm120.yaml
@@ -1,0 +1,90 @@
+# evidence: The exact Qwen3 c3d placement child built the same f32-accumulator times f16-scale
+# expression on A100 with an explicit conversion, and sm120 offers and realizes this reduced
+# REDUCE=coop, WORK=t32 schedule before nvcc rejects only the emitted mixed-dtype expression.
+compute_cap:
+- 12
+- 0
+programs:
+- inputs:
+  - x
+  - scale
+  - bias
+  outputs:
+  - out
+  nodes:
+  - id: bias
+    op: input
+    outputs:
+    - - bias
+      - f32
+      - - 4
+        - 1
+  - id: scale
+    op: input
+    outputs:
+    - - scale
+      - f16
+      - - 4
+        - 1
+  - id: x
+    op: input
+    outputs:
+    - - x
+      - f16
+      - - 4
+        - 128
+  - id: sum
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: sum
+      axis: 1
+    inputs:
+    - x
+    outputs:
+    - - sum
+      - f32
+      - - 4
+        - 1
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - sum
+    - scale
+    outputs:
+    - - mul
+      - f32
+      - - 4
+        - 1
+  - id: out
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - bias
+    - mul
+    outputs:
+    - - out
+      - f32
+      - - 4
+        - 1
+configs:
+- program: 0
+  target:
+    origins:
+    - mul
+    - out
+    - sum
+  realizations:
+  - name: k_out_reduce.b58195b2f8d5
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE: coop
+      WORK: t32
+    identity: 2cdff6ae0ea7b5e5e5776ef1b4d819aef2b3115db1858009357330d732c4045b

--- a/tests/compiler/realization/helpers.py
+++ b/tests/compiler/realization/helpers.py
@@ -424,10 +424,12 @@ def bench_command(case: Case, output: Path) -> list[str]:
     A corpus case is deliberately not `VERIFIED` — filling `measurements` would auto-pin it in
     `emmy run --golden` and fold test data into the replay tooling's trusted evidence — so the
     authored row is pinned with `--ab`, which is exactly "bench this row beside the greedy pick".
+    Include the input pins in that explicit row: the golden target context selects the ordinary
+    compile, while each A/B variant re-lowers independently under its own pin context.
     """
     import sys  # noqa: PLC0415
 
-    row = ",".join(f"{name}={value}" for name, value in case.record.knobs.items())
+    row = ",".join(f"{name}={value}" for name, value in case.pinned.items())
     return [
         sys.executable,
         "-m",

--- a/tests/compiler/realization/test_helpers.py
+++ b/tests/compiler/realization/test_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 
 from tests.compiler.realization import helpers
@@ -19,3 +20,15 @@ def test_built_loads_the_lowered_program_through_nvcc(monkeypatch) -> None:
 
     assert helpers.built(case) is lowered
     assert seen == [(lowered, {"x": source})]
+
+
+def test_bench_command_keeps_structural_input_pins_in_the_ab_row() -> None:
+    case = SimpleNamespace(
+        pinned={"FAST_MATH": False, "PLACE@a7": "cut", "WORK": "w1x1"},
+        record=SimpleNamespace(name="k_example"),
+        path=Path("case.yaml"),
+    )
+
+    command = helpers.bench_command(case, Path("result.json"))
+
+    assert command[command.index("--ab") + 1] == "FAST_MATH=False,PLACE@a7=cut,WORK=w1x1"

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -92,6 +92,8 @@
  "tests/compiler/cli/test_golden_file_replay.py::test_compile_working_file_uses_exact_loop_target": 0.34,
  "tests/compiler/cli/test_golden_file_replay.py::test_working_file_golden_conflicts_with_direct_input": 0.2,
  "tests/compiler/cli/test_golden_file_replay.py::test_working_file_requires_name_and_reports_its_own_available_rows": 0.38,
+ "tests/compiler/cli/test_golden_file_replay.py::test_working_shared_placement_pins_select_the_exact_compile_target[explicit]": 6.68,
+ "tests/compiler/cli/test_golden_file_replay.py::test_working_shared_placement_pins_select_the_exact_compile_target[ordinary]": 7.26,
  "tests/compiler/cli/test_run.py::test_accuracy_check_fails_scrambled_output_passes_outliers": 0.05,
  "tests/compiler/cli/test_run.py::test_accuracy_check_gaussian_fp16_budget_not_free": 1.25,
  "tests/compiler/cli/test_run.py::test_accuracy_check_heavy_tailed_fp16_outputs": 1.68,

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -145,7 +145,7 @@
  "tests/compiler/cli/test_run.py::test_run_no_code_errors": 0.78,
  "tests/compiler/cli/test_run.py::test_run_positional_json_like_ir@cuda-cli": 16.8,
  "tests/compiler/cli/test_run.py::test_run_record_shape_option_is_retired": 0.18,
- "tests/compiler/cli/test_run_golden.py::test_naming_one_target_skips_the_multi_target_walk@cuda-cli": 1.56,
+ "tests/compiler/cli/test_run_golden.py::test_naming_one_target_skips_the_multi_target_walk": 1.56,
  "tests/compiler/cli/test_run_golden.py::test_target_requires_golden": 0.18,
  "tests/compiler/cli/test_trace.py::test_trace_command_writes_only_golden_yaml": 0.14,
  "tests/compiler/cli/test_trace.py::test_trace_inventory_keeps_flash_attention_as_one_target": 0.08,


### PR DESCRIPTION
## Summary

- rebase the draft onto current main `b88763fa` and requalify exact source `857ba7e9` on A100, V100, and RTX 4090
- preserve provider evaluation domains, dependency-order composed operands, scalar dump replay, and computed-B provider cones
- tune persisted unscheduled Tile children and replay explicit scoped-OFF exceptions beside non-OFF bare schedule pins
- promote exact A100 GQA, workspace-chain, and PV schedules plus the V100 single-buffer schedule
- keep every change small, independently tested, and backed by strict exact-GPU replay

## Exact A100 corpus

The combined O3 lane collected 201 tests: five passed, one independent stat-fill watchdog failed, and 195 skipped.

| case | Emmy | `torch.compile` | launches | result |
| --- | ---: | ---: | ---: | --- |
| GQA B cut | 6.907 us | 10.026 us | 2 | correct; 1.45x faster |
| computed value cut | 6.193 us | 8.039 us | 2 | correct; 1.30x faster |
| workspace chain | 75.855 us | 11.469 us | 1 | correct; 6.61x slower |
| split-K unit row | 9.183 us | 2.839 us | 3 | correct; 3.23x slower |
| batched PV transpose | 17.664 us | 11.894 us | 1 | correct; 1.49x slower |
| stat fill | about 280 ms/iteration | 19.456 us | — | aggregate GPU-time watchdog |

The GQA discrepancy was a replay bug: A/B canonicalization discarded `REDUCE@...=''` exceptions, then bare
`REDUCE=coop` fanned out to those sites and selected a slower consumer. Preserving explicit scoped exceptions changes
the unchanged perf command from 10.193 us to 6.857-7.100 us and restores the direct-row source.

The PV promotion is about 4x faster than the prior checked row. Eight strict neighbour rows found no further schedule
gain. Its remaining gap is 32 stride-512 scalar transpose stores per thread; vector-store enabled/disabled emits
byte-identical CUDA. The workspace schedule improves 13.5%, but its fused CUDA still recomputes Q/K RMSNorm and the
softmax score scan inside downstream loops.

## Other exact platforms

- V100: the promoted Volta MMA row is correct at 3,130.368 us versus 757.760 us for `torch.compile`; the second sm70
  case still fails strict correctness with 26,418/524,288 mismatches, so its timing is inadmissible
- RTX 4090: 201 collected and 201 skipped; the corpus contains no exact closed sm89 case, so there is no parity claim

## Remaining compiler gaps

- workspace attention needs reuse/materialization that moves Q/K RMSNorm and softmax scans outside repeated loops
- PV needs a transpose-aware epilogue or different contraction orientation
- true split-K needs either partial/finalize/consumer launches or atomic reset; removing the floor safely requires a
  cross-CTA completion primitive or proved consumer-side reset protocol
- stat-fill needs split-first ordering in its child-identity schedule receipts: record a split choice, then join the
  exact children and their measured
  schedules; the best correct six-seam route is 3,342 us versus 17.238 us
- Volta needs a producer/consumer warp-band staging primitive with named barriers; depth and geometry tuning are spent

Parity is therefore not achieved. No large serving run was started while three A100 losses, the stat-fill watchdog,
and both V100 gaps remain.

Detailed measurements and limitations are in `experiments/golden-bench-2026/kernels/RESULTS.md`.

## Verification

- combined `make test`: 3,981 passed, 1,012 skipped, 5 xfailed
- `make test-corpus-regen`: corpus current
- `make lint`: passed; 745 files formatted
- exact combined A100 corpus: 5 passed, 1 watchdog failure, 195 skipped
- exact combined V100 corpus: 2 measured; one strict pass and one strict correctness failure
- exact combined RTX 4090 corpus: 201 skipped, no sm89 cases
- branch CI was green through `4dca9692`; current-head CI is running after this push

CloudRift A100 instance `4b313b56-a34c-11f1-b318-27d2c594140a` (`riftuser@66.172.10.246`) is intentionally retained
and must not be torn down per the owner request.


## Review follow-up (2026-08-29)

An architect review pass moved policy into the library and deduplicated predicates, with no behavior change:

- working-file placement-pin selection now lives in `search/golden.py` (`shared_placement_pins`); `commands/` only calls
  it, and the private cross-command context wrapper is gone (`pinned_knobs({})` is already a no-op)
- `GoldenRecord.is_receipt` + `pins_freeze_cut` give the receipt predicate one spelling shared by the loader's validator
  and strict decode
- the scoped-OFF replay exception moved beside its mirror-image rule as `knob.replay_pin_spelling`
- greedy's verified pick derives its branch filter from the row key once instead of passing the same data twice
- `_factor` drops an unreachable `cell_op` pass-through and states the identity-keyed schedule constraint;
  two provably unreachable cycle errors became asserts
- the working-file CLI test asserts the kernel-set shape through `run_cli` instead of pinning hashed kernel names
- invariant notes added for the broadcast-batch orientation swap's precedence with `_orient_shared`, the
  evaluation-domain guard's two arms, and the three provider-closure walks (`ir/tile/ARCHITECTURE.md`)

Known accepted limits, called out in code: `_kernel_nodes`' sealed check reads `work`, which is also `None` for
scheduled per-cell forms (redundant re-search, not incorrect); both GQA corpus cases now pin `FAST_MATH: true`, so the
standard lane has no GQA case until one is measured there.
