### PR TITLE
Share structurally identical cones and offer provider-closed statistics seams

### DIFF
--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -72,12 +72,24 @@ exclusive consumption (every moved definition dies into the closed edges), so th
 duplicated. Both rules measure an edge's captures with `Fold.deps` — scope-aware, so a name a sibling operand binds
 inside the edge is not a capture and an already-closed edge never re-fires the rewrite. A cone closed at its axes is
 what the placement fork can offer as a workspace seam, which is how a computed operand (the RMSNorm'd, RoPE'd K
-vector) becomes materializable once per key instead of recomputed per query row.
+vector) becomes materializable once per key instead of recomputed per query row. A body-member fold these rules
+leave capturing host names is not lost to placement: the fork closes it at offer time through provider closure
+(`lowering/tile/_cut.py`), without moving anything in the stored tree.
 
 An identity pass-through — a projection that only re-exposes its single operand's results — dissolves wherever a
 projection is formed or revisited. That is not cosmetic: a pass-through is what makes two occurrences of the same
 computation compare unequal, and the placement fork's value clustering (`lowering/tile/_cut.py`) relies on
 alpha-equivalent cones converging to one canonical shape.
+
+Normalization ends by restoring OBJECT SHARING: structurally equal cones with the same captures collapse onto one
+Fold object (`_share_common_cones`), so a value fusion inlined into several consumption sites — attention's softmax
+statistics, read by the weight cone and by the epilogue — is one node again. This is an invariant, not an
+optimization: seam grouping and cut realization key on object identity, so severed sharing silently turns one value
+into per-site recompute that no schedule can undo (the class PR #679 measured at three orders of magnitude). A
+recompute observed across kernels is therefore ALWAYS a Tile-level sharing or seam-offer defect — fix it here or in
+the placement fork; a Loop IR fusion or emission workaround sees one kernel at a time and is the wrong altitude by
+construction. Copies that differ in captured axis names cannot share an object and stay with value clustering; copies
+that differ in exposed result names stay distinct because unifying them would rename their consumers.
 
 An output sweep used by any nested contraction operand is promoted into the Tile's free-axis placement. Promotion
 expands the enclosing-axis context, so construction normalizes the Fold tree once more under that final scope; one

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -1,8 +1,16 @@
 """Contextual canonical forms for Tile IR Fold trees.
 
 Each :class:`Fold` already owns context-independent lambda-body ordering. The rewrites here need
-the enclosing Tile axes or parent Fold; nonlocal sibling clustering belongs to later algebraic
-rewrite passes.
+the enclosing Tile axes or parent Fold.
+
+INVARIANT — normalization ends with structurally identical cones as ONE shared object
+(:func:`_share_common_cones`). Object identity is how the placement machinery recognizes that two
+consumption sites read one value, so a rewrite that copies a cone (the close rewrites do, by
+design) is only sound because this final pass restores the sharing. Recompute elimination is a
+Tile-level placement concern built on that identity: a duplicated value becomes one seam, and a
+composed cut materializes it once for every reader. Do NOT patch recompute downstream — a Loop IR
+fusion or emission workaround sees one kernel at a time and cannot know two kernels re-derive the
+same value; fix the sharing or the seam offer here instead.
 """
 
 from __future__ import annotations
@@ -743,6 +751,58 @@ def _normalize_fold(fold: Fold, axes: tuple[str, ...], implicit_axes: frozenset[
     return _hoist_closed_folds(node, axes, sweep_axes)
 
 
+def _share_common_cones(root: Fold) -> Fold:
+    """Restore object sharing between structurally identical cones — the tree-wide half of
+    canonicalization.
+
+    Fusion and the close rewrites inline one value into every consumption site, so a traced value
+    consumed twice (attention's softmax statistics, read by the weight cone and the epilogue)
+    reappears as equal-but-distinct copies. Everything downstream keys on object identity —
+    ``cuttable_seams`` groups occurrences by it, ``realize`` replaces cut values by it — so a
+    severed sharing silently turns one value into per-site recompute that no schedule can undo.
+    This walk hash-conses every Fold bottom-up: copies that are structurally EQUAL (same captured
+    names included — the bucket key adds ``deps`` so α-equivalent cones under different captures,
+    the K-cone family, stay value clustering's job) collapse onto the first occurrence in walk
+    order. Emission is untouched: lowering walks tree positions, and every position still holds
+    an equal term. Identity-preserving off the replacement spine, like ``_replace_fold``."""
+    canon: dict[tuple, list[Fold]] = {}
+    seen: dict[int, Fold] = {}
+
+    def member(stmt):
+        if isinstance(stmt, Fold):
+            return visit(stmt)
+        nested = stmt.nested()
+        if not nested:
+            return stmt
+        bodies = tuple(Body(tuple(member(child) for child in body)) for body in nested)
+        unchanged = all(
+            len(body) == len(original) and all(piece is child for piece, child in zip(body, original, strict=True))
+            for body, original in zip(bodies, nested, strict=True)
+        )
+        return stmt if unchanged else stmt.with_bodies(bodies)
+
+    def visit(node: Fold) -> Fold:
+        if id(node) in seen:
+            return seen[id(node)]
+        operands = tuple(visit(edge) if isinstance(edge, Fold) else edge for edge in node.operands)
+        body = tuple(member(stmt) for stmt in node.lift.body)
+        current = node
+        if any(piece is not edge for piece, edge in zip(operands, node.operands, strict=True)):
+            current = replace(current, operands=operands)
+        if any(piece is not stmt for piece, stmt in zip(body, node.lift.body, strict=True)):
+            current = current.with_bodies((Body(body),))
+        bucket = canon.setdefault((current.structural_key(), current.deps()), [])
+        for prior in bucket:
+            if prior == current:
+                seen[id(node)] = prior
+                return prior
+        bucket.append(current)
+        seen[id(node)] = current
+        return current
+
+    return visit(root)
+
+
 def normalize_fold_tree(root, axes: Iterable[str] = (), implicit_axes: Iterable[str] = (), sweep_axes: Iterable[str] = ()):
     """Normalize a complete Tile IR tree bottom-up; ``None`` placeholders pass through.
 
@@ -774,6 +834,7 @@ def normalize_fold_tree(root, axes: Iterable[str] = (), implicit_axes: Iterable[
             break
         normalized = again
     result = root if normalized == root else normalized
+    result = _share_common_cones(result)
     instance_memo(result, "_memo_normal_scopes")[scope] = True
     return result
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1551,7 +1551,8 @@ The "owning rule" for the schedule codecs is the tile scheduler (the `040_schedu
 enumerator spells each family exactly once, site-local, where a row becomes stored state.
 
 **`PLACE`** (STR structural fork, `fuse` or `cut`) — a stored Fold edge's kernel placement, addressed by the same
-tree-path codec as schedule sites. The maximal fused kernel and every semantically closed cut are siblings. A cut is
+tree-path codec as schedule sites. The maximal fused kernel and every semantically closed cut are siblings — closure
+counting the offer-time provider closure and dependent-seam composition `passes/ARCHITECTURE.md` describes. A cut is
 consumed by the graph splice and therefore is not stamped on either fresh kernel; exact routing replay reads it from
 the structural decision trace. A scoped cut consumes its authoritative placement decision on both fresh pieces, which
 proceed to scheduling. Bare `PLACE=cut` selects the primary seam but, like an unpinned cut, leaves both pieces able to

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -82,7 +82,17 @@ whose workspace dtypes stay undetermined).
 A contraction-operand seam stands for a VALUE, not only an object: closed cones that are alpha-equivalent up to
 their captured axis names (attention's normalized K cone, once per score contraction) fold into one seam, each
 duplicate carried as a sibling with its capture correspondence, and the cut replaces every one with workspace loads
-spelled through its own axes. Scoped `PLACE@path=cut` pins are authoritative and COMPOSE: every pin that resolves on
+spelled through its own axes. A body-member fold capturing host-provided names is cuttable through PROVIDER
+CLOSURE: a capture whose producer chain is pure `Load`/`Assign` stmts joins the produced piece verbatim, and a
+capture only a sibling fold defines makes the seam DEPENDENT — its piece reads the name back through that producer's
+workspace, so cutting it composes the producer's cut in (attention's second softmax-statistics pass reading the
+first's accumulator; a pinned dependent cut pulls its producers in transitively, and pinning a producer `fuse`
+beside it is an error). This is what lets the row statistics materialize once per query row instead of once per
+output weight. Provider-closed and dependent seams are SCOPED-PIN-ONLY: the unpinned fork and bare `PLACE=cut`
+never select them, because nearly every kernel — and every fresh cut piece, which copies its providers — hosts
+some, so offering them would make recursive placement inexhaustible and the candidate walk explode. A route through
+them is spelled by authored or golden-decoded pins.
+Scoped `PLACE@path=cut` pins are authoritative and COMPOSE: every pin that resolves on
 one kernel joins a single realization — one producer per seam, one consumer, a producer reading another seam's
 workspace when its value nests inside (attention's statistics cone contains the score dots whose operand cones are
 cut beside it) — and all pieces set `placement_decided` and proceed to scheduling. A scoped pin whose site path does
@@ -409,7 +419,9 @@ unmapped.
 Maximal Loop fusion remains canonical. Tile lowering may expose two kinds of graph-fragment siblings without changing
 that canonical input:
 
-- **`030_cut`** offers the maximal fused Fold tree and every closed stored child-Fold seam. A cut writes one workspace
+- **`030_cut`** offers the maximal fused Fold tree and every closed stored child-Fold seam — body-member folds
+  closed at offer time by provider closure and dependent seams stay scoped-pin-only (see the placement discussion
+  above). A cut writes one workspace
   per state component and replaces all occurrences of the same canonically shared Fold object with workspace loads.
   Closure and replaceability are semantic gates; operation family, expected speed, row order, and search-space size
   are not. Closure reads the complete lowered statement stream through `Body`'s scope-aware dependence analysis:

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
@@ -56,6 +56,17 @@ def _pin(tile: TileOp, seams) -> tuple[tuple, str, bool] | None:
         elif not any(chosen is seam for chosen in cut):
             cut.append(seam)
     cut = [seam for seam in cut if seam.spelling not in fused]
+    # A dependent seam's producers join the composed decision transitively: the requirement is
+    # structural (its piece reads the producer's workspace), not a choice a pin can decline.
+    queue = list(cut)
+    while queue:
+        for _, producer in queue.pop().requires:
+            required = by_node[id(producer)]
+            if required.spelling in fused:
+                raise ValueError(f"PLACE pins fuse {required.spelling!r}, the producer a pinned dependent cut requires")
+            if not any(chosen is required for chosen in cut):
+                cut.append(required)
+                queue.append(required)
     if cut:
         return tuple(cut), "cut", True
     if fused:
@@ -69,8 +80,13 @@ def _pin(tile: TileOp, seams) -> tuple[tuple, str, bool] | None:
         # rule ranges over ALL PLACE sites and can land on an edge no cut realizes (an unclosed
         # cone, a seam whose workspace dtypes stay undetermined), so a bare pin resolves among
         # the CUTTABLE seams instead: the root-most one.
+        # Provider-closed and dependent seams are scoped-pin-only: bare-cut recursion terminates
+        # because pieces run OUT of seams, and provider closure keeps every piece supplied.
+        plain = [seam for seam in seams if not (seam.providers or seam.requires)]
+        if not plain:
+            return ("PLACE",), "fuse", False
         depth = {id(site.node): site.depth for site in all_sites}
-        seam = min(seams, key=lambda s: depth[id(s.node)])
+        seam = min(plain, key=lambda s: depth[id(s.node)])
         return (seam,), value, False
     if missing:
         # A pin-driven compile whose scoped pins all address other kernels decides FUSE here —
@@ -104,6 +120,12 @@ def rewrite(match: Match, root: Node, ctx=None):
 
     options = [DeferredFork(lambda: replace(tile, placement_decided=True), {"PLACE": "fuse"})]
     options.extend(
-        DeferredFork(lambda seam=seam: realize(match, root, (seam,), renamed), {seam.spelling: "cut"}, structural=True) for seam in seams
+        # Provider-closed and dependent seams stay OUT of the unpinned fork: every kernel and
+        # every fresh piece hosts some (the piece copies its providers), so offering them makes
+        # recursive placement inexhaustible and the candidate walk explodes. A route through them
+        # is spelled by scoped pins, which realize every member in one composed decision.
+        DeferredFork(lambda seam=seam: realize(match, root, (seam,), renamed), {seam.spelling: "cut"}, structural=True)
+        for seam in seams
+        if not (seam.providers or seam.requires)
     )
     return options

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -51,6 +51,17 @@ class CutSite:
     #: replaces every sibling with workspace loads spelled through its own axes. Object sharing is
     #: the degenerate case (identity, with the identity correspondence).
     siblings: tuple = ()
+    #: Sibling stmts (``Load``/``Assign``, fold-free) the produced piece prepends to close the
+    #: cone — a body-member fold may capture host-provided scalars (attention's mask/scale
+    #: constants) that a plain-closure seam carries inside its cone. Identical across every
+    #: hosting body, or the seam is not offered.
+    providers: tuple = ()
+    #: Captured names this cone can only take from ANOTHER seam's workspace: ``(name, producer
+    #: Fold)`` pairs where the producer is itself an offered seam (attention's second statistics
+    #: pass reading the first pass's accumulator). Cutting this seam is only realizable as a
+    #: composed decision that also cuts every producer; the produced piece reads the name back
+    #: through the producer's workspace loads.
+    requires: tuple = ()
 
 
 @dataclass(frozen=True)
@@ -189,11 +200,97 @@ def _workspace_dtypes(node: Fold, tile: TileOp, consumer: Fold | None) -> tuple 
     return dtypes
 
 
+def _member_hosts(root: Fold) -> dict[int, list[Fold]]:
+    """Each stored fold's hosting folds — every enclosing fold whose lift body holds it as a
+    member. A shared cone (normalization guarantees structurally identical cones are one object)
+    records every host, which is what lets provider closure demand the hosts agree."""
+    hosts: dict[int, list[Fold]] = {}
+    visited: set[int] = set()
+
+    def visit(node: Fold) -> None:
+        if id(node) in visited:
+            return
+        visited.add(id(node))
+        for edge in node.operands:
+            if isinstance(edge, Fold):
+                visit(edge)
+        for stmt in node.lift.body:
+            if isinstance(stmt, Fold):
+                hosts.setdefault(id(stmt), []).append(node)
+                visit(stmt)
+
+    visit(root)
+    return hosts
+
+
+def _provider_closure(node: Fold, scopes, hosts: list[Fold]) -> tuple[tuple, tuple] | None:
+    """The ``(providers, requires)`` that close an SSA-capturing body-member seam, or ``None``.
+
+    A member fold may read names its hosting body provides — attention's softmax statistics
+    capture the mask/scale scalars, and the second statistics pass reads the first pass's
+    accumulator. A capture whose producer chain is pure ``Load``/``Assign`` stmts joins the
+    produced piece verbatim (``providers``); a capture only a sibling or host-operand Fold
+    defines becomes a ``requires`` pair, realizable only when that producer is cut beside this
+    seam. Every hosting body must agree — structurally equal providers, the same producer
+    objects — and the closed piece must capture nothing but scope axes at every occurrence."""
+    if not hosts:
+        return None
+    axis_names = {axis.name for scope in scopes for axis in scope}
+    closures = []
+    for host in hosts:
+        defined: dict[str, object] = {}
+        for stmt in host.lift.body:
+            for name in stmt.defines():
+                defined[name] = stmt
+        for edge in host.operands:
+            for name in _operand_result_names(edge):
+                defined.setdefault(name, edge)
+        providers: list = []
+        requires: list = []
+        queue = sorted(set(_external_reads(node)) - axis_names)
+        resolved: set[str] = set()
+        while queue:
+            name = queue.pop()
+            if name in resolved:
+                continue
+            resolved.add(name)
+            producer = defined.get(name)
+            if producer is None or producer is node:
+                return None
+            if isinstance(producer, Fold):
+                requires.append((name, producer))
+                continue
+            if not isinstance(producer, (Load, Assign)):
+                return None
+            if not any(chosen is producer for chosen in providers):
+                providers.append(producer)
+            queue.extend(sorted(deep_reads([producer]) - axis_names - resolved))
+        order = {id(stmt): position for position, stmt in enumerate(host.lift.body)}
+        providers.sort(key=lambda stmt: order.get(id(stmt), -1))
+        closures.append((tuple(providers), tuple(sorted(requires, key=lambda pair: pair[0]))))
+    first_providers, first_requires = closures[0]
+    for providers, requires in closures[1:]:
+        aligned = providers == first_providers and len(requires) == len(first_requires)
+        if not aligned or any(
+            a != b or producer_a is not producer_b for (a, producer_a), (b, producer_b) in zip(requires, first_requires, strict=True)
+        ):
+            return None  # the hosts spell different closures — one seam cannot read two sources
+    provided = {name for stmt in first_providers for name in stmt.defines()}
+    provided.update(name for name, _ in first_requires)
+    outside = (set(_external_reads(node)) | {name for stmt in first_providers for name in deep_reads([stmt])}) - provided
+    if any(outside - {axis.name for axis in scope} for scope in scopes):
+        return None
+    return first_providers, first_requires
+
+
 def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     """Every semantically closed stored Fold edge whose workspace dtypes are determined, grouped
     only by object sharing. A contraction's operand edges are seams too — cutting one materializes
     the cone feeding the operand into its own kernel and the contraction reads it back as an
-    ordinary load — and they take the explicit contraction-operand dtype rule (`_workspace_dtypes`)."""
+    ordinary load — and they take the explicit contraction-operand dtype rule (`_workspace_dtypes`).
+    A body-member fold capturing host-provided names is offered through provider closure
+    (:func:`_provider_closure`); one whose closure needs another seam's workspace is offered as a
+    dependent seam and drops out unless that producer is offered too."""
     all_sites = sites(tile.op)
     contraction_operands = {
         id(edge): site.node
@@ -206,13 +303,21 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     occurrence_axes: dict[int, list[tuple]] = {}
     for node, available in islice(walk(tile.op, outer), 1, None):
         occurrence_axes.setdefault(id(node), []).append(available)
+    hosts = _member_hosts(tile.op) if isinstance(tile.op, Fold) else {}
     out: list[CutSite] = []
     seen: set[int] = set()
     for site in family_sites("PLACE", all_sites):
         node = site.node
         scopes = occurrence_axes.get(id(node), ())
-        if not isinstance(node, Fold) or id(node) in seen or not scopes or not all(_closed_at(node, scope) for scope in scopes):
+        if not isinstance(node, Fold) or id(node) in seen or not scopes:
             continue
+        providers: tuple = ()
+        requires: tuple = ()
+        if not all(_closed_at(node, scope) for scope in scopes):
+            closure = _provider_closure(node, scopes, hosts.get(id(node), []))
+            if closure is None:
+                continue
+            providers, requires = closure
         if node.observed:
             # An observed fold's per-step results exist only inside its stream — a cut would
             # separate the scan from its streamed boundary store, which no piece can then spell.
@@ -229,8 +334,24 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
         seen.add(id(node))
         axes = tuple({axis.name: axis for scope in scopes for axis in scope}.values())
         out.append(
-            CutSite(node=node, spelling=spell(tile.op, "PLACE", node, all_sites=all_sites), axes=axes, dtypes=dtypes, frontier=frontier)
+            CutSite(
+                node=node,
+                spelling=spell(tile.op, "PLACE", node, all_sites=all_sites),
+                axes=axes,
+                dtypes=dtypes,
+                frontier=frontier,
+                providers=providers,
+                requires=requires,
+            )
         )
+    # A dependent seam stands only while every required producer is itself offered; dropping one
+    # can orphan the next link of a chain, so filter to the fixpoint.
+    while True:
+        offered = {id(seam.node) for seam in out}
+        kept = [seam for seam in out if all(id(producer) in offered for _, producer in seam.requires)]
+        if len(kept) == len(out):
+            break
+        out = kept
     return _cluster_value_seams(out, {id(seam.node): seam.frontier is None and contraction_operands.get(id(seam.node)) for seam in out})
 
 
@@ -343,6 +464,23 @@ def output_map(root: Node) -> dict[str, str]:
     return {name: f"{name}__placed" for name in root.buffer_names()}
 
 
+def _requires_order(seams) -> tuple:
+    """``seams`` with every required producer ahead of its dependents; a producer absent from the
+    composed decision is left for the realization's per-name error. Requirement chains follow SSA
+    definition order, so the graph is acyclic by construction."""
+    present = {id(seam.node) for seam in seams}
+    remaining = list(seams)
+    ordered: list = []
+    placed: set[int] = set()
+    while remaining:
+        step = [seam for seam in remaining if all(id(producer) in placed or id(producer) not in present for _, producer in seam.requires)]
+        assert step, "cyclic seam requirements cannot arise from SSA definition order"
+        ordered.extend(step)
+        placed.update(id(seam.node) for seam in step)
+        remaining = [seam for seam in remaining if not any(seam is chosen for chosen in step)]
+    return tuple(ordered)
+
+
 def realize(
     match: Match,
     root: Node,
@@ -364,7 +502,8 @@ def realize(
     unpinned cuts leave it false so the fresh pieces can expose and decide smaller seams."""
     tile: TileOp = root.op
     pieces = []
-    for seam in seams:
+    workspace_loads: dict[int, tuple] = {}
+    for seam in _requires_order(seams):
         child = seam.node
         front = seam.frontier
         if front is not None:
@@ -373,6 +512,17 @@ def realize(
         else:
             names = _operand_result_names(child)
             produced = child
+        if seam.providers or seam.requires:
+            # Provider closure: the piece carries the host-provided scalar chain, and every
+            # required name arrives through its producer seam's workspace load — the same Load
+            # objects the replacement spells, so the two spellings cannot drift apart.
+            prefix = list(seam.providers)
+            for name, producer in seam.requires:
+                producer_loads = workspace_loads.get(id(producer))
+                if producer_loads is None:
+                    raise ValueError(f"seam {seam.spelling!r} requires {name!r} from a producer seam absent from this composed cut")
+                prefix.extend(load for load in producer_loads if isinstance(load, Load) and name in load.defines())
+            produced = Fold.projection(body=Body((*prefix, produced)), results=names)
         axes = _workspace_axes(seam, produced)
         index = tuple(Var(axis.name) for axis in axes)
         token = digest(tile.structural_key(), seam.spelling)[:10]
@@ -383,6 +533,7 @@ def realize(
             raw = replace(loads[0], dtype=front.dtype)
             loads = (Fold.projection(body=Body((raw, *front.residue)), results=child.lift.results),)
         replacements = {id(child): loads}
+        workspace_loads[id(child)] = loads
         for sibling, pairs in seam.siblings:
             # A clustered duplicate reads the SAME workspace, spelled through its own captured
             # axes via the correspondence the clustering proved.

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -347,6 +347,34 @@ def test_key_swept_statistic_stays_when_a_sibling_reads_it() -> None:
     assert id(score.b) not in {id(seam.node) for seam in cuttable_seams(tile)}
 
 
+def test_normalization_shares_structurally_identical_cones() -> None:
+    """The tree-wide invariant: after normalization, no two DISTINCT Fold objects in the tree are
+    structurally equal with the same captures — copies fusion inlined into several consumption
+    sites (attention's softmax statistics, once in the weight cone and once in the epilogue) are
+    one object, so placement sees one value and a composed cut materializes it once. Severed
+    sharing is the recompute class PR #679 measured at three orders of magnitude."""
+    case = Path(__file__).parents[2] / "realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml"
+    (record,) = load_golden_records(load_golden_file(case))
+    tile = _lifted_target(record)
+
+    def folds(node, out):
+        if isinstance(node, Fold):
+            out.setdefault(id(node), node)
+            for edge in node.operands:
+                folds(edge, out)
+            for stmt in node.lift.body:
+                folds(stmt, out)
+        return out
+
+    by_identity = folds(tile.op, {})
+    by_value: dict[tuple, list[Fold]] = {}
+    for node in by_identity.values():
+        by_value.setdefault((node.structural_key(), node.deps()), []).append(node)
+    for twins in by_value.values():
+        distinct_equals = [(a, b) for index, a in enumerate(twins) for b in twins[index + 1 :] if a == b]
+        assert not distinct_equals, "normalization left structurally equal cones as distinct objects"
+
+
 def test_reduced_qk_attention_offers_the_statistic_arm_b_seams_idempotently() -> None:
     """The reduced Qwen3 q/k-norm SDPA target offers the score contractions' K operand cones."""
     case = Path(__file__).parents[2] / "realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml"
@@ -355,10 +383,11 @@ def test_reduced_qk_attention_offers_the_statistic_arm_b_seams_idempotently() ->
     tile = _lifted_target(record)
     seams = {seam.spelling: seam for seam in cuttable_seams(tile)}
     seam = seams["PLACE@map.fold.a.map.fold.fold.b1"]
-    # The score contractions' K cones are one VALUE: the sigma-equivalent duplicates — the sum
-    # arm, the softmax-V arm, and the second-path copies of both statistic arms — ride the
-    # representative seam as siblings, each with its capture correspondence.
-    assert len(seam.siblings) == 4
+    # The score contractions' K cones are one VALUE. Name-identical copies (the second-path
+    # duplicates of each statistic arm) collapse into shared objects at normalization, so only
+    # the copies captured under DIFFERENT axis names — the sum arm and the softmax-V arm — remain
+    # clustering siblings, each with its capture correspondence.
+    assert len(seam.siblings) == 2
     assert all(dict(pairs).keys() == dict(seam.siblings[0][1]).keys() for _, pairs in seam.siblings)
     assert "PLACE@map.fold.a.map.fold.fold.b2" not in seams
     assert TileOp(op=tile.op, name=tile.name, place=tile.place, output_specs=tile.output_specs).op is tile.op

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -327,6 +327,89 @@ def test_composed_scoped_place_pins_cut_together_and_foreign_pins_are_skipped() 
     assert any(set(node.inputs) & workspaces for node in producers), "the nested value's producer must read a sibling workspace"
 
 
+def _composed_case_match() -> tuple[Match, Graph]:
+    case = Path(__file__).parents[1] / "realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml"
+    (record,) = load_golden_records(load_golden_file(case))
+    tile = _lifted_target(record)
+    graph = Graph()
+    for name, tensor in tile.inputs.items():
+        graph.add_node(InputOp(), [], tensor, node_id=name)
+    graph.add_node(tile, list(tile.inputs), next(iter(tile.outputs.values())), node_id=tile.name)
+    return Match(graph=graph, root_node_id=tile.name, rule=Rule(name="test", pattern=[])), graph
+
+
+_STAT_PINS = {
+    "PLACE@map.fold.a21": "cut",
+    "PLACE@map.fold.a.map.fold.fold.b1": "cut",
+    "PLACE@map.fold.a.map.fold.fold.a1": "cut",
+    "PLACE@map.fold.a1": "cut",
+    "PLACE@map.fold.a.map.fold.a31": "cut",
+    "PLACE@map.fold.a.map.fold.a32": "cut",
+}
+
+
+def test_statistics_seams_close_via_providers_and_declare_requirements() -> None:
+    """The softmax-statistics folds capture host-provided scalars and each other's accumulator;
+    provider closure offers them anyway, with the chain recorded as a requirement."""
+    match, graph = _composed_case_match()
+    tile = next(node.op for node in graph.nodes.values() if isinstance(node.op, TileOp))
+    seams = {seam.spelling: seam for seam in cuttable_seams(tile)}
+    first = seams["PLACE@map.fold.a.map.fold.a31"]
+    second = seams["PLACE@map.fold.a.map.fold.a32"]
+    assert first.providers and not first.requires
+    assert second.providers and len(second.requires) == 1
+    assert second.requires[0][1] is first.node
+
+
+def test_dependent_seam_pins_pull_their_producer_into_the_composed_cut() -> None:
+    """Pinning only the second statistics pass cuts the first beside it — the requirement is
+    structural, so the pin cannot decline it."""
+    match, graph = _composed_case_match()
+    node = next(node for node in graph.nodes.values() if isinstance(node.op, TileOp))
+    with pinned_knobs({"PLACE@map.fold.a.map.fold.a32": "cut", **_OFF}):
+        fork = _CUT.rewrite(match, node)
+    assert set(fork.knobs) == {"PLACE@map.fold.a.map.fold.a32", "PLACE@map.fold.a.map.fold.a31"}
+
+
+def test_statistics_route_shares_the_row_reduction_across_output_keys() -> None:
+    """The composed statistics route computes each row statistic once per query: no piece repeats
+    a key-extent reduce beneath its output-key axis, and the softmax-weight piece keeps only the
+    per-element score contraction (the recompute PR #679 measured at three orders of magnitude)."""
+    match, graph = _composed_case_match()
+    node = next(node for node in graph.nodes.values() if isinstance(node.op, TileOp))
+    key_extent = 8
+
+    def reduce_extents(op) -> list[int]:
+        out = []
+        stack = [op]
+        while stack:
+            current = stack.pop()
+            if isinstance(current, Fold):
+                if current.axis is not None:
+                    out.append(current.axis.extent.as_static())
+                stack.extend(current.operands)
+                stack.extend(current.lift.body)
+        return out
+
+    with pinned_knobs({**_STAT_PINS, **_OFF}):
+        fragment = _CUT.rewrite(match, node).expand()[0]
+    pieces = [piece for piece in fragment.nodes.values() if isinstance(piece.op, TileOp)]
+    assert len(pieces) == 7  # six workspaces plus the consumer
+    workspaces = {piece.id for piece in pieces if "__place_" in piece.id}
+    # The two statistics pieces each run the key-extent scan ONCE, into a per-query workspace
+    # (batch·head × query — no output-key axis).
+    statistics = [piece for piece in pieces if "__place_" in piece.id and reduce_extents(piece.op.op).count(key_extent) == 1]
+    assert len(statistics) == 2
+    assert all(len(piece.op.place.free) == 2 for piece in statistics)
+    # The softmax-weight piece sweeps the output-key axis, reads those workspaces back, and keeps
+    # only the per-element score contraction — the key-extent scan does not reappear beneath its
+    # output-key axis, and neither does it in the consumer beyond the softmax·V contraction itself.
+    weight = next(piece for piece in pieces if "__place_" in piece.id and len(piece.op.place.free) == 3 and set(piece.inputs) & workspaces)
+    assert key_extent not in reduce_extents(weight.op.op)
+    consumer = next(piece for piece in pieces if "__place_" not in piece.id)
+    assert reduce_extents(consumer.op.op).count(key_extent) == 1
+
+
 def _receipt_fields() -> dict:
     return {
         "name": "sdpa.child",

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-sdpa-stat-fill.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-sdpa-stat-fill.yaml
@@ -57,7 +57,6 @@ configs:
       TILE: mma_m16n8k16_f16_f32/f1x1
       TILE@a.fold.a4: mma_m16n8k16_f16_f32/f1x1
       TILE@a8: ''
-      TILE@map.fold.fold.a41: mma_m16n8k16_f16_f32/f1x1
       REDUCE@map.fold.a21: ''
       REDUCE@a7: ''
       REDUCE@a.fold.a3: ''
@@ -65,8 +64,6 @@ configs:
       REDUCE@a.b.fold.a4: ''
       REDUCE@map.fold.a.fold.a81: ''
       REDUCE@b.fold.a8: ''
-      REDUCE@map.fold.a31: ''
-      REDUCE@map.fold.fold.a41: ''
       STAGE@map.fold.a21: ''
       STAGE@a7: d1/smem
       STAGE@a.fold.a3: ''
@@ -74,6 +71,4 @@ configs:
       STAGE@a.b.fold.a4: ''
       STAGE@map.fold.a.fold.a81: ''
       STAGE@b.fold.a8: ''
-      STAGE@map.fold.a31: ''
-      STAGE@map.fold.fold.a41: d1/smem
     identity: 5ddf1772501faa05906fce50274ec678cfb78a51d14cb9793d6b2b65971b8b70

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-route.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-route.yaml
@@ -1,0 +1,67 @@
+# evidence: the sibling composed-cut case realizes the three-cut route on this program, and the
+# provider-closed softmax-statistics seams realize beside it (the pinned six-cut route removes the
+# per-output-key recompute of the row statistics: each statistics piece runs once per query row and
+# the softmax-weight piece reads the workspaces back). Guards the seam offer itself: if provider
+# closure or dependent-seam composition regresses, this pin stops being offered.
+compute_cap:
+- 12
+- 0
+programs:
+- inputs: [q, k, v, qw, kw]
+  outputs: [out]
+  nodes:
+  - id: k
+    op: input
+    outputs: [[k, f16, [1, 2, 8, 16]]]
+  - id: kw
+    op: input
+    outputs: [[kw, f16, [16]]]
+  - id: kn
+    op: torch.rms_norm
+    attrs: {eps: 1.0e-06}
+    inputs: [k, kw]
+    outputs: [[kn, f16, [1, 2, 8, 16]]]
+  - id: q
+    op: input
+    outputs: [[q, f16, [1, 2, 8, 16]]]
+  - id: qw
+    op: input
+    outputs: [[qw, f16, [16]]]
+  - id: qn
+    op: torch.rms_norm
+    attrs: {eps: 1.0e-06}
+    inputs: [q, qw]
+    outputs: [[qn, f16, [1, 2, 8, 16]]]
+  - id: v
+    op: input
+    outputs: [[v, f16, [1, 2, 8, 16]]]
+  - id: out
+    op: torch.sdpa
+    attrs: {is_causal: true, sliding_window: null, scale: null}
+    inputs: [qn, kn, v]
+    outputs: [[out, f16, [1, 2, 8, 16]]]
+configs:
+- program: 0
+  target:
+    origins:
+    - kn
+    - out
+    - qn
+  realizations:
+  - name: k_sdpa_rms_norm_reduce_dd476e.6741552db729
+    bindings: {}
+    pins:
+      FAST_MATH: false
+      PLACE@map.fold.a21: cut
+      PLACE@map.fold.a.map.fold.fold.b1: cut
+      PLACE@map.fold.a.map.fold.fold.a1: cut
+      PLACE@map.fold.a1: cut
+      PLACE@map.fold.a.map.fold.a31: cut
+      PLACE@map.fold.a.map.fold.a32: cut
+    knobs:
+      TILE: ''
+      WORK: ''
+      REDUCE: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 83e4f2a6fa484a4b2a50babe833fc9cf35021c1f551fcfabaf496658c24d055f


### PR DESCRIPTION
## Summary

- restore object sharing between structurally identical cones as the final Tile IR normalization step (`_share_common_cones`), and document it as an invariant: cross-kernel recompute is a Tile-level sharing or seam-offer defect — never a Loop IR fusion or emission patch
- offer body-member statistics folds through provider closure at the placement fork: host-provided scalar chains join the produced piece, and a capture defined by a sibling fold makes the seam dependent — realizable only as a composed cut with its producer, whose workspace the piece reads back
- keep provider-closed and dependent seams scoped-pin-only: bare `PLACE=cut` recursion terminates by seam depletion, and provider closure otherwise makes every fresh piece inexhaustible (one corpus case's enumeration went from 0.5 s to unbounded before this bound)
- add the closed corpus case `attention/rmsnorm-qk-sdpa-stat-route.yaml` (offered, realized, built, correct on sm_120) and structural tests asserting the row reduction is not duplicated beneath the output-key axis
- re-author `rmsnorm-gqa-sdpa-stat-fill.yaml`, whose knob row carried keys for the duplicate sites sharing removed

## Why

PR #679's diagnosis: the softmax-materialization child stayed at 72–111 ms under every schedule because it recomputed the complete 512-key row-statistics reduction — including each 128-channel score contraction — per output weight. On the checked s512 target the two normalizer folds turn out to be equal-but-distinct copies (`==` equal, identical captures, equal `structural_key`) in the weight cone and the epilogue; `realize` replaces by object identity and value clustering covers only contraction-operand seams, so no composed cut could reach them. With sharing restored and the statistics seams offerable, the pinned six-cut route computes each row statistic once per query row into a `[16, 512]` workspace; the weight piece keeps only its per-element score contraction and the consumer only the softmax·V contraction.

## Verification

- `make test`: 4690 passed, 49 skipped, 16 xfailed, 2 xpassed (the two xpasses are the known PR #438 TMA-staging last-ulp flakes, unrelated), 5:47 wall — no suite-wide slowdown from the sharing walk
- `make lint`: clean
- new corpus case passes all four stages on the local RTX 5090; composed statistics route also matches a numpy reference on a fresh rmsnorm+causal-SDPA build (max abs err equal to the fused kernel's)
- the previously hanging `rmsnorm-qk-sdpa-stat-cut.yaml` offered stage is back to 0.5 s

Per-child retuning of the s512 route on real hardware (the receipts from #681) is follow-up work, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5cicFbCxJGpS6fSkEMP5A