### PR TITLE
Persist per-child split schedules as child-identity receipts

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -257,6 +257,10 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
   dimension bindings and input pin regimes that were tuned for that target.
 - **Realization** — One statically bound or symbolic instance of a golden configuration: named dimension bindings,
   input knob pins, the selected schedule knobs, and (after verification) paired measurements.
+- **Child-identity schedule receipt** — A realization that records one split child's schedule: the route's cut(s)
+  frozen in its input pins, the child's schedule row in its knobs, and the child kernel's deploy identity stored as
+  its identity. The stored identity is the verified-tier join key and the strict decode's kernel selector — one flat
+  knobs map decorates exactly one kernel, so conflicting per-child schedules persist as sibling receipts.
 - **Working golden file** — A mutable local YAML inventory used to exchange program targets, unmeasured
   realizations, proposed knob rows, and tune ranking feedback. It is search state, not trusted deployment evidence.
 - **Canonical golden file** — A reviewed per-GPU YAML. Model goldens live at

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1273,6 +1273,20 @@ rejected shape is a bare OFF beside scoped keys of the same family: a bare OFF p
 replay and contradicts the scoped decisions, so `stamp_schedule_families` drops it when stamping and promotion
 rejects any that remain.
 
+**A split's children persist as child-identity schedule receipts.** One flat `knobs` map decorates exactly one
+kernel, so a route whose cut splits the target into several kernels cannot record conflicting per-child schedules in
+one realization. Each child instead gets its own sibling realization — a *receipt*: the route's cut(s) frozen in
+`pins` (replay context that lets the strict decode reach the children), the child's schedule row in `knobs`, and the
+child kernel's deploy identity stored in `identity`. A stored identity is authoritative for the verified-tier join
+(`kernel_identity` returns it as-is — the target's own lift stops at the pre-cut kernel and cannot name a child), and
+the join stays fail-closed: a stale identity matches no live fork and decides nothing. The strict decode is stricter —
+the stored identity must equal one kernel resolved under the record's pins, and the spelled row must equal one of
+THAT kernel's enumerated rows, so a sibling child's row never vouches. At deploy the pin-regime check skips PLACE
+pins (the route is the routing consult's decision; the identity join guarantees a receipt only decorates a
+structurally identical kernel), and validation rejects a realization that schedules behind pinned cuts without a
+stored identity. A stored identity equal to the target's own lift is the corpus's derived stamp, not a receipt, and
+keeps the pooled decode.
+
 The preferred reference is the runnable Torch slice (`torch-eager`) or the applicable library kernel (`cublas`). A
 Loop IR fallback has no frontend callable by construction; an origin slice can also have synthetic boundaries whose
 post-fusion output geometry is not independently comparable to its Torch slice. Such a target may use a separately

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -180,8 +180,11 @@ class GoldenRecord:
     loop_index: int | None = None
     loop_wire: dict | None = None
     #: The record's stored ``deploy_identity`` (see :func:`kernel_identity`), when the file keeps
-    #: one. Model inventories do not; the realization corpus does, because a new fingerprint fact
-    #: must show up as a diff there rather than silently re-key a checked-in reproducer.
+    #: one. Model inventories mostly do not; the realization corpus does, because a new fingerprint
+    #: fact must show up as a diff there rather than silently re-key a checked-in reproducer. A
+    #: stored identity is authoritative for the deploy join, and it is how a **child-identity
+    #: schedule receipt** names its kernel: a record whose pins freeze a cut lowers to several
+    #: kernels, and only the stored identity says which child this row's schedule decorates.
     identity: str | None = None
     #: Measured microseconds per ``Context.hardware_id``: ``{card: {emmy_us, tcompile_us}}``. A
     #: model golden is one file per card and uses the flat ``measurements`` block instead; a corpus
@@ -498,6 +501,12 @@ def validate_golden_file(
                 families = {str(key).split("@", 1)[0] for key in realization["knobs"]}
                 if "PLACE" in families and families != {"PLACE"}:
                     raise ValueError(f"{realization_where} mixes PLACE routing knobs with schedule knobs")
+                pins_cut = any(str(name).split("@", 1)[0] == "PLACE" and str(value) == "cut" for name, value in pins.items())
+                if families and "PLACE" not in families and pins_cut and "identity" not in realization:
+                    raise ValueError(
+                        f"{realization_where} schedules a kernel behind pinned cut(s) without naming it; "
+                        "a child-identity schedule receipt must store the child kernel's identity"
+                    )
                 if strict:
                     for family in families:
                         scoped = [str(key) for key in realization["knobs"] if str(key).split("@", 1)[0] == family]
@@ -670,10 +679,11 @@ def _record_fingerprint(record: GoldenRecord) -> str:
     return digest(cached[1], str(record.target_key), str(record.bindings), str(record.compute_cap), record.gpu_name or "")
 
 
-#: Enumerated rows per (target, pins) — sibling realizations of one config decode against one
-#: enumeration (the tripwire and the migration validator walk whole files) — and ONE Context per
-#: card, so same-shape targets share the schedule pool cache across configs and files.
-_DECODE_ROWS_CACHE: dict[tuple, list[dict]] = {}
+#: Enumerated rows per (target, pins), bucketed by kernel identity — sibling realizations of one
+#: config decode against one enumeration (the tripwire and the migration validator walk whole
+#: files) — and ONE Context per card, so same-shape targets share the schedule pool cache across
+#: configs and files.
+_DECODE_ROWS_CACHE: dict[tuple, dict[str | None, frozenset]] = {}
 _DECODE_CTX_CACHE: dict[tuple, object] = {}
 
 
@@ -736,14 +746,17 @@ def decode_record(record: GoldenRecord) -> str | None:
     program selects exactly one kernel; a routing record names a legal closed Fold seam; a SCHEDULE record's spelled row
     equals one enumerated
     leaf (``canonical_row_key`` equality under the record's own pins) — no prefix matching, no
-    any-of, no classified shape."""
+    any-of, no classified shape. A child-identity schedule receipt (a stored identity that is not
+    the target's own lift) is stricter still: its identity must equal one kernel resolved under the
+    record's pins, and the spelled row must equal one of THAT kernel's rows — a sibling child's row
+    must not vouch for it."""
     from emmy.compiler.pipeline.knob import schedule_row_key  # noqa: PLC0415
 
     try:
         tile = _lifted_target(record)
     except Exception as exc:  # noqa: BLE001 — the reason IS the product here
         return f"{type(exc).__name__}: {exc}"
-    verdict_key = digest(_record_fingerprint(record), str(sorted(record.knobs.items())), str(record.pins))
+    verdict_key = digest(_record_fingerprint(record), str(sorted(record.knobs.items())), str(record.pins), record.identity or "")
     store = _identity_store()
     verdicts = store.setdefault("verdicts", {})
     if verdict_key in verdicts:
@@ -771,11 +784,19 @@ def decode_record(record: GoldenRecord) -> str | None:
             if site is None or id(site.node) not in seam_ids:
                 return _remember_verdict(verdict_key, f"routing key {key!r} names no legal cut seam on the Fold tree")
         return _remember_verdict(verdict_key, None)
-    candidates = _candidate_row_keys(record)
-    if schedule_row_key(record.knobs) in candidates:
-        reason = None
+    candidates = _candidate_rows(record)
+    row = schedule_row_key(record.knobs)
+    if record.identity is not None and record.identity != deploy_identity(tile):
+        child_rows = candidates.get(record.identity)
+        if child_rows is None:
+            reason = f"stored identity equals none of the {len(candidates)} kernel identities resolved under the record's pins"
+        elif row in child_rows:
+            reason = None
+        else:
+            reason = f"no enumerated row of the identified kernel equals the recording ({len(child_rows)} candidate rows)"
     else:
-        reason = f"no enumerated row equals the recording ({len(candidates)} candidate rows)"
+        pooled = frozenset().union(*candidates.values()) if candidates else frozenset()
+        reason = None if row in pooled else f"no enumerated row equals the recording ({len(pooled)} candidate rows)"
     verdicts[verdict_key] = reason
     global _IDENTITY_STORE_DIRTY
     _IDENTITY_STORE_DIRTY = True
@@ -789,11 +810,14 @@ def _remember_verdict(key: str, reason: str | None) -> str | None:
     return reason
 
 
-def _candidate_row_keys(record: GoldenRecord) -> frozenset:
-    """Every schedule-row identity the record's target can realize under its pins: the fork
-    leaves' rows, PLUS each resolved kernel's own realized row — a forkless kernel (the schedule
-    space collapsed to one row, often the all-OFF anchor) never opens a fork, so its one row is
-    read off the resolved op instead."""
+def _candidate_rows(record: GoldenRecord) -> dict[str | None, frozenset]:
+    """Every schedule-row identity the record's target can realize under its pins, bucketed by the
+    ``deploy_identity`` of the kernel that offers it (``None`` for forks whose root is not a
+    recognized ``TileOp``): the fork leaves' rows, PLUS each resolved kernel's own realized row — a
+    forkless kernel (the schedule space collapsed to one row, often the all-OFF anchor) never opens
+    a fork, so its one row is read off the resolved op instead. Under pinned cuts the buckets are
+    exactly the split children, which is what lets a child-identity receipt decode against its own
+    kernel only."""
     from emmy.compiler.context import Context  # noqa: PLC0415
     from emmy.compiler.ir.tile import TileOp  # noqa: PLC0415
     from emmy.compiler.pipeline import TILE_PASSES, Pipeline  # noqa: PLC0415
@@ -810,35 +834,45 @@ def _candidate_row_keys(record: GoldenRecord) -> frozenset:
     ctx = _DECODE_CTX_CACHE.get(ctx_key)
     if ctx is None:
         ctx = _DECODE_CTX_CACHE.setdefault(ctx_key, Context.from_target(ctx_key[0], gpu_name=ctx_key[1]))
-    keys: set = set()
+    buckets: dict[str | None, set] = {}
+
+    def _identity_of(op) -> str | None:
+        return deploy_identity(op) if isinstance(op, TileOp) and op.op is not None else None
 
     def decide(fp):
         leaves = flatten_leaves(fp.options)
         ops = [o for o in leaves if not _is_structural_option(o)]
+        identity = _identity_of(fp.root_op)
         for leaf in ops:
             row = leaf_knobs(leaf)
             if row:
-                keys.add(schedule_row_key(row))
+                buckets.setdefault(identity, set()).add(schedule_row_key(row))
         return ops[0] if ops else leaves[0]
 
     with pinned_knobs(record.pin_map):
         out, _ = Run(pipeline=Pipeline.build(TILE_PASSES), ctx=ctx).resolve(record.target_program.copy(), decide)
     for node in out.nodes.values():
         if isinstance(node.op, TileOp):
-            keys.add(schedule_row_key(dict(node.op.knobs or {})))
-    result = frozenset(keys)
+            buckets.setdefault(_identity_of(node.op), set()).add(schedule_row_key(dict(node.op.knobs or {})))
+    result = {identity: frozenset(rows) for identity, rows in buckets.items()}
     _DECODE_ROWS_CACHE[cache_key] = result
     return result
 
 
 def kernel_identity(record: GoldenRecord) -> str | None:
     """The record's kernel identity under the CURRENT compiler — the verified-tier join key
-    (``_schedule.deploy_identity``) of the lifted tile of the record's ONE target kernel,
-    derived through the exact total lift the live compile uses (``_fromloop.lift_loop_op``).
+    (``_schedule.deploy_identity``). A STORED identity is authoritative and returned as-is: it is
+    how a child-identity receipt names the one split child its schedule decorates (the target's own
+    lift stops at the pre-cut kernel and cannot say), and the deploy join is fail-closed, so a
+    stale stored identity matches no live fork and decides nothing — the strict decode is where it
+    fails loudly. Without one, the identity is derived as the lift of the record's ONE target
+    kernel, through the exact total lift the live compile uses (``_fromloop.lift_loop_op``).
     ``None`` when the record cannot carry a deploy identity: the target lowers to several kernels
     (a schedule row decorates exactly one), or selection/lifting fails — best-effort here
     (a corpus row must never break a compile); nightly strict decoding is where failure is loud."""
     global _IDENTITY_STORE_DIRTY
+    if record.identity is not None:
+        return record.identity
     key = _record_cache_key(record)
     if key in _IDENTITY_CACHE:
         return _IDENTITY_CACHE[key]

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -503,11 +503,17 @@ def _pins_live(pins: dict) -> bool:
     precision universe (:data:`_PRECISION_PINS`, umbrella semantics per ``space.precision_pin``)
     is compared even for pins the record omits (omitted = measured OFF)."""
     from emmy import config  # noqa: PLC0415
-    from emmy.compiler.pipeline.knob import KnobType, registry  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import KnobType, family_of, registry  # noqa: PLC0415
     from emmy.compiler.pipeline.search.space import precision_pin  # noqa: PLC0415
 
     knobs = registry()
     for name, value in pins.items():
+        if family_of(str(name)) == "PLACE":
+            # Routing pins are record-side replay context (a child-identity receipt freezes its
+            # cut there so the strict decode can reach the child); at deploy the route is the
+            # routing consult's decision, and the identity join guarantees the receipt only ever
+            # decorates a structurally identical kernel.
+            continue
         kn = knobs.get(str(name))
         raw = kn.raw() if kn is not None else config.knob_raw(str(name))
         if kn is not None and kn.type is KnobType.BOOL:

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -120,7 +120,9 @@ sample apart. `test_move_catalog.py` checks that independent
 roots with reversed M/N readings combine only when their tile
 widths and unit counts match on the physical output axes, and that f32 computed-A contractions retain scalar
 output-tile rows when no MMA atom applies. `test_cut_forks.py` checks fused and closed Fold-edge choices for SDPA score
-production, causal SDPA, and multi-output roots, then pins each representative cut through CUDA lowering. Direct
+production, causal SDPA, and multi-output roots, then pins each representative cut through CUDA lowering, and proves
+child-identity schedule receipts round-trip: under a pinned cut each child's stored identity decodes only its own
+kernel's schedule rows and joins the verified tier as-is. Direct
 contraction-operand cuts remain strict xfails until Tile IR represents their materialized workspace dtype.
 The generated carrier's numerical laws are covered
 independently by `tests/compiler/ir/pure/test_carrier_gen.py` and `test_lambda_monoid.py`; end-to-end softmax and

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -19,11 +19,21 @@ from emmy.compiler.ir.frontend.ir import SdpaOp, SoftmaxOp
 from emmy.compiler.ir.pure.fold import Channel, Fold
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
+from emmy.compiler.ir.tile.identity import deploy_identity
 from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Match, Pipeline, Rule, RuleSkipped
 from emmy.compiler.pipeline.fork import Fork
 from emmy.compiler.pipeline.passes.lowering.tile._cut import CutSite, _workspace_axes, cuttable_seams
 from emmy.compiler.pipeline.pipeline import Run, _is_structural_option
-from emmy.compiler.pipeline.search.golden import GoldenRecord, _lifted_target, decode_record, load_golden_file, load_golden_records
+from emmy.compiler.pipeline.search.golden import (
+    GoldenRecord,
+    _candidate_rows,
+    _lifted_target,
+    decode_record,
+    kernel_identity,
+    load_golden_file,
+    load_golden_records,
+    validate_golden_file,
+)
 from emmy.compiler.pipeline.search.pins import pinned_knobs
 from emmy.compiler.torch_wire import graph_to_wire
 from tests.compiler.helpers import requires_cuda
@@ -315,3 +325,67 @@ def test_composed_scoped_place_pins_cut_together_and_foreign_pins_are_skipped() 
     assert all(node.op.placement_decided for node in pieces)
     workspaces = {node.id for node in producers}
     assert any(set(node.inputs) & workspaces for node in producers), "the nested value's producer must read a sibling workspace"
+
+
+def _receipt_fields() -> dict:
+    return {
+        "name": "sdpa.child",
+        "gpu_name": "",
+        "compute_cap": (12, 0),
+        "model": None,
+        "program_index": 0,
+        "program_wire": graph_to_wire(_sdpa_graph(False)),
+        "origins": ("out",),
+        "bindings": (),
+        "pins": (("PLACE@a3", "cut"),),
+        "measurements": None,
+        "ranking": None,
+    }
+
+
+def test_child_identity_receipts_decode_per_child_and_join_by_stored_identity() -> None:
+    """Conflicting per-child schedules behind one pinned cut persist as sibling receipts: each
+    stored child identity selects its own kernel's rows, a sibling child's row does not vouch for
+    it, and the verified-tier join reads the stored identity instead of the pre-cut lift."""
+    fields = _receipt_fields()
+    parent = GoldenRecord(knobs={}, **fields)
+    lift_identity = deploy_identity(_lifted_target(parent))
+    children = {i: rows for i, rows in _candidate_rows(parent).items() if i is not None and i != lift_identity}
+    assert len(children) == 2, "the pinned cut must resolve to two distinctly identified child kernels"
+    (id_a, rows_a), (id_b, rows_b) = sorted(children.items())
+    row_a = next(iter(rows_a - rows_b), None)
+    assert row_a is not None, "the children must offer at least one distinguishing schedule row"
+
+    receipt = GoldenRecord(knobs=dict(row_a), identity=id_a, **fields)
+    assert decode_record(receipt) is None
+    assert kernel_identity(receipt) == id_a
+
+    sibling = GoldenRecord(knobs=dict(row_a), identity=id_b, **fields)
+    reason = decode_record(sibling)
+    assert reason is not None and "no enumerated row of the identified kernel" in reason
+
+    stale = GoldenRecord(knobs=dict(row_a), identity="0" * 64, **fields)
+    reason = decode_record(stale)
+    assert reason is not None and "equals none" in reason
+
+
+def test_receipt_validation_requires_child_identity_and_place_pins_stay_live() -> None:
+    from emmy.compiler.pipeline.search.policy.greedy import _pins_live
+
+    fields = _receipt_fields()
+    document = {
+        "compute_cap": [12, 0],
+        "programs": [fields["program_wire"]],
+        "configs": [
+            {
+                "program": 0,
+                "target": {"origins": ["out"]},
+                "realizations": [{"name": "sdpa.child", "bindings": {}, "pins": {"PLACE@a3": "cut"}, "knobs": {"WORK": "w4x2"}}],
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="child-identity schedule receipt"):
+        validate_golden_file(document)
+    document["configs"][0]["realizations"][0]["identity"] = "0" * 64
+    validate_golden_file(document)
+    assert _pins_live({"PLACE@a3": "cut"}), "a receipt's routing pins are replay context, never a dead env regime"

--- a/tests/compiler/realization/helpers.py
+++ b/tests/compiler/realization/helpers.py
@@ -237,7 +237,7 @@ def offered(case: Case) -> str | None:
         # A FORKLESS kernel: its schedule space collapsed to one row, so it opens no fork and the
         # enumeration has nothing to return. There is no schedule to be denied, so nothing here can
         # fail — `realized` still proves it lowers, and the later stages still prove it runs. This
-        # mirrors how `_candidate_row_keys` reads a forkless kernel's row off the resolved op.
+        # mirrors how `_candidate_rows` reads a forkless kernel's row off the resolved op.
         return None
     return f"no enumerated row carries the pin ({len(rows)} rows offered at sm_{''.join(map(str, case.compute_cap))})"
 


### PR DESCRIPTION
## Problem

The DB supports individual child schedules for a split route, but the flat golden `knobs` map cannot serialize
conflicting per-child schedules (surfaced by the golden-bench-2026 pinned-cut experiments, PR #679). Three codec
assumptions each pinned a realization to exactly one kernel: PLACE knobs may not mix with schedule knobs, the knob
key space (`FAMILY[@site]`) has no child axis, and `_lifted_target` refuses a target that lowers to several kernels —
so `kernel_identity` returned `None` and the verified tier skipped the record entirely.

## Fix: child-identity schedule receipts

One sibling realization per split child:

- the route's cut(s) frozen in `pins` — the replay context that lets the strict decode reach the children;
- the child's schedule row in `knobs`;
- the child kernel's `deploy_identity` stored in `identity` — now authoritative for the verified-tier join
  (`kernel_identity` returns it as-is; the target's own lift stops at the pre-cut kernel and cannot name a child;
  the join stays fail-closed, so a stale identity decides nothing).

Mechanics:

- `decode_record` buckets enumerated rows by the offering kernel's `deploy_identity` (`_candidate_rows`); a receipt's
  spelled row must equal one of **its** kernel's rows — a sibling child's row never vouches. A stored identity equal
  to the target's own lift is the corpus's derived stamp and keeps the pooled decode (all existing corpus cut cases
  unchanged).
- `_pins_live` skips PLACE-family pins: at deploy the route is the routing consult's decision, and the identity join
  guarantees a receipt only decorates a structurally identical kernel. Previously a cut-pinned record could never be
  live.
- Validation rejects a realization that schedules behind pinned cuts without a stored identity.

Deploy-side (`_verified_index` / `_verified_pick`) needed no changes — it already joins per fork on
`deploy_identity`.

## Tests

- `test_child_identity_receipts_decode_per_child_and_join_by_stored_identity`: a pinned SDPA cut resolves two
  distinctly identified children; each receipt decodes only against its own kernel's rows, a sibling identity and a
  bogus identity both fail loudly, and `kernel_identity` returns the stored join key.
- `test_receipt_validation_requires_child_identity_and_place_pins_stay_live`: the validation guard and the PLACE-pin
  regime exemption.

Full suite: 4681 passed, 250 skipped, 16 xfailed, 2 xpassed (the known last-ulp bit-parity flakes, present on
pristine main per their own xfail reason); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5cicFbCxJGpS6fSkEMP5A