### PR TITLE
Five correctness fixes in the placement cut

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -84,6 +84,17 @@ These are term operations spelled the same way so one canonicalizer and one deep
 vocabularies; they are not statement behaviour, and `Fold` has no `render`. Impure computation stays
 in Loop IR until total lift; there is no impure `Lambda` construction path.
 
+**`nested()` is the STATEMENT protocol, and it deliberately does not reach a Fold's operand edges**
+— it yields the lift body, and nothing at all for a contraction, whose algebra is meant to read as
+edges rather than body deps. Every walk built on it (`Body.iter`, and so `Body.loads` /
+`Body.writes`) therefore answers for a fully flattened stream only. A lowered body is not always
+one: a term survives lowering wherever a region kept it (`ProjectionRegion` holds its cones as
+terms), and a walk over `Fold.lower()` then silently under-reports everything beneath such an edge.
+Ask `loaded_buffers` instead whenever the answer must cover what a consumer of the STORED tree will
+reach — the kernel materializer walks that tree, so anything deciding a node's graph inputs has to
+see what it sees. Asking the lowered view there is what let a cut declare fewer inputs than the
+kernel it produced went on to read.
+
 ## Invariants by stage
 
 - **Frontend → tensor** (after `decomposition`): `LinearOp`, `MatmulOp`,

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -875,6 +875,42 @@ def deep_reads(stmts: list[Stmt]) -> set[str]:
     return out
 
 
+def loaded_buffers(node) -> set[str]:
+    """Every graph BUFFER loaded under ``node`` — a term, a stmt, or a body of them.
+
+    ``Body.loads`` walks ``Stmt.nested()``, and a Fold's operand EDGES are not nested statements:
+    :meth:`Fold.nested` yields the lift body, and nothing at all for a contraction, whose algebra
+    is meant to read as edges rather than body deps. That is fine for a fully flattened stream,
+    but a lowered body still carries Folds as TERMS wherever a region kept them
+    (:class:`~emmy.compiler.ir.tile.ir.ProjectionRegion` holds its cones as terms), so asking the
+    lowered body alone silently under-reports every buffer beneath such an edge.
+
+    Ask this whenever the answer must cover what a consumer of the STORED tree will reach — the
+    cut declaring a piece's graph inputs, ordering pieces by the workspaces they read. A cut that
+    declared the lowered view instead named fewer inputs than the kernel the materializer built
+    from the same tree went on to read, and the workspace producers, unreferenced, were pruned as
+    orphans."""
+    out: set[str] = set()
+    seen: set[int] = set()
+    stack = [node]
+    while stack:
+        item = stack.pop()
+        if id(item) in seen:
+            continue
+        seen.add(id(item))
+        if isinstance(item, Load):
+            out.add(item.input)
+        elif isinstance(item, Fold):
+            stack.extend(item.operands)
+            stack.extend(item.lift.body)
+        elif isinstance(item, (list, tuple, Body)):
+            stack.extend(item)
+        else:
+            for body in item.nested():
+                stack.extend(body)
+    return out
+
+
 def stmt_axis_names(stmts) -> set[str]:
     """Every loop induction variable bound anywhere in ``stmts`` (deep). A composed structural node
     sitting in the body needs no special case — it is a ``Stmt``, so its children are reached through
@@ -1047,11 +1083,12 @@ def _(s: Fold, rename, sigma, axis_fn):
 
 __all__ = [
     "Channel",
-    "Fold",
     "deep_defines",
     "deep_reads",
     "edge_refs_axis",
+    "Fold",
     "is_contraction",
+    "loaded_buffers",
     "operand_body",
     "operand_name",
     "refs_axis",

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -68,6 +68,18 @@ def cone_seam(cone, k_name: str) -> tuple[tuple, tuple, tuple[str, ...]]:
     return (pro, cell, stats) if stats else ((), cell, ())
 
 
+def _dtype_key(edge, scope: dict | None) -> tuple:
+    """An edge's cache key: its identity plus the dtypes its CAPTURES resolve to at this
+    occurrence. Captures are what make the answer occurrence-dependent; an edge with none keys the
+    same with or without a scope, so the unscoped and scoped walks share their entries."""
+    # Identity keying is only valid while the tree is alive — which it is for every caller, who
+    # holds the root across the walk.
+    captures = sorted(edge.deps()) if isinstance(edge, Fold) else ()
+    if not captures or not scope:
+        return (id(edge), ())
+    return (id(edge), tuple((name, getattr(scope.get(name), "name", None)) for name in captures))
+
+
 def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict | None = None) -> tuple:
     """Infer an edge's result dtypes in the lexical scope where the edge occurs.
 
@@ -78,16 +90,17 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict
     capturing seam whose occurrences resolve to equal providers, and equal providers type equally.
     """
     cache = {} if cache is None else cache
-    if id(edge) in cache:
-        return cache[id(edge)]
+    key = _dtype_key(edge, scope)
+    if key in cache:
+        return cache[key]
     if isinstance(edge, Load):
         tensor = inputs.get(edge.input) if inputs else None
         result = (tensor.dtype if tensor is not None else None,) * len(edge.names)
-        cache[id(edge)] = result
+        cache[key] = result
         return result
     if not isinstance(edge, Fold):
         result = (None,) * len(_operand_result_names(edge))
-        cache[id(edge)] = result
+        cache[key] = result
         return result
 
     env = dict(scope or {})
@@ -116,7 +129,7 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict
     else:
         carried = lifted[: len(edge.combine.results)]
         result = carried + tuple(env.get(name) for name in _operand_result_names(edge)[len(carried) :])
-    cache[id(edge)] = result
+    cache[key] = result
     return result
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -20,7 +20,15 @@ from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
-from emmy.compiler.ir.pure.fold import Fold, _expectation_bindings, _operand_result_names, deep_defines, deep_reads, is_contraction
+from emmy.compiler.ir.pure.fold import (
+    Fold,
+    _expectation_bindings,
+    _operand_result_names,
+    deep_defines,
+    deep_reads,
+    is_contraction,
+    loaded_buffers,
+)
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.ops import edge_dtypes
@@ -212,12 +220,27 @@ def _environments(root: Fold) -> dict[int, list[tuple[Fold, ...]]]:
     def visit(node: Fold, outer: tuple[Fold, ...]) -> None:
         inner = (node, *outer)
         for child in (*node.operands, *node.lift.body):
-            if isinstance(child, Fold):
-                environments.setdefault(id(child), []).append(inner)
-                visit(child, inner)
+            for stored in _stored_folds(child):
+                environments.setdefault(id(stored), []).append(inner)
+                visit(stored, inner)
 
     visit(root, ())
     return environments
+
+
+def _stored_folds(member):
+    """``member`` itself when it is a Fold, else every Fold stored in its nested bodies.
+
+    A plain statement binds axes, not SSA definitions, so it is not a resolution scope — but it can
+    HOLD a stored fold (a ``ProjectionRegion`` keeps its cones), and one reached only that way had
+    no environment at all, which drops its seam. ``_tree.walk`` alternates node-wise and
+    statement-wise for the same reason."""
+    if isinstance(member, Fold):
+        yield member
+        return
+    for body in member.nested():
+        for stmt in body:
+            yield from _stored_folds(stmt)
 
 
 def _closed_in(node: Fold, environment: tuple[Fold, ...], axis_names: set[str]) -> tuple[tuple, tuple] | None:
@@ -294,6 +317,23 @@ def _provider_closure(node: Fold, scopes, environments: list[tuple[Fold, ...]]) 
     return first_providers, first_requires
 
 
+def _dtype_table(tile: TileOp) -> dict[int, tuple]:
+    """Each stored edge's inferred result dtypes, typed in its own lexical scope — and only where
+    every occurrence agrees.
+
+    ``edge_dtypes`` keys its cache by edge identity AND the dtypes of that occurrence's captures,
+    because one shared cone under two scopes has two answers. A seam stands for ONE value, so a
+    node whose occurrences disagree has no determined workspace and simply does not appear here;
+    :func:`_workspace_dtypes` then declines to offer it, which is the same answer provider closure
+    gives when the occurrences spell different sources."""
+    cache: dict[tuple, tuple] = {}
+    edge_dtypes(tile.op, tile.inputs, cache)
+    answers: dict[int, set[tuple]] = {}
+    for (node_id, _captures), dtypes in cache.items():
+        answers.setdefault(node_id, set()).add(dtypes)
+    return {node_id: next(iter(seen)) for node_id, seen in answers.items() if len(seen) == 1}
+
+
 def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     """Every semantically closed stored Fold edge whose workspace dtypes are determined, grouped
     only by object sharing. A contraction's operand edges are seams too — cutting one materializes
@@ -327,7 +367,7 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     dtype_table: dict[int, tuple] = {}
     if isinstance(tile.op, Fold):
         environments = _environments(tile.op)
-        edge_dtypes(tile.op, tile.inputs, dtype_table)
+        dtype_table = _dtype_table(tile)
     out: list[CutSite] = []
     seen: set[int] = set()
     for site in family_sites("PLACE", all_sites):
@@ -379,6 +419,14 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     return _cluster_value_seams(out, {id(seam.node): seam.frontier is None and store_dtype_consumers.get(id(seam.node)) for seam in out})
 
 
+def _closure_key(seam: CutSite) -> tuple:
+    """What a seam closes over, as a comparable value: its provider stmts and the SOURCES its
+    requirements name. Two cones can be alpha-equivalent and still read different sources — a
+    capture is a free name, and one host may define ``x = sum(a)`` where the other defines
+    ``x = sum(b)`` — so the closure is part of the value, and clustering compares it."""
+    return (seam.providers, tuple((name, id(producer)) for name, producer in seam.requires))
+
+
 def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) -> tuple[CutSite, ...]:
     """Fold duplicate operand cones — alpha-equivalent up to captured axis names — into ONE seam per value.
 
@@ -391,7 +439,13 @@ def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) ->
     (:func:`~emmy.compiler.ir.pure.closure.equivalent_clusters`); a member joins only when its
     paired axes agree on extent and window, its workspace dtypes match, and every workspace axis
     is a mapped capture — otherwise it stays its own seam."""
-    eligible = [index for index, seam in enumerate(seams) if operand_of.get(id(seam.node))]
+    # A seam ANOTHER seam requires never joins a cluster, as representative or as member. A
+    # dependent's piece reads its producer's workspace by the name that producer binds, and
+    # clustering re-points a value at the representative — whose result names are its own. Leaving
+    # a required producer alone keeps the requirement pointing at a seam that still exists and
+    # still binds the name the dependent reads.
+    required = {id(producer) for seam in seams for _, producer in seam.requires}
+    eligible = [index for index, seam in enumerate(seams) if operand_of.get(id(seam.node)) and id(seam.node) not in required]
     if len(eligible) < 2:
         return tuple(seams)
     scoped = {index: Closure.over_edge(seams[index].node, tuple(axis.name for axis in seams[index].axes)) for index in eligible}
@@ -411,9 +465,13 @@ def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) ->
             member = seams[member_index]
             member_params = scoped[member_index].axes
             member_axes = {axis.name: axis for axis in member.axes}
-            aligned = member.dtypes == rep.dtypes and all(
-                (a := rep_axes[rn]).extent == (b := member_axes[mn]).extent and a.window == b.window
-                for rn, mn in zip(rep_params, member_params, strict=True)
+            aligned = (
+                member.dtypes == rep.dtypes
+                and _closure_key(member) == _closure_key(rep)
+                and all(
+                    (a := rep_axes[rn]).extent == (b := member_axes[mn]).extent and a.window == b.window
+                    for rn, mn in zip(rep_params, member_params, strict=True)
+                )
             )
             if not aligned:
                 continue
@@ -472,7 +530,14 @@ def _workspace_axes(seam: CutSite, produced: Fold) -> tuple:
 
 
 def _piece_inputs(root: Node, fold: Fold, first: tuple[str, ...] = ()) -> list[str]:
-    reads = {load.input for load in Body.coerce(fold.lower()).loads}
+    """A piece's graph inputs: its workspaces, then every buffer of ``root``'s the piece reads.
+
+    The read set is the STORED tree's (:func:`loaded_buffers`), not the lowered body's, because the
+    kernel this node becomes is materialized from that tree. A Fold a region keeps as a term hides
+    its operand edges from a lowered-body walk, so declaring the lowered view named fewer inputs
+    than the kernel went on to read; the workspace producers then had no consumer edge, were pruned
+    as orphans, and the launch asked for a buffer nothing had allocated."""
+    reads = loaded_buffers(fold)
     return [*first, *(name for name in root.inputs if name in reads)]
 
 
@@ -517,7 +582,7 @@ def _producer_order(pieces) -> list:
     ordered = []
     available: set[str] = set()
     while remaining:
-        ready = [piece for piece in remaining if {load.input for load in Body.coerce(piece[1].lower()).loads} & workspaces <= available]
+        ready = [piece for piece in remaining if loaded_buffers(piece[1]) & workspaces <= available]
         assert ready, "strict Fold containment makes the cut-workspace dependency graph acyclic"
         ordered.extend(ready)
         available.update(buffer for *_, buffers in ready for buffer in buffers)
@@ -565,7 +630,14 @@ def realize(
                 producer_loads = workspace_loads.get(id(producer))
                 if producer_loads is None:
                     raise ValueError(f"seam {seam.spelling!r} requires {name!r} from a producer seam absent from this composed cut")
-                prefix.extend(load for load in producer_loads if isinstance(load, Load) and name in load.defines())
+                # Whatever binds the name, taken by the name it BINDS: a plain workspace ``Load``,
+                # or — when the producer cut at a storage frontier — the projection wrapping the
+                # raw load and its decode residue. Matching on ``Load`` alone skipped the frontier
+                # form and left the requirement unbound in the piece.
+                supplied = [entry for entry in producer_loads if name in _operand_result_names(entry)]
+                if not supplied:
+                    raise ValueError(f"seam {seam.spelling!r} requires {name!r}, which its producer seam does not bind")
+                prefix.extend(supplied)
             produced = Fold.projection(body=Body((*prefix, produced)), results=names)
         axes = _workspace_axes(seam, produced)
         index = tuple(Var(axis.name) for axis in axes)
@@ -621,7 +693,7 @@ def realize(
         producer = replace(producer, knobs=consume_kernel_row(producer.knobs))
         shape = tuple(axis.extent for axis in axes)
         workspace_tensors = tuple(Tensor(name=buffer, shape=shape, dtype=dtype) for buffer, dtype in zip(buffers, seam.dtypes, strict=True))
-        reads = {load.input for load in Body.coerce(produced.lower()).loads}
+        reads = loaded_buffers(produced)
         fragment.add_node(
             op=producer,
             inputs=_piece_inputs(root, produced, tuple(buffer for buffer in all_buffers if buffer in reads)),

--- a/tests/compiler/ir/pure/test_loaded_buffers.py
+++ b/tests/compiler/ir/pure/test_loaded_buffers.py
@@ -1,0 +1,52 @@
+"""``loaded_buffers`` — every buffer a stored term reads, operand edges included."""
+
+from __future__ import annotations
+
+from emmy.compiler.dim import Dim
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.pure import Fold, Lambda
+from emmy.compiler.ir.pure.fold import loaded_buffers
+from emmy.compiler.ir.stmt import Assign, Body, Load
+from emmy.compiler.ir.tile.ir import ProjectionRegion
+
+
+def _region_holding_a_cone() -> Fold:
+    """A cone whose OPERAND edge loads ``ws``, kept as a TERM inside a ``ProjectionRegion``.
+
+    This is DeepSeek-V4 ``post4096``'s shape, minimized: repeated placement leaves the fused root
+    holding its cut cones inside output regions, and each cone reads its workspace through an
+    operand edge."""
+    source = Fold.projection(body=Body((Load(name="w", input="ws", index=(Var("j"),)),)), results=("w",))
+    cone = Fold.projection(operands=(source,), body=Body((Assign(name="c", op="relu", args=("w",)),)), results=("c",))
+    region = ProjectionRegion(axis=Axis("j", Dim(4)), lift=Lambda(params=("j",), body=Body((cone,)), results=("c",)))
+    return Fold.projection(body=Body((region, Assign(name="out", op="copy", args=("c",)))), results=("out",))
+
+
+def test_a_cone_kept_as_a_term_still_reports_its_operand_buffers() -> None:
+    """The lowered body cannot answer this, which is why the cut may not ask it.
+
+    ``Body.loads`` walks ``Stmt.nested()``, and a Fold's operand edges are not nested statements —
+    so a region that keeps its cone as a term hides every buffer beneath that edge. A cut that
+    declared the lowered view named fewer graph inputs than the kernel the materializer built from
+    the same tree went on to read; the workspace producers lost their only consumer edge, were
+    pruned as orphans, and the launch asked for a buffer nothing had allocated
+    (``KeyError: '<node>__place_<token>_0'`` on DeepSeek-V4's TP8xPP2 boot)."""
+    root = _region_holding_a_cone()
+
+    assert {load.input for load in Body.coerce(root.lower()).loads} == set()
+    assert loaded_buffers(root) == {"ws"}
+
+
+def test_loaded_buffers_reads_a_contraction_through_its_edges() -> None:
+    """A contraction's ``nested()`` is empty by design — its algebra IS its operand edges."""
+    from emmy.compiler.ir.pure import Channel
+
+    contraction = Fold.contraction(
+        k_axis=Axis("k", Dim(8)),
+        a=Load(name="av", input="x", index=(Var("m"), Var("k"))),
+        channels=(Channel(b=Load(name="bv", input="w", index=(Var("n"), Var("k"))), acc="acc"),),
+    )
+
+    assert contraction.nested() == ()
+    assert loaded_buffers(contraction) == {"x", "w"}

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -225,3 +225,32 @@ def test_iteration_variables_are_not_captures() -> None:
 
 
 # --- the projection binder ----------------------------------------------------------------------- #
+
+
+def test_a_shared_cone_is_typed_in_each_occurrence_scope() -> None:
+    """``edge_dtypes`` answers per OCCURRENCE, not per object.
+
+    Normalization shares one Fold object between structurally identical cones, so the same cone
+    can sit under an f16 capture in one host and an f32 capture in another. Its result dtype is a
+    property of the occurrence, and a cache keyed on identity alone handed every occurrence the
+    first one's answer — which a cut then believes when it sizes the seam's workspace."""
+    from emmy.compiler.dtype import get as get_dtype
+    from emmy.compiler.ir.tile.ops import edge_dtypes
+    from emmy.compiler.tensor import Tensor
+
+    shared = Fold.projection(body=Body((Assign(name="y", op="relu", args=("x",)),)), results=("y",))
+    inputs = {"a": Tensor("a", (4,), get_dtype("f16")), "b": Tensor("b", (4,), get_dtype("f32"))}
+
+    def host(buf: str, out: str) -> Fold:
+        source = Fold.projection(body=Body((Load(name="x", input=buf, index=(Var("i"),)),)), results=("x",))
+        return Fold.projection(operands=(source, shared), body=Body((Assign(name=out, op="copy", args=("y",)),)), results=(out,))
+
+    # Both hosts stay referenced for the whole check: the cache keys on object identity, which is
+    # only stable while the keyed objects are alive.
+    narrow_host, wide_host = host("a", "z0"), host("b", "z1")
+    cache: dict = {}
+    narrow = edge_dtypes(narrow_host, inputs, cache)
+    wide = edge_dtypes(wide_host, inputs, cache)
+
+    assert [dtype.name for dtype in narrow] == ["f16"]
+    assert [dtype.name for dtype in wide] == ["f32"]

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -24,7 +24,13 @@ from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.loop_wire import loop_graph_to_wire
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule, RuleSkipped
 from emmy.compiler.pipeline.fork import Fork
-from emmy.compiler.pipeline.passes.lowering.tile._cut import CutSite, _producer_order, _workspace_axes, cuttable_seams
+from emmy.compiler.pipeline.passes.lowering.tile._cut import (
+    CutSite,
+    _environments,
+    _producer_order,
+    _workspace_axes,
+    cuttable_seams,
+)
 from emmy.compiler.pipeline.pipeline import Run, _is_structural_option
 from emmy.compiler.pipeline.search.golden import (
     GoldenRecord,
@@ -592,3 +598,73 @@ def test_pool_group_fuses_node_id_respellings_and_keys_on_pins() -> None:
 
     unpinned = GoldenRecord(knobs={}, **{**fields, "pins": ()})
     assert unpinned.pool_group != a.pool_group, "the pin regime is a group-key term"
+
+
+def test_a_fold_held_by_a_plain_statement_still_gets_an_environment() -> None:
+    """A plain statement binds axes, not SSA definitions — but it can HOLD a stored fold.
+
+    ``ProjectionRegion`` keeps its cones as terms, and a fold reached only that way had no lexical
+    environment at all, so provider closure could not resolve its captures and silently dropped its
+    seam. The canonical tree walk alternates node-wise and statement-wise for the same reason."""
+    from emmy.compiler.ir.pure import Lambda
+    from emmy.compiler.ir.tile.ir import ProjectionRegion
+
+    cone = Fold.projection(body=Body((Assign(name="c", op="relu", args=("x",)),)), results=("c",))
+    region = ProjectionRegion(axis=Axis("j", 4), lift=Lambda(params=("j",), body=Body((cone,)), results=("c",)))
+    root = Fold.projection(
+        body=Body((Load(name="x", input="a", index=(Var("j"),)), region, Assign(name="out", op="copy", args=("c",)))),
+        results=("out",),
+    )
+
+    assert id(cone) in _environments(root), "a cone a region holds must still resolve its captures"
+    assert _environments(root)[id(cone)] == [(root,)]
+
+
+def _cone_seam(providers: tuple = (), requires: tuple = ()) -> CutSite:
+    """A bare seam record standing in for a clustered operand cone."""
+    node = Fold.projection(body=Body((Load(name="w", input="w", index=(Var("n"), Var("k"))),)), results=("w",))
+    return CutSite(node=node, spelling="PLACE@b", axes=(Axis("n", 8), Axis("k", 8)), dtypes=(F16,), providers=providers, requires=requires)
+
+
+def test_two_cones_that_close_over_different_sources_are_not_one_value() -> None:
+    """Clustering merges cones that are alpha-equivalent — but a capture is a FREE name.
+
+    Two B cones can spell ``w[n,k] * x`` identically while one host defines ``x = sum(a)`` and the
+    other ``x = sum(b)``; normalization refuses to sink either reduce, so both cones keep the same
+    free name. Merging them materializes one and lets the other read it, which silently hands the
+    second contraction the first's value. The closure is part of the value."""
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import _cluster_value_seams
+
+    first_source = Fold.projection(body=Body((Load(name="x", input="a", index=(Var("k"),)),)), results=("x",))
+    second_source = Fold.projection(body=Body((Load(name="x", input="b", index=(Var("k"),)),)), results=("x",))
+    consumer = object()
+
+    same = [_cone_seam(requires=(("x", first_source),)), _cone_seam(requires=(("x", first_source),))]
+    differing = [_cone_seam(requires=(("x", first_source),)), _cone_seam(requires=(("x", second_source),))]
+
+    clustered = _cluster_value_seams(same, {id(seam.node): consumer for seam in same})
+    assert len(clustered) == 1 and len(clustered[0].siblings) == 1
+
+    kept = _cluster_value_seams(differing, {id(seam.node): consumer for seam in differing})
+    assert len(kept) == 2 and not any(seam.siblings for seam in kept)
+
+
+def test_a_required_producer_keeps_its_own_seam() -> None:
+    """A dependent reads its producer's workspace by the name that producer BINDS.
+
+    Clustering re-points a value at its representative, whose result names are its own, so folding
+    a required producer into somebody else's cluster leaves the requirement naming a seam that no
+    longer exists — or, worse, one that binds a different name."""
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import _cluster_value_seams
+
+    # The producer is deliberately NOT first: the cluster representative is whoever leads, so a
+    # required producer that trails would be folded away as a sibling.
+    twin, producer = _cone_seam(), _cone_seam()
+    dependent = _cone_seam(requires=(("w", producer.node),))
+    consumer = object()
+    seams = [twin, producer, dependent]
+
+    kept = _cluster_value_seams(seams, {id(seam.node): consumer for seam in seams})
+
+    assert any(seam.node is producer.node for seam in kept), "the required producer must survive as its own seam"
+    assert not any(sibling is producer.node for seam in kept for sibling, _ in seam.siblings)


### PR DESCRIPTION
Rebased onto `83130d6d9` (#690). **#679 landed this branch's original fix** — the
evaluation-domain rule (`_carries_iteration` and both refusals) is on main
character-for-character, along with an equivalent producer ordering — so that is
dropped from here. Since then **#688** replaced the scoped-lambda privates with
`Closure`, **#689** moved kernel identity onto the canonical lowered body, and
**#690** reworked reduce binding; this branch merges cleanly over all three, and
every fix below was re-checked against the new base rather than assumed to survive.

What remains is five bugs main still carries. One is the `KeyError` that killed the
TP8xPP2 boot; the other four came from two rounds of codex review on this branch.

## The boot blocker: a piece declared its inputs from the lowered body

DeepSeek-V4's TP8xPP2 boot got through weight load, per-layer compile and KV sizing,
then died in whole-program graph capture:

```
KeyError: 'matmul_1_b_unsq_bc__place_7174ebb040_0'
GraphCaptureError: whole-program capture failed
```

Traced on the live V100: the node's `arg_order` held eight buffers its `node.inputs`
did not; the divergence appeared at `010_materialize`; and the TileOp going in already
read all eight — `Fold.lower()` simply did not surface them.

`Body.loads` walks `Stmt.nested()`, and a Fold's operand **edges** are not nested
statements: `Fold.nested` yields the lift body, and nothing at all for a contraction,
whose algebra is meant to read as edges rather than body deps. That is fine for a fully
flattened stream, but a lowered body still carries Folds as **terms** wherever a region
kept them — `post4096`'s root holds its cones inside `ProjectionRegion`s. `_piece_inputs`
and `_producer_order` asked exactly that walk. Each cut on the node re-derived its inputs
from the lossy view and dropped more; the materializer builds the kernel from the
**stored** tree and emitted them all; the workspace producers, left without a consumer
edge, were pruned as orphans.

`loaded_buffers` answers the question the cut actually has, and the three sites that ask
it use it. **Verified on the V100: `post4096` builds its plan and launches**, where it
previously raised.

## Four from review

- **A shared cone was typed once, not per occurrence.** `edge_dtypes` gained a `scope`,
  and seeded from the root it doubles as the tree's dtype table — but it cached under
  `id(edge)`, so one cone under an f16 and an f32 capture got the first answer for both
  and a cut sized the seam's workspace at the wrong dtype. Keyed now by edge plus its
  captures' dtypes; the table keeps only nodes whose occurrences agree.
- **A fold a plain statement holds had no lexical environment.** A statement binds axes,
  not SSA definitions, so it is not a resolution scope — but it can hold a stored fold,
  and one reached only that way could not resolve its captures, silently dropping its seam.
- **A cone's closure is part of its value.** Clustering compared cone syntax only. Two B
  cones can be alpha-equivalent and still read different sources — a capture is a free
  name, and one host may define `x = sum(a)` where the other defines `x = sum(b)`. Merging
  them materializes one and lets the other read it, handing the second contraction the
  first's value. `_closure_key` makes what a seam closes over part of the comparison.
- **A required producer keeps its own seam.** A dependent reads its producer's workspace
  by the name that producer *binds*, while clustering re-points a value at a representative
  whose result names are its own. Required producers no longer cluster at all.

Plus: requirement injection matched `Load` only, so a producer that cut at a storage
frontier — whose entry is the projection wrapping the raw load and its residue — supplied
nothing and left the name unbound.

## Verification

`make test` 3988 passed / 0 failed; `make lint` clean. Six regression tests, each checked
to fail against `origin/main` and pass here.

Codex's second round re-verified the earlier fixes and separately cleared `loaded_buffers`
(including that it need not follow `step_stmts()` — derived folds reuse stored `Load` edges
and introduce no new buffer, which matches the on-host evidence), `_carries_iteration`, and
both evaluation-domain refusals. On enumeration cost: `post4096` is 50 folds / 50
occurrences / 0.1 ms, attention 23 folds / 38 occurrences / 0.03 ms, max depth 8.

**Line balance (step 18): +133 under `emmy/`.** `loaded_buffers` is new shared capability —
the honest reader for "what does this stored term read", now used by three call sites — and
the rest is the four fixes plus the docstrings this repo keeps beside the failure each one
prevents. The one place the growth was layering, an inline seven-clause alignment test,
became `_closure_key`.

## Still open, and not this PR

`post4096` now launches and then runs for tens of minutes: wide contractions nested under
projection regions lower to serial loops. That is a fusion legality/pricing question and is
what still stands between this branch and a serving boot. Probe on the host at
`~/post4096only.py`; log `~/diag/post4096.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

