### PR TITLE
Resume corpus qualification after child-schedule merge

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -229,7 +229,7 @@ overrides, rather than defaulting every failure to the standard lane. `run --gol
 compiler pipeline. When that replay has
 pinned rows, its greedy execution returns same-input outputs so every pinned schedule receives the normal wrong-answer
 check; strict JSON labels the reference `same-input-greedy` when no Torch twin exists. That reference is accepted only
-for an embedded Loop target whose worker returned the exact same inputs and outputs; runnable frontend targets still
+for a non-frontend IR target whose worker returned the exact same inputs and outputs; runnable frontend targets still
 require direct eager correctness. A completed reference survives a later greedy
 timing watchdog: JSON records the exact failure and one-run timing, omits the isolated greedy row, and keeps the command
 nonzero while the pinned schedules receive their normal timed and reference-clean checks. Frontend replay can instead
@@ -237,7 +237,8 @@ request a direct eager correctness proof. Reference-free Loop replay does not al
 of each boundary input; full-program price probes therefore retain the execution path's device-memory contract.
 Repeated names that resolve to different embedded targets remain ambiguous;
 qualification scopes a temporary working YAML to one target rather than guessing. A direct `run --ir` input remains a
-stage-complete artifact and runs only the later passes. JSON records whole-program end-to-end timing for multi-kernel
+stage-complete artifact and runs only the later passes, except that a persisted unmapped Tile child runs the schedule
+rule before that tail without repeating lift or cut. JSON records whole-program end-to-end timing for multi-kernel
 rows, so promotion compares aggregate execution rather than a sum of isolated launch windows.
 `--record` attributes that latency to the measured realization by exact name, pins, and knobs; a repeated name alone
 is never enough to choose a row. Newly appended tune winners start without copied latency because the seed row's

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -172,8 +172,8 @@ def register_run_command(subparsers):
         dest="strict_correctness",
         action="store_true",
         help=(
-            "With --bench on a traced model, runnable frontend IR, or an embedded golden, fail unless every requested backend, "
-            "captured timing, exact pin, and direct Emmy-vs-eager comparison is valid."
+            "With --bench on a traced model or replayable IR, fail unless every requested backend, captured timing, exact pin, "
+            "and direct eager or same-input correctness comparison is valid."
         ),
     )
     parser.add_argument(
@@ -987,6 +987,19 @@ def _failed_bench_status(exc: BaseException) -> str:
     return "compile_timeout" if compile_budget_overrun(exc) else "bench_fail"
 
 
+def _pinned_correctness(run_outputs, ref_outputs, graph, *, strict=False, reference="eager"):
+    """Return flags and the optional strict proof for one same-input pinned replay."""
+    if run_outputs is None or ref_outputs is None:
+        return [], None
+    outputs = _comparison_outputs(run_outputs, graph)
+    if not strict:
+        flag = _wrong_answer_flag(outputs, ref_outputs)
+        return ([flag] if flag else []), None
+    proof = _strict_correctness_proof(outputs, ref_outputs, reference=reference)
+    flag = f"strict {reference} correctness failed: {proof.get('error', 'tolerance exceeded')}"
+    return ([flag] if proof["status"] != "pass" else []), proof
+
+
 async def _bench_golden_variants(
     backend,
     source,
@@ -997,6 +1010,7 @@ async def _bench_golden_variants(
     ref=None,
     strict_correctness=False,
     strict_reference="eager",
+    compile_sample=None,
 ):
     """Compile + bench each recorded golden config with its knobs pinned — one
     ``_GoldenBench`` per config so :func:`_print_kernel_stats` can show each as a measured
@@ -1030,7 +1044,9 @@ async def _bench_golden_variants(
     outputs — an output-correctness check. The default check compares against the greedy
     Emmy output with :func:`_wrong_answer_flag`; ``strict_correctness`` compares every pinned
     row directly against ``strict_reference`` under rtol=atol=1e-3 and records error statistics.
-    Flags render as a ``!`` marker in the table and ride the ``--json`` record."""
+    Flags render as a ``!`` marker in the table and ride the ``--json`` record. Direct IR A/B
+    replay supplies ``compile_sample`` so it shares these gates without pretending the artifact
+    is a frontend source."""
     from emmy.commands.trace import graph_from_code  # noqa: PLC0415
     from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs  # noqa: PLC0415
 
@@ -1050,21 +1066,24 @@ async def _bench_golden_variants(
         try:
             dynamic_shapes = build_torch_dynamic_shapes(parse_position_specs(list(dyn))) if dyn else None
             with pinned_knobs(replay_knobs):
-                # Fresh graph; lowering mutates it and bakes the pins into the kernel.
-                if isinstance(source, str):
-                    graph, _, _ = graph_from_code(source, dynamic_shapes=dynamic_shapes)
+                if compile_sample is not None:
+                    g_compiled = compile_sample(sample)
                 else:
-                    graph = source.copy()
-                g_compiled = backend.compile(graph)
+                    # Fresh graph; lowering mutates it and bakes the pins into the kernel.
+                    if isinstance(source, str):
+                        graph, _, _ = graph_from_code(source, dynamic_shapes=dynamic_shapes)
+                    else:
+                        graph = source.copy()
+                    g_compiled = backend.compile(graph)
         except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own bench table
-            logger.warning("[golden] %s: compile of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
+            logger.warning("[pinned] %s: compile of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
             out.append(_GoldenBench(sample, None, None, [f"compile failed: {exc}"], "bench_fail"))
             continue
         flag = unreproducible_pin_flag(replay_knobs, _cuda_knob_dicts(g_compiled))
         if flag:
             flags.append(f"{flag} — row NOT benched")
             logger.error(
-                "[golden] %s: %s — the pinned config did not realize, so benching it would measure the planner's "
+                "[pinned] %s: %s — the pinned config did not realize, so benching it would measure the planner's "
                 "own pick under the pin's name; fix the pin spelling (row kept unbenched in the table / --json)",
                 sample.name,
                 flag,
@@ -1077,26 +1096,19 @@ async def _bench_golden_variants(
             )
         except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own bench table
             st = _failed_bench_status(exc)
-            logger.warning("[golden] %s: bench of the pinned config failed (%s) — row kept as %s", sample.name, exc, st)
+            logger.warning("[pinned] %s: bench of the pinned config failed (%s) — row kept as %s", sample.name, exc, st)
             out.append(_GoldenBench(sample, g_compiled, None, [f"{st}: {exc}"], st))
             continue
-        run_outputs = _comparison_outputs(run_outputs, g_compiled) if run_outputs is not None else None
-        correctness = None
-        if run_outputs is not None and ref_outputs is not None:
-            if strict_correctness:
-                correctness = _strict_correctness_proof(run_outputs, ref_outputs, reference=strict_reference)
-                if correctness["status"] != "pass":
-                    flags.append(f"strict {strict_reference} correctness failed: {correctness.get('error', 'tolerance exceeded')}")
-            else:
-                flag = _wrong_answer_flag(run_outputs, ref_outputs)
-                if flag:
-                    flags.append(flag)
+        correctness_flags, correctness = _pinned_correctness(
+            run_outputs, ref_outputs, g_compiled, strict=strict_correctness, reference=strict_reference
+        )
+        flags.extend(correctness_flags)
         total_us = (g_bench.min_ms if g_bench.min_ms is not None else g_bench.time_ms) * 1000
         flag = _intensity_floor_flag(sample, total_us)
         if flag:
             flags.append(flag)
         for f in flags:
-            logger.warning("[golden] %s: %s — row flagged (marked ! in the table, flagged in --json)", sample.name, f)
+            logger.warning("[pinned] %s: %s — row flagged (marked ! in the table, flagged in --json)", sample.name, f)
         out.append(_GoldenBench(sample, g_compiled, g_bench, flags, "ok", correctness))
     return out
 
@@ -1879,6 +1891,22 @@ def _replay_stage_and_passes(graph, *, embedded_golden: bool) -> tuple[str, list
     return stage, _passes_after_stage(stage)
 
 
+def _needs_tile_schedule(graph) -> bool:
+    """Whether a direct Tile target persisted before its ordinary schedule decision."""
+    from emmy.compiler.ir.tile import TileOp  # noqa: PLC0415
+
+    return any(isinstance(node.op, TileOp) and node.op.op is not None and not node.op.place.is_mapped for node in graph.nodes.values())
+
+
+def _lower_ir_replay(graph, tail, *, db=None, dump=None):
+    """Lower direct IR while scheduling a persisted Tile child without repeating structural rules."""
+    from emmy.compiler.pipeline import Pipeline  # noqa: PLC0415
+
+    if _needs_tile_schedule(graph):
+        graph = Pipeline.build(["lowering/tile"], select={"schedule"}).run(graph, db=db, dump=dump)
+    return Pipeline.build(tail).run(graph, db=db, dump=dump) if tail else graph
+
+
 def _random_source_values(rng, shape, dtype):
     """Return nontrivial deterministic values in a constant's declared storage dtype."""
     import numpy as np  # noqa: PLC0415
@@ -2014,9 +2042,6 @@ async def bench_lowered_vs_torch(
             # Torch copy is useful only when a frontend reference exists.
             if frontend is not None:
                 input_tensors[nid] = _to_cuda_tensor(arr, node.output.dtype)
-        elif isinstance(node.op, ConstantOp) and node.op.value is not None:
-            input_data[nid] = [float(node.op.value)]
-
     input_data.update(bind_constants(lowered, sources))
     if frontend is not None:
         for fid, arr in bind_constants(frontend, sources).items():
@@ -2218,7 +2243,6 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
 
     from emmy.compiler.backend import torch_ref
     from emmy.compiler.graph import Graph
-    from emmy.compiler.pipeline import Pipeline
 
     strict_correctness = bool(getattr(args, "strict_correctness", False))
     embedded = getattr(args, "_golden_graph", None)
@@ -2235,6 +2259,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
 
     stage, tail = _replay_stage_and_passes(graph, embedded_golden=embedded is not None)
     logger.info("Loaded %s IR; running tail passes: %s", stage, tail or "(none)")
+    replayable = bool(tail or _needs_tile_schedule(graph))
 
     dump = CompilerDump.resolve(args.dump_dir)
     if dump:
@@ -2245,7 +2270,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     # the same table the --code path produces for a debug Graph IR input.
     # Non-frontend IR (loop/tile/…) has no torch twin → emmy-only bench.
     frontend = graph.copy() if torch_ref.is_runnable(graph) else None
-    same_input_greedy = strict_correctness and embedded is not None and frontend is None
+    same_input_greedy = strict_correctness and frontend is None
 
     backend = CudaBackend(debug=args.debug or None, dump=dump, tune_db="auto")
     db = None
@@ -2254,13 +2279,13 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
 
         db = SearchDB(path=backend.tune_db)
         logger.info("Using tuning DB: %s", backend.tune_db)
-    if tail:
+    if replayable:
         # Finish the tail lowering. NOTE: the single-shot ``Pipeline.run`` has no
         # prior (uniform PUCT → emission-order, option-0) and does not replay tuned
         # variants from the DB; ``db=`` is kept for perf recording only. Wiring a
         # warm-started prior into single-shot compile is a deferred follow-up.
         with pinned_knobs(getattr(args, "golden_target_pins", None) or {}):
-            graph = Pipeline.build(tail).run(graph, db=db, dump=dump)
+            graph = _lower_ir_replay(graph, tail, db=db, dump=dump)
 
     if not args.bench:
         # No bench: one in-process run + non-fatal accuracy vs the torch reference
@@ -2290,7 +2315,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     # (``bench_lowered_vs_torch`` rebuilt in-child from the frontend snapshot) and every
     # ``--ab`` row are jobs on one persistent SIGKILL-able worker; a hung kernel dies with
     # the child and the row records bench_fail.
-    if args.ab and not tail:
+    if args.ab and not replayable:
         logger.warning("--ab ignored: %s IR is fully lowered (no forks left to pin)", stage)
 
     async def _bench_session():
@@ -2310,7 +2335,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                     warmup=args.warmup,
                     iters=args.iters,
                     seed=args.seed,
-                    want_ref=bool(pinned and tail),
+                    want_ref=bool((pinned or args.ab) and replayable),
                     strict_accuracy=strict_correctness and not same_input_greedy,
                 )
             except RuntimeError as exc:
@@ -2331,10 +2356,10 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                     )
                 if resp.get("greedy_error"):
                     greedy_fail = f"greedy timing failed after reference execution: {resp['greedy_error']}"
-            if pinned and tail:
+            if pinned and replayable:
                 if ab_ref is None:
                     reason = greedy_fail or "the greedy worker returned no run outputs"
-                    missing = "pinned embedded-Loop verification requires same-input greedy outputs, but none were returned"
+                    missing = "pinned replay requires same-input greedy outputs, but none were returned"
                     reference_error = f"{missing}: {reason}"
                 elif same_input_greedy or not strict_correctness or accuracy_error is None:
                     if greedy_fail:
@@ -2351,11 +2376,26 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                         strict_correctness=strict_correctness,
                         strict_reference="same-input-greedy" if same_input_greedy else "eager",
                     )
-            elif not pinned and args.ab and tail:
-                if greedy_fail:
-                    logger.error("%s — greedy row marked bench_fail; --ab rows still bench in the worker", greedy_fail)
-                greedy_iso = await _bench_greedy_isolated(backend, graph, warmup=args.warmup, iters=args.iters)
-                ab_benches = await _bench_ab_variants_ir(backend, path, tail, args.ab, warmup=args.warmup, iters=args.iters, db=db)
+            elif not pinned and args.ab and replayable:
+                if strict_correctness and ab_ref is None:
+                    reason = greedy_fail or "the greedy worker returned no run outputs"
+                    reference_error = f"exact --ab verification requires same-input outputs, but none were returned: {reason}"
+                else:
+                    if greedy_fail:
+                        logger.error("%s — greedy row marked bench_fail; --ab rows still bench in the worker", greedy_fail)
+                    greedy_iso = await _bench_greedy_isolated(backend, graph, warmup=args.warmup, iters=args.iters)
+                    ab_benches = await _bench_ab_variants_ir(
+                        backend,
+                        path,
+                        tail,
+                        args.ab,
+                        warmup=args.warmup,
+                        iters=args.iters,
+                        db=db,
+                        ref=ab_ref,
+                        strict_correctness=strict_correctness,
+                        strict_reference="same-input-greedy" if same_input_greedy else "eager",
+                    )
         finally:
             await backend.aclose_async_worker()
         return (
@@ -2464,50 +2504,39 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         sys.exit(1)  # every row is reported above; any failed row (greedy or --ab) exits non-zero
 
 
-async def _bench_ab_variants_ir(backend, ir_path, tail, specs, *, warmup, iters, db=None):
-    """The ``--ab`` counterpart of :func:`_bench_golden_variants` for the ``--ir``
-    path: each config reloads the IR file fresh (the tail lowering mutates the graph
-    in place) and re-lowers it with the knobs pinned, so the pin collapses every
-    remaining fork. Same row semantics as the golden path: a config that fails to
-    compile / bench is kept as a ``bench_fail`` row, a pin the re-lowering didn't
-    realize fails its row loudly BEFORE benching (``pin_unmatched`` — benching the
-    fallback would measure the planner's own pick under the pin's name), and every
-    bench is one job on the backend's persistent SIGKILL-able worker, so a hung row
-    dies with the child and the remaining rows continue on a fresh one. Serialized
-    ops drop ``knobs``, so only tail-lowered kernels carry realized values — a pinned
-    family the tail never re-decides has no stamp to check and is skipped
-    (ungateable), while a family the tail did re-decide still verifies."""
-    import json as _json  # noqa: PLC0415
+async def _bench_ab_variants_ir(
+    backend,
+    ir_path,
+    tail,
+    specs,
+    *,
+    warmup,
+    iters,
+    db=None,
+    ref=None,
+    strict_correctness=False,
+    strict_reference="eager",
+):
+    """Bench exact pins against fresh direct-IR replays."""
+    import json  # noqa: PLC0415
 
     from emmy.compiler.graph import Graph  # noqa: PLC0415
-    from emmy.compiler.pipeline import Pipeline  # noqa: PLC0415
 
-    out = []
-    for sample in _ab_samples(specs):
-        replay_knobs = _sample_replay_knobs(sample)
-        try:
-            with pinned_knobs(replay_knobs):
-                g = Graph.from_dict(_json.loads(Path(ir_path).read_text()))
-                if tail:
-                    g = Pipeline.build(tail).run(g, db=db)
-        except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own table
-            logger.warning("[ab] %s: compile of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
-            out.append(_GoldenBench(sample, None, None, [f"compile failed: {exc}"], "bench_fail"))
-            continue
-        flag = unreproducible_pin_flag(replay_knobs, _cuda_knob_dicts(g))
-        if flag:
-            logger.error("[ab] %s: %s — the pinned config did not realize; fix the pin spelling (row kept unbenched)", sample.name, flag)
-            out.append(_GoldenBench(sample, g, None, [f"{flag} — row NOT benched"], "pin_unmatched"))
-            continue
-        try:
-            g_bench, _ = await backend.bench_pinned_async(g, warmup=warmup, num_iters=iters)
-        except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own table
-            st = _failed_bench_status(exc)
-            logger.warning("[ab] %s: bench of the pinned config failed (%s) — row kept as %s", sample.name, exc, st)
-            out.append(_GoldenBench(sample, g, None, [f"{st}: {exc}"], st))
-            continue
-        out.append(_GoldenBench(sample, g, g_bench, []))
-    return out
+    def compile_sample(_sample):
+        graph = Graph.from_dict(json.loads(Path(ir_path).read_text()))
+        return _lower_ir_replay(graph, tail, db=db)
+
+    return await _bench_golden_variants(
+        backend,
+        None,
+        _ab_samples(specs),
+        warmup=warmup,
+        iters=iters,
+        ref=ref,
+        strict_correctness=strict_correctness,
+        strict_reference=strict_reference,
+        compile_sample=compile_sample,
+    )
 
 
 def _bind_inputs(compiled, module, example_args, example_kwargs, checkpoint=None):

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -301,11 +301,13 @@ The wall-clock cap is `asyncio.wait_for`; on overrun the child is SIGKILLed and 
 device. Because the persistent worker is reused across configs, an illegal / misaligned access is a hazard: that error
 is **sticky** — it corrupts the CUDA context so every later call returns the same status until the process dies, which
 would cascade identical false `bench_fail`s across all subsequent configs. So after any failure the worker probes its
-context (`_context_dirty` — a cheap `deviceSynchronize`) and *exits* if it's poisoned; `run_job` respawns a clean
-context on the next request (the dead-proc check before `await self._spawn()`). Benign failures (NVRTC compile errors,
-cleaned-up OOM) leave the context healthy and keep the worker alive, so they pay no respawn cost. A stale-worker race
-on the send (a `BrokenPipeError`/`ConnectionResetError` from `stdin.drain` after the worker's dirty-context exit)
-triggers one respawn + resend before surfacing as `bench worker died during request send`. Error paths `await aclose()`
+context (`_context_dirty` — a cheap `deviceSynchronize`) and hard-exits after writing its response if it's poisoned;
+the hard exit bypasses CUDA's process-exit handlers, which otherwise wait forever on a reported hung kernel. `run_job`
+respawns a clean context on the next request (the dead-proc check before `await self._spawn()`). Benign failures (NVRTC
+compile errors, cleaned-up OOM) leave the context healthy and keep the worker alive, so they pay no respawn cost. A
+stale-worker race on the send (a `BrokenPipeError`/`ConnectionResetError` from `stdin.drain` after the worker's
+dirty-context exit) triggers one respawn + resend before surfacing as `bench worker died during request send`. Error
+paths `await aclose()`
 (SIGKILL + reap) so the subprocess transport is cleaned before the loop closes.
 
 Three transport behaviors worth knowing: (1) the child's **stderr is drained continuously** by a background task into

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -301,13 +301,10 @@ The wall-clock cap is `asyncio.wait_for`; on overrun the child is SIGKILLed and 
 device. Because the persistent worker is reused across configs, an illegal / misaligned access is a hazard: that error
 is **sticky** — it corrupts the CUDA context so every later call returns the same status until the process dies, which
 would cascade identical false `bench_fail`s across all subsequent configs. So after any failure the worker probes its
-context (`_context_dirty` — a cheap `deviceSynchronize`) and hard-exits after writing its response if it's poisoned;
-the hard exit bypasses CUDA's process-exit handlers, which otherwise wait forever on a reported hung kernel. `run_job`
-respawns a clean context on the next request (the dead-proc check before `await self._spawn()`). Benign failures (NVRTC
-compile errors, cleaned-up OOM) leave the context healthy and keep the worker alive, so they pay no respawn cost. A
-stale-worker race on the send (a `BrokenPipeError`/`ConnectionResetError` from `stdin.drain` after the worker's
-dirty-context exit) triggers one respawn + resend before surfacing as `bench worker died during request send`. Error
-paths `await aclose()`
+context (`_context_dirty` — a cheap `deviceSynchronize`) and hard-exits after its response if poisoned; normal CUDA
+teardown can wait forever on a reported hung kernel. `run_job` respawns a clean context on the next request. Benign
+failures (NVRTC compile errors, cleaned-up OOM) keep a healthy worker alive. A stale-worker send race after the dirty
+exit respawns once before surfacing `bench worker died during request send`; error paths call `await aclose()`
 (SIGKILL + reap) so the subprocess transport is cleaned before the loop closes.
 
 Three transport behaviors worth knowing: (1) the child's **stderr is drained continuously** by a background task into

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -318,11 +318,9 @@ def main() -> None:
         os.write(out_fd, len(payload).to_bytes(8, "little"))
         os.write(out_fd, payload)
         if dirty:
-            # Corrupted context — don't serve more requests from it. Exit so the
-            # parent respawns a fresh context on its next bench (program.py
-            # ``_AsyncBenchWorker.run_job`` re-spawns when the proc is dead). A hung
-            # kernel also makes CUDA's normal process-exit handlers wait forever, so
-            # bypass Python teardown after the response has been written with os.write.
+            # A corrupted context cannot serve another request; hard-exit because normal CUDA
+            # teardown can wait forever on a reported hung kernel. The parent respawns a clean
+            # worker on its next bench.
             os._exit(0)
 
 

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -320,8 +320,10 @@ def main() -> None:
         if dirty:
             # Corrupted context — don't serve more requests from it. Exit so the
             # parent respawns a fresh context on its next bench (program.py
-            # ``_AsyncBenchWorker.run_job`` re-spawns when the proc is dead).
-            return
+            # ``_AsyncBenchWorker.run_job`` re-spawns when the proc is dead). A hung
+            # kernel also makes CUDA's normal process-exit handlers wait forever, so
+            # bypass Python teardown after the response has been written with os.write.
+            os._exit(0)
 
 
 if __name__ == "__main__":

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -130,6 +130,10 @@ These are term operations spelled the same way so one canonicalizer and one deep
 vocabularies; they are not statement behaviour, and `Fold` has no `render`. Impure computation stays
 in Loop IR until total lift; there is no impure `Lambda` construction path.
 
+`result_slice` applies `Body.backward_cone` to a zero-axis Fold's selected results and recursively
+narrows only projection operands. It never slices a reducing Fold's carrier components; that would
+change the monoid rather than select a projection result.
+
 **`nested()` is the STATEMENT protocol, and it deliberately does not reach a Fold's operand edges**
 — it yields the lift body, and nothing at all for a contraction, whose algebra is meant to read as
 edges rather than body deps. Every walk built on it (`Body.iter`, and so `Body.loads` /
@@ -420,7 +424,9 @@ specialized at the singleton), so update-vs-combine consistency holds by constru
 componentwise pair constructor (DEGENERATE is the derived `component_ops(combine)` shape predicate, not a storage
 arm; `rename_combine` carries the rename lockstep incl. the twisted regeneration rule). A `Fold` carries NO
 precision: accumulator dtype is a KERNEL-IR fact, stamped on the lowered `Accum` by the Init-placement pass, and a
-reduce `Loop` arriving with a typed `Accum` is not canonical input to total lift. A twisted
+reduce `Loop` arriving with a typed `Accum` is not canonical input to total lift. Tile edge inference follows the
+typed defining statements in each projection scope; a heterogeneous projection therefore keeps one inferred dtype
+per result without changing a reducing edge's established operand dtype. A twisted
 monoid's
 combine is the exp/LSE generator's program, selected structurally, never by a stored family name. The module also
 ships the executable SPEC: `eval_lambda` / `foldmap_eval`, the ~20-line denotational evaluator the agreement

--- a/emmy/compiler/ir/pure/__init__.py
+++ b/emmy/compiler/ir/pure/__init__.py
@@ -39,6 +39,7 @@ from emmy.compiler.ir.pure.fold import (
     operand_body,
     operand_name,
     refs_axis,
+    result_slice,
     splice_operands,
     stmt_axis_names,
 )
@@ -66,6 +67,7 @@ __all__ = [
     "operand_body",
     "operand_name",
     "refs_axis",
+    "result_slice",
     "splice_operands",
     "stmt_axis_names",
     "rename_combine",

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -1035,7 +1035,7 @@ def result_slice(edge, required: set[str]):
                 continue
             sliced = result_slice(operand, wanted)
             selected[id(operand)] = sliced
-            lowered = Body(sliced.lower())
+            lowered = Body(operand_body(sliced))
             captures = set(lowered.forward_cone(lowered).external_reads)
             if not captures <= needed:
                 needed.update(captures)

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -1002,6 +1002,49 @@ def _operand_result_names(op) -> tuple[str, ...]:
     return (operand_name(op),)
 
 
+def result_slice(edge, required: set[str]):
+    """Return the minimal projection cone that produces ``required`` edge results.
+
+    Zero-axis projections may expose several independent values. A consumer-local slice keeps
+    only the requested result cone and recursively narrows projection operands it reads. A
+    reducing Fold retains its complete carrier interface; slicing monoid components would change
+    its algebra rather than only its projection.
+    """
+    if not isinstance(edge, Fold):
+        return edge
+    if edge.axis is not None:
+        needed = edge.lift.body.backward_cone(edge.lift.results).external_reads
+        operands = tuple(
+            result_slice(operand, set(_operand_result_names(operand)) & needed) if set(_operand_result_names(operand)) & needed else operand
+            for operand in edge.operands
+        )
+        return edge if all(a is b for a, b in zip(operands, edge.operands, strict=True)) else replace(edge, operands=operands)
+
+    ordered = tuple(result for result in _operand_result_names(edge) if result in required)
+    if not ordered:
+        return edge
+    cone = edge.body.backward_cone(ordered)
+    needed = set(cone.external_reads)
+    selected: dict[int, object] = {}
+    changed = True
+    while changed:
+        changed = False
+        for operand in edge.operands:
+            wanted = set(_operand_result_names(operand)) & needed
+            if not wanted:
+                continue
+            sliced = result_slice(operand, wanted)
+            selected[id(operand)] = sliced
+            lowered = Body(sliced.lower())
+            captures = set(lowered.forward_cone(lowered).external_reads)
+            if not captures <= needed:
+                needed.update(captures)
+                changed = True
+    operands = tuple(selected[id(operand)] for operand in edge.operands if id(operand) in selected)
+    sliced = Fold.projection(operands=operands, body=Body(cone.members), results=ordered)
+    return edge if sliced == edge else sliced
+
+
 def refs_axis(s: Stmt, name: str) -> bool:
     """``s`` references axis ``name`` in any carried expr (deep) — ``Stmt.exprs``: a ``Load`` /
     ``Write`` index, a ``Select``'s branch predicates. Both spellings are coordinate reads, so both
@@ -1129,6 +1172,7 @@ __all__ = [
     "loaded_buffers",
     "operand_body",
     "operand_name",
+    "result_slice",
     "refs_axis",
     "splice_operands",
     "stmt_axis_names",

--- a/emmy/compiler/ir/schedule/classic_projection.py
+++ b/emmy/compiler/ir/schedule/classic_projection.py
@@ -472,6 +472,8 @@ def materialize_classic(
         schedule=assignment,
         materialization=ClassicMaterialization(placed, resolved),
         workers=WarpSpec(assignment.kernel.work.producer) if assignment.kernel.work.producer else None,
+        placement_decided=tile.placement_decided,
+        split_consumed=tile.split_consumed,
     )
 
 

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -248,6 +248,8 @@ against the schedule. A classic materialization contains exactly the contraction
 placed geometry and exactly the edges whose accepted transport is non-direct. Every placed tile must equal the
 geometry derived from the structural placement and its axis-free choice; every resolved stage must retain its edge's
 choice. Construction rejects missing, extra, mismatched, or partly attached facts.
+Scheduling preserves the structural receipts that say placement and cross-CTA splitting were already consumed, so a
+scheduled cut child can be serialized and reloaded without exposing a different kernel set.
 
 `ir/schedule/classic.py` owns the semantic contract for the ordinary grid/CTA/warp/thread/register schedule:
 

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -50,6 +50,14 @@ order-visible, so the schedule offers exactly the serial reduce plan and the cro
 There is no SDPA matching, byte-identity recognition gate, softmax pairing, fused view, or raw-loop fallback at this
 boundary. Unsupported non-canonical Loop IR fails loudly. Kernel placement is a later fork over this complete tree.
 
+A structural cut can change which free-axis accesses remain in one kernel. Before a fresh unmapped piece receives its
+identity stamp, Tile lowering derives that piece's complete schedule-free Loop body and reuses Loop's split-free-axis
+canonicalization, then performs this same total lift. The normalization can therefore fuse a reshape's output-axis
+pair once the cut removes the access that kept the pair distinct. Re-lifting preserves the output index through the
+exact quotient/remainder substitution, and the fresh piece converges with the equivalent initially canonical kernel
+identity before semiring recognition or scheduling. This is the same canonicalization at a new structural boundary,
+not a second scheduler path.
+
 ## Canonicalization
 
 `Lambda.__post_init__` owns context-independent construction normalization through `ir/pure/normalize.py`: every

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -78,6 +78,11 @@ inside the edge is not a capture and an already-closed edge never re-fires the r
 what the placement fork can offer as a workspace seam, which is how a computed operand (the RMSNorm'd, RoPE'd K
 vector) becomes materializable once per key instead of recomputed per query row.
 
+Closing one captured edge does not make its provider exclusive to that edge. If another sibling operand still
+captures one of the provider's results, the provider remains at their shared enclosing projection as well as riding
+the closed edge. This remains true after a composed placement cut reconstructs the Fold tree with workspace loads;
+every fresh output-owning piece must stay closed under the same normalization.
+
 An iteration never crosses into a new evaluation domain. Attaching an iteration-bearing provider to a contraction
 operand would evaluate it once per step of every intervening binder; normalization therefore leaves that provider at
 its defining scope. Straight-line chains still close normally, and a reducing root's own axis counts as its existing

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -282,7 +282,7 @@ scheduled cut child can be serialized and reloaded without exposing a different 
   and semantically refused assignments.
 
 Structural choices are deliberately outside this algebra. A cut or split changes the kernel set first; every fresh
-kernel then constructs a fresh problem and fresh sites. Search ranks encoded accepted leaves and materialization
+kernel is itself the new site index. Search ranks encoded accepted leaves and materialization
 consumes the typed assignment, so neither layer defines schedule membership.
 
 The single `lowering/tile/030_cut` pass reaches a fixpoint over kernel-set alternatives before scheduling: placement
@@ -299,6 +299,15 @@ edges. Both producer and consumer are fresh unmapped `TileOp`s. Unpinned cuts re
 any pinned Fold-edge cut carries the consumed placement decision on both pieces and proceeds to reduction splitting.
 Synthesized evaluation nodes are not cut sites, and the rule neither recognizes operation families nor filters legal
 cuts by profitability.
+
+A safe multi-result zero-axis Fold additionally exposes a structural `.result.<position>` child for an independent
+suffix result. The producer materializes that result's dependence slice at its own inferred dtype; the consumer
+retains the prefix slice and replaces only the selected name with a workspace load. Restricting the offer to a suffix
+keeps the parent's positional operand interface unchanged; splitting an interior result would need segmented
+retained edges. Result addresses are resolved by the placement codec but never join `path.sites`, the `TileOp`
+node/edge site index, or the `TILE`, `REDUCE`, and `STAGE` domains. The workspace still uses the ordinary
+captured-axis tuple. Quotienting or flattening repeated coordinates is a separate edge-transport decision, not part
+of result placement.
 
 A computed edge injected into a twisted expectation is already the operand of the derived contraction that appears
 when placement materializes it. Its workspace therefore uses the consumer's public store dtype, not the producer's

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -287,11 +287,13 @@ consumes the typed assignment, so neither layer defines schedule membership.
 
 The single `lowering/tile/030_cut` pass reaches a fixpoint over kernel-set alternatives before scheduling: placement
 first, then cross-CTA reduction splitting. `PLACE` uses the tree-path codec to address a stored non-root Fold edge.
-The explicit `PLACE@root` site applies only when a zero-axis root contains a pure prefix followed by independent
-output-owning `ProjectionRegion`s. Its cut sibling partitions all sibling regions in one structural choice, closes
-each region over the prefix, and lifts that region's leading axes into a fresh root-global placement. Bare `PLACE`
-still resolves only among stored Fold edges. Every fresh region piece re-enters the ordinary placement fixpoint, so
-nested sibling regions use the same rule rather than a separate traversal.
+The explicit `PLACE@root` site applies only when a zero-axis root contains a pure prefix followed by one or more
+independent output-owning `ProjectionRegion`s. Its cut sibling partitions sibling regions in one structural choice,
+closes each region over the prefix and root operands, and lifts that region's leading axes into a fresh root-global
+placement. A single region can remain after earlier cuts; the same choice then weighs reusing its prefix under a
+serial projection against duplicating that prefix across the fully parallel placement. Bare `PLACE` still resolves
+only among stored Fold edges. Every fresh region piece re-enters the ordinary placement fixpoint, so nested sibling
+regions use the same rule rather than a separate traversal.
 
 The fused sibling preserves the maximal Fold tree; each semantically closed Fold-edge cut sibling writes the child
 Fold's complete state tuple to workspaces and replaces every canonically shared occurrence with ordinary `Load`

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -281,13 +281,19 @@ kernel then constructs a fresh problem and fresh sites. Search ranks encoded acc
 consumes the typed assignment, so neither layer defines schedule membership.
 
 The single `lowering/tile/030_cut` pass reaches a fixpoint over kernel-set alternatives before scheduling: placement
-first, then cross-CTA reduction splitting. `PLACE` uses the same tree-path codec to address a
-stored non-root Fold edge. The fused sibling preserves the maximal Fold tree; each semantically closed cut sibling
-writes the child Fold's complete state tuple to workspaces and replaces every canonically shared occurrence with
-ordinary `Load` edges. Both producer and consumer are fresh unmapped `TileOp`s. Unpinned cuts re-enter placement
-before scheduling; any pinned cut carries the consumed placement decision on both pieces and proceeds to reduction
-splitting. Synthesized evaluation nodes are not cut sites, and the rule neither recognizes operation families nor
-filters legal cuts by profitability.
+first, then cross-CTA reduction splitting. `PLACE` uses the tree-path codec to address a stored non-root Fold edge.
+The explicit `PLACE@root` site applies only when a zero-axis root contains a pure prefix followed by independent
+output-owning `ProjectionRegion`s. Its cut sibling partitions all sibling regions in one structural choice, closes
+each region over the prefix, and lifts that region's leading axes into a fresh root-global placement. Bare `PLACE`
+still resolves only among stored Fold edges. Every fresh region piece re-enters the ordinary placement fixpoint, so
+nested sibling regions use the same rule rather than a separate traversal.
+
+The fused sibling preserves the maximal Fold tree; each semantically closed Fold-edge cut sibling writes the child
+Fold's complete state tuple to workspaces and replaces every canonically shared occurrence with ordinary `Load`
+edges. Both producer and consumer are fresh unmapped `TileOp`s. Unpinned cuts re-enter placement before scheduling;
+any pinned Fold-edge cut carries the consumed placement decision on both pieces and proceeds to reduction splitting.
+Synthesized evaluation nodes are not cut sites, and the rule neither recognizes operation families nor filters legal
+cuts by profitability.
 
 A computed edge injected into a twisted expectation is already the operand of the derived contraction that appears
 when placement materializes it. Its workspace therefore uses the consumer's public store dtype, not the producer's

--- a/emmy/compiler/ir/tile/__init__.py
+++ b/emmy/compiler/ir/tile/__init__.py
@@ -17,6 +17,7 @@ from emmy.compiler.ir.tile.ir import (
     extract_output_specs,
     lower_with_output_specs,
     observed_result_names,
+    projection_results,
 )
 from emmy.compiler.ir.tile.normalize import normalize_fold_tree
 
@@ -34,6 +35,7 @@ __all__ = [
     "apply_output_specs",
     "lower_with_output_specs",
     "observed_result_names",
+    "projection_results",
     "normalize_fold_tree",
     "extract_output_specs",
 ]

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -232,12 +232,12 @@ def apply_output_specs(stmts, specs, *, observed: frozenset = frozenset()) -> li
     return out
 
 
-def _projection_results(body) -> set[str]:
+def projection_results(body) -> set[str]:
     out = set()
     for member in body:
         if isinstance(member, ProjectionRegion):
             out.update(member.results)
-            out.update(_projection_results(member.body))
+            out.update(projection_results(member.body))
     return out
 
 
@@ -316,7 +316,7 @@ def lower_with_output_specs(op, specs) -> list[Stmt]:
 
     if isinstance(op, Fold) and op.axis is None:
         body = [*(stmt for edge in op.operands for stmt in operand_body(edge)), *lower_body(op.body)]
-        root_specs = tuple(spec for spec in specs if not set(spec.write.values) <= _projection_results(op.body))
+        root_specs = tuple(spec for spec in specs if not set(spec.write.values) <= projection_results(op.body))
         return apply_output_specs(body, root_specs, observed=observed_result_names(op))
     return apply_output_specs(op.lower(), specs, observed=observed_result_names(op))
 
@@ -690,6 +690,7 @@ __all__ = [
     "extract_output_specs",
     "lower_with_output_specs",
     "observed_result_names",
+    "projection_results",
 ]
 
 

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -494,6 +494,7 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
 
     live = set(root.lift.results)
     live.update(name for stmt in remaining_body for name in _member_reads(stmt))
+    live.update(name for edge in rewritten_operands if id(edge) not in moved_edges for name in _edge_free_names(edge))
     remaining_operands = tuple(
         edge for edge in rewritten_operands if id(edge) not in moved_edges or live & set(_operand_result_names(edge))
     )

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -78,6 +78,28 @@ def _dtype_key(edge, scope: dict | None) -> tuple:
     return (id(edge), tuple((name, getattr(scope.get(name), "name", None)) for name in captures))
 
 
+def _update_dtype_env(members, env: dict, inputs, cache: dict) -> None:
+    """Type one lexical statement sequence and every structural node nested inside it."""
+    for stmt in members:
+        if isinstance(stmt, Load):
+            tensor = inputs.get(stmt.input) if inputs else None
+            env.update((name, tensor.dtype if tensor is not None else None) for name in stmt.names)
+        elif isinstance(stmt, Fold):
+            env.update(zip(_operand_result_names(stmt), edge_dtypes(stmt, inputs, cache, env), strict=True))
+        elif isinstance(stmt, Assign):
+            args = [env.get(name) for name in stmt.args]
+            env[stmt.name] = stmt.dtype or (get_dtype(dtype_promote(stmt.op.name, [dtype.name for dtype in args])) if all(args) else None)
+        elif isinstance(stmt, Init):
+            env[stmt.name] = stmt.dtype
+        elif isinstance(stmt, Select):
+            branch_dtypes = [env.get(branch.value) for branch in stmt.branches]
+            env[stmt.name] = branch_dtypes[0] if branch_dtypes and all(dtype == branch_dtypes[0] for dtype in branch_dtypes) else None
+        else:
+            for body in stmt.nested():
+                _update_dtype_env(body, dict(env), inputs, cache)
+            env.update((name, None) for name in stmt.defines())
+
+
 def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict | None = None) -> tuple:
     """Infer an edge's result dtypes in the lexical scope where the edge occurs.
 
@@ -104,22 +126,7 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict
     env = dict(scope or {})
     for operand in edge.operands:
         env.update(zip(_operand_result_names(operand), edge_dtypes(operand, inputs, cache, env), strict=True))
-    for stmt in edge.lift.body:
-        if isinstance(stmt, Load):
-            tensor = inputs.get(stmt.input) if inputs else None
-            env.update((name, tensor.dtype if tensor is not None else None) for name in stmt.names)
-        elif isinstance(stmt, Fold):
-            env.update(zip(_operand_result_names(stmt), edge_dtypes(stmt, inputs, cache, env), strict=True))
-        elif isinstance(stmt, Assign):
-            args = [env.get(name) for name in stmt.args]
-            env[stmt.name] = stmt.dtype or (get_dtype(dtype_promote(stmt.op.name, [dtype.name for dtype in args])) if all(args) else None)
-        elif isinstance(stmt, Init):
-            env[stmt.name] = stmt.dtype
-        elif isinstance(stmt, Select):
-            branch_dtypes = [env.get(branch.value) for branch in stmt.branches]
-            env[stmt.name] = branch_dtypes[0] if branch_dtypes and all(dtype == branch_dtypes[0] for dtype in branch_dtypes) else None
-        else:
-            env.update((name, None) for name in stmt.defines())
+    _update_dtype_env(edge.lift.body, env, inputs, cache)
 
     lifted = tuple(env.get(result) if isinstance(result, str) else F32 for result in edge.lift.results)
     if edge.axis is None:

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -384,6 +384,8 @@ def scheduled(
     schedule=None,
     materialization=None,
     workers=None,
+    placement_decided: bool = False,
+    split_consumed: bool = False,
 ):
     """Build a scheduled ``TileOp`` from one accepted semantic assignment.
 
@@ -407,6 +409,8 @@ def scheduled(
         output_specs=tuple(output_specs),
         schedule=schedule,
         materialization=materialization,
+        placement_decided=placement_decided,
+        split_consumed=split_consumed,
     )
 
 

--- a/emmy/compiler/ir/tile/path.py
+++ b/emmy/compiler/ir/tile/path.py
@@ -1,10 +1,11 @@
 """The structural placement path codec over the stored Fold tree.
 
-Grammar: ``PLACE@<node-path>[.<axis>][<n>] = value``. Placement addresses a stored Fold edge by position because it
-is a structural decision made before a classic problem exists; ``PLACE@root`` addresses the root output-region
-boundary without admitting that boundary to bare ``PLACE`` resolution. A shortest unique path spelling is canonical;
-ambiguity and stale paths fail loudly. The retired ``in.<operand>`` prefix and leading-``=`` value-name form remain
-reserved.
+Grammar: ``PLACE@<node-path>[.<axis>][<n>] = value``. A selected result appends
+``.result.<position>``. Placement addresses a stored Fold edge by position because it is a
+structural decision made before schedule sites exist; ``PLACE@root`` addresses the root
+output-region boundary without admitting that boundary to bare ``PLACE`` resolution. A shortest
+unique path spelling is canonical; ambiguity and stale paths fail loudly. The retired
+``in.<operand>`` prefix and leading-``=`` value-name form remain reserved.
 
 Classic choices never use this codec. A classic problem constructs sites only after every structural choice is
 consumed, and its strict codec addresses integer node ids and ``(consumer, operand)`` edge tuples.
@@ -16,7 +17,7 @@ import re
 from dataclasses import dataclass
 from itertools import combinations
 
-from emmy.compiler.ir.pure.fold import Fold
+from emmy.compiler.ir.pure.fold import Fold, _operand_result_names
 from emmy.compiler.ir.pure.tree import walk
 from emmy.compiler.structural import instance_memo
 
@@ -57,6 +58,9 @@ class Site:
     segments: tuple[str, ...]
     ordinal: int = 1
     derived: bool = False
+    #: One-based selected result position. Ordinary stored node sites carry ``None``; result
+    #: sites are resolved structural addresses and never join :func:`sites`.
+    result: int | None = None
 
     @property
     def depth(self) -> int:
@@ -283,6 +287,17 @@ def resolve(root, key: str, *, all_sites: tuple[Site, ...] | None = None) -> Sit
     A final component with trailing digits is first read as a literal axis name; only when no site
     carries that axis is it retried as ``<axis><ordinal>`` (so an axis named ``k2`` never loses to
     an ordinal reading)."""
+    result_key = _result_key(key)
+    if result_key is not None:
+        base, position = result_key
+        site = resolve(root, base, all_sites=all_sites)
+        if site is None or not isinstance(site.node, Fold) or site.node.axis is not None:
+            raise MissingSiteError(f"knob key {key!r} names no zero-axis result on this tree")
+        results = _operand_result_names(site.node)
+        if len(results) < 2 or position > len(results):
+            raise MissingSiteError(f"knob key {key!r} names no result on this tree")
+        return Site(site.node, site.axis, site.segments, site.ordinal, site.derived, position)
+
     parsed = parse_key(key)
     matched_key = parsed
     all_sites = sites(root) if all_sites is None else all_sites
@@ -346,7 +361,33 @@ def canonical(root, key: str, *, all_sites: tuple[Site, ...] | None = None) -> s
     site = resolve(root, key, all_sites=all_sites)
     if site is None:
         return None
+    if site.result is not None:
+        return spell_result(root, site.node, site.result, all_sites=all_sites)
     return spell(root, parse_key(key).family, site.node, all_sites=all_sites)
+
+
+def _result_key(key: str) -> tuple[str, int] | None:
+    """Return the base node key and one-based position from a selected-result spelling."""
+    family, at, suffix = key.partition("@")
+    if not at:
+        return None
+    components = suffix.split(".")
+    if len(components) < 2 or components[-2] != "result" or not components[-1].isdigit():
+        return None
+    position = int(components[-1])
+    if position < 1:
+        raise ValueError(f"knob key {key!r} has a non-positive result position")
+    base_suffix = ".".join(components[:-2])
+    return (family if not base_suffix else f"{family}@{base_suffix}"), position
+
+
+def spell_result(root, node: Fold, position: int, *, all_sites: tuple[Site, ...] | None = None) -> str:
+    """Canonical structural spelling for one result of a multi-result zero-axis Fold."""
+    results = _operand_result_names(node)
+    if node.axis is not None or len(results) < 2 or not 1 <= position <= len(results):
+        raise ValueError("a result address requires a valid position on a multi-result zero-axis Fold")
+    base = spell(root, "PLACE", node, all_sites=all_sites)
+    return f"PLACE@result.{position}" if base == "PLACE" else f"{base}.result.{position}"
 
 
 __all__ = [
@@ -361,4 +402,5 @@ __all__ = [
     "resolve",
     "sites",
     "spell",
+    "spell_result",
 ]

--- a/emmy/compiler/ir/tile/path.py
+++ b/emmy/compiler/ir/tile/path.py
@@ -1,9 +1,10 @@
 """The structural placement path codec over the stored Fold tree.
 
-Grammar: ``PLACE@<node-path>[.<axis>][<n>] = value``. Placement addresses a stored Fold edge by
-position because it is a structural decision made before a classic problem exists. Its shortest
-unique path spelling is canonical; ambiguity and stale paths fail loudly. The retired
-``in.<operand>`` prefix and leading-``=`` value-name form remain reserved.
+Grammar: ``PLACE@<node-path>[.<axis>][<n>] = value``. Placement addresses a stored Fold edge by position because it
+is a structural decision made before a classic problem exists; ``PLACE@root`` addresses the root output-region
+boundary without admitting that boundary to bare ``PLACE`` resolution. A shortest unique path spelling is canonical;
+ambiguity and stale paths fail loudly. The retired ``in.<operand>`` prefix and leading-``=`` value-name form remain
+reserved.
 
 Classic choices never use this codec. A classic problem constructs sites only after every structural choice is
 consumed, and its strict codec addresses integer node ids and ``(consumer, operand)`` edge tuples.
@@ -23,7 +24,7 @@ from emmy.compiler.structural import instance_memo
 PATH_FAMILIES = ("PLACE",)
 
 #: The path-segment vocabulary: node kinds + the contraction operand-edge role labels.
-_SEGMENT_TOKENS = frozenset({"map", "fold", "a", "b"})
+_SEGMENT_TOKENS = frozenset({"root", "map", "fold", "a", "b"})
 
 #: Split a final component into a literal prefix plus trailing digits. :func:`resolve` tries the
 #: unsplit literal first, then moves the split left one digit at a time. Thus ``a22`` can resolve as
@@ -239,6 +240,10 @@ def spell(root, family: str, node, *, all_sites: tuple[Site, ...] | None = None)
     discriminates, else the shortest anchored path subsequence (deepest anchors preferred), with
     the 1-based ordinal only on a true same-path collision. Stampers and stored evidence use this
     spelling and nothing else."""
+    if node is root:
+        if family not in PATH_FAMILIES:
+            family_sites(family, ())  # raise the structural-family error
+        return f"{family}@root"
     tables = instance_memo(root, "_memo_spellings")
     table = tables.get(family)
     if table is None:
@@ -281,6 +286,9 @@ def resolve(root, key: str, *, all_sites: tuple[Site, ...] | None = None) -> Sit
     parsed = parse_key(key)
     matched_key = parsed
     all_sites = sites(root) if all_sites is None else all_sites
+    if parsed.segments == ("root",) and parsed.axis is None and parsed.ordinal is None:
+        family_sites(parsed.family, ())  # validate the family without admitting root to bare PLACE
+        return all_sites[0] if all_sites else None
     fam_sites = family_sites(parsed.family, all_sites)
     if parsed.bare:
         if not fam_sites:

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1288,8 +1288,8 @@ they become trusted deploy evidence. `load_golden_file` and `dump_golden_file` v
 the parsed entries, and dumping refuses replacement unless its caller opts in explicitly.
 A promoted classic row is already complete: bare `WORK` and `RASTER`, with `TILE`, `REDUCE`, and `STAGE` bare when
 their family has one applicable node and `@n<N>`-qualified only when the family is ambiguous. `STAGE` records one
-transport choice per consumer node, including an explicit empty direct choice. Promotion rejects incomplete rows,
-aliases, and unknown sites. It never fills or repairs a recording.
+transport choice per consumer node, including an explicit empty direct choice; a node-free row contains only `WORK`
+and `RASTER`. Promotion rejects incomplete rows, aliases, and unknown sites. It never fills or repairs a recording.
 
 **A split's children persist as child-identity schedule receipts.** One flat `knobs` map decorates exactly one
 kernel, so a route whose cut splits the target into several kernels cannot record conflicting per-child schedules in

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -742,9 +742,8 @@ and selects the global argmin. This preserves the fitted model's semantics, at t
 until schedule composition and scoring are factorized end to end. With no online prior the `OfflinePrior` ranks
 (including a positive `MMA_tier` warp preference — a fitted weight, not a hand-written rule); if `load_prior` returns
 nothing entirely every fork falls to the first leaf in emission order, which is meaningless and may be slow.
-Greedy benches nothing, so it can only *use* a prior, never train one. Direct DB descent has already joined the row by
-its `S_*` signature and context, so it ignores `S_*` / `H_*` values carried by intermediate fork levels and matches
-only their tuning knobs against the feature-free measured row.
+Greedy benches nothing, so it can only *use* a prior, never train one. After joining a DB row by `S_*` signature and
+context, direct descent ignores intermediate `S_*` / `H_*` values and matches only tuning knobs.
 
 **And it scores each decision once.** A decision is a conclusion over evidence, so it is memoized GREEDY-SIDE (one
 factory call — one compile attempt; never shared ambient state, which would hand MCTS cached picks): the memo

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -742,7 +742,9 @@ and selects the global argmin. This preserves the fitted model's semantics, at t
 until schedule composition and scoring are factorized end to end. With no online prior the `OfflinePrior` ranks
 (including a positive `MMA_tier` warp preference — a fitted weight, not a hand-written rule); if `load_prior` returns
 nothing entirely every fork falls to the first leaf in emission order, which is meaningless and may be slow.
-Greedy benches nothing, so it can only *use* a prior, never train one.
+Greedy benches nothing, so it can only *use* a prior, never train one. Direct DB descent has already joined the row by
+its `S_*` signature and context, so it ignores `S_*` / `H_*` values carried by intermediate fork levels and matches
+only their tuning knobs against the feature-free measured row.
 
 **And it scores each decision once.** A decision is a conclusion over evidence, so it is memoized GREEDY-SIDE (one
 factory call — one compile attempt; never shared ambient state, which would hand MCTS cached picks): the memo

--- a/emmy/compiler/pipeline/fork.py
+++ b/emmy/compiler/pipeline/fork.py
@@ -1,11 +1,8 @@
-"""Fork interface + implementations: the deferred fork options the search
-engine ranks and resolves, and the hierarchical Fork-tree builder shared by
-pipeline rules that enumerate a knob cartesian.
+"""Deferred fork options and the lazy Fork-tree builders shared by pipeline rules.
 
 :class:`Fork` is the interface — ``knobs``, ``is_leaf``, ``expand()``.
-Implementations hold their producer's state as data:
-:class:`OptionFork` (a concrete ``Op``/``Graph`` leaf) and the tree node
-classes :class:`_Branch` / :class:`_Leaf` built by :func:`build_fork_tree`.
+Implementations hold their producer's state as data: :class:`OptionFork` is a concrete ``Op``/``Graph`` leaf, while
+:class:`_Branch` / :class:`_Leaf` are built by :func:`build_fork_tree`.
 
 The tree builder reads an addressable sequence of variant knob rows through
 the root :class:`_Branch`: each ``Level`` groups
@@ -17,13 +14,12 @@ its COMPLETE row as ``knobs`` — the row IS the variant identity (the
 the online prior key leaves and branches by knobs alone, no structural
 probing. ``expand()`` yields ``materialize(row)`` once the search engine
 resolves a leaf.
-Everything is lazy: construction reads no row, no Fork below the root exists until search expands
-it, and branches retain indices into the shared sequence rather than row copies. Siblings are
-emitted in grouping order — RANKING IS SEARCH POLICY: the
+Everything is lazy: construction reads no row, no Fork below the root exists until search expands it, and branches
+retain indices into the shared sequence rather than row copies. A schedule prefix caches its immutable derived
+children while each expansion returns a fresh list. Siblings are emitted in grouping order — RANKING IS SEARCH POLICY: the
 policies rank the frontier with the online prior (Forks carry no score).
 
-The engine in ``pipeline.py`` consumes ``fork.knobs`` flat (it doesn't walk
-ancestors): branch Forks pin their level's slice of the row, leaves carry
+The engine in ``pipeline.py`` consumes ``fork.knobs`` flat: branches pin their level's row slice, while leaves carry
 the whole row.
 """
 
@@ -153,7 +149,7 @@ class _ScheduleTree:
 
 @dataclass(frozen=True)
 class _ScheduleFork(Fork):
-    """One immutable prefix in a generic lazy schedule tree."""
+    """One immutable prefix in a generic lazy schedule tree, with its derived frontier cached."""
 
     tree: _ScheduleTree
     context: ScheduleContext
@@ -176,7 +172,11 @@ class _ScheduleFork(Fork):
         return self.tree.pool_descent_bound
 
     def expand(self) -> list[Fork]:
-        return self.tree.step(self.context, self.row)
+        cached = self.__dict__.get("_memo_expansion")
+        if cached is None:
+            cached = tuple(self.tree.step(self.context, self.row))
+            object.__setattr__(self, "_memo_expansion", cached)
+        return list(cached)
 
 
 def schedule_forks(

--- a/emmy/compiler/pipeline/fork.py
+++ b/emmy/compiler/pipeline/fork.py
@@ -4,15 +4,11 @@
 Implementations hold their producer's state as data: :class:`OptionFork` is a concrete ``Op``/``Graph`` leaf, while
 :class:`_Branch` / :class:`_Leaf` are built by :func:`build_fork_tree`.
 
-The tree builder reads an addressable sequence of variant knob rows through
-the root :class:`_Branch`: each ``Level`` groups
-siblings by a (sub)tuple of knob values and collapses levels whose key has
-a single distinct value across the group (rows with an empty key skip the
-level). Below the last level every row becomes one :class:`_Leaf` carrying
-its COMPLETE row as ``knobs`` — the row IS the variant identity (the
-``S_*`` structural-feature knobs ride the merged dict), so the perf DB and
-the online prior key leaves and branches by knobs alone, no structural
-probing. ``expand()`` yields ``materialize(row)`` once the search engine
+The tree builder reads an addressable sequence of variant knob rows through the root :class:`_Branch`. Each ``Level``
+groups siblings by a knob subtuple and collapses levels whose key has one value (rows with an empty key skip the level).
+Below the last level every row becomes one :class:`_Leaf` carrying its COMPLETE row as ``knobs`` — the row IS the
+variant identity, including its ``S_*`` structural-feature knobs. The perf DB and online prior key forks by knobs.
+``expand()`` yields ``materialize(row)`` once the search engine
 resolves a leaf.
 Everything is lazy: construction reads no row, no Fork below the root exists until search expands it, and branches
 retain indices into the shared sequence rather than row copies. A schedule prefix caches its immutable derived
@@ -35,6 +31,7 @@ if TYPE_CHECKING:
     from emmy.compiler.ir.base import Op
 
 from emmy.compiler.ir.schedule import Schedule, ScheduleContext, schedule
+from emmy.compiler.structural import instance_memo
 
 
 class Fork(ABC):
@@ -171,12 +168,15 @@ class _ScheduleFork(Fork):
     def pool_descent_bound(self) -> int:
         return self.tree.pool_descent_bound
 
+    def __getstate__(self):
+        """Pickle the schedule prefix, never its derived children."""
+        return {name: self.__dict__[name] for name in self.__dataclass_fields__ if name in self.__dict__}
+
     def expand(self) -> list[Fork]:
-        cached = self.__dict__.get("_memo_expansion")
-        if cached is None:
-            cached = tuple(self.tree.step(self.context, self.row))
-            object.__setattr__(self, "_memo_expansion", cached)
-        return list(cached)
+        memo = instance_memo(self, "_memo_expansion")
+        if "children" not in memo:
+            memo["children"] = tuple(self.tree.step(self.context, self.row))
+        return list(memo["children"])
 
 
 def schedule_forks(

--- a/emmy/compiler/pipeline/knob.py
+++ b/emmy/compiler/pipeline/knob.py
@@ -636,9 +636,9 @@ def complete_kernel_row(knobs: dict) -> dict[str, str]:
     """Return one realized kernel row, rejecting structurally incomplete schedules.
 
     Exact coverage is problem-dependent and is enforced by :class:`ClassicScheduleCodec` at leaf
-    construction. This recording boundary enforces the context-free half: kernel families are
-    bare, node families may be bare or use canonical node sites, and at least one node assignment
-    is present.
+    construction. This recording boundary enforces the context-free half: kernel families are bare,
+    node families may be bare or use canonical sites, and an emitted node or edge family requires a
+    node assignment. A node-free kernel legitimately emits only its two kernel choices.
     """
     out = dict(tuning_knob_items(knobs))
     present = {family_of(key) for key in out}
@@ -666,7 +666,7 @@ def complete_kernel_row(knobs: dict) -> dict[str, str]:
                     raise ValueError(f"classic schedule key {key!r} is not canonical; expected {family}@n<ordinal>") from None
             if family in {"TILE", "REDUCE"}:
                 node_keys.append(key)
-        if not node_keys:
+        if not node_keys and present & {"TILE", "REDUCE", "STAGE"}:
             raise ValueError("complete classic schedule row has no node assignment")
         for key, value in out.items():
             if family_of(key) in SCHEDULE_FAMILIES:

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -72,10 +72,11 @@ post-decomposition Python source file for known format names.
 ## The tile scheduler: one stored tree
 
 `020_twisted` first applies the general exp-family Fold rewrite described at the boundary below. The single `030_cut`
-pass runs to a fixpoint over two ordered domains. It first offers the maximal fused tree beside every semantically
-closed stored Fold-edge cut whose workspace dtypes are determined (an undeterminable seam is not offered — the offer
-and realization must agree). Once placement is consumed, it offers the unsplit tree beside every cross-CTA reduce
-split the head Fold admits. A selected cut or split replaces the kernel with fresh unmapped pieces. A bare
+pass runs to a fixpoint over two ordered domains. Placement first offers the maximal fused tree beside every
+semantically closed stored Fold-edge cut whose workspace dtypes are determined and, where the root has several
+independent output regions, beside one root output-region cut. Once placement is consumed, the pass offers the
+unsplit tree beside every cross-CTA reduce split the head Fold admits. A selected cut or split replaces the kernel
+with fresh unmapped pieces. A bare
 `PLACE=cut` pin
 names the
 placement decision, not a site, so it resolves among the CUTTABLE seams (the root-most one) rather than through the
@@ -179,8 +180,9 @@ exhaustively compared with the literal Cartesian reference. That compatibility p
 flash attention the unconstrained product is 8.9e6 against 13,280 compatible rows, and on an EXL3 coded linear 5.3e12
 against 19,407,312.
 
-The cut phase is the outer enumeration. `030_cut` reaches a fixpoint over fused/cut placement choices and then
-unsplit/split reduction choices and emits those pass-native structural forks directly. `040_schedule` follows and
+The cut phase is the outer enumeration. `030_cut` reaches a fixpoint over fused/output-region/stored-edge placement
+choices and then unsplit/split reduction choices and emits those pass-native structural forks directly.
+`040_schedule` follows and
 supplies `ClassicScheduleContext` to the generic driver for Algorithm 1(c, p, t). A structural realization creates
 ordinary fresh kernels, so any later placement or split decision is discovered by the same pass rather than by a
 classic-context refusal.
@@ -530,7 +532,8 @@ unsupported forms remain unmapped.
 Maximal Loop fusion remains canonical. Tile lowering may expose two kinds of graph-fragment siblings without changing
 that canonical input:
 
-- **`030_cut`** offers the maximal fused Fold tree and every closed stored child-Fold seam — body-member folds
+- **`030_cut`** offers the maximal fused Fold tree, one composed split of independent root output regions, and every
+  closed stored child-Fold seam — body-member folds
   closed at offer time by provider closure, and dependent seams offered as principal closures (see the placement
   discussion above). A cut writes one workspace
   per state component and replaces all occurrences of the same canonically shared Fold object with workspace loads.
@@ -559,6 +562,13 @@ that canonical input:
   split receipt, every placement piece inherits it, so a later cut cannot make the same split pending again. A piece
   minted by a structural apply stays in the ordinary pass sequence; no schedule-specific visitor discovers or
   realizes another placement decision.
+
+  The root output-region arm exists only when a zero-axis root is exactly a pure prefix followed by at least two
+  `ProjectionRegion`s whose recursive results uniquely partition the output specifications and whose captures close
+  over the prefix. `PLACE@root=cut` separates all sibling regions in one structural choice and lifts each region's
+  leading axes into that fresh piece's root-global placement. Bare `PLACE` retains its stored-edge primary semantics.
+  Fresh pieces re-enter this same fixpoint, so nested sibling regions need no second enumerator. This changes only
+  which kernels exist; node schedules and edge transports remain independent classic domains.
 
 - **The cross-CTA reduce split is structural.** Splitting the reduce axis across CTAs into a partial and finalize
   changes which kernels exist, so `030_cut` offers it after stored-edge placement and before any assignment

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -566,9 +566,11 @@ that canonical input:
   The root output-region arm exists only when a zero-axis root is exactly a pure prefix followed by at least two
   `ProjectionRegion`s whose recursive results uniquely partition the output specifications and whose captures close
   over the prefix. `PLACE@root=cut` separates all sibling regions in one structural choice and lifts each region's
-  leading axes into that fresh piece's root-global placement. Bare `PLACE` retains its stored-edge primary semantics.
-  Fresh pieces re-enter this same fixpoint, so nested sibling regions need no second enumerator. This changes only
-  which kernels exist; node schedules and edge transports remain independent classic domains.
+  leading axes into that fresh piece's root-global placement. Because that choice changes the kernel set, it is
+  consumed before graph-scoped child `PLACE@site` pins are resolved against the fresh pieces; a coincident path in
+  the unsplit parent cannot capture a child's pin. Bare `PLACE` retains its stored-edge primary semantics. Fresh
+  pieces re-enter this same fixpoint, so nested sibling regions need no second enumerator. This changes only which
+  kernels exist; node schedules and edge transports remain independent classic domains.
 
 - **The cross-CTA reduce split is structural.** Splitting the reduce axis across CTAs into a partial and finalize
   changes which kernels exist, so `030_cut` offers it after stored-edge placement and before any assignment

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -74,7 +74,9 @@ post-decomposition Python source file for known format names.
 `020_twisted` first applies the general exp-family Fold rewrite described at the boundary below. The single `030_cut`
 pass runs to a fixpoint over two ordered domains. Placement first offers the maximal fused tree beside every
 semantically closed stored Fold-edge cut whose workspace dtypes are determined and, where the root has several
-independent output regions, beside one root output-region cut. Once placement is consumed, the pass offers the
+independent output regions, beside one root output-region cut. A safe multi-result zero-axis edge also offers each
+independently retained result under a `.result.<position>` address; the address is structural and never becomes a
+classic node or edge site. Once placement is consumed, the pass offers the
 unsplit tree beside every cross-CTA reduce split the head Fold admits. A selected cut or split replaces the kernel
 with fresh unmapped pieces. A bare
 `PLACE=cut` pin
@@ -380,6 +382,9 @@ decomposition may place one transient, shape-only buffer between the accumulator
 that direct private copy inherits the same accumulator dtype. Actual computation over private reduction state remains
 untyped, so normalization and softmax keep their f32 state until their own public result store. Fusion and placement
 then preserve the typed `copy` as an ordinary statement rather than reconstructing a boundary from graph topology.
+Index-map composition preserves that same distinction: it composes through a transient shape-only tensor, but stops
+at a non-transient producer because deleting that tensor would erase a source-program storage boundary before store
+rounding can spell its conversion.
 
 Loop fusion is maximal and schedule-blind: every structurally legal merge is taken to fixpoint before lowering
 considers a kernel boundary. Fusion never asks whether the merged body is recognized, schedulable by an optimized
@@ -555,7 +560,12 @@ that canonical input:
   that seam rather than joining the offer: the raw bits dominate the fed-store workspace on both precision (exact vs
   re-rounded) and footprint (storage width vs store width), so there is no trade for the evidence to decide. Every
   seam's per-component dtypes are decided at offer time and ride the seam into realization, so the two cannot
-  disagree. A cut workspace retains captured axes plus static unit axes: unit extents add no storage, while preserving
+  disagree. An independent suffix result of a zero-axis Fold uses its own dependence slice and dtype, retains the
+  prefix result slice in the consumer, and replaces only selected reads. The suffix restriction preserves the
+  parent's positional operand interface; interior selection needs segmented retained edges. It keeps the ordinary
+  captured-axis workspace transport; flattening a quotient coordinate belongs to edge transport, not this
+  node-placement choice. A cut workspace retains captured
+  axes plus static unit axes: unit extents add no storage, while preserving
   them keeps later schedule and split axes in their original geometric roles. The new producer and consumer are fresh
   unmapped TileOps, so further legal cuts and schedules use the same ordinary passes. An unpinned cut may expose more
   cut choices; any pinned cut consumes its restriction on every piece. If the parent already carries a cross-CTA

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -575,14 +575,16 @@ that canonical input:
   minted by a structural apply stays in the ordinary pass sequence; no schedule-specific visitor discovers or
   realizes another placement decision.
 
-  The root output-region arm exists only when a zero-axis root is exactly a pure prefix followed by at least two
+  The root output-region arm exists only when a zero-axis root is exactly a pure prefix followed by one or more
   `ProjectionRegion`s whose recursive results uniquely partition the output specifications and whose captures close
-  over the prefix. `PLACE@root=cut` separates all sibling regions in one structural choice and lifts each region's
-  leading axes into that fresh piece's root-global placement. Because that choice changes the kernel set, it is
-  consumed before graph-scoped child `PLACE@site` pins are resolved against the fresh pieces; a coincident path in
-  the unsplit parent cannot capture a child's pin. Bare `PLACE` retains its stored-edge primary semantics. Fresh
-  pieces re-enter this same fixpoint, so nested sibling regions need no second enumerator. This changes only which
-  kernels exist; node schedules and edge transports remain independent classic domains.
+  over the prefix and root operands. `PLACE@root=cut` separates sibling regions in one structural choice and lifts
+  each region's leading axes into that fresh piece's root-global placement. When earlier cuts leave one region, the
+  same choice weighs shared-prefix reuse under the serial projection against duplicating that prefix across the fully
+  parallel placement. Because the choice replaces the kernel set, it is consumed before graph-scoped child
+  `PLACE@site` pins are resolved against the fresh pieces; a coincident path in the unsplit parent cannot capture a
+  child's pin. Bare `PLACE` retains its stored-edge primary semantics. Fresh pieces re-enter this same fixpoint, so
+  nested sibling regions need no second enumerator. Node schedules and edge transports remain independent classic
+  domains.
 
 - **The cross-CTA reduce split is structural.** Splitting the reduce axis across CTAs into a partial and finalize
   changes which kernels exist, so `030_cut` offers it after stored-edge placement and before any assignment

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -105,7 +105,9 @@ rather than being cut off by any count or depth guard.
 Scoped `PLACE@path=cut` pins are authoritative and COMPOSE: every pin that resolves on
 one kernel joins a single realization — one producer per seam, one consumer, a producer reading another seam's
 workspace when its value nests inside (attention's statistics cone contains the score dots whose operand cones are
-cut beside it) — and all pieces set `placement_decided` and proceed to scheduling. A bare pinned cut consumes its one
+cut beside it). A selected-result seam's retained sibling slice is itself a consumer, so every other seam in the same
+decision replaces matching descendants inside that slice before the consumer is formed. All pieces set
+`placement_decided` and proceed to scheduling. A bare pinned cut consumes its one
 root-most cut the same way and may join scoped cuts in that single decision. A scoped pin whose site path does
 not exist on a kernel addresses another kernel of the graph; a kernel none of the pins address fuses, deterministic,
 so the unpinned placement fork never returns under a pin-driven compile. A pin that resolves to an edge no cut

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -569,7 +569,12 @@ that canonical input:
   node-placement choice. A cut workspace retains captured
   axes plus static unit axes: unit extents add no storage, while preserving
   them keeps later schedule and split axes in their original geometric roles. The new producer and consumer are fresh
-  unmapped TileOps, so further legal cuts and schedules use the same ordinary passes. An unpinned cut may expose more
+  unmapped TileOps. Before the splice stamps their identities, every structural choice lowers each fresh piece through
+  its schedule-free Loop spelling and reuses the split-free-axis canonicalization. A cut can remove the access that
+  kept a reshape's output-axis pair distinct; re-fusing the now-clean pair makes semiring geometry and the identity
+  match the equivalent initially canonical kernel. This deterministic normalization is neither a placement choice nor
+  a node or edge schedule, and it runs before the fresh pieces re-enter the ordinary cut and schedule passes. An
+  unpinned cut may expose more
   cut choices; any pinned cut consumes its restriction on every piece. If the parent already carries a cross-CTA
   split receipt, every placement piece inherits it, so a later cut cannot make the same split pending again. A piece
   minted by a structural apply stays in the ordinary pass sequence; no schedule-specific visitor discovers or

--- a/emmy/compiler/pipeline/passes/frontend/optimization/010_compose_indexmaps.py
+++ b/emmy/compiler/pipeline/passes/frontend/optimization/010_compose_indexmaps.py
@@ -36,6 +36,8 @@ def rewrite(match: Match, producer: Node, consumer: Node) -> Graph | None:
     consumer_op = consumer.op
     if not isinstance(producer_op, IndexMapOp) or not isinstance(consumer_op, IndexMapOp):
         raise RuleSkipped("producer or consumer is no longer an IndexMapOp")
+    if not producer.output.transient:
+        raise RuleSkipped("producer output is a source-program storage boundary")
 
     # Only compose when the producer has a single source; multi-source
     # IndexMaps (cat) can't be folded positionally.

--- a/emmy/compiler/pipeline/passes/loop/canonicalize/010_fuse_split_free_axes.py
+++ b/emmy/compiler/pipeline/passes/loop/canonicalize/010_fuse_split_free_axes.py
@@ -30,6 +30,12 @@ quiescent — canonicalizing a producer that still awaits a merge could re-spell
 splicer composes through — and before ``loop/stamp``, so kernel identity and everything downstream
 (classification's trailing pair, shape keys, goldens) see one canonical spelling. Split and unsplit
 spellings of the same contraction thereby converge to one kernel identity.
+
+``030_cut`` reuses this substitution when a structural choice creates fresh unmapped Tile pieces.
+A cut can remove the access whose div/mod residue originally kept the pair distinct; the fresh piece
+therefore lowers through its schedule-free Loop spelling, runs this canonicalization, and lifts back
+before the splice stamps its identity. This is deterministic structural normalization, not a schedule
+choice, and never rewrites a TileOp after a schedule is attached.
 """
 
 from __future__ import annotations
@@ -37,119 +43,11 @@ from __future__ import annotations
 from dataclasses import replace
 
 from emmy.compiler.graph import Node
-from emmy.compiler.ir.address import split_pair
-from emmy.compiler.ir.axis import Axis, AxisRole
-from emmy.compiler.ir.expr import BinaryExpr, CastExpr, Expr, FuncCallExpr, Literal, SimplifyCtx, TernaryExpr, Var
 from emmy.compiler.ir.loop import LoopOp
-from emmy.compiler.ir.sigma import Sigma
-from emmy.compiler.ir.stmt import Body, Load, Loop, Write
-from emmy.compiler.ir.stmt.passes import simplify as _simplify_stmt
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
+from emmy.compiler.pipeline.passes.loop.canonicalize._split_free_axes import fuse_split_free_axes
 
 PATTERN = [Pattern("root", LoopOp)]
-
-
-def _no_divmod_on(e: Expr, name: str) -> bool:
-    """No ``/`` / ``%`` subterm of ``e`` has ``name`` in its dividend — the residue detector."""
-    if isinstance(e, BinaryExpr):
-        if e.op in ("/", "//", "%") and name in e.left.free_vars():
-            return False
-        return _no_divmod_on(e.left, name) and _no_divmod_on(e.right, name)
-    if isinstance(e, TernaryExpr):
-        return all(_no_divmod_on(x, name) for x in (e.cond, e.if_true, e.if_false))
-    if isinstance(e, CastExpr):
-        return _no_divmod_on(e.expr, name)
-    if isinstance(e, FuncCallExpr):
-        return all(_no_divmod_on(a, name) for a in e.args)
-    return True
-
-
-def _access_ok(index: tuple, shape, fname: str, store: bool = False) -> bool:
-    """A rewritten access folds clean when its index exprs carry no div/mod residue on the fused
-    axis, or — the split-store spelling ``[…, f/Q, f%Q]`` — when the buffer's row-major flatten
-    recomposes the residue to an affine address (needs the full static shape). A ``store`` may
-    also keep the bare pair at permuted strides (``[…, f/Q, …, f%Q]``): every tier addresses an
-    output element at its own coordinate, so the spelling is exact by construction."""
-    if all(_no_divmod_on(e, fname) for e in index if fname in e.free_vars()):
-        return True
-    if store and split_pair(index, fname) is not None:
-        return True
-    if shape is None or len(shape) != len(index) or not all(getattr(d, "is_static", False) for d in shape):
-        return False
-    flat: Expr = Literal(0, "int")
-    stride = 1
-    for e, d in zip(reversed(index), reversed(list(shape)), strict=True):
-        flat = BinaryExpr("+", flat, BinaryExpr("*", e, Literal(stride, "int")))
-        stride *= d.as_static()
-    return _no_divmod_on(flat.simplify(SimplifyCtx.empty()), fname)
-
-
-def _folds_clean(fused: Loop, fname: str, shapes: dict) -> bool:
-    for s in Body((fused,)).iter():
-        if isinstance(s, Load):
-            if not _access_ok(s.index, shapes.get(s.input), fname):
-                return False
-        elif isinstance(s, Write):
-            if not _access_ok(s.index, shapes.get(s.output), fname, store=True):
-                return False
-        elif any(fname in e.free_vars() and not _no_divmod_on(e, fname) for e in s.exprs()):
-            return False
-    return True
-
-
-def _fuse_pair(outer: Loop, inner: Loop, shapes: dict, between: tuple[Loop, ...] = ()) -> Loop | None:
-    """The fused nest for a perfectly-nested free pair, or ``None`` when the pair declines. The
-    free loops ``between`` them (outermost first) interchange outward: the fused axis sits where
-    ``inner`` was, under them."""
-    p, q = outer.axis, inner.axis
-    if p.name == q.name or p.window is not None or q.window is not None:
-        return None
-    if not (p.extent.is_static and q.extent.is_static):
-        return None
-    big, small = p.extent.as_static(), q.extent.as_static()
-    if big <= 1 or small <= 1:
-        return None  # a size-1 side is drop_size_one_free_axes' job
-    for s in Body(tuple(inner.body)).iter():
-        ax = getattr(s, "axis", None)
-        if ax is not None and ax.name in (p.name, q.name):
-            return None  # an inner loop shadows a pair name — substitution would capture
-    f = Var(q.name)
-    lit = Literal(small, "int")
-    sigma = Sigma({p.name: BinaryExpr("//", f, lit), q.name: BinaryExpr("%", f, lit)})
-    body = Body(tuple(s.rewrite(lambda n: n, sigma) for s in inner.body))
-    fused = Loop(axis=Axis(q.name, big * small), body=body, unroll=outer.unroll or inner.unroll, role=AxisRole.FREE, seed=inner.seed)
-    fused = _simplify_stmt(fused, SimplifyCtx.empty())
-    if not _folds_clean(fused, q.name, shapes):
-        return None
-    for mid in reversed(between):
-        fused = replace(mid, body=Body((fused,)))
-    return fused
-
-
-def _free_chain(loop: Loop) -> list[Loop]:
-    """``loop`` and the perfectly-nested free loops under it, outermost first."""
-    out = [loop]
-    while len(out[-1].body) == 1 and isinstance(out[-1].body[0], Loop) and not out[-1].body[0].is_reduce:
-        out.append(out[-1].body[0])
-    return out
-
-
-def _fuse_once(body: Body, shapes: dict) -> Body | None:
-    """The body with ONE pair fused (outermost-first, depth-first, the nearest partner first), or
-    ``None`` when no pair fuses. The caller iterates to fixpoint, so an outer pair exposed by an
-    inner fusion is picked up on the next round."""
-    for i, s in enumerate(body):
-        if not isinstance(s, Loop) or s.is_reduce:
-            continue
-        chain = _free_chain(s)
-        for j in range(1, len(chain)):
-            fused = _fuse_pair(s, chain[j], shapes, tuple(chain[1:j]))
-            if fused is not None:
-                return Body((*body[:i], fused, *body[i + 1 :]))
-        inner = _fuse_once(s.body, shapes)
-        if inner is not None:
-            return Body((*body[:i], replace(s, body=inner), *body[i + 1 :]))
-    return None
 
 
 def rewrite(match: Match, root: Node, ctx=None) -> LoopOp:
@@ -157,10 +55,7 @@ def rewrite(match: Match, root: Node, ctx=None) -> LoopOp:
     if not isinstance(op, LoopOp):
         raise RuleSkipped("root is no longer a LoopOp")
     shapes = {name: t.shape for name, t in {**op.inputs, **op.outputs}.items()}
-    body = op.body
-    fused_any = False
-    while (step := _fuse_once(body, shapes)) is not None:
-        body, fused_any = step, True
-    if not fused_any:
+    body = fuse_split_free_axes(op.body, shapes)
+    if body is None:
         raise RuleSkipped("no adjacent free-axis pair fuses")
     return replace(op, body=body)

--- a/emmy/compiler/pipeline/passes/loop/canonicalize/_split_free_axes.py
+++ b/emmy/compiler/pipeline/passes/loop/canonicalize/_split_free_axes.py
@@ -1,0 +1,125 @@
+"""Shared split-free-axis substitution for canonical Loop bodies and fresh Tile pieces."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from emmy.compiler.ir.address import split_pair
+from emmy.compiler.ir.axis import Axis, AxisRole
+from emmy.compiler.ir.expr import BinaryExpr, CastExpr, Expr, FuncCallExpr, Literal, SimplifyCtx, TernaryExpr, Var
+from emmy.compiler.ir.sigma import Sigma
+from emmy.compiler.ir.stmt import Body, Load, Loop, Write
+from emmy.compiler.ir.stmt.passes import simplify as _simplify_stmt
+
+
+def _no_divmod_on(e: Expr, name: str) -> bool:
+    """No ``/`` / ``%`` subterm of ``e`` has ``name`` in its dividend."""
+    if isinstance(e, BinaryExpr):
+        if e.op in ("/", "//", "%") and name in e.left.free_vars():
+            return False
+        return _no_divmod_on(e.left, name) and _no_divmod_on(e.right, name)
+    if isinstance(e, TernaryExpr):
+        return all(_no_divmod_on(x, name) for x in (e.cond, e.if_true, e.if_false))
+    if isinstance(e, CastExpr):
+        return _no_divmod_on(e.expr, name)
+    if isinstance(e, FuncCallExpr):
+        return all(_no_divmod_on(a, name) for a in e.args)
+    return True
+
+
+def _access_ok(index: tuple, shape, fname: str, store: bool = False) -> bool:
+    """Whether a rewritten access leaves no unresolved split-axis residue."""
+    if all(_no_divmod_on(e, fname) for e in index if fname in e.free_vars()):
+        return True
+    if store and split_pair(index, fname) is not None:
+        return True
+    if shape is None or len(shape) != len(index) or not all(getattr(d, "is_static", False) for d in shape):
+        return False
+    flat: Expr = Literal(0, "int")
+    stride = 1
+    for e, d in zip(reversed(index), reversed(list(shape)), strict=True):
+        flat = BinaryExpr("+", flat, BinaryExpr("*", e, Literal(stride, "int")))
+        stride *= d.as_static()
+    return _no_divmod_on(flat.simplify(SimplifyCtx.empty()), fname)
+
+
+def _folds_clean(fused: Loop, fname: str, shapes: dict) -> bool:
+    for stmt in Body((fused,)).iter():
+        if isinstance(stmt, Load):
+            if not _access_ok(stmt.index, shapes.get(stmt.input), fname):
+                return False
+        elif isinstance(stmt, Write):
+            if not _access_ok(stmt.index, shapes.get(stmt.output), fname, store=True):
+                return False
+        elif any(fname in expr.free_vars() and not _no_divmod_on(expr, fname) for expr in stmt.exprs()):
+            return False
+    return True
+
+
+def _fuse_pair(outer: Loop, inner: Loop, shapes: dict, between: tuple[Loop, ...] = ()) -> Loop | None:
+    """The fused nest for one clean free-axis pair, or ``None`` when it declines."""
+    p, q = outer.axis, inner.axis
+    if p.name == q.name or p.window is not None or q.window is not None:
+        return None
+    if not (p.extent.is_static and q.extent.is_static):
+        return None
+    big, small = p.extent.as_static(), q.extent.as_static()
+    if big <= 1 or small <= 1:
+        return None
+    for stmt in Body(tuple(inner.body)).iter():
+        axis = getattr(stmt, "axis", None)
+        if axis is not None and axis.name in (p.name, q.name):
+            return None
+    fused_var = Var(q.name)
+    small_lit = Literal(small, "int")
+    sigma = Sigma({p.name: BinaryExpr("//", fused_var, small_lit), q.name: BinaryExpr("%", fused_var, small_lit)})
+    body = Body(tuple(stmt.rewrite(lambda name: name, sigma) for stmt in inner.body))
+    fused = Loop(
+        axis=Axis(q.name, big * small),
+        body=body,
+        unroll=outer.unroll or inner.unroll,
+        role=AxisRole.FREE,
+        seed=inner.seed,
+    )
+    fused = _simplify_stmt(fused, SimplifyCtx.empty())
+    if not _folds_clean(fused, q.name, shapes):
+        return None
+    for middle in reversed(between):
+        fused = replace(middle, body=Body((fused,)))
+    return fused
+
+
+def _free_chain(loop: Loop) -> list[Loop]:
+    """``loop`` and the perfectly nested free loops under it, outermost first."""
+    out = [loop]
+    while len(out[-1].body) == 1 and isinstance(out[-1].body[0], Loop) and not out[-1].body[0].is_reduce:
+        out.append(out[-1].body[0])
+    return out
+
+
+def _fuse_once(body: Body, shapes: dict) -> Body | None:
+    """The body with one clean pair fused, outermost-first and depth-first."""
+    for index, stmt in enumerate(body):
+        if not isinstance(stmt, Loop) or stmt.is_reduce:
+            continue
+        chain = _free_chain(stmt)
+        for inner_index in range(1, len(chain)):
+            fused = _fuse_pair(stmt, chain[inner_index], shapes, tuple(chain[1:inner_index]))
+            if fused is not None:
+                return Body((*body[:index], fused, *body[index + 1 :]))
+        inner = _fuse_once(stmt.body, shapes)
+        if inner is not None:
+            return Body((*body[:index], replace(stmt, body=inner), *body[index + 1 :]))
+    return None
+
+
+def fuse_split_free_axes(body: Body, shapes: dict) -> Body | None:
+    """Return the fixpoint with at least one split free-axis pair fused, else ``None``."""
+    result = body
+    changed = False
+    while (step := _fuse_once(result, shapes)) is not None:
+        result, changed = step, True
+    return result if changed else None
+
+
+__all__ = ["fuse_split_free_axes"]

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -200,7 +200,9 @@ structurally different primitives — sit behind one `fill`/`commit`/`wait` seam
 **one atom-agnostic driver** (`_atom._staged`) builds the operand pair + the transport for either atom; the atom
 supplies only the slab drain leaf via `_AtomOps.staged_drain` (the shared inner fragment drain
 `_staged_inner_atom_loop` — `ldmatrix` on modern atoms, a cooperative shared gather on Volta — or the scalar
-`_scalar_drain`). A fill's gmem-address σ binds **every** tiled output axis, not just the operand's own: the tile
+`_scalar_drain`). A compute fill walks its cone in order: a varying top-level definition is cell-local;
+ordinary nested definitions stay in their block, and only finalized `Accum` carriers reach later siblings. A fill's
+gmem-address σ binds **every** tiled output axis, not just the operand's own: the tile
 axis at `tile_base + cell` (masked axes clamp in-bounds) and the SIBLING axis at its block base — a slab is
 CTA-shared across the sibling, so a sibling var can only survive as a value-dead flat-index reshape residue (a
 merged / reshaped weight row), and left unbound it would emit the unsplit axis name the kernel no longer defines. The staging **decision** does not live here at all: the

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -66,7 +66,7 @@ from emmy.compiler.ir.schedule import Raster
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
 from emmy.compiler.ir.tile import FoldMove, Level, Reduce, ReduceStage
-from emmy.compiler.ir.tile.ir import ProjectionRegion, _projection_results, apply_output_specs, observed_result_names
+from emmy.compiler.ir.tile.ir import ProjectionRegion, apply_output_specs, observed_result_names, projection_results
 from emmy.compiler.ir.tile.ops import UnbindableProjection, projection_regions, sched_of
 from emmy.compiler.pipeline.passes.lowering._reduction import Reduction, loop_state_head
 from emmy.compiler.pipeline.passes.lowering.kernel._atom import (
@@ -313,7 +313,7 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
             elif required := set(_operand_result_names(edge)) & projection_reads:
                 siblings.extend(_emit(_provider_slice(edge, required), ctx).body)
         proj = [*siblings, *_emit_body(op.body, ctx, output_specs)]
-        region_results = _projection_results(op.body)
+        region_results = projection_results(op.body)
         root_specs = tuple(spec for spec in output_specs if not set(spec.write.values) <= region_results)
         # A STREAMED store (values = an observer's results) rides the recursion down to the leaf
         # so the scalar arm can splice it into the observed fold's reduce loop — applying it here
@@ -556,7 +556,7 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
             bt = lane.extent.as_static() if lane is not None else None
         elif plan is None or (plan.coop <= 1 and plan.reg <= 1):
             body = [*_emit(op, ctx, output_specs).body, *tail]
-            root_specs = tuple(spec for spec in output_specs if not set(spec.write.values) <= _projection_results(op.body))
+            root_specs = tuple(spec for spec in output_specs if not set(spec.write.values) <= projection_results(op.body))
             if root_specs:
                 # ``observed`` streams a scan store into its reduce loop; every other spec keeps
                 # its kernel-tail reconstitution.
@@ -1046,7 +1046,7 @@ def _tile_chain_members(
         *hoisted, rloop = _emit(member, ctx).body
         fold.extend(hoisted)
         fold.extend(_strided_fold(member, rloop, plan, ctx, lane if plan.coop > 1 else None))
-    region_results = _projection_results(op.body)
+    region_results = projection_results(op.body)
     trailing = [
         *_emit_body(Body(tuple(segment)), ctx, output_specs),
         *(spec.write for spec in output_specs if not set(spec.write.values) <= region_results),

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -61,6 +61,7 @@ from emmy.compiler.ir.pure.fold import (
     edge_free_axes,
     is_contraction,
     operand_body,
+    result_slice,
 )
 from emmy.compiler.ir.schedule import Raster
 from emmy.compiler.ir.sigma import Sigma
@@ -270,13 +271,7 @@ def _cell_provider_closure(edge, siblings: tuple) -> tuple[object, frozenset[int
 
 def _provider_slice(provider, required: set[str]):
     """Narrow a projection provider to the result cone its cell consumer needs."""
-    results = _operand_result_names(provider)
-    if not isinstance(provider, Fold) or provider.axis is not None or required == set(results):
-        return provider
-    ordered = tuple(result for result in results if result in required)
-    cone = provider.body.backward_cone(ordered)
-    operands = tuple(edge for edge in provider.operands if set(_operand_result_names(edge)) & cone.external_reads)
-    return Fold.projection(operands=operands, body=Body(cone.members), results=ordered)
+    return result_slice(provider, required)
 
 
 def _close_cell_providers(contraction: Fold, siblings: tuple) -> tuple[Fold, frozenset[int]]:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -720,15 +720,10 @@ class SyncTransport:
                 vals.append(val)
             hoisted_defs = {nm for p, stmt in enumerate(cell_stmts[0]) if plans[p] == "hoist" for nm in deep_defines(stmt)}
             vals = [val if val in hoisted_defs else f"{val}__c{j}" for j, val in enumerate(vals)]
-            # Per-cell SSA defs — the names each replica suffixes. HOISTED positions (run-invariant
-            # stmts: the stat-row loads, whose value is identical across the run's cells) emit once,
-            # unsuffixed, and per-cell references pass through to them; VECTOR positions (a scalar
-            # gmem ``Load`` whose last-dim index advances by exactly +1 per cell — the cone's
-            # k-indexed operand read) merge the run's V scalar 2 B loads into ONE vector ``Load``
-            # binding every cell's suffixed name (one 16 B ld like the cp.async fill, instead of V
-            # scalar loads — the compute fill issued 3.6x cuBLAS's LSU instructions). Everything
-            # else replicates per cell as before.
-            local = {nm for p, st in enumerate(cell_stmts[0]) if plans[p] != "hoist" for nm in deep_defines(st)}
+            # HOISTED positions emit once, unsuffixed. VECTOR positions merge a stride-1 run into
+            # one vector ``Load``. Everything else replicates per cell, renaming only definitions
+            # visible so far plus the current statement's nested scope.
+            local: set[str] = set()
             for p in range(len(cell_stmts[0])):
                 if plans[p] == "hoist":
                     body.append(cell_stmts[0][p])
@@ -736,11 +731,14 @@ class SyncTransport:
                 if plans[p] == "vector":
                     ld = cell_stmts[0][p]
                     body.append(Load(names=tuple(f"{ld.names[0]}__c{j}" for j in range(v)), input=ld.input, index=ld.index, dtype=ld.dtype))
-                    continue
-                for j in range(v):
-                    sfx = f"__c{j}"
-                    ren = lambda nm, sfx=sfx, local=local: f"{nm}{sfx}" if nm in local else nm  # noqa: E731
-                    body.append(cell_stmts[j][p].rewrite(ren))
+                else:
+                    for j in range(v):
+                        sfx = f"__c{j}"
+                        position_local = local | deep_defines(cell_stmts[j][p])
+                        ren = lambda nm, sfx=sfx, local=position_local: f"{nm}{sfx}" if nm in local else nm  # noqa: E731
+                        body.append(cell_stmts[j][p].rewrite(ren))
+                stmt = cell_stmts[0][p]
+                local |= set(stmt.defines()) | {acc.name for nested in stmt.nested() for acc in nested.accums}
             # ONE vector Write per run (the run is ``V`` contiguous 16-byte-aligned cells, so the
             # store is a single st.128 like the cp.async fill's chunk deposit) — V scalar 2 B
             # stores at 16 B thread stride were 8-way bank-conflicted, and the downstream

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
@@ -1,8 +1,8 @@
 """Enumerate every kernel-set cut before schedule assignments.
 
-Stored-Fold-edge placement is the first domain and cross-CTA reduction splitting is the second.
-The rule runs to a fixpoint, so each successful choice and every fresh piece re-enters these ordered
-domains before scheduling.
+Output-region and stored-Fold-edge placement form the first domain; cross-CTA reduction splitting is the second. The
+rule runs to a fixpoint, so each successful choice and every fresh piece re-enters these ordered domains before
+scheduling.
 """
 
 from __future__ import annotations
@@ -16,7 +16,12 @@ from emmy.compiler.ir.tile.path import MissingSiteError, resolve, sites
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
 from emmy.compiler.pipeline.fork import DeferredFork
 from emmy.compiler.pipeline.knob import family_of, family_pins
-from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams, output_map, realize
+from emmy.compiler.pipeline.passes.lowering.tile._cut import (
+    cuttable_seams,
+    output_map,
+    realize,
+)
+from emmy.compiler.pipeline.passes.lowering.tile._pieces import projection_region_pieces, realize_projection_regions
 from emmy.compiler.pipeline.passes.lowering.tile._split import split_forks
 
 PATTERN = [Pattern("root", TileOp)]
@@ -74,7 +79,7 @@ def _rootmost_plain(seams, all_sites, refuse: frozenset[str] = frozenset()):
     return min(plain, key=lambda candidate: depth[id(candidate.node)])
 
 
-def _placement_restriction(tile: TileOp, seams) -> tuple[tuple, str] | None:
+def _placement_restriction(tile: TileOp, seams, region_pieces) -> tuple[tuple, str, dict] | None:
     """The authoritative placement spelled by live PLACE pins, or ``None``.
 
     This restriction is consumed entirely by the cut pass before classic schedule enumeration.
@@ -97,6 +102,7 @@ def _placement_restriction(tile: TileOp, seams) -> tuple[tuple, str] | None:
     by_node = _seam_index(seams)
     cut: list = []
     fused: list[str] = []
+    root_value = None
     missing = False
     for name, value in pins:
         if name == "PLACE":
@@ -105,6 +111,12 @@ def _placement_restriction(tile: TileOp, seams) -> tuple[tuple, str] | None:
             site = resolve(tile.op, name, all_sites=all_sites)
         except MissingSiteError:
             missing = True  # the key addresses a seam of another kernel in the graph
+            continue
+        if site.node is tile.op:
+            if not region_pieces:
+                missing = True
+            else:
+                root_value = value
             continue
         if id(site.node) not in by_node:
             raise ValueError(f"PLACE pin {name!r} does not address a cuttable Fold edge in this kernel")
@@ -115,6 +127,8 @@ def _placement_restriction(tile: TileOp, seams) -> tuple[tuple, str] | None:
             cut.append(seam)
     refused = frozenset(fused)
     cut = [seam for seam in cut if seam.spelling not in refused]
+    if root_value == "cut":
+        return (("PLACE@root",), "regions", {})
     bare = next(((name, value) for name, value in pins if name == "PLACE"), None)
     if bare is not None and bare[1] == "cut":
         seam = _rootmost_plain(seams, all_sites, refused)
@@ -122,14 +136,17 @@ def _placement_restriction(tile: TileOp, seams) -> tuple[tuple, str] | None:
             cut.append(seam)
     cut = list(_with_required(cut, by_node, refuse=refused))
     if cut:
-        return tuple(cut), "cut"
+        extra = {"PLACE@root": "fuse"} if root_value == "fuse" else {}
+        return tuple(cut), "cut", extra
     if fused:
-        return (fused[0],), "fuse"
+        return (fused[0],), "fuse", {}
+    if root_value == "fuse":
+        return (("PLACE@root",), "fuse", {})
     for name, value in pins:
         if name != "PLACE":
             continue
         if value == "fuse":
-            return (name,), value
+            return (name,), value, {}
         # A bare ``PLACE=cut`` names the placement DECISION, not a site: the codec's primary
         # rule ranges over ALL PLACE sites and can land on an edge no cut realizes (an unclosed
         # cone, a seam whose workspace dtypes stay undetermined), so a bare pin resolves among
@@ -138,36 +155,51 @@ def _placement_restriction(tile: TileOp, seams) -> tuple[tuple, str] | None:
         # root-most plain seam and is consumed on the fresh pieces.
         seam = _rootmost_plain(seams, all_sites)
         if seam is None:
-            return ("PLACE",), "fuse"
-        return (seam,), value
+            return ("PLACE",), "fuse", {}
+        return (seam,), value, {}
     if missing:
         # A pin-driven compile whose scoped pins all address other kernels decides FUSE here —
         # deterministic, and the unpinned placement fork never returns under a pin.
-        return ("PLACE",), "fuse"
+        return ("PLACE",), "fuse", {}
     return None
 
 
 def _placement_forks(match: Match, root: Node, tile: TileOp):
     """Return the next stored-edge cut fork, or ``None`` when that domain is consumed."""
     seams = cuttable_seams(tile)
-    if not seams:
+    region_pieces = projection_region_pieces(tile)
+    if not seams and not region_pieces:
         return None
 
     renamed = output_map(root)
     match.output = renamed
-    pinned = _placement_restriction(tile, seams)
+    pinned = _placement_restriction(tile, seams, region_pieces)
     if pinned is not None:
-        chosen, value = pinned
+        chosen, value, extra = pinned
         if value == "fuse":
             (spelling,) = chosen
             return DeferredFork(lambda: replace(tile, placement_decided=True), {spelling: "fuse"})
+        if value == "regions":
+            return DeferredFork(
+                lambda: realize_projection_regions(match, root, region_pieces),
+                {"PLACE@root": "cut"},
+                structural=True,
+            )
         return DeferredFork(
             lambda: realize(match, root, chosen, renamed, placement_decided=True),
-            {seam.spelling: "cut" for seam in chosen},
+            {**{seam.spelling: "cut" for seam in chosen}, **extra},
             structural=True,
         )
 
     options = [DeferredFork(lambda: replace(tile, placement_decided=True), {"PLACE": "fuse"})]
+    if region_pieces:
+        options.append(
+            DeferredFork(
+                lambda: realize_projection_regions(match, root, region_pieces),
+                {"PLACE@root": "cut"},
+                structural=True,
+            )
+        )
     by_node = _seam_index(seams)
     closures: dict[frozenset[str], tuple] = {}
     for seam in seams:

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
@@ -21,7 +21,11 @@ from emmy.compiler.pipeline.passes.lowering.tile._cut import (
     output_map,
     realize,
 )
-from emmy.compiler.pipeline.passes.lowering.tile._pieces import projection_region_pieces, realize_projection_regions
+from emmy.compiler.pipeline.passes.lowering.tile._pieces import (
+    canonicalize_fresh_pieces,
+    projection_region_pieces,
+    realize_projection_regions,
+)
 from emmy.compiler.pipeline.passes.lowering.tile._split import split_forks
 
 PATTERN = [Pattern("root", TileOp)]
@@ -228,6 +232,13 @@ def _placement_forks(match: Match, root: Node, tile: TileOp):
     return options
 
 
+def _canonicalized(choice: DeferredFork) -> DeferredFork:
+    """Normalize every structural choice's fresh pieces before the splice stamps them."""
+    if not choice.structural:
+        return choice
+    return replace(choice, materialize=lambda: canonicalize_fresh_pieces(choice.materialize()))
+
+
 def rewrite(match: Match, root: Node, ctx=None):
     del ctx
     tile: TileOp = root.op
@@ -239,5 +250,5 @@ def rewrite(match: Match, root: Node, ctx=None):
     if choices is None:
         raise RuleSkipped("no pending kernel-set cut")
     choices = choices if isinstance(choices, list) else [choices]
-    options = [assignment.kernel for assignment in schedule(_CutContext(tuple(choices)))]
+    options = [_canonicalized(assignment.kernel) for assignment in schedule(_CutContext(tuple(choices)))]
     return options if len(options) > 1 else options[0]

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
@@ -100,6 +100,12 @@ def _placement_restriction(tile: TileOp, seams, region_pieces) -> tuple[tuple, s
             raise ValueError(f"bad PLACE value {value!r}; expected 'fuse' or 'cut'")
     all_sites = sites(tile.op)
     by_node = _seam_index(seams)
+    root_pin = next((value for name, value in pins if name == "PLACE@root"), None)
+    if root_pin == "cut" and region_pieces:
+        # The root boundary changes the kernel set before stored-edge placement. Pins for the
+        # resulting pieces are graph-scoped and must not be interpreted against the parent tree,
+        # where the same path can name an unrelated non-cuttable Fold.
+        return (("PLACE@root",), "regions", {})
     cut: list = []
     fused: list[str] = []
     root_value = None

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
@@ -50,18 +50,24 @@ class _CutContext(ScheduleContext[DeferredFork, object, object]):
         return replace(self, _assignment=pick)
 
 
-def _seam_index(seams) -> dict[int, object]:
-    """Map every seam node and clustered sibling to its shared decision."""
-    return {id(node): seam for seam in seams for node in (seam.node, *(sibling for sibling, _ in seam.siblings))}
+def _seam_index(seams) -> dict[tuple[int, int | None], object]:
+    """Map every complete node or selected result to its shared decision."""
+    out = {}
+    for seam in seams:
+        results = tuple(seam.node.defines())
+        position = results.index(seam.selected) + 1 if seam.selected is not None else None
+        for node in (seam.node, *(sibling for sibling, _ in seam.siblings)):
+            out[(id(node), position)] = seam
+    return out
 
 
-def _with_required(chosen, by_node: dict[int, object], refuse: frozenset = frozenset()) -> tuple:
+def _with_required(chosen, by_node: dict[tuple[int, int | None], object], refuse: frozenset = frozenset()) -> tuple:
     """Expand chosen seams with every transitively required producer seam."""
     out = list(chosen)
     queue = list(out)
     while queue:
         for _, producer in queue.pop().requires:
-            required = by_node[id(producer)]
+            required = by_node[(id(producer), None)]
             if required.spelling in refuse:
                 raise ValueError(f"PLACE pins fuse {required.spelling!r}, the producer a pinned dependent cut requires")
             if not any(member is required for member in out):
@@ -72,7 +78,7 @@ def _with_required(chosen, by_node: dict[int, object], refuse: frozenset = froze
 
 def _rootmost_plain(seams, all_sites, refuse: frozenset[str] = frozenset()):
     """Return the root-most plain seam not excluded by a scoped fuse pin."""
-    plain = [seam for seam in seams if not (seam.providers or seam.requires) and seam.spelling not in refuse]
+    plain = [seam for seam in seams if seam.selected is None and not (seam.providers or seam.requires) and seam.spelling not in refuse]
     if not plain:
         return None
     depth = {id(site.node): site.depth for site in all_sites}
@@ -118,15 +124,15 @@ def _placement_restriction(tile: TileOp, seams, region_pieces) -> tuple[tuple, s
         except MissingSiteError:
             missing = True  # the key addresses a seam of another kernel in the graph
             continue
-        if site.node is tile.op:
+        if site.node is tile.op and site.result is None:
             if not region_pieces:
                 missing = True
             else:
                 root_value = value
             continue
-        if id(site.node) not in by_node:
+        seam = by_node.get((id(site.node), site.result))
+        if seam is None:
             raise ValueError(f"PLACE pin {name!r} does not address a cuttable Fold edge in this kernel")
-        seam = by_node[id(site.node)]
         if value == "fuse":
             fused.append(seam.spelling)
         elif not any(chosen is seam for chosen in cut):

--- a/emmy/compiler/pipeline/passes/lowering/tile/__init__.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/__init__.py
@@ -4,9 +4,12 @@
 to a ``Fold``. ``020_twisted`` rewrites equivalent exp-family siblings into one twisted Fold. The
 single ``030_cut`` pass runs to a fixpoint: it first offers the maximal fused tree beside every
 closed stored Fold-edge cut, then the unsplit tree beside every cross-CTA reduce split the head Fold
-admits. A structural choice replaces the kernel with fresh unmapped pieces that re-enter this pass.
-``040_schedule`` schedules the stored tree only after the cut rule is quiescent.
+admits. A structural choice replaces the kernel with fresh unmapped pieces. Before the splice stamps
+their identities, each piece reuses Loop's split-free-axis canonicalization because the cut may have
+removed the access that kept a reshape's output axes distinct; the canonical pieces then re-enter this
+pass. ``040_schedule`` schedules the stored tree only after the cut rule is quiescent.
 
 ``030_cut`` reads the structural tree through ``ir.pure.tree``. ``040_schedule`` adapts the classic
-schedule model's accepted assignments to lazy pipeline forks; schedule membership remains independent of traversal order.
+schedule model's accepted assignments to lazy pipeline forks; schedule membership remains independent of traversal
+order.
 """

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -17,7 +17,6 @@ from itertools import islice
 from emmy.compiler.dtype import F32
 from emmy.compiler.dtype import get as get_dtype
 from emmy.compiler.graph import Graph, Node
-from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
 from emmy.compiler.ir.pure.fold import (
@@ -36,6 +35,7 @@ from emmy.compiler.ir.tile.ops import carries_partition, edge_dtypes
 from emmy.compiler.ir.tile.path import family_sites, sites, spell
 from emmy.compiler.pipeline import Match
 from emmy.compiler.pipeline.knob import consume_kernel_row
+from emmy.compiler.pipeline.passes.lowering.tile._pieces import input_fragment, piece_inputs
 from emmy.compiler.structural import digest
 from emmy.compiler.tensor import Tensor
 
@@ -529,25 +529,6 @@ def _workspace_axes(seam: CutSite, produced: Fold) -> tuple:
     return tuple(axis for axis in seam.axes if axis.name in captures or (axis.extent.is_static and axis.extent.as_static() == 1))
 
 
-def _piece_inputs(root: Node, fold: Fold, first: tuple[str, ...] = ()) -> list[str]:
-    """A piece's graph inputs: its workspaces, then every buffer of ``root``'s the piece reads.
-
-    The read set is the STORED tree's (:func:`loaded_buffers`), not the lowered body's, because the
-    kernel this node becomes is materialized from that tree. A Fold a region keeps as a term hides
-    its operand edges from a lowered-body walk, so declaring the lowered view named fewer inputs
-    than the kernel went on to read; the workspace producers then had no consumer edge, were pruned
-    as orphans, and the launch asked for a buffer nothing had allocated."""
-    reads = loaded_buffers(fold)
-    return [*first, *(name for name in root.inputs if name in reads)]
-
-
-def _input_fragment(match: Match, root: Node) -> Graph:
-    fragment = Graph()
-    for name in root.inputs:
-        fragment.add_node(op=InputOp(), inputs=[], output=match.graph.buffer(name), node_id=name)
-    return fragment
-
-
 def output_map(root: Node) -> dict[str, str]:
     """Stable temporary output names used by every cut sibling of ``root``."""
     return {name: f"{name}__placed" for name in root.buffer_names()}
@@ -675,7 +656,7 @@ def realize(
         others = {target: loads for target, loads in everything.items() if target not in replacements}
         produced_pieces.append((seam, _replace_fold(produced, others) if others else produced, axes, index, token, names, buffers))
 
-    fragment = _input_fragment(match, root)
+    fragment = input_fragment(match, root)
     all_buffers = [buffer for *_, buffers in produced_pieces for buffer in buffers]
     # A producer reading another seam's workspace must follow the node that writes it. Strict
     # containment makes this dependency graph acyclic, including chains whose members have the
@@ -700,7 +681,7 @@ def realize(
         reads = loaded_buffers(produced)
         fragment.add_node(
             op=producer,
-            inputs=_piece_inputs(root, produced, tuple(buffer for buffer in all_buffers if buffer in reads)),
+            inputs=piece_inputs(root, produced, *(buffer for buffer in all_buffers if buffer in reads)),
             outputs=workspace_tensors,
             node_id=buffers[0],
         )
@@ -725,7 +706,7 @@ def realize(
     all_buffers = [buffer for *_, buffers in produced_pieces for buffer in buffers]
     fragment.add_node(
         op=consumer,
-        inputs=_piece_inputs(root, parent_fold, all_buffers),
+        inputs=piece_inputs(root, parent_fold, *all_buffers),
         outputs=output_tensors,
         node_id=renamed_outputs[root.id],
     )

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -27,12 +27,13 @@ from emmy.compiler.ir.pure.fold import (
     deep_reads,
     is_contraction,
     loaded_buffers,
+    result_slice,
 )
 from emmy.compiler.ir.pure.tree import walk
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.ops import carries_partition, edge_dtypes
-from emmy.compiler.ir.tile.path import family_sites, sites, spell
+from emmy.compiler.ir.tile.path import family_sites, sites, spell, spell_result
 from emmy.compiler.pipeline import Match
 from emmy.compiler.pipeline.knob import consume_kernel_row
 from emmy.compiler.pipeline.passes.lowering.tile._pieces import input_fragment, piece_inputs
@@ -51,6 +52,10 @@ class CutSite:
     spelling: str
     axes: tuple
     dtypes: tuple
+    #: One named component selected by a result placement. ``None`` means the complete node.
+    selected: str | None = None
+    #: The consumer-local projection slice the produced piece materializes.
+    produced: Fold | None = None
     frontier: Frontier | None = None
     #: Duplicate cones this seam ALSO stands for — alpha-equivalent up to their captured axis
     #: names (contraction-operand seams only): each sibling is
@@ -375,13 +380,6 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
         scopes = occurrence_axes.get(id(node), ())
         if not isinstance(node, Fold) or id(node) in seen or not scopes:
             continue
-        providers: tuple = ()
-        requires: tuple = ()
-        if not all(_closed_at(node, scope) for scope in scopes):
-            closure = _provider_closure(node, scopes, environments.get(id(node), []))
-            if closure is None:
-                continue
-            providers, requires = closure
         if node.observed:
             # An observed fold's per-step results exist only inside its stream — a cut would
             # separate the scan from its streamed boundary store, which no piece can then spell.
@@ -397,17 +395,52 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
             continue
         seen.add(id(node))
         axes = tuple({axis.name: axis for scope in scopes for axis in scope}.values())
-        out.append(
-            CutSite(
-                node=node,
-                spelling=spell(tile.op, "PLACE", node, all_sites=all_sites),
-                axes=axes,
-                dtypes=dtypes,
-                frontier=frontier,
-                providers=providers,
-                requires=requires,
+
+        def offer(
+            produced: Fold,
+            selected: str | None,
+            spelling: str,
+            offered_dtypes: tuple,
+            *,
+            node=node,
+            scopes=scopes,
+            axes=axes,
+            frontier=frontier,
+        ) -> None:
+            providers: tuple = ()
+            requires: tuple = ()
+            if not all(_closed_at(produced, scope) for scope in scopes):
+                closure = _provider_closure(produced, scopes, environments.get(id(node), []))
+                if closure is None:
+                    return
+                providers, requires = closure
+            out.append(
+                CutSite(
+                    node=node,
+                    spelling=spelling,
+                    axes=axes,
+                    dtypes=offered_dtypes,
+                    selected=selected,
+                    produced=produced if selected is not None else None,
+                    frontier=frontier,
+                    providers=providers,
+                    requires=requires,
+                )
             )
-        )
+
+        results = _operand_result_names(node)
+        offer(node, None, spell(tile.op, "PLACE", node, all_sites=all_sites), dtypes)
+        if node.axis is None and len(results) > 1 and frontier is None:
+            # A selected suffix result can be replaced by one load after the retained prefix
+            # without reordering the parent's positional operand interface. Interior and prefix
+            # components need a segmented retained edge, which is a separate transport change.
+            position, name = len(results), results[-1]
+            retained = result_slice(node, set(results[:-1]))
+            # A retained sibling that also computes the selected result would bind the same SSA
+            # name as its workspace load. Such an interface can only be cut as a whole.
+            if name not in deep_defines(retained):
+                produced = result_slice(node, {name})
+                offer(produced, name, spell_result(tile.op, node, position, all_sites=all_sites), (dtypes[position - 1],))
     # A dependent seam stands only while every required producer is itself offered; dropping one
     # can orphan the next link of a chain, so filter to the fixpoint.
     while True:
@@ -445,7 +478,11 @@ def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) ->
     # a required producer alone keeps the requirement pointing at a seam that still exists and
     # still binds the name the dependent reads.
     required = {id(producer) for seam in seams for _, producer in seam.requires}
-    eligible = [index for index, seam in enumerate(seams) if operand_of.get(id(seam.node)) and id(seam.node) not in required]
+    eligible = [
+        index
+        for index, seam in enumerate(seams)
+        if seam.selected is None and operand_of.get(id(seam.node)) and id(seam.node) not in required
+    ]
     if len(eligible) < 2:
         return tuple(seams)
     scoped = {index: Closure.over_edge(seams[index].node, tuple(axis.name for axis in seams[index].axes)) for index in eligible}
@@ -603,8 +640,8 @@ def realize(
             names = (front.name,)
             produced = Fold.projection(body=Body(front.producer), results=names)
         else:
-            names = _operand_result_names(child)
-            produced = child
+            names = (seam.selected,) if seam.selected is not None else _operand_result_names(child)
+            produced = seam.produced or child
         if seam.providers or seam.requires:
             # Provider closure: the piece carries the host-provided scalar chain, and every
             # required name arrives through its producer seam's workspace load — the same Load
@@ -632,7 +669,11 @@ def realize(
         if front is not None:
             raw = replace(loads[0], dtype=front.dtype)
             loads = (Fold.projection(body=Body((raw, *front.residue)), results=child.lift.results),)
-        replacements = {id(child): loads}
+        replacement = loads
+        if seam.selected is not None:
+            results = _operand_result_names(child)
+            replacement = (result_slice(child, set(results[:-1])), *loads)
+        replacements = {id(child): replacement}
         workspace_loads[id(child)] = loads
         for sibling, pairs in seam.siblings:
             # A clustered duplicate reads the SAME workspace, spelled through its own captured

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -525,7 +525,13 @@ def _unchanged(pieces: tuple, members) -> bool:
 
 def _replace_member(member, targets: dict[int, tuple]):
     if id(member) in targets:
-        return targets[id(member)]
+        # A selected-result replacement contains the retained sibling slice. That slice can
+        # still hold another seam selected by the SAME composed decision, so it remains a
+        # consumer and must see the other workspace substitutions. Drop only this target while
+        # walking its replacement: retaining it would recurse into itself, while dropping every
+        # target leaves nested producer cones live beside their already-emitted workspaces.
+        remaining = {target: replacement for target, replacement in targets.items() if target != id(member)}
+        return tuple(piece for replacement in targets[id(member)] for piece in _replace_member(replacement, remaining))
     if isinstance(member, Fold):
         return (_replace_fold(member, targets),)
     nested = member.nested()

--- a/emmy/compiler/pipeline/passes/lowering/tile/_pieces.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_pieces.py
@@ -1,0 +1,157 @@
+"""Fresh output-owning Tile pieces shared by structural kernel-set rewrites."""
+
+from dataclasses import replace
+
+from emmy.compiler.graph import Graph, Node
+from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.pure.fold import Fold, loaded_buffers
+from emmy.compiler.ir.schedule import Placement
+from emmy.compiler.ir.stmt import Assign, Body, Init, Load, Select
+from emmy.compiler.ir.tile import OutputSpec, ProjectionRegion, TileOp
+from emmy.compiler.ir.tile.ir import projection_results
+from emmy.compiler.ir.tile.ops import carries_partition
+from emmy.compiler.pipeline import Match
+from emmy.compiler.pipeline.knob import consume_kernel_row
+
+
+def input_fragment(match: Match, root: Node) -> Graph:
+    """A replacement fragment seeded with the replaced node's inputs."""
+    fragment = Graph()
+    for name in root.inputs:
+        fragment.add_node(InputOp(), [], match.graph.buffer(name), node_id=name)
+    return fragment
+
+
+def piece_inputs(root: Node, body, *first: str) -> list[str]:
+    """Fragment buffers followed by external inputs read by one piece."""
+    if isinstance(body, TileOp):
+        reads = loaded_buffers(body.op)
+    elif isinstance(body, Fold):
+        reads = loaded_buffers(body)
+    else:
+        reads = {load.input for load in Body.coerce(body).loads}
+    return [*first, *(name for name in root.inputs if name in reads)]
+
+
+def output_root(root: Node, outputs: set[str]) -> Node:
+    """A graph-node view containing only the ports one output piece owns."""
+    by_name = dict(zip(root.buffer_names(), root.outputs, strict=True))
+    ordered = tuple(name for name in root.buffer_names() if name in outputs)
+    if outputs != set(ordered):
+        raise ValueError(f"projection stores target unknown output buffers: {sorted(outputs - set(ordered))}")
+    return replace(root, id=ordered[0], outputs=tuple(replace(by_name[name], name=name) for name in ordered))
+
+
+def tile_piece(body, free, *, output_specs=()) -> TileOp:
+    """One fresh unscheduled Tile kernel preserving its Fold algebra."""
+    op = body if isinstance(body, Fold) else Fold.projection(body=Body.coerce(body))
+    piece = TileOp(op=op, place=Placement(free=tuple(free)), output_specs=tuple(output_specs))
+    return replace(piece, knobs=consume_kernel_row(piece.knobs))
+
+
+def _peel_region(region: ProjectionRegion) -> tuple[tuple, Body]:
+    """Lift one region's leading parallel chain into its piece's placement."""
+    axes = [region.axis]
+    prefix = []
+    current = list(region.body)
+    while True:
+        index = 0
+        while index < len(current) and isinstance(current[index], (Load, Assign, Init, Select)):
+            index += 1
+        head, rest = current[:index], current[index:]
+        if len(rest) != 1 or not isinstance(rest[0], ProjectionRegion):
+            return tuple(axes), Body((*prefix, *current))
+        prefix.extend(head)
+        axes.append(rest[0].axis)
+        current = list(rest[0].body)
+
+
+def projection_region_pieces(tile: TileOp) -> tuple[tuple[Body, tuple, tuple[OutputSpec, ...]], ...]:
+    """Closed pieces for a root prefix followed by independent output regions.
+
+    One TileOp has one root-global placement. This offer therefore separates sibling regions so
+    each can lift its own leading axes into an ordinary placement. It declines unless the body is
+    exactly a pure prefix followed by regions, every output has one owner, and every capture
+    closes over that prefix.
+    """
+    root = tile.op
+    if not isinstance(root, Fold) or root.axis is not None or root.operands:
+        return ()
+    first = next((index for index, member in enumerate(root.body) if isinstance(member, ProjectionRegion)), len(root.body))
+    prefix, regions = root.body[:first], root.body[first:]
+    if len(regions) < 2 or any(not isinstance(member, ProjectionRegion) for member in regions):
+        return ()
+
+    grouped = [[] for _ in regions]
+    result_sets = tuple(projection_results((region,)) for region in regions)
+    for spec in tile.output_specs:
+        owners = [index for index, results in enumerate(result_sets) if set(spec.write.values) <= results]
+        if len(owners) != 1:
+            return ()
+        grouped[owners[0]].append(spec)
+    if any(not stores for stores in grouped):
+        return ()
+    output_groups = [{spec.write.output for spec in stores} for stores in grouped]
+    if any(left & right for index, left in enumerate(output_groups) for right in output_groups[index + 1 :]):
+        return ()
+    if tile.outputs and set().union(*output_groups) != set(tile.outputs):
+        return ()
+
+    outer_axes = {axis.name for axis in tile.place.free}
+    pieces = []
+    for region, stores in zip(regions, grouped, strict=True):
+        provider = prefix.backward_cone(region.deps())
+        if provider.external_reads - outer_axes:
+            return ()
+        axes, body = _peel_region(region)
+        free = (*tile.place.free, *axes)
+        if len({axis.name for axis in free}) != len(free):
+            return ()
+        pieces.append((Body((*provider.members, *body)), free, tuple(stores)))
+    return tuple(pieces)
+
+
+def add_output_piece(match: Match, fragment: Graph, root: Node, piece: TileOp, inputs: list[str]) -> Graph:
+    """Add one piece and extend the graph-splice output mapping with its owned ports."""
+    buffers = root.buffer_names()
+    renamed = {name: f"{name}__split" for name in buffers}
+    piece = replace(
+        piece,
+        output_specs=tuple(
+            replace(spec, write=replace(spec.write, output=renamed.get(spec.write.output, spec.write.output)))
+            for spec in piece.output_specs
+        ),
+    )
+    tensors = (
+        replace(root.outputs[0], name=buffers[0]),
+        *(replace(tensor, name=renamed[name]) for name, tensor in zip(buffers[1:], root.outputs[1:], strict=True)),
+    )
+    fragment.add_node(piece, inputs, outputs=tensors, node_id=renamed[buffers[0]])
+    fragment.outputs.extend(renamed.values())
+    output = dict(match.output) if isinstance(match.output, dict) else {}
+    output.update(renamed)
+    match.output = output
+    return fragment
+
+
+def realize_projection_regions(match: Match, root: Node, pieces) -> Graph:
+    """Replace one sibling-region root with fresh output-owning TileOps."""
+    tile: TileOp = root.op
+    fragment = input_fragment(match, root)
+    receipt = tile.split_consumed or carries_partition(tile.op)
+    for body, free, stores in pieces:
+        owned = output_root(root, {store.write.output for store in stores})
+        piece = replace(tile_piece(body, free, output_specs=stores), split_consumed=receipt)
+        add_output_piece(match, fragment, owned, piece, piece_inputs(owned, piece))
+    return fragment
+
+
+__all__ = [
+    "add_output_piece",
+    "input_fragment",
+    "output_root",
+    "piece_inputs",
+    "projection_region_pieces",
+    "realize_projection_regions",
+    "tile_piece",
+]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_pieces.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_pieces.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 
 from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.base import InputOp
-from emmy.compiler.ir.pure.fold import Fold, loaded_buffers
+from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, loaded_buffers
 from emmy.compiler.ir.schedule import Placement
 from emmy.compiler.ir.stmt import Assign, Body, Init, Load, Select
 from emmy.compiler.ir.tile import OutputSpec, ProjectionRegion, TileOp
@@ -67,19 +67,20 @@ def _peel_region(region: ProjectionRegion) -> tuple[tuple, Body]:
 
 
 def projection_region_pieces(tile: TileOp) -> tuple[tuple[Body, tuple, tuple[OutputSpec, ...]], ...]:
-    """Closed pieces for a root prefix followed by independent output regions.
+    """Closed pieces for a root prefix followed by one or more output regions.
 
     One TileOp has one root-global placement. This offer therefore separates sibling regions so
-    each can lift its own leading axes into an ordinary placement. It declines unless the body is
-    exactly a pure prefix followed by regions, every output has one owner, and every capture
-    closes over that prefix.
+    each can lift its own leading axes into an ordinary placement. A single region can remain after
+    earlier cuts; it uses the same offer because lifting its axes still trades shared-prefix reuse
+    for parallel placement. It declines unless the body is exactly a pure prefix followed by
+    regions, every output has one owner, and every capture closes over the prefix and root operands.
     """
     root = tile.op
-    if not isinstance(root, Fold) or root.axis is not None or root.operands:
+    if not isinstance(root, Fold) or root.axis is not None:
         return ()
     first = next((index for index, member in enumerate(root.body) if isinstance(member, ProjectionRegion)), len(root.body))
     prefix, regions = root.body[:first], root.body[first:]
-    if len(regions) < 2 or any(not isinstance(member, ProjectionRegion) for member in regions):
+    if not regions or any(not isinstance(member, ProjectionRegion) for member in regions):
         return ()
 
     grouped = [[] for _ in regions]
@@ -98,16 +99,19 @@ def projection_region_pieces(tile: TileOp) -> tuple[tuple[Body, tuple, tuple[Out
         return ()
 
     outer_axes = {axis.name for axis in tile.place.free}
+    operand_names = {name for edge in root.operands for name in _operand_result_names(edge)}
     pieces = []
     for region, stores in zip(regions, grouped, strict=True):
         provider = prefix.backward_cone(region.deps())
-        if provider.external_reads - outer_axes:
+        needed_operands = provider.external_reads - outer_axes
+        if needed_operands - operand_names:
             return ()
+        operands = tuple(edge for edge in root.operands if set(_operand_result_names(edge)) & needed_operands)
         axes, body = _peel_region(region)
         free = (*tile.place.free, *axes)
         if len({axis.name for axis in free}) != len(free):
             return ()
-        pieces.append((Body((*provider.members, *body)), free, tuple(stores)))
+        pieces.append((Body((*operands, *provider.members, *body)), free, tuple(stores)))
     return tuple(pieces)
 
 
@@ -135,7 +139,7 @@ def add_output_piece(match: Match, fragment: Graph, root: Node, piece: TileOp, i
 
 
 def realize_projection_regions(match: Match, root: Node, pieces) -> Graph:
-    """Replace one sibling-region root with fresh output-owning TileOps."""
+    """Replace one output-region root with fresh output-owning TileOps."""
     tile: TileOp = root.op
     fragment = input_fragment(match, root)
     receipt = tile.split_consumed or carries_partition(tile.op)

--- a/emmy/compiler/pipeline/passes/lowering/tile/_pieces.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_pieces.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 
 from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, loaded_buffers
 from emmy.compiler.ir.schedule import Placement
 from emmy.compiler.ir.stmt import Assign, Body, Init, Load, Select
@@ -12,6 +13,8 @@ from emmy.compiler.ir.tile.ir import projection_results
 from emmy.compiler.ir.tile.ops import carries_partition
 from emmy.compiler.pipeline import Match
 from emmy.compiler.pipeline.knob import consume_kernel_row
+from emmy.compiler.pipeline.passes.loop.canonicalize._split_free_axes import fuse_split_free_axes
+from emmy.compiler.pipeline.passes.lowering.tile._fromloop import lift_loop_op
 
 
 def input_fragment(match: Match, root: Node) -> Graph:
@@ -47,6 +50,26 @@ def tile_piece(body, free, *, output_specs=()) -> TileOp:
     op = body if isinstance(body, Fold) else Fold.projection(body=Body.coerce(body))
     piece = TileOp(op=op, place=Placement(free=tuple(free)), output_specs=tuple(output_specs))
     return replace(piece, knobs=consume_kernel_row(piece.knobs))
+
+
+def canonicalize_fresh_pieces(fragment: Graph) -> Graph:
+    """Re-fuse clean split free axes before fresh Tile pieces receive their identity stamp.
+
+    Structural cuts can remove the access that kept a reshape's output-axis pair distinct. The
+    resulting unscheduled piece re-enters total lift through its one schedule-free Loop spelling,
+    so the same canonicalization used before the original lift can recognize its new geometry.
+    """
+    for node in fragment.nodes.values():
+        tile = node.op
+        if not isinstance(tile, TileOp) or tile.op is None or tile.place.is_mapped or tile.schedule is not None:
+            continue
+        shapes = {name: tensor.shape for name, tensor in {**tile.inputs, **tile.outputs}.items()}
+        body = fuse_split_free_axes(tile.loop_body, shapes)
+        if body is None:
+            continue
+        lifted = lift_loop_op(LoopOp(body=body, inputs=tile.inputs, outputs=tile.outputs), name=tile.name)
+        node.op = replace(tile, op=lifted.op, place=lifted.place, output_specs=lifted.output_specs)
+    return fragment
 
 
 def _peel_region(region: ProjectionRegion) -> tuple[tuple, Body]:
@@ -152,6 +175,7 @@ def realize_projection_regions(match: Match, root: Node, pieces) -> Graph:
 
 __all__ = [
     "add_output_piece",
+    "canonicalize_fresh_pieces",
     "input_fragment",
     "output_root",
     "piece_inputs",

--- a/emmy/compiler/pipeline/passes/lowering/tile/_split.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_split.py
@@ -33,7 +33,6 @@ from emmy.compiler.dim import Dim
 from emmy.compiler.dtype import BF16, F16, F32
 from emmy.compiler.graph import Graph, Node, Tensor
 from emmy.compiler.ir.axis import Axis, Window
-from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.pure import Lambda
 from emmy.compiler.ir.pure.algebra import component_ops
@@ -45,17 +44,22 @@ from emmy.compiler.ir.stmt import Body, Load, Write
 from emmy.compiler.ir.stmt.passes import projection_distributes
 from emmy.compiler.ir.tile import (
     OutputSpec,
-    Placement,
     TileOp,
     extract_output_specs,
-    lower_with_output_specs,
 )
 from emmy.compiler.ir.tile.ir import apply_output_specs
 from emmy.compiler.ir.tile.ops import Sched, carries_partition, head, projection_regions, projection_tail
 from emmy.compiler.ir.tile.path import sites
 from emmy.compiler.pipeline import Match
 from emmy.compiler.pipeline.fork import DeferredFork
-from emmy.compiler.pipeline.knob import axis_of, consume_kernel_row
+from emmy.compiler.pipeline.knob import axis_of
+from emmy.compiler.pipeline.passes.lowering.tile._pieces import (
+    add_output_piece,
+    input_fragment,
+    output_root,
+    piece_inputs,
+    tile_piece,
+)
 from emmy.compiler.pipeline.search.space import REDUCE, WORK
 
 logger = logging.getLogger(__name__)
@@ -311,7 +315,7 @@ def _sliced_contraction(node: Fold, w: int) -> tuple[Axis, Fold]:
     return ksplit, sliced
 
 
-# ---- the piece / fragment builders ------------------------------------------------------------ #
+# ---- the piece builders ----------------------------------------------------------------------- #
 
 
 def _boundary(stmts) -> tuple[tuple, tuple]:
@@ -331,65 +335,13 @@ def _cell_index(stmts, free) -> tuple:
     return tuple(Var(ax.name) for ax in free)
 
 
-def _frag(match: Match, root: Node) -> Graph:
-    """A fragment seeded with the split node's inputs — the graph a piece is stamped against (its
-    structural features fold in its operands' dtypes, which need the buffers)."""
-    frag = Graph()
-    for inp in root.inputs:
-        frag.add_node(op=InputOp(), inputs=[], output=match.graph.buffer(inp), node_id=inp)
-    return frag
-
-
-def _piece_inputs(root: Node, body, *first: str) -> list[str]:
-    """Return fragment buffers followed by external inputs actually read by a piece."""
-    if isinstance(body, TileOp):
-        body = lower_with_output_specs(body.op, body.output_specs)
-    elif isinstance(body, Fold):
-        body = body.lower()
-    reads = {load.input for load in Body.coerce(body).loads}
-    return [*first, *(inp for inp in root.inputs if inp in reads)]
-
-
-def _add_output_piece(match: Match, frag: Graph, root: Node, piece: TileOp, inputs: list[str]) -> Graph:
-    """Add a fresh piece with its owned output ports and arrange their splice identities."""
-    buffers = root.buffer_names()
-    renamed = {name: f"{name}__split" for name in buffers}
-    piece = replace(
-        piece,
-        output_specs=tuple(
-            replace(spec, write=replace(spec.write, output=renamed.get(spec.write.output, spec.write.output)))
-            for spec in piece.output_specs
-        ),
-    )
-    tensors = (
-        replace(root.outputs[0], name=buffers[0]),
-        *(replace(tensor, name=renamed[name]) for name, tensor in zip(buffers[1:], root.outputs[1:], strict=True)),
-    )
-    frag.add_node(op=piece, inputs=inputs, outputs=tensors, node_id=renamed[buffers[0]])
-    frag.outputs.extend(renamed.values())
-    output = dict(match.output) if isinstance(match.output, dict) else {}
-    output.update(renamed)
-    match.output = output
-    return frag
-
-
 def _one(match: Match, frag: Graph, root: Node, piece: TileOp) -> Graph:
     """The ATOMIC arm's one-kernel fragment. It replaces the split kernel with ONE kernel, but it
     is a SPLICE, never an op rebind: a rebind is how the engine says "the same kernel, decided
     further", so it merges the replaced op's knobs forward and does not restart the pass scan. The
     atomic partial is a different kernel — its own placement, its own body — and it has to reach
     scheduling carrying nothing of the kernel it replaced."""
-    return _add_output_piece(match, frag, root, piece, list(root.inputs))
-
-
-def _piece(body, free, *, output_specs: tuple = ()) -> TileOp:
-    """One fresh unscheduled Tile kernel preserving its Fold algebra verbatim."""
-    op = body if isinstance(body, Fold) else Fold.projection(body=Body.coerce(body))
-    piece = TileOp(op=op, place=Placement(free=tuple(free)), output_specs=output_specs)
-    # A split CONSUMES the kernel it replaces: the piece drops its schedule row and its structural
-    # identity. Built fresh here, so this states the contract rather than doing work — and the rule
-    # that mints a kernel is where that has to be said.
-    return replace(piece, knobs=consume_kernel_row(piece.knobs))
+    return add_output_piece(match, frag, root, piece, list(root.inputs))
 
 
 def _state_fold(axis: Axis, algebra: Fold, loads: tuple[Load, ...]) -> Fold:
@@ -410,16 +362,6 @@ def _project(fold: Fold, body) -> Fold:
     return Fold.projection(operands=(fold,), body=body) if body else fold
 
 
-def _output_root(root: Node, outputs: set[str]) -> Node:
-    """A graph-node view containing only the output ports owned by one projection Fold."""
-    by_name = dict(zip(root.buffer_names(), root.outputs, strict=True))
-    ordered = tuple(name for name in root.buffer_names() if name in outputs)
-    if outputs != set(ordered):
-        raise ValueError(f"projection stores target unknown output buffers: {sorted(outputs - set(ordered))}")
-    tensors = tuple(replace(by_name[name], name=name) for name in ordered)
-    return replace(root, id=ordered[0], outputs=tensors)
-
-
 def _split_projection(tile: TileOp, root: Node, selected: Fold):
     """Separate an independent MIMO projection into output-owning Fold pieces."""
     op = tile.op
@@ -429,7 +371,7 @@ def _split_projection(tile: TileOp, root: Node, selected: Fold):
     pieces = []
     chosen = None
     for fold, body, stores in projection_regions(op, tile.output_specs):
-        node = _output_root(root, {store.write.output for store in stores})
+        node = output_root(root, {store.write.output for store in stores})
         entry = (node, fold, body, stores)
         if fold is selected:
             chosen = entry
@@ -448,8 +390,8 @@ def _add_projection_pieces(match: Match, frag: Graph, pieces: tuple, free: tuple
     (``split_consumed``): a ``REDUCE`` pin's ``g`` half strips on it instead of splitting the
     sibling region again (or raising)."""
     for root, fold, body, stores in pieces:
-        tile = replace(_piece(_project(fold, body), free, output_specs=stores), split_consumed=True)
-        _add_output_piece(match, frag, root, tile, _piece_inputs(root, tile))
+        tile = replace(tile_piece(_project(fold, body), free, output_specs=stores), split_consumed=True)
+        add_output_piece(match, frag, root, tile, piece_inputs(root, tile))
     return frag
 
 
@@ -507,7 +449,7 @@ def realize_split(match: Match, root: Node, cta: int, finalize: str) -> Graph:
     if fold_at is not None:
         prologue = _captured_prologue(partial_fold, projection[:fold_at], split, free)
         projection = (*projection[:fold_at], *projection[fold_at + 1 :])
-    frag = _frag(match, root)
+    frag = input_fragment(match, root)
 
     if finalize == "atomic":
         # Direct atomic finalize: ONE kernel — each CTA atomicAdds its slice's state into the
@@ -529,9 +471,9 @@ def realize_split(match: Match, root: Node, cta: int, finalize: str) -> Graph:
             # ``fold_at`` indexes the PRE-strip ``projection``, and it stays valid against
             # ``p_body`` because the strip removed exactly the stmt AT that index and
             # ``_boundary`` only extracts trailing ``Write``s, which sit after the fold.
-            piece = _piece((*p_body[:fold_at], partial_fold, *p_body[fold_at:]), (split, *free), output_specs=p_stores)
+            piece = tile_piece((*p_body[:fold_at], partial_fold, *p_body[fold_at:]), (split, *free), output_specs=p_stores)
         else:
-            piece = _piece(_project(partial_fold, p_body), (split, *free), output_specs=p_stores)
+            piece = tile_piece(_project(partial_fold, p_body), (split, *free), output_specs=p_stores)
         result = _one(match, frag, root, piece)
         return _add_projection_pieces(match, result, projection_pieces, free)
 
@@ -559,7 +501,7 @@ def realize_split(match: Match, root: Node, cta: int, finalize: str) -> Graph:
     # lead axes from the placement, so nothing is restamped on the node.
     ws_stores = tuple(OutputSpec(write=Write(output=ws_name, index=ws_index(i), value=states[i])) for i in range(n_comp))
     partial_body = (*prologue, partial_fold) if prologue else partial_fold
-    partial_tile = _piece(partial_body, (split, *free), output_specs=ws_stores)
+    partial_tile = tile_piece(partial_body, (split, *free), output_specs=ws_stores)
 
     # --- finalize kernel: identity-lift each workspace state tuple through the SAME monoid.
     # The merge axis carries the SAME consumed-split receipt the partial's slice does: the
@@ -580,8 +522,8 @@ def realize_split(match: Match, root: Node, cta: int, finalize: str) -> Graph:
     # kernel's structural features fold in its operands' dtypes, which only resolve once the
     # buffer is a graph node.
     frag.add_node(op=partial_tile, inputs=list(root.inputs), output=Tensor(ws_name, ws_shape, F32), node_id=ws_name)
-    fin_tile = _piece(_project(fin_fold, fin_proj), free, output_specs=fin_stores)
-    result = _add_output_piece(match, frag, root, fin_tile, _piece_inputs(root, fin_tile, ws_name))
+    fin_tile = tile_piece(_project(fin_fold, fin_proj), free, output_specs=fin_stores)
+    result = add_output_piece(match, frag, root, fin_tile, piece_inputs(root, fin_tile, ws_name))
     return _add_projection_pieces(match, result, projection_pieces, free)
 
 

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -816,7 +816,9 @@ def decode_record(record: GoldenRecord) -> str | None:
         axes.extend(store.sweep.name for store in tile.output_specs if store.sweep is not None)
         tile = replace(tile, op=rewrite_twisted(tile.op, axes))
         seams = cuttable_seams(tile)
-        seam_ids = {id(seam.node) for seam in seams}
+        seam_sites = {
+            (id(seam.node), tuple(seam.node.defines()).index(seam.selected) + 1 if seam.selected is not None else None) for seam in seams
+        }
         all_sites = sites(tile.op)
         for key, value in record.knobs.items():
             if str(value) != "cut":
@@ -825,7 +827,7 @@ def decode_record(record: GoldenRecord) -> str | None:
                 site = resolve(tile.op, str(key), all_sites=all_sites)
             except ValueError as exc:
                 return _remember_verdict(verdict_key, f"routing key {key!r} does not resolve: {exc}")
-            if site is None or id(site.node) not in seam_ids:
+            if site is None or (id(site.node), site.result) not in seam_sites:
                 return _remember_verdict(verdict_key, f"routing key {key!r} names no legal cut seam on the Fold tree")
         return _remember_verdict(verdict_key, None)
     candidates = _candidate_rows(record)

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -9,16 +9,16 @@ correctness for admissible rows, and fresh `torch.compile` measurements where th
 The A100 s512 attention all-four cut produced five kernels, but initially failed before launch with
 `KeyError: linear_1_wt`. Cut-piece graph inputs came from lowered root statements, which omit contraction operands
 retained structurally beneath a projection region even though kernel materialization later expands and reads them.
-Commit `a9672422` now collects buffer reads from the complete structural Fold tree and uses the same inventory for
-piece inputs and producer ordering. The former route now carries all 23 required inputs, exercises tuning on the A100,
-and has a focused regression test. The combined branch gate passed 3,993 tests with 1,012 skips and five expected
-failures on the qualification host; local focused replay passed 22 tests with one skip, and lint is clean.
+The historical cut-local fix was commit `a9672422`. Main's later generic schedule reconstruction superseded it:
+`loaded_buffers` inventories the complete stored Fold tree, and both piece inputs and producer ordering consume that
+shared reading. At the historical source, the route carried all 23 required inputs and exercised A100 tuning. Its gate
+passed 3,993 tests with 1,012 skips and five expected failures; focused replay passed 22 tests with one skip.
 
 A second bounded reduction found that legal placement sites beneath a projection region were absent from provider
 closure: the lexical-environment walk only visited direct Fold members while placement used the complete stored-child
-walk. Commit `8c2bb5cb` shares that traversal. The current s512 normalized-K projection plus rotary seam now lowers as
-two kernels, materializing the value once and reading its workspace in the consumer. This is a real new route, but a
-complete correct s512 assembly still has another child that exceeds the 15-second bound.
+walk. Historical commit `8c2bb5cb` fixed that locally; main now supersedes it with the generic `_stored_folds` traversal
+and its regression test. At that source, the normalized-K projection plus rotary seam lowered as two
+kernels, but a complete correct s512 assembly still had another child that exceeded the 15-second bound.
 
 Manually selected A100 child rows demonstrate that schedule quality is not the immediate blocker:
 
@@ -37,9 +37,11 @@ value materialization across independent projection regions, not a larger schedu
 The V100 manual screen found one correct and repeatable schedule improvement. The standalone model-sized Volta
 projection fell from 3,571.7 µs to 1,868.8 µs with `WORK=w4x2`, f16 MMA `f2x4/k4`, and `STAGE=d1/smem`, while
 `torch.compile` measured 756.736 µs. A fresh repeat measured 1,881.088 versus 757.760 µs with strict zero error. The
-exact-card CLI recorded the first pair in the realization case. This is a 1.9x Emmy improvement but remains about
-2.5x behind. Its CUDA uses two CTA barriers in a 192-iteration K loop, 123 registers per thread, and 25% occupancy, so
-the remaining gap needs a better SM70 blocking-copy software pipeline rather than another currently offered schedule.
+exact-card CLI recorded the first pair in the realization case. These measurements predate main's #691 generic
+schedule reconstruction and are historical rather than current-head latency evidence; the authored row still passes
+the current GPU-free realization checks but needs an exact V100 timing refresh. At the measured source it was a 1.9x
+Emmy improvement but remained about 2.5x behind; its CUDA used two CTA barriers in a 192-iteration K loop, 123
+registers per thread, and 25% occupancy.
 
 The V100 linear-cut diagnostic fell from 1,160.2 µs to 247.0-247.8 µs by selecting the unsplit child, versus
 65.7-66.0 µs for `torch.compile`, but it is not admissible: both strict repeats fail with 26,441 mismatches and maximum
@@ -64,8 +66,8 @@ promoted without repeated correct reference measurements.
 Manual scheduling therefore improved the measured ceilings and exposed one fixed compiler bug, but did not establish
 parity. Across Ampere and Ada the next shared problem is forming reusable value boundaries before child scheduling;
 on Volta the independent remaining problems are synchronous staging efficiency and the strict large-linear numerical
-contract. After integrating both placement fixes and the recorded Volta row, the combined local gate passed 3,994
-tests with 1,012 skips and five expected failures; lint remained clean. The A100 VM remains running.
+contract. At the historical source, the combined local gate passed 3,994 tests with 1,012 skips and five expected
+failures; lint remained clean. The A100 VM remained running.
 
 ## Post-#689 structural-identity qualification (2026-08-29)
 
@@ -130,10 +132,10 @@ linear-cut; strict linear-cut correctness still found 26,418 mismatches with max
 A fresh 10-candidate workspace tune exposed one deploy replay gap. Its fastest DB row was 76.012 µs, but direct
 descent compared the schedule tree's intermediate `S_warp_eligible` feature with a feature-free measured row after
 the `S_*` signature had already joined them. Every measured row therefore appeared disjoint and deploy fell back to
-the prior at about 85 µs. Commit `d2505362` ignores `S_*` / `H_*` fork keys during that tuning-knob descent. Exact
-A100 strict replay then selected the measured `WORK=t8` row at 76.0 µs with direct eager correctness, rather than the
-prior's `WORK=t4` fallback. This closes evidence replay but not the workspace performance gap: 76.0 µs remains about
-6.9x slower than the 11 µs `torch.compile` result.
+the prior at about 85 µs. Historical commit `d2505362` ignored `S_*` / `H_*` fork keys during tuning-knob descent.
+That implementation is now in main; this branch retains its focused measured-row regression coverage. At the measured
+source, exact A100 strict replay selected `WORK=t8` at 76.0 µs with direct eager correctness rather than the prior's
+`WORK=t4` fallback. This closed evidence replay but not the roughly 6.9x workspace performance gap.
 
 Stat-fill's remaining persistence gap is larger. A four-candidate fused probe stayed at 277,229 µs and produced no
 children. Replaying the previously correct six-cut route did enroll its resulting kernels: a four-candidate cap per
@@ -144,8 +146,8 @@ split-first persistence: record the route decision, realize the resulting kernel
 to its measured schedule before writing a replayable winner. This is not a safe small follow-up to the DB descent
 fix, and no unqualified stat-fill row was promoted.
 
-Draft PR #687 carries the replay fix. Local verification is 3,982 passed, 1,012 skipped, five expected failures, and
-clean lint; its GitHub test and lint jobs are also green. The retained A100 VM remains running.
+Draft PR #687 carried the original replay fix. Its local verification was 3,982 passed, 1,012 skipped, five expected
+failures, and clean lint; its GitHub test and lint jobs were green. The A100 VM remained running.
 
 ## Current-head corpus requalification (2026-08-29)
 

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,5 +1,42 @@
 # Golden-bench kernel corpus
 
+## Post-merge qualification and measured-row replay fix (2026-08-29)
+
+Qualification resumed from merged main `5f0a2076` on branch `codex/post-679-corpus-qualification`. The exact-main
+corpus run reproduced the prior platform verdicts; the merge's review follow-up did not regress a pinned kernel.
+
+| platform | exact coverage | result |
+| --- | --- | --- |
+| A100 sm80 | 6 cases | 2 wins, 3 measurable losses, and the same stat-fill watchdog |
+| V100 sm70 | 2 cases | Volta MMA remains a correct 4.13x loss; linear-cut remains incorrect and inadmissible |
+| RTX 4090 sm89 | 0 cases | 201 collected and skipped; no exact sm89 closed case |
+
+The exact-main A100 rows were 7.041 µs versus 10.016 µs for GQA and 6.076 µs versus 8.009 µs for computed-value
+attention. The remaining pinned rows were 84.224 µs versus 12.902 µs for the workspace chain, 9.060 µs versus
+4.175 µs for split-K, and 17.664 µs versus 11.106 µs for PV transpose. Stat-fill again exceeded its watchdog. V100
+reproduced 3,130.368 µs versus 756.736 µs for the promoted Volta row and 1,160.192 µs versus 66.048 µs for
+linear-cut; strict linear-cut correctness still found 26,418 mismatches with maximum absolute error 0.25.
+
+A fresh 10-candidate workspace tune exposed one deploy replay gap. Its fastest DB row was 76.012 µs, but direct
+descent compared the schedule tree's intermediate `S_warp_eligible` feature with a feature-free measured row after
+the `S_*` signature had already joined them. Every measured row therefore appeared disjoint and deploy fell back to
+the prior at about 85 µs. Commit `d2505362` ignores `S_*` / `H_*` fork keys during that tuning-knob descent. Exact
+A100 strict replay then selected the measured `WORK=t8` row at 76.0 µs with direct eager correctness, rather than the
+prior's `WORK=t4` fallback. This closes evidence replay but not the workspace performance gap: 76.0 µs remains about
+6.9x slower than the 11 µs `torch.compile` result.
+
+Stat-fill's remaining persistence gap is larger. A four-candidate fused probe stayed at 277,229 µs and produced no
+children. Replaying the previously correct six-cut route did enroll its resulting kernels: a four-candidate cap per
+kernel completed 53 measurements and found a 2.093 µs child. The written working golden nevertheless contained only
+the route seed and a 9,950.886 µs placement total—no child identities and no child schedule receipts. That total is
+not deploy evidence because a reload cannot reconstruct the measured ordered assembly. The required change is
+split-first persistence: record the route decision, realize the resulting kernel identities, then join each identity
+to its measured schedule before writing a replayable winner. This is not a safe small follow-up to the DB descent
+fix, and no unqualified stat-fill row was promoted.
+
+Draft PR #687 carries the replay fix. Local verification is 3,982 passed, 1,012 skipped, five expected failures, and
+clean lint; its GitHub test and lint jobs are also green. The retained A100 VM remains running.
+
 ## Current-head corpus requalification (2026-08-29)
 
 The draft is based on current main `b88763fa`; the exact combined source for this pass is `857ba7e9`. Every hardware

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,5 +1,54 @@
 # Golden-bench kernel corpus
 
+## Post-#691 generic-schedule requalification (2026-09-01)
+
+The qualification branch was rebased onto main `b93a86c2`, which replaced the former classic schedule machinery with
+generic schedule composition. Two historical cut-local fixes were omitted during the rebase because main now owns
+their contracts more generally: stored-tree `loaded_buffers` supplies cut inputs and producer ordering, while
+`_stored_folds` supplies placement environments through projection regions. Main already carries regressions for both.
+
+The schedule audit found one compatibility authority and no second pipeline enumerator. `ClassicDomains` exposes
+independent kernel, node, and operand-edge factors; `ClassicScheduleContext` accepts their compatible subset; and the
+generic schedule walk is the only traversal. Grouping a node with its incident edges remains a pruning step under the
+current one-`STAGE`-per-consumer codec, not a collapsed assignment. A divergent-edge probe matched the literal
+Cartesian oracle, and traversal-order tests preserved the accepted set.
+
+All 210 realization cases had current derived halves after the schedule rewrite. GPU-free offered and realized replay
+matched every expectation; an exact sm_120 systemd sandbox slice passed 19 closed build/correct checks and retained
+five expected correctness gaps. No realization verdict changed, so the corpus required no regeneration or new xfail.
+
+The experiment goldens did contain schedule-codec drift. A strict current-candidate audit migrated 78 verified rows
+whose only difference was the applicable empty-family vocabulary; every stored measurement, program, proposal, and
+inventory row was preserved. Exact verified rows increased from 62 to 140. The audit deliberately left 9 unoffered
+rows, 5 substantive schedule mismatches, and 1 invalid `STAGE` pin unchanged, along with 32 verified, 78 proposal, and
+2 inventory records that carry no schedule row. Those require retuning or compiler investigation, not normalization.
+
+The fresh Qwen3-0.6B s512 trace on RTX 5090 now has six targets rather than the old nine. A small boundary was strictly
+correct at 1.390 µs versus 2.051 µs for `torch.compile`. The first large fused target did not complete unpinned
+compilation inside 90 seconds. Profiling attributed 32.9 seconds to structural pricing, including 65 nested kernel
+prices and 24.2 seconds of schedule-tree expansion. Caching each immutable schedule prefix's derived frontier reduced
+the same compile from 95.26 to 88.57 seconds without changing row order or target selection.
+
+An edge-first traversal prototype reduced that compile further to 45.77 seconds by avoiding repeated node × transport
+support checks, but it changed complete-row emission order. A tied structural price then selected an unsplit two-kernel
+route instead of the exact working golden's three-kernel route. The prototype was rejected in full: membership alone
+was unchanged, but deploy selection was not. Separating those factors safely therefore also requires canonical
+tie-breaking that is independent of traversal order; this branch does not mix that larger scoring change into the
+prefix cache.
+
+Pinning all legal cuts exposed 12 child schedules in 28.9 seconds and found one genuine compiler gap. A synchronous
+compute fill flattened nested definitions before replicating its cells, so a later loop-local binding captured an
+earlier outer read with the same SSA spelling and emitted 32 undefined suffixed CUDA names. The fix now accumulates
+visible top-level definitions in statement order while keeping ordinary nested definitions inside their block; the
+exact child lowers with the outer names intact. The complete cut route still exceeded the bounded 180-second replay,
+so no latency or replacement working golden was recorded.
+
+Current-head parity is therefore not established. The small sm_120 boundaries beat `torch.compile`, but the large
+attention target remains blocked first by repeated structural pricing and then by an unqualified large child. The next
+architecture work is traversal-order-independent structural tie-breaking followed by the edge/node factorization
+above, plus separate tuning or compiler work for the 15 nontrivial golden mismatches. The recorded Volta schedule also
+needs an exact V100 timing refresh after #691 before its historical latency can be called current.
+
 ## Manual child-schedule qualification after #689 (2026-08-29)
 
 Manual route selection confirmed that child scheduling works once placement exposes ordinary kernels. The exact source

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,5 +1,56 @@
 # Golden-bench kernel corpus
 
+## Manual child-schedule qualification after #689 (2026-08-29)
+
+Manual route selection confirmed that child scheduling works once placement exposes ordinary kernels. The exact source
+was `226619ca`; the retained A100, V100, and RTX 4090 lanes used deployable O3, bounded searches, strict eager
+correctness for admissible rows, and fresh `torch.compile` measurements where the current CLI could produce them.
+
+The A100 s512 attention all-four cut produced five kernels, but initially failed before launch with
+`KeyError: linear_1_wt`. Cut-piece graph inputs came from lowered root statements, which omit contraction operands
+retained structurally beneath a projection region even though kernel materialization later expands and reads them.
+Commit `a9672422` now collects buffer reads from the complete structural Fold tree and uses the same inventory for
+piece inputs and producer ordering. The former route now carries all 23 required inputs, exercises tuning on the A100,
+and has a focused regression test. The combined branch gate passed 3,993 tests with 1,012 skips and five expected
+failures on the qualification host; local focused replay passed 22 tests with one skip, and lint is clean.
+
+Manually selected A100 child rows demonstrate that schedule quality is not the immediate blocker:
+
+| child role | best correct O3 latency | schedule highlight |
+| --- | ---: | --- |
+| s512 attention statistics | 2.322 µs | `WORK=t128`, cooperative reduction |
+| s512 elementwise split | 5.3 µs | `WORK=t128`, cooperative reduction |
+| s512 MLP product | 86.229 µs | `WORK=w2x2`, f16 MMA `f4x8/k8` |
+| s1 final consumer | 60.536 µs | `WORK=w1x1`, f16 MMA `f1x4/k8`, synchronous shared-memory stages |
+
+No complete A100 route is promotable yet. Every legal composed cut retains at least one large child that recomputes a
+Q/K/V projection, rotary transform, SDPA, or output projection inside another projection region. Those children
+either expose no applicable MMA schedule or take 10-15 seconds per launch. The next compiler boundary is therefore
+value materialization across independent projection regions, not a larger schedule search.
+
+The V100 manual screen found one correct and repeatable schedule improvement. The standalone model-sized Volta
+projection fell from 3,571.7 µs to 1,871.9-1,876.0 µs with `WORK=w4x2`, f16 MMA `f2x4/k4`, and `STAGE=d1/smem`;
+`torch.compile` measured 758.8-764.9 µs. This is a 1.9x Emmy improvement but remains about 2.5x behind. Its CUDA uses
+two CTA barriers in a 192-iteration K loop, 123 registers per thread, and 25% occupancy, so the remaining gap needs a
+better SM70 blocking-copy software pipeline rather than another currently offered schedule.
+
+The V100 linear-cut diagnostic fell from 1,160.2 µs to 247.0-247.8 µs by selecting the unsplit child, versus
+65.7-66.0 µs for `torch.compile`, but it is not admissible: both strict repeats fail with 26,441 mismatches and maximum
+absolute error 0.25. Eight tensor-core schedules failed identically, and a plain large FP16 `F.linear` reproducer
+without placement or residual addition has the same numerical character. That row is retained only as diagnostic
+evidence and must not be promoted under the strict contract.
+
+The RTX 4090 selector again found zero exact sm89 corpus cases. A fresh Qwen3-0.6B s512 trace produced six targets;
+the 29-origin target exceeded a six-second watchdog, while manual cuts produced best measured child totals of about
+152,231 + 64 µs and 153,764 + 56 µs. The dominant child preserves the same repeated attention computation as the
+A100 route, so further knob search is not a plausible route to parity. No sm89 realization or canonical golden was
+promoted without repeated correct reference measurements.
+
+Manual scheduling therefore improved the measured ceilings and exposed one fixed compiler bug, but did not establish
+parity. Across Ampere and Ada the next shared problem is forming reusable value boundaries before child scheduling;
+on Volta the independent remaining problems are synchronous staging efficiency and the strict large-linear numerical
+contract. The A100 VM remains running.
+
 ## Post-#689 structural-identity qualification (2026-08-29)
 
 The draft was rebased cleanly onto main `e782e991`; exact qualification source was `79f14e3b`. Main's canonical

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,5 +1,48 @@
 # Golden-bench kernel corpus
 
+## Post-#689 structural-identity qualification (2026-08-29)
+
+The draft was rebased cleanly onto main `e782e991`; exact qualification source was `79f14e3b`. Main's canonical
+Loop-IR identity migration deliberately orphans earlier tune-DB rows. `make test-corpus-regen` reported the realization
+corpus current, and its GPU-free replay passed 623 cases with 424 skips and five expected failures, so its 210 identity
+stamps need no branch-local regeneration.
+
+The two staged A100 experiment goldens do need more than a key update. Reconstructing their embedded stable Torch IR
+on current main yields four s1 targets and six s512 targets, instead of the nine provenance targets in each checked
+file. The s1 layer now has three small targets plus one 73-origin fused target. The s512 layer has four small targets
+plus 53-origin and 29-origin fused targets. The old provenance selections therefore cannot be renamed onto the new
+identities.
+
+A fresh, isolated O3 A100 tune used a four-candidate cap and patience two. The three s1 small targets completed in
+3.5-29.2 seconds with 1.1-2.0 µs winners. Four s512 small targets completed in 4.5-5.8 seconds with 1.684-3.081 µs
+winners. The first candidate for every fused target exceeded the 60-second kernel watchdog: the s1 73-origin target,
+the s512 53-origin target, and the s512 29-origin target. None produced a measured cut assembly or child schedule
+receipts. The regenerated working files are retained as host-local evidence, but were not promoted because an
+incomplete file would replace replayable goldens with unqualified fused rows. Current regeneration therefore needs
+the tuner to select a cut before benchmarking the fused terminal, then tune and persist the resulting child identities
+as one replayable assembly.
+
+The exact post-rebase A100 realization corpus retained two wins, three losses, and the existing stat-fill watchdog:
+
+| A100 case | Emmy | `torch.compile` | result |
+| --- | ---: | ---: | --- |
+| GQA B cut | 7.026 µs | 10.030 µs | 1.43x faster |
+| computed-value attention cut | 6.072 µs | 8.018 µs | 1.32x faster |
+| Q/K workspace chain | 84.224 µs | 11.947 µs | 7.05x slower |
+| unit-row split-K | 9.113 µs | 2.856 µs | 3.19x slower |
+| batched PV transpose | 17.682 µs | 11.658 µs | 1.52x slower |
+| stat-fill | watchdog | — | unchanged failure |
+
+Both current SM70 cases passed correctness on V100. Linear-cut measured 1,160.192 µs versus 66.048 µs for
+`torch.compile`; Volta MMA measured 3,129.344 µs versus 754.688 µs. The command's nonzero status was only the
+missing-duration guard for these newly measured rows. The regenerated corpus still contains no exact SM89 closed case.
+
+The failed fused candidates exposed one independent bounded-tuning bug: after reporting `HungKernelError`, the child
+returned through normal Python teardown, where CUDA waited forever for the still-running kernel. The worker now
+hard-exits after writing the failure response, and a CPU-only regression test proves that Python exit handlers cannot
+wedge the next candidate. This restores the existing clean-worker continuation contract; it does not improve a kernel.
+No new golden or large serving result was promoted, and the retained A100 remains running.
+
 ## Post-merge qualification and measured-row replay fix (2026-08-29)
 
 Qualification resumed from merged main `5f0a2076` on branch `codex/post-679-corpus-qualification`. The exact-main

--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -14,6 +14,12 @@ piece inputs and producer ordering. The former route now carries all 23 required
 and has a focused regression test. The combined branch gate passed 3,993 tests with 1,012 skips and five expected
 failures on the qualification host; local focused replay passed 22 tests with one skip, and lint is clean.
 
+A second bounded reduction found that legal placement sites beneath a projection region were absent from provider
+closure: the lexical-environment walk only visited direct Fold members while placement used the complete stored-child
+walk. Commit `8c2bb5cb` shares that traversal. The current s512 normalized-K projection plus rotary seam now lowers as
+two kernels, materializing the value once and reading its workspace in the consumer. This is a real new route, but a
+complete correct s512 assembly still has another child that exceeds the 15-second bound.
+
 Manually selected A100 child rows demonstrate that schedule quality is not the immediate blocker:
 
 | child role | best correct O3 latency | schedule highlight |
@@ -29,16 +35,25 @@ either expose no applicable MMA schedule or take 10-15 seconds per launch. The n
 value materialization across independent projection regions, not a larger schedule search.
 
 The V100 manual screen found one correct and repeatable schedule improvement. The standalone model-sized Volta
-projection fell from 3,571.7 µs to 1,871.9-1,876.0 µs with `WORK=w4x2`, f16 MMA `f2x4/k4`, and `STAGE=d1/smem`;
-`torch.compile` measured 758.8-764.9 µs. This is a 1.9x Emmy improvement but remains about 2.5x behind. Its CUDA uses
-two CTA barriers in a 192-iteration K loop, 123 registers per thread, and 25% occupancy, so the remaining gap needs a
-better SM70 blocking-copy software pipeline rather than another currently offered schedule.
+projection fell from 3,571.7 µs to 1,868.8 µs with `WORK=w4x2`, f16 MMA `f2x4/k4`, and `STAGE=d1/smem`, while
+`torch.compile` measured 756.736 µs. A fresh repeat measured 1,881.088 versus 757.760 µs with strict zero error. The
+exact-card CLI recorded the first pair in the realization case. This is a 1.9x Emmy improvement but remains about
+2.5x behind. Its CUDA uses two CTA barriers in a 192-iteration K loop, 123 registers per thread, and 25% occupancy, so
+the remaining gap needs a better SM70 blocking-copy software pipeline rather than another currently offered schedule.
 
 The V100 linear-cut diagnostic fell from 1,160.2 µs to 247.0-247.8 µs by selecting the unsplit child, versus
 65.7-66.0 µs for `torch.compile`, but it is not admissible: both strict repeats fail with 26,441 mismatches and maximum
 absolute error 0.25. Eight tensor-core schedules failed identically, and a plain large FP16 `F.linear` reproducer
 without placement or residual addition has the same numerical character. That row is retained only as diagnostic
 evidence and must not be promoted under the strict contract.
+
+The numerical discrepancy reduces to FP16 `[1,17,1536] × [17,1536]`. Emmy emits FP32-accumulating Volta MMA across
+the complete K dimension and performs one final FP32-to-FP16 store. Disabling PyTorch's reduced-precision FP16 GEMM
+reduction makes the unchanged Emmy row pass the strict comparison, identifying reference reduction policy—not an
+intermediate Emmy FP16 carrier, split-K, or store—as the distinguishing semantic. A proposed `_xfail_correct` corpus
+case correctly XPASSed because corpus correctness uses the NumPy backend and its documented narrow-operand tolerance;
+it cannot encode a PyTorch-eager policy mismatch. Reproducing cuBLAS's reduced-precision chunking would require an
+explicit compiler numerical-policy decision, so no tolerance or speculative code change was committed.
 
 The RTX 4090 selector again found zero exact sm89 corpus cases. A fresh Qwen3-0.6B s512 trace produced six targets;
 the 29-origin target exceeded a six-second watchdog, while manual cuts produced best measured child totals of about
@@ -49,7 +64,8 @@ promoted without repeated correct reference measurements.
 Manual scheduling therefore improved the measured ceilings and exposed one fixed compiler bug, but did not establish
 parity. Across Ampere and Ada the next shared problem is forming reusable value boundaries before child scheduling;
 on Volta the independent remaining problems are synchronous staging efficiency and the strict large-linear numerical
-contract. The A100 VM remains running.
+contract. After integrating both placement fixes and the recorded Volta row, the combined local gate passed 3,994
+tests with 1,012 skips and five expected failures; lint remained clean. The A100 VM remains running.
 
 ## Post-#689 structural-identity qualification (2026-08-29)
 

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s1_a100.golden.yaml
@@ -1213,9 +1213,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      LOOPIFY: '0'
-      REDUCE: coop
       WORK: t512
+      REDUCE: coop
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
       emmy_us: 2.3804
       reference_us: 121.8653

--- a/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
+++ b/experiments/golden-bench-2026/kernels/golden/qwen3-06b-s512_a100.golden.yaml
@@ -1226,9 +1226,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      LOOPIFY: '0'
-      REDUCE: coop
       WORK: t256
+      REDUCE: coop
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
       emmy_us: 3.1764
       reference_us: 191.6096
@@ -1243,10 +1244,12 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      LOOPIFY: '0'
-      STAGE: d3/smem-async
-      TILE: mma_m16n8k16_f16_f32/f4x4/k8
       WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      REDUCE: ''
+      STAGE: d3/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
       emmy_us: 17.426
       reference_us: 12.9707
@@ -1263,10 +1266,12 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      LOOPIFY: '0'
-      STAGE: d1/smem-async
-      TILE: mma_m16n8k16_f16_f32/f1x4/k8
       WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
       emmy_us: 22.2549
       reference_us: 100.7909
@@ -1283,10 +1288,12 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      LOOPIFY: '0'
-      STAGE: d3/smem-async
-      TILE: mma_m16n8k16_f16_f32/f4x4/k8
       WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      REDUCE: ''
+      STAGE: d3/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
       emmy_us: 17.2844
       reference_us: 60.1009
@@ -1358,10 +1365,12 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      LOOPIFY: '0'
-      STAGE: d3/smem-async
-      TILE: mma_m16n8k16_f16_f32/f4x4/k8
       WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k8
+      REDUCE: ''
+      STAGE: d3/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
       emmy_us: 46.6651
       reference_us: 32.4267

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx4090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx4090.yaml
@@ -7390,9 +7390,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t64
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7415,9 +7413,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7438,8 +7434,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7790,9 +7784,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7815,9 +7807,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7838,8 +7828,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7860,8 +7848,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx5090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx5090.yaml
@@ -7390,9 +7390,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7415,9 +7413,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t8
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7438,8 +7434,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7460,8 +7454,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7632,9 +7624,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t4
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7655,8 +7645,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7711,9 +7699,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7736,9 +7722,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t8
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7759,8 +7743,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7815,9 +7797,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t4
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7838,8 +7818,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7894,9 +7872,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: r2
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7919,9 +7895,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t4
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7942,8 +7916,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7964,8 +7936,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_v100.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_v100.yaml
@@ -7390,9 +7390,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7415,9 +7413,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7438,8 +7434,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7460,8 +7454,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7632,9 +7624,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7655,8 +7645,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7711,9 +7699,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7736,9 +7722,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7759,8 +7743,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7815,9 +7797,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t4
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7838,8 +7818,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7894,9 +7872,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7919,9 +7895,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7942,8 +7916,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7964,8 +7936,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx4090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx4090.yaml
@@ -5014,9 +5014,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -5217,9 +5215,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w1x4
       TILE: mma_m16n8k16_f16_f32/f4x4/k2
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''
@@ -5269,9 +5268,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -5457,9 +5454,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: ''
       TILE: ''
-      REDUCE: ''
       STAGE: ''
       LOOPIFY: '0'
       RASTER: ''

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx5090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx5090.yaml
@@ -5014,9 +5014,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -5217,9 +5215,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w8x4
       TILE: mma_m16n8k16_f16_f32/f1x4/k4
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''
@@ -5232,9 +5231,10 @@ configs:
     pins:
       FAST_MATH: true
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w8x4
       TILE: mma_m16n8k16_f16_f16/f1x4/k4
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''
@@ -5284,9 +5284,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t512
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -5502,9 +5500,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w1x1
       TILE: mma_m16n8k16_f16_f32/f1x4/k8
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''
@@ -5517,9 +5516,10 @@ configs:
     pins:
       FAST_MATH: true
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w1x1
       TILE: mma_m16n8k16_f16_f16/f1x4/k8
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_v100.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_v100.yaml
@@ -5014,9 +5014,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -5202,9 +5200,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w16x1
       TILE: mma_m8n8k4_f16_f32/f1x8/k8
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''
@@ -5248,9 +5247,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t256
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -5443,9 +5440,10 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
+      REDUCE@n1: ''
+      REDUCE@n4: ''
       WORK: w1x1
       TILE: mma_m8n8k4_f16_f32/f1x2/k8
-      REDUCE: ''
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_rtx4090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_rtx4090.yaml
@@ -7390,9 +7390,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7415,9 +7413,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7438,8 +7434,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7632,9 +7626,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7655,8 +7647,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7814,9 +7804,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7839,9 +7827,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t128
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7862,8 +7848,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f2
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7884,8 +7868,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_v100.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_v100.yaml
@@ -7390,9 +7390,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7415,9 +7413,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t4
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7438,8 +7434,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7632,9 +7626,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t64
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7655,8 +7647,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7711,9 +7701,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7736,9 +7724,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t4
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7759,8 +7745,6 @@ configs:
     knobs:
       WORK: ''
       TILE: f4
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7854,9 +7838,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: ''
-      TILE: ''
       REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7879,9 +7861,7 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: t64
-      TILE: ''
       REDUCE: coop
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7902,8 +7882,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
@@ -7924,8 +7902,6 @@ configs:
     knobs:
       WORK: ''
       TILE: ''
-      REDUCE: ''
-      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:

--- a/tests/compiler/backend/test_bench_worker_recovery.py
+++ b/tests/compiler/backend/test_bench_worker_recovery.py
@@ -94,6 +94,36 @@ def test_worker_exits_after_context_corruption() -> None:
         proc.wait(timeout=5)
 
 
+def test_hung_worker_bypasses_python_exit_handlers() -> None:
+    """A reported hung kernel must not wedge in CUDA's process-exit handlers."""
+    child = """
+        import atexit
+        import time
+
+        import emmy.compiler.backend.cuda.program as program
+        from emmy.compiler.backend.cuda.program import HungKernelError
+
+        atexit.register(lambda: time.sleep(60))
+
+        def _hung(graph, **kw):
+            raise HungKernelError('synthetic hung kernel')
+
+        program.benchmark_program = _hung
+        from emmy.compiler.backend.cuda._bench_worker import main
+        main()
+    """
+    proc = _spawn(child)
+    try:
+        _send(proc, _DUMMY_REQ)
+        resp = _recv(proc)
+        assert resp is not None and resp["ok"] is False
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5)
+
+
 def test_kill_idempotent_when_no_proc() -> None:
     """``_kill()`` on a worker that was never spawned must be a silent no-op."""
     from emmy.compiler.backend.cuda.program import _AsyncBenchWorker

--- a/tests/compiler/cli/test_golden_file_replay.py
+++ b/tests/compiler/cli/test_golden_file_replay.py
@@ -351,18 +351,19 @@ def test_run_replays_embedded_loop_golden_through_structural_stamps(tmp_path):
 
 
 def test_emmy_only_benchmark_returns_same_input_reference():
-    """Embedded Loop replay can return its greedy inputs/outputs without a Torch twin."""
+    """Embedded Loop replay returns runtime inputs without overriding self-contained constants."""
     import numpy as np
 
     from emmy.commands.run import bench_lowered_vs_torch
 
     graph = Graph()
-    graph.add_node(ConstantOp(name="y", value=2.0), [], Tensor("y", (1,)), node_id="y")
+    graph.add_node(ConstantOp(name="y", value=2.0), [], Tensor("y", (4,)), node_id="y")
     graph.outputs = ["y"]
-    outputs = {"y": np.array([2.0], dtype=np.float32)}
+    outputs = {"y": np.full(4, 2.0, dtype=np.float32)}
 
     class FakeBackend:
         def run(self, _graph, *, input_data):
+            assert input_data == {}
             return SimpleNamespace(outputs=outputs), None
 
         async def benchmark_async(self, *_args, **_kwargs):
@@ -383,7 +384,7 @@ def test_emmy_only_benchmark_returns_same_input_reference():
         )
     )
     assert len(refs) == 1
-    assert refs[0][0] == {"y": [2.0]}
+    assert refs[0][0] == {}
     assert refs[0][1] is outputs
 
 

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -330,13 +330,15 @@ def test_ir_ab_replay_retains_boolean_input_pins(tmp_path, monkeypatch):
         yield
 
     class Backend:
-        async def bench_pinned_async(self, _graph, *, warmup, num_iters):
+        async def bench_pinned_async(self, _graph, *, run_inputs, run_inputs_key, warmup, num_iters):
+            assert run_inputs is None and run_inputs_key is None
             assert (warmup, num_iters) == (1, 2)
             return SimpleNamespace(min_ms=0.1, time_ms=0.1), None
 
     source = tmp_path / "loop.json"
     source.write_text("{}")
     monkeypatch.setattr(run_mod, "pinned_knobs", capture_pins)
+    monkeypatch.setattr(run_mod, "_needs_tile_schedule", lambda _graph: False)
     monkeypatch.setattr(run_mod, "_cuda_knob_dicts", lambda _graph: [{"TILE": "f2x4"}])
     monkeypatch.setattr(Graph, "from_dict", staticmethod(lambda _document: object()))
 
@@ -344,6 +346,59 @@ def test_ir_ab_replay_retains_boolean_input_pins(tmp_path, monkeypatch):
 
     assert seen == [{"FAST_MATH": "False", "TILE": "f2x4"}]
     assert len(rows) == 1 and rows[0].status == "ok"
+
+
+def test_ir_ab_replay_schedules_persisted_tile_child_with_strict_reference(tmp_path, monkeypatch):
+    """A post-cut Tile child runs schedule only and proves its pinned output against greedy."""
+    from types import SimpleNamespace
+
+    import numpy as np
+
+    from emmy.commands import run as run_mod
+    from emmy.compiler.graph import Graph
+    from emmy.compiler.pipeline import Pipeline
+
+    built = []
+
+    class FakePipeline:
+        def run(self, graph, **_kwargs):
+            return graph
+
+    def build(passes, *, select=None):
+        built.append((passes, select))
+        return FakePipeline()
+
+    class Backend:
+        async def bench_pinned_async(self, _graph, *, run_inputs, run_inputs_key, warmup, num_iters):
+            assert run_inputs == {"x": [1.0]} and run_inputs_key is not None
+            assert (warmup, num_iters) == (1, 2)
+            return SimpleNamespace(min_ms=0.1, time_ms=0.1), {"y": np.array([2.0])}
+
+    source = tmp_path / "tile.json"
+    source.write_text("{}")
+    monkeypatch.setattr(Pipeline, "build", build)
+    monkeypatch.setattr(Graph, "from_dict", staticmethod(lambda _document: object()))
+    monkeypatch.setattr(run_mod, "_needs_tile_schedule", lambda _graph: True)
+    monkeypatch.setattr(run_mod, "_cuda_knob_dicts", lambda _graph: [{"WORK": "t128"}])
+    monkeypatch.setattr(run_mod, "_comparison_outputs", lambda outputs, _graph: outputs)
+
+    rows = asyncio.run(
+        run_mod._bench_ab_variants_ir(
+            Backend(),
+            source,
+            (),
+            ["WORK=t128"],
+            warmup=1,
+            iters=2,
+            ref=({"x": [1.0]}, {"y": np.array([2.0])}),
+            strict_correctness=True,
+            strict_reference="same-input-greedy",
+        )
+    )
+
+    assert built == [(["lowering/tile"], {"schedule"})]
+    assert rows[0].status == "ok" and rows[0].flags == []
+    assert rows[0].correctness["reference"] == "same-input-greedy"
 
 
 def test_bench_golden_variants_retraces_with_dynamic_spec(monkeypatch):

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -1571,6 +1571,32 @@ def test_write_ab_json_greedy_bench_fail_and_record_knobs(tmp_path):
     assert any("NOT benched" in f for f in row["flags"])
 
 
+def test_write_ab_json_records_a_node_free_kernel_schedule(tmp_path):
+    """A projection-only kernel has no classic node assignment, but its accepted schedule still
+    carries the complete kernel-scoped WORK and RASTER choices. Reporting must preserve that
+    accepted row after benchmarking instead of rejecting it as an incomplete node schedule."""
+    import json
+    from types import SimpleNamespace
+
+    from emmy.commands.run import _write_ab_json
+    from emmy.compiler.graph import Graph, Tensor
+    from emmy.compiler.ir.cuda.ir import CudaOp
+
+    graph = Graph()
+    graph.add_node(
+        op=CudaOp(kernel_name="k_projection", knobs={"WORK": "", "RASTER": ""}),
+        inputs=[],
+        output=Tensor("o", (4,)),
+        node_id="n0",
+    )
+    args = SimpleNamespace(json=str(tmp_path / "ab.json"), code="x + 1", input=None, ir=None, golden=None, dynamic=None, warmup=1, iters=1)
+
+    _write_ab_json(args, {}, graph, None, [], greedy_fail=None)
+
+    row = json.loads((tmp_path / "ab.json").read_text())["greedy"]["kernels"][0]
+    assert row["record_knobs"] == {"RASTER": "", "WORK": ""}
+
+
 def test_print_kernel_stats_greedy_bench_fail_row(capsys):
     """Degraded kernel table: ``bench=None`` + ``greedy_fail`` prints the greedy kernels
     with ``--`` timings, a ``bench_fail`` TOTAL, the failure reason as a ``!`` line, and the

--- a/tests/compiler/ir/pure/test_fold.py
+++ b/tests/compiler/ir/pure/test_fold.py
@@ -1,0 +1,26 @@
+"""Stored Fold-tree transformations."""
+
+from emmy.compiler.dtype import F32
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.pure.fold import Fold, result_slice
+from emmy.compiler.ir.stmt import Assign, Body, Load
+
+
+def test_result_slice_preserves_a_materialized_operand() -> None:
+    source = Load(name="loaded", input="x", index=(Var("k"),))
+    projection = Fold.projection(
+        operands=(source,),
+        body=Body(
+            (
+                Assign(name="kept", op="copy", args=("loaded",), dtype=F32),
+                Assign(name="dropped", op="copy", args=("loaded",), dtype=F32),
+            )
+        ),
+        results=("kept", "dropped"),
+    )
+
+    sliced = result_slice(projection, {"kept"})
+
+    assert sliced.operands == (source,)
+    assert sliced.body == Body((projection.body[0],))
+    assert sliced.defines() == ("kept",)

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -254,3 +254,60 @@ def test_a_shared_cone_is_typed_in_each_occurrence_scope() -> None:
 
     assert [dtype.name for dtype in narrow] == ["f16"]
     assert [dtype.name for dtype in wide] == ["f32"]
+
+
+def test_edge_dtypes_reaches_a_fold_nested_in_a_projection_region() -> None:
+    """A region is a lexical container, so its nested Fold results retain their explicit types."""
+    from emmy.compiler.dtype import F16, F32
+    from emmy.compiler.ir.pure import Lambda
+    from emmy.compiler.ir.tile import ProjectionRegion
+    from emmy.compiler.ir.tile.ops import edge_dtypes
+
+    pair = Fold.projection(
+        body=Body(
+            (
+                Assign(name="wide", op="copy", args=("x",), dtype=F32),
+                Assign(name="narrow", op="copy", args=("x",), dtype=F16),
+            )
+        ),
+        results=("wide", "narrow"),
+    )
+    region = ProjectionRegion(axis=Axis("j", 4), lift=Lambda(params=("j", "x"), body=Body((pair,)), results=()))
+    root = Fold.projection(body=Body((region,)), results=())
+    cache: dict = {}
+
+    edge_dtypes(root, {}, cache, {"x": F32})
+
+    assert cache[(id(pair), (("x", "f32"),))] == (F32, F16)
+
+
+def test_zero_axis_results_keep_explicitly_typed_projection_components() -> None:
+    from emmy.compiler.dtype import F16, F32
+    from emmy.compiler.ir.pure import Lambda
+    from emmy.compiler.ir.tile.ops import edge_dtypes
+    from emmy.compiler.tensor import Tensor
+
+    reduction = Fold(
+        axis=Axis("k", 4),
+        operands=(Load(name="x", input="x", index=(Var("k"),)),),
+        lift=Lambda(params=("k", "x"), body=Body(), results=("x",)),
+        init=(0.0,),
+        combine=Lambda(
+            params=("total", "total__o"),
+            body=Body((Assign(name="total", op="add", args=("total", "total__o")),)),
+            results=("total",),
+        ),
+    )
+    pair = Fold.projection(
+        operands=(reduction,),
+        body=Body(
+            (
+                Assign(name="wide_state", op="copy", args=("total",), dtype=F32),
+                Assign(name="wide", op="reciprocal", args=("wide_state",)),
+                Assign(name="narrow", op="copy", args=("total",), dtype=F16),
+            )
+        ),
+        results=("wide", "narrow"),
+    )
+
+    assert edge_dtypes(pair, {"x": Tensor("x", (4,), F16)}) == (F32, F16)

--- a/tests/compiler/ir/tile/test_path_codec.py
+++ b/tests/compiler/ir/tile/test_path_codec.py
@@ -9,7 +9,7 @@ from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure.fold import Channel, Fold
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
 from emmy.compiler.ir.tile import TileOp
-from emmy.compiler.ir.tile.path import Site, _spellings, canonical, family_sites, parse_key, primary, resolve, sites, spell
+from emmy.compiler.ir.tile.path import Site, _spellings, canonical, family_sites, parse_key, primary, resolve, sites, spell, spell_result
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
 
 
@@ -100,6 +100,32 @@ def test_place_spelling_round_trips_for_nested_edges() -> None:
         key = spell(root, "PLACE", node)
         assert resolve(root, key).node is node
         assert canonical(root, key) == key
+
+
+def test_result_address_round_trips_without_becoming_a_schedule_site() -> None:
+    pair = Fold.projection(
+        body=Body((Assign(name="left", op="copy", args=("x",)), Assign(name="right", op="copy", args=("y",)))),
+        results=("left", "right"),
+    )
+    root = Fold.projection(operands=(pair,), results=("left",))
+    ordinary = sites(root)
+
+    key = spell_result(root, pair, 2, all_sites=ordinary)
+
+    assert key == "PLACE@result.2"
+    assert resolve(root, key, all_sites=ordinary) == Site(pair, None, ("map", "map"), result=2)
+    assert canonical(root, key, all_sites=ordinary) == key
+    assert len(sites(root)) == len(ordinary) == 2
+
+
+def test_result_address_rejects_a_nonexistent_component() -> None:
+    from emmy.compiler.ir.tile.path import MissingSiteError
+
+    child = Fold.projection(body=Body((Assign(name="only", op="copy", args=("x",)),)), results=("only",))
+    root = Fold.projection(operands=(child,), results=("only",))
+
+    with pytest.raises(MissingSiteError, match="names no result"):
+        resolve(root, "PLACE@result.2")
 
 
 def test_schedule_families_are_not_structural_paths() -> None:

--- a/tests/compiler/ir/tile/test_path_codec.py
+++ b/tests/compiler/ir/tile/test_path_codec.py
@@ -152,6 +152,15 @@ def test_family_sites_and_primary() -> None:
     assert primary("PLACE", placements).node is stream
 
 
+def test_root_placement_path_is_explicit_without_changing_the_bare_primary() -> None:
+    root, stream, _qk, _pv = _flash_tree()
+
+    assert spell(root, "PLACE", root) == "PLACE@root"
+    assert resolve(root, "PLACE@root").node is root
+    assert canonical(root, "PLACE@root") == "PLACE@root"
+    assert resolve(root, "PLACE").node is stream
+
+
 def test_site_is_a_frozen_value() -> None:
     s = Site(node=None, axis="k", segments=("fold",))
     assert s.depth == 1 and s.ordinal == 1

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -140,7 +140,9 @@ composed-only enumerator or post-product membership rule exists.
 The structural-split boundary proves that the outer pass consumes a pinned GRID stage before constructing `c` for a
 fresh piece. The piece's schedule restriction therefore compares only the remaining schedule stages. Sampled walks
 and composed cross-CTA split pieces exercise the same enumeration, and the duration baseline records their bounded
-test cost.
+test cost. The fresh-piece canonicalization case constructs a cut producer whose logical output axis is still split
+across two clean free axes. It proves finalization fuses that pair before identity stamping, exposes the same
+contraction as the initially canonical Loop program, and converges to its complete Loop body and kernel identity.
 The producer-band boundary projects uniform, `+p1`, and `+p2` kernel choices before reading parameters, proves an exact
 `WORK` parameter leaves that domain unchanged, and checks that only compatible TMA edge assignments survive.
 The shared-constant cone fixture also pins a multi-channel contraction to the scalar tier: every channel remains in one

--- a/tests/compiler/passes/test_classic_schedule_domains.py
+++ b/tests/compiler/passes/test_classic_schedule_domains.py
@@ -61,7 +61,12 @@ def _schedule_leaves(tile, name, target):
 
 def test_production_enumeration_is_the_compatible_independent_product() -> None:
     root = Fold.projection(body=Body((Assign("y", "add", ("x", "x")),)), results=("y",))
-    tile = TileOp(op=root, place=Placement(free=(Axis("n", 8),)))
+    tile = TileOp(
+        op=root,
+        place=Placement(free=(Axis("n", 8),)),
+        placement_decided=True,
+        split_consumed=True,
+    )
     target = Context.from_target((12, 0))
     domains = project_classic(tile, target)
     codec = ClassicScheduleCodec(_context(tile, target, domains))
@@ -74,6 +79,8 @@ def test_production_enumeration_is_the_compatible_independent_product() -> None:
     (materialized,) = leaves[0].expand()
     assert materialized.schedule == leaves[0].schedule
     assert materialized.place == tile.place.on_grid()
+    assert materialized.placement_decided
+    assert materialized.split_consumed
 
 
 def test_complete_c_proves_its_singleton_without_changing_domains() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -11,20 +11,23 @@ import pytest
 
 from emmy.compiler.backend.cuda.backend import CudaBackend
 from emmy.compiler.context import Context
+from emmy.compiler.dim import Dim
 from emmy.compiler.dtype import F16, F32
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.axis import Axis, Window
 from emmy.compiler.ir.base import InputOp
-from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.frontend.ir import SdpaOp, SoftmaxOp
+from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.pure.carrier import exp_combine_states
-from emmy.compiler.ir.pure.fold import Channel, Fold, Lambda, loaded_buffers
-from emmy.compiler.ir.stmt import Assign, Body, Load, Write
+from emmy.compiler.ir.pure.fold import Channel, Fold, Lambda, is_contraction, loaded_buffers
+from emmy.compiler.ir.schedule.classic_projection import project_classic
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, ProjectionRegion, TileOp
 from emmy.compiler.ir.tile.path import sites
 from emmy.compiler.loop_wire import loop_graph_to_wire
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule
-from emmy.compiler.pipeline.fork import Fork
+from emmy.compiler.pipeline.fork import DeferredFork, Fork
 from emmy.compiler.pipeline.passes.lowering.tile._cut import (
     CutSite,
     _environments,
@@ -63,6 +66,81 @@ def test_cut_and_assignment_passes_share_the_generic_schedule_driver() -> None:
 
     assert _CUT.schedule is schedule
     assert import_module("emmy.compiler.pipeline.fork").schedule is schedule
+
+
+def _split_reduction_graph(op=None) -> Graph:
+    """The fresh 761/cc22 producer shape: N is spelled by the clean ``(a1, a25)`` pair."""
+    if op is None:
+        composite = BinaryExpr("+", BinaryExpr("*", Var("a1"), Literal(128, "int")), Var("a25"))
+        reduction = Loop(
+            axis=Axis("a26", 1024),
+            body=Body(
+                (
+                    Load(name="weight", input="linear_wt", index=(Var("a26"), composite)),
+                    Load(name="norm", input="norm", index=(Var("a26"),)),
+                    Load(name="value", input="to", index=(Literal(0, "int"), Var("a0"), Var("a26"))),
+                    Load(name="scale", input="scale", index=(Var("a0"),)),
+                    Assign(name="scaled", op="multiply", args=("scale", "value")),
+                    Assign(name="converted", op="copy", args=("scaled",), dtype=F16),
+                    Assign(name="normalized", op="multiply", args=("norm", "converted")),
+                    Assign(name="product", op="multiply", args=("normalized", "weight")),
+                    Accum(name="acc", value="product", op="add"),
+                )
+            ),
+        )
+        cell = Body((reduction, Write(output="out", index=(Var("a0"), Var("a1"), Var("a25")), value="acc")))
+        body = Body(
+            (
+                Loop(
+                    axis=Axis("a0", 512),
+                    body=Body((Loop(axis=Axis("a1", 16), body=Body((Loop(axis=Axis("a25", 128), body=cell),))),)),
+                ),
+            )
+        )
+        op = LoopOp(body=body)
+
+    graph = Graph()
+    for name, shape in (
+        ("linear_wt", (1024, 2048)),
+        ("norm", (1024,)),
+        ("to", (1, 512, 1024)),
+        ("scale", (512,)),
+    ):
+        _input(graph, name, shape)
+    graph.add_node(op, ["linear_wt", "norm", "to", "scale"], Tensor("out", (512, 16, 128), F16), node_id="out")
+    graph.inputs, graph.outputs = ["linear_wt", "norm", "to", "scale"], ["out"]
+    return graph
+
+
+def test_fresh_cut_piece_fuses_newly_clean_split_axes_before_identity_stamp() -> None:
+    """A structural cut can remove the access that kept a reshape's output axes distinct. Its
+    fresh piece must re-enter the one Loop canonicalization before identity is stamped, so the
+    split-axis spelling converges with an initially canonical kernel and exposes the contraction."""
+    original = _split_reduction_graph()
+    raw_tile = Pipeline.build(["lowering/tile"], select=["lift"]).run(original).nodes["out"].op
+    fresh = _split_reduction_graph(replace(raw_tile, name="mul_3__place_761458f514_0", placement_decided=True))
+    before = fresh.nodes["out"].op
+    assert [axis.extent for axis in before.place.free] == [Dim(512), Dim(16), Dim(128)]
+    assert not any(is_contraction(site.node) for site in sites(before.op))
+
+    choice = DeferredFork(lambda: fresh, {"PLACE@root": "cut"}, structural=True)
+    (fragment,) = _CUT._canonicalized(choice).expand()
+    actual = fragment.nodes["out"].op
+    assert actual.name == before.name and actual.placement_decided
+    assert [axis.extent for axis in actual.place.free] == [Dim(512), Dim(2048)]
+    assert any(is_contraction(site.node) for site in sites(actual.op))
+    domains = project_classic(actual, _CTX)
+    assert any(choice.tile.is_warp for choices in domains.nodes.values() for choice in choices)
+
+    canonical_loop = Pipeline.build(["loop/canonicalize"]).run(_split_reduction_graph())
+    canonical = Pipeline.build(["lowering/tile"], select=["lift"]).run(canonical_loop).nodes["out"].op
+    assert actual.loop_body == canonical.loop_body
+    assert actual.identity_key() == canonical.identity_key()
+
+    again = fragment.nodes["out"].op
+    (same_fragment,) = _CUT._canonicalized(DeferredFork(lambda: fragment, structural=True)).expand()
+    assert same_fragment is fragment
+    assert fragment.nodes["out"].op is again
 
 
 def test_placement_cut_preserves_a_cross_cta_split_receipt() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -185,6 +185,42 @@ def _projection_region_graph() -> Graph:
     return graph
 
 
+def _single_projection_region_graph() -> Graph:
+    """A cut consumer with one output region behind a prefix and materialized operand."""
+    batch, row, column = Axis("a0", 2), Axis("a1", 4), Axis("a25", 8)
+    inner = ProjectionRegion(
+        axis=column,
+        lift=Lambda(
+            params=("a25", "a0", "a1", "scale"),
+            body=Body(
+                (
+                    Load(name="value", input="x", index=(Var("a0"), Var("a1"), Var("a25"))),
+                    Assign(name="result", op="multiply", args=("value", "scale")),
+                )
+            ),
+            results=("result",),
+        ),
+    )
+    region = ProjectionRegion(
+        axis=row,
+        lift=Lambda(params=("a1", "a0", "scale"), body=Body((inner,)), results=()),
+    )
+    tile = TileOp(
+        op=Fold.projection(
+            operands=(Load(name="stat", input="stat_workspace", index=(Var("a0"),)),),
+            body=Body((Assign(name="scale", op="reciprocal", args=("stat",)), region)),
+        ),
+        place=Placement(free=(batch,)),
+        output_specs=(OutputSpec(Write(output="out", index=(Var("a0"), Var("a1"), Var("a25")), value="result")),),
+    )
+    graph = Graph()
+    _input(graph, "stat_workspace", (2,), dtype="f32")
+    _input(graph, "x", (2, 4, 8), dtype="f32")
+    graph.add_node(tile, ["stat_workspace", "x"], Tensor("out", (2, 4, 8), F32), node_id="out")
+    graph.inputs, graph.outputs = ["stat_workspace", "x"], ["out"]
+    return graph
+
+
 def _shared_provider_region_graph() -> Graph:
     """Two output regions, one reading a scalar provider from the shared prefix."""
     m, n, p = Axis("m", 4), Axis("n", 4), Axis("p", 4)
@@ -624,6 +660,39 @@ def test_root_projection_region_cut_lifts_each_piece_placement() -> None:
         {"out0__split"},
         {"out1__split"},
     ]
+
+
+def test_root_projection_region_cut_lifts_a_single_remaining_region() -> None:
+    """A prior cut may leave one region whose axes still need a root placement choice."""
+    graph = _single_projection_region_graph()
+    offered = _offered(graph)
+    assert {"PLACE": "fuse"} in offered
+    assert {"PLACE@root": "cut"} in offered
+
+    graph = _single_projection_region_graph()
+    root = graph.nodes["out"]
+    match = Match(graph=graph, root_node_id=root.id, rule=Rule(name="test", pattern=[]))
+    with pinned_knobs({"PLACE@root": "fuse"}):
+        fused = _CUT.rewrite(match, root).expand()[0]
+    assert isinstance(fused, TileOp)
+    assert [axis.name for axis in fused.place.free] == ["a0"]
+    assert any(isinstance(member, ProjectionRegion) for member in fused.op.body.iter())
+
+    graph = _single_projection_region_graph()
+    root = graph.nodes["out"]
+    match = Match(graph=graph, root_node_id=root.id, rule=Rule(name="test", pattern=[]))
+    with pinned_knobs({"PLACE@root": "cut"}):
+        choice = _CUT.rewrite(match, root)
+    choice = choice[0] if isinstance(choice, list) else choice
+    fragment = choice.expand()[0]
+    pieces = [node.op for node in fragment.nodes.values() if isinstance(node.op, TileOp)]
+
+    assert len(pieces) == 1
+    piece = pieces[0]
+    assert [axis.name for axis in piece.place.free] == ["a0", "a1", "a25"]
+    assert not any(isinstance(member, ProjectionRegion) for member in piece.op.body.iter())
+    assert loaded_buffers(piece.op) == {"stat_workspace", "x"}
+    assert fragment.outputs == ["out__split"]
 
 
 def test_root_projection_region_pin_lowers_two_independently_scheduled_kernels() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -33,6 +33,7 @@ from emmy.compiler.pipeline.passes.lowering.tile._cut import (
     output_map,
     realize,
 )
+from emmy.compiler.pipeline.passes.lowering.tile._pieces import projection_region_pieces, realize_projection_regions
 from emmy.compiler.pipeline.pipeline import Run, _is_structural_option
 from emmy.compiler.pipeline.search.golden import (
     GoldenRecord,
@@ -180,6 +181,91 @@ def _projection_region_graph() -> Graph:
         node_id="out0",
     )
     graph.inputs, graph.outputs = ["a", "b", "c", "d"], ["out0", "out1"]
+    return graph
+
+
+def _shared_provider_region_graph() -> Graph:
+    """Two output regions, one reading a scalar provider from the shared prefix."""
+    m, n, p = Axis("m", 4), Axis("n", 4), Axis("p", 4)
+    contraction_axis, reduction_axis = Axis("k", 8), Axis("h", 8)
+    scaled = Fold.projection(
+        body=Body(
+            (
+                Load(name="qv", input="q", index=(Var("m"), Var("k"))),
+                Assign(name="av", op="multiply", args=("qv", "scale")),
+            )
+        ),
+        results=("av",),
+    )
+    contraction = Fold.contraction(
+        k_axis=contraction_axis,
+        a=scaled,
+        channels=(Channel(b=Load(name="wv", input="w", index=(Var("k"), Var("n"))), acc="acc"),),
+    )
+    reduction = Fold(
+        axis=reduction_axis,
+        lift=Lambda(
+            params=("h",),
+            body=Body((Load(name="rv", input="r", index=(Var("n"), Var("h"))),)),
+            results=("rv",),
+        ),
+        init=(0.0,),
+        combine=Lambda(
+            params=("red", "red__o"),
+            body=Body((Assign(name="red", op="add", args=("red", "red__o")),)),
+            results=("red",),
+        ),
+    )
+    inner = ProjectionRegion(
+        axis=n,
+        lift=Lambda(
+            params=("n", "m", "scale"),
+            body=Body(
+                (
+                    contraction,
+                    reduction,
+                    Assign(name="sum", op="add", args=("acc", "red")),
+                    Assign(name="result", op="add", args=("sum", "scale")),
+                )
+            ),
+            results=("result",),
+        ),
+    )
+    first = ProjectionRegion(axis=m, lift=Lambda(params=("m", "scale"), body=Body((inner,)), results=()))
+    second = ProjectionRegion(
+        axis=p,
+        lift=Lambda(
+            params=("p",),
+            body=Body((Load(name="other", input="z", index=(Var("p"),)),)),
+            results=("other",),
+        ),
+    )
+    tile = TileOp(
+        op=Fold.projection(
+            body=Body(
+                (
+                    Load(name="epsilon", input="epsilon", index=()),
+                    Assign(name="scale", op="reciprocal", args=("epsilon",)),
+                    first,
+                    second,
+                )
+            )
+        ),
+        output_specs=(
+            OutputSpec(Write(output="out", index=(Var("m"), Var("n")), value="result")),
+            OutputSpec(Write(output="other_out", index=(Var("p"),), value="other")),
+        ),
+    )
+    graph = Graph()
+    for name, shape in (("epsilon", ()), ("q", (4, 8)), ("w", (8, 4)), ("r", (4, 8)), ("z", (4,))):
+        _input(graph, name, shape, dtype="f32")
+    graph.add_node(
+        tile,
+        ["epsilon", "q", "w", "r", "z"],
+        outputs=(Tensor("out", (4, 4), F32), Tensor("other_out", (4,), F32)),
+        node_id="out",
+    )
+    graph.inputs, graph.outputs = ["epsilon", "q", "w", "r", "z"], ["out", "other_out"]
     return graph
 
 
@@ -437,6 +523,45 @@ def test_root_projection_region_pin_lowers_two_independently_scheduled_kernels()
     assert lowered.outputs == ["out0", "out1"]
     assert sum(type(node.op).__name__ == "CudaOp" for node in lowered.nodes.values()) == 2
     assert not any(isinstance(node.op, TileOp) for node in lowered.nodes.values())
+
+
+def test_composed_cut_keeps_a_shared_prefix_provider_on_an_output_piece() -> None:
+    """Replacing one nested Fold must not move the output piece's shared provider exclusively
+    under a sibling contraction and leave the piece's remaining consumer open."""
+    graph = _shared_provider_region_graph()
+    root = graph.nodes["out"]
+    match = Match(graph=graph, root_node_id=root.id, rule=Rule(name="test", pattern=[]))
+    fragment = realize_projection_regions(match, root, projection_region_pieces(root.op))
+    piece = next(
+        node
+        for node in fragment.nodes.values()
+        if isinstance(node.op, TileOp) and any(spec.write.output == "out__split" for spec in node.op.output_specs)
+    )
+    assert set(piece.op.op.deps()) <= {axis.name for axis in piece.op.place.free}
+
+    seams = tuple(seam for seam in cuttable_seams(piece.op) if seam.node.axis is not None and seam.node.axis.name in {"k", "h"})
+    assert {seam.node.axis.name for seam in seams} == {"k", "h"}
+    composed = realize(
+        Match(graph=fragment, root_node_id=piece.id, rule=Rule(name="test", pattern=[])),
+        piece,
+        seams,
+        output_map(piece),
+        placement_decided=True,
+    )
+
+    for child in (node.op for node in composed.nodes.values() if isinstance(node.op, TileOp)):
+        assert set(child.op.deps()) <= {axis.name for axis in child.place.free}
+
+
+def test_root_region_cut_precedes_scoped_child_site_resolution() -> None:
+    """A root cut changes the kernel set before graph-scoped child paths become meaningful."""
+    graph = _shared_provider_region_graph()
+    tile = graph.nodes["out"].op
+
+    with pinned_knobs({"PLACE@root": "cut", "PLACE@a": "cut"}):
+        restriction = _CUT._placement_restriction(tile, cuttable_seams(tile), projection_region_pieces(tile))
+
+    assert restriction == (("PLACE@root",), "regions", {})
 
 
 def test_scoped_place_cut_is_consumed_once_by_both_pieces() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -20,7 +20,7 @@ from emmy.compiler.ir.frontend.ir import SdpaOp, SoftmaxOp
 from emmy.compiler.ir.pure.carrier import exp_combine_states
 from emmy.compiler.ir.pure.fold import Channel, Fold, Lambda
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
-from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
+from emmy.compiler.ir.tile import OutputSpec, Placement, ProjectionRegion, TileOp
 from emmy.compiler.loop_wire import loop_graph_to_wire
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule
 from emmy.compiler.pipeline.fork import Fork
@@ -139,6 +139,44 @@ def _mimo_graph() -> Graph:
         tile,
         ["a", "b", "c", "d"],
         outputs=(Tensor("out0", (8, 8), "f16"), Tensor("out1", (8, 8), "f16")),
+        node_id="out0",
+    )
+    graph.inputs, graph.outputs = ["a", "b", "c", "d"], ["out0", "out1"]
+    return graph
+
+
+def _projection_region_graph() -> Graph:
+    """A scalar Tile root over two independently owned contraction regions."""
+    k = Axis("k", 16)
+
+    def region(row: Axis, column: Axis, a: str, b: str, acc: str) -> ProjectionRegion:
+        product = Fold.contraction(
+            k_axis=k,
+            a=Load(name=f"{a}_v", input=a, index=(Var(row.name), Var("k"))),
+            channels=(Channel(b=Load(name=f"{b}_v", input=b, index=(Var("k"), Var(column.name))), acc=acc),),
+        )
+        inner = ProjectionRegion(
+            axis=column,
+            lift=Lambda(params=(column.name, row.name), body=Body((product,)), results=(acc,)),
+        )
+        return ProjectionRegion(axis=row, lift=Lambda(params=(row.name,), body=Body((inner,)), results=()))
+
+    m, n = Axis("m", 4), Axis("n", 8)
+    p, q = Axis("p", 8), Axis("q", 4)
+    tile = TileOp(
+        op=Fold.projection(body=Body((region(m, n, "a", "b", "first"), region(p, q, "c", "d", "second")))),
+        output_specs=(
+            OutputSpec(Write(output="out0", index=(Var("m"), Var("n")), value="first")),
+            OutputSpec(Write(output="out1", index=(Var("p"), Var("q")), value="second")),
+        ),
+    )
+    graph = Graph()
+    for name, shape in (("a", (4, 16)), ("b", (16, 8)), ("c", (8, 16)), ("d", (16, 4))):
+        _input(graph, name, shape)
+    graph.add_node(
+        tile,
+        ["a", "b", "c", "d"],
+        outputs=(Tensor("out0", (4, 8), "f16"), Tensor("out1", (8, 4), "f16")),
         node_id="out0",
     )
     graph.inputs, graph.outputs = ["a", "b", "c", "d"], ["out0", "out1"]
@@ -370,6 +408,35 @@ def test_mimo_cut_preserves_both_outputs_and_lowers_both_pieces() -> None:
     lowered = _lower_cut(_mimo_graph(), cuts[0])
     assert lowered.outputs == ["out0", "out1"]
     assert sum(type(node.op).__name__ == "CudaOp" for node in lowered.nodes.values()) == 2
+
+
+def test_root_projection_region_cut_lifts_each_piece_placement() -> None:
+    offered = _offered(_projection_region_graph())
+    assert {"PLACE": "fuse"} in offered and {"PLACE@root": "cut"} in offered
+
+    graph = _projection_region_graph()
+    match = Match(graph=graph, root_node_id="out0", rule=Rule(name="test", pattern=[]))
+    with pinned_knobs({"PLACE@root": "cut"}):
+        choice = _CUT.rewrite(match, graph.nodes["out0"])
+    choice = choice[0] if isinstance(choice, list) else choice
+    fragment = choice.expand()[0]
+    pieces = [node.op for node in fragment.nodes.values() if isinstance(node.op, TileOp)]
+
+    assert fragment.outputs == ["out0__split", "out1__split"]
+    assert [[axis.extent.as_static() for axis in piece.place.free] for piece in pieces] == [[4, 8], [8, 4]]
+    assert all(not piece.placement_decided for piece in pieces)
+    assert [{spec.write.output for spec in piece.output_specs} for piece in pieces] == [
+        {"out0__split"},
+        {"out1__split"},
+    ]
+
+
+def test_root_projection_region_pin_lowers_two_independently_scheduled_kernels() -> None:
+    lowered = _lower(_projection_region_graph(), {"PLACE@root": "cut"})
+
+    assert lowered.outputs == ["out0", "out1"]
+    assert sum(type(node.op).__name__ == "CudaOp" for node in lowered.nodes.values()) == 2
+    assert not any(isinstance(node.op, TileOp) for node in lowered.nodes.values())
 
 
 def test_scoped_place_cut_is_consumed_once_by_both_pieces() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -334,6 +334,55 @@ def _computed_value_expectation_tile() -> TileOp:
     )
 
 
+def _typed_value_projection_graph() -> Graph:
+    """A typed value contraction paired with a query-dependent result."""
+    query, column, key, inner = Axis("query", 4), Axis("column", 8), Axis("key", 16), Axis("v", 32)
+    value = Fold.contraction(
+        k_axis=inner,
+        a=Load(name="x_value", input="x", index=(Var("key"), Var("v"))),
+        channels=(Channel(b=Load(name="weight", input="weight", index=(Var("v"), Var("column"))), acc="value"),),
+    )
+    pair = Fold.projection(
+        operands=(value,),
+        body=Body(
+            (
+                Load(name="score", input="score", index=(Var("query"), Var("key"))),
+                Assign(name="probability", op="copy", args=("score",), dtype=F32),
+                Assign(name="rounded_value", op="copy", args=("value",), dtype=F16),
+            )
+        ),
+        results=("probability", "rounded_value"),
+    )
+    attention = Fold(
+        axis=key,
+        operands=(pair,),
+        lift=Lambda(
+            params=("key", "probability", "rounded_value"),
+            body=Body((Assign(name="weighted", op="multiply", args=("probability", "rounded_value")),)),
+            results=("weighted",),
+        ),
+        init=(0.0,),
+        combine=Lambda(
+            params=("out", "out__o"),
+            body=Body((Assign(name="out", op="add", args=("out", "out__o")),)),
+            results=("out",),
+        ),
+    )
+    tile = TileOp(
+        op=attention,
+        name="out",
+        place=Placement(free=(query, column)),
+        output_specs=(OutputSpec(Write(output="out", index=(Var("query"), Var("column")), value="out")),),
+    )
+    graph = Graph()
+    _input(graph, "score", (4, 16))
+    _input(graph, "x", (16, 32))
+    _input(graph, "weight", (32, 8))
+    graph.add_node(tile, ["score", "x", "weight"], Tensor("out", (4, 8), "f16"), node_id="out")
+    graph.inputs, graph.outputs = ["score", "x", "weight"], ["out"]
+    return graph
+
+
 def _offered(graph: Graph, *, frontend: bool = False) -> list[dict]:
     offered: list[dict] = []
     passes = TILE_PASSES if frontend else ["lowering/tile"]
@@ -485,6 +534,65 @@ def test_twisted_expectation_value_cut_uses_the_public_store_dtype() -> None:
 
     assert seams[("vacc",)].dtypes == (F16,)
     assert seams[("maximum", "denominator", "expectation")].dtypes == (F32, F32, F32)
+
+
+def test_selected_result_cut_uses_its_own_dtype_and_axes() -> None:
+    """A selected result retains its sibling without inheriting the sibling's query axis."""
+    graph = _typed_value_projection_graph()
+    tile = graph.nodes["out"].op
+    value = next(seam for seam in cuttable_seams(tile) if seam.selected == "rounded_value")
+
+    assert value.spelling == "PLACE@result.2"
+    assert value.dtypes == (F16,)
+    match = Match(graph=graph, root_node_id="out", rule=Rule(name="test", pattern=[]))
+    with pinned_knobs({value.spelling: "cut"}):
+        fork = _CUT.rewrite(match, graph.nodes["out"])
+    assert fork.knobs == {value.spelling: "cut"} and _is_structural_option(fork)
+    (fragment,) = fork.expand()
+    producer = next(node for node in fragment.nodes.values() if "__place_" in node.id)
+    consumer = next(node for node in fragment.nodes.values() if isinstance(node.op, TileOp) and node is not producer)
+
+    assert tuple(dim.as_static() for dim in producer.output.shape) == (8, 16)
+    assert producer.output.dtype == F16
+    assert [axis.name for axis in producer.op.place.free] == ["column", "key"]
+    lowered = Body(consumer.op.op.lower())
+    assert any(isinstance(stmt, Load) and stmt.name == "rounded_value" for stmt in lowered.iter())
+    assert any("probability" in stmt.defines() for stmt in lowered.iter())
+
+
+def test_a_result_needed_by_its_sibling_can_only_be_cut_as_a_whole() -> None:
+    axis = Axis("k", 4)
+    child = Fold.projection(
+        body=Body(
+            (
+                Load(name="raw", input="x", index=(Var("k"),)),
+                Assign(name="value", op="copy", args=("raw",), dtype=F32),
+                Assign(name="dependent", op="multiply", args=("value", "value")),
+            )
+        ),
+        results=("value", "dependent"),
+    )
+    root = Fold(
+        axis=axis,
+        operands=(child,),
+        lift=Lambda(
+            params=("k", "value", "dependent"),
+            body=Body((Assign(name="product", op="multiply", args=("value", "dependent")),)),
+            results=("product",),
+        ),
+        init=(0.0,),
+        combine=Lambda(
+            params=("out", "out__o"),
+            body=Body((Assign(name="out", op="add", args=("out", "out__o")),)),
+            results=("out",),
+        ),
+    )
+    tile = replace(TileOp(op=root), inputs={"x": Tensor("x", (4,), F32)}, outputs={"out": Tensor("out", (), F32)})
+
+    spellings = {seam.spelling for seam in cuttable_seams(tile)}
+
+    assert "PLACE@result.1" not in spellings
+    assert "PLACE@result.2" in spellings
 
 
 def test_mimo_cut_preserves_both_outputs_and_lowers_both_pieces() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -18,9 +18,10 @@ from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.frontend.ir import SdpaOp, SoftmaxOp
 from emmy.compiler.ir.pure.carrier import exp_combine_states
-from emmy.compiler.ir.pure.fold import Channel, Fold, Lambda
+from emmy.compiler.ir.pure.fold import Channel, Fold, Lambda, loaded_buffers
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, ProjectionRegion, TileOp
+from emmy.compiler.ir.tile.path import sites
 from emmy.compiler.loop_wire import loop_graph_to_wire
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule
 from emmy.compiler.pipeline.fork import Fork
@@ -749,6 +750,64 @@ def test_bare_and_scoped_place_cuts_compose_in_one_decision() -> None:
     (fragment,) = fork.expand()
     pieces = [node for node in fragment.nodes.values() if isinstance(node.op, TileOp)]
     assert len(pieces) == 3 and all(node.op.placement_decided for node in pieces)
+
+
+def test_selected_result_replacement_applies_a_nested_cut_to_its_retained_slice() -> None:
+    """A retained result slice remains a consumer of every nested seam cut beside it."""
+    k = Axis("k", 8)
+    nested = Fold(
+        axis=k,
+        lift=Lambda(
+            params=("k",),
+            body=Body((Load(name="value", input="values", index=(Var("k"),)),)),
+            results=("value",),
+        ),
+        init=(0.0,),
+        combine=Lambda(
+            params=("total", "total__o"),
+            body=Body((Assign(name="total", op="add", args=("total", "total__o")),)),
+            results=("total",),
+        ),
+    )
+    pair = Fold.projection(
+        operands=(nested, Load(name="other", input="other", index=())),
+        body=Body(
+            (
+                Assign(name="kept", op="copy", args=("total",), dtype=F32),
+                Assign(name="selected", op="copy", args=("other",), dtype=F32),
+            )
+        ),
+        results=("kept", "selected"),
+    )
+    root_fold = Fold.projection(
+        operands=(pair,),
+        body=Body((Assign(name="out", op="add", args=("kept", "selected"), dtype=F32),)),
+        results=("out",),
+    )
+    tile = TileOp(op=root_fold, name="out")
+    graph = Graph()
+    _input(graph, "values", (8,), dtype="f32")
+    _input(graph, "other", (), dtype="f32")
+    graph.add_node(tile, ["values", "other"], Tensor("out", (), F32), node_id="out")
+    graph.inputs, graph.outputs = ["values", "other"], ["out"]
+    node = graph.nodes["out"]
+    seams = cuttable_seams(tile)
+    selected = next(seam for seam in seams if seam.node is pair and seam.selected == "selected")
+    nested_seam = next(seam for seam in seams if seam.node is nested and seam.selected is None)
+
+    fragment = realize(
+        Match(graph=graph, root_node_id=node.id, rule=Rule(name="test", pattern=[])),
+        node,
+        (selected, nested_seam),
+        output_map(node),
+        placement_decided=True,
+    )
+
+    consumer = next(piece for piece in fragment.nodes.values() if isinstance(piece.op, TileOp) and "__place_" not in piece.id)
+    producer = next(piece for piece in fragment.nodes.values() if isinstance(piece.op, TileOp) and "values" in piece.inputs)
+    assert producer.id in loaded_buffers(consumer.op.op)
+    assert "values" not in loaded_buffers(consumer.op.op)
+    assert all(site.node.axis is None or site.node.axis.name != "k" for site in sites(consumer.op.op))
 
 
 def _composed_case_match() -> tuple[Match, Graph]:

--- a/tests/compiler/passes/test_optimization_rules.py
+++ b/tests/compiler/passes/test_optimization_rules.py
@@ -6,12 +6,18 @@ inputs in IndexMapOps, so every ElementwiseOp post-decomposition has all
 inputs at the output shape — the rank-preserving Tensor IR invariant.
 """
 
+from dataclasses import replace
+
 import numpy as np
 
 from emmy.compiler.backend.numpy import NumpyBackend
+from emmy.compiler.dtype import F16
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import ConstantOp, InputOp
-from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp
+from emmy.compiler.ir.expr import Var, placeholder
+from emmy.compiler.ir.loop import Accum, Assign, Axis, Load, Loop, LoopOp, Write
+from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp, IndexSource
+from emmy.compiler.pipeline import Pipeline
 from emmy.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to
 
 rng = np.random.default_rng(42)
@@ -137,3 +143,64 @@ def test_tracer_emits_broadcast_explicit_elementwise():
             assert inp_shape == out_shape, (
                 f"ElementwiseOp {n.id} input shape {inp_shape} != output {out_shape} — tracer must insert broadcast IndexMapOp"
             )
+
+
+# ===================================================================
+# Index-map composition — source-program storage boundaries
+# ===================================================================
+
+
+def _public_indexmap_boundary_graph() -> Graph:
+    row, inner = Axis("row", 4), Axis("inner", 8)
+    reduction = LoopOp(
+        body=(
+            Loop(
+                axis=row,
+                body=(
+                    Loop(
+                        axis=inner,
+                        body=(
+                            Load(name="value", input="x", index=(Var("row"), Var("inner"))),
+                            Accum(name="total", value="value", op="add"),
+                        ),
+                    ),
+                    Write(output="stage", index=(Var("row"),), value="total"),
+                ),
+            ),
+        ),
+    )
+
+    def identity() -> IndexMapOp:
+        return IndexMapOp(out_shape=(4,), sources=(IndexSource(0, (placeholder(0),)),))
+
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (4, 8), F16), node_id="x")
+    graph.add_node(reduction, ["x"], Tensor("stage", (4,), F16, transient=True), node_id="stage")
+    graph.add_node(identity(), ["stage"], Tensor("rounded", (4,), F16), node_id="rounded")
+    graph.add_node(identity(), ["rounded"], Tensor("view", (4,), F16), node_id="view")
+    graph.inputs, graph.outputs = ["x"], ["view"]
+    return graph
+
+
+def test_indexmap_composition_preserves_a_public_rounding_boundary() -> None:
+    graph = _public_indexmap_boundary_graph()
+    values = {"x": rng.standard_normal((4, 8)).astype(np.float16)}
+    before = _run(graph, values)
+
+    optimized = Pipeline.build(["frontend/optimization"], select={"compose_indexmaps"}).run(graph)
+    assert "rounded" in optimized.nodes
+    np.testing.assert_allclose(_run(optimized, values)["view"], before["view"], rtol=0, atol=0)
+
+    lifted = Pipeline.build(["loop/lifting"]).run(optimized)
+    rounded = lifted.nodes["rounded"].op
+    copies = [stmt.dtype for stmt in rounded.body.iter() if isinstance(stmt, Assign) and stmt.op.name == "copy"]
+    assert copies == [F16]
+
+
+def test_indexmap_composition_still_elides_a_transient_shape_boundary() -> None:
+    graph = _public_indexmap_boundary_graph()
+    graph.nodes["rounded"].outputs = (replace(graph.nodes["rounded"].output, transient=True),)
+
+    optimized = Pipeline.build(["frontend/optimization"], select={"compose_indexmaps"}).run(graph)
+
+    assert "rounded" not in optimized.nodes

--- a/tests/compiler/passes/test_sync_transport.py
+++ b/tests/compiler/passes/test_sync_transport.py
@@ -92,6 +92,31 @@ def test_compute_fill_suffixes_nested_ssa_for_every_vector_cell() -> None:
     assert {assign.name for assign in fill.iter_of_type(Assign)} == {f"out__c{i}" for i in range(8)}
 
 
+def test_compute_fill_nested_binding_does_not_capture_an_earlier_hoisted_value() -> None:
+    """A later nested binding with the same spelling must not rename an earlier outer read."""
+
+    def value(_k0, _row, col):
+        inner_axis = Axis("inner", 2)
+        inner = Loop(
+            axis=inner_axis,
+            body=Body((Load(name="scale", input="nested", index=(col, Var(inner_axis.name))),)),
+        )
+        return [
+            Load(name="scale", input="scalar", index=(Literal(0, "int"),)),
+            Load(name="cell", input="x", index=(col,)),
+            Assign(name="mixed", op=ElementwiseImpl("add"), args=("cell", "scale")),
+            inner,
+            Assign(name="out", op=ElementwiseImpl("copy"), args=("mixed",)),
+        ], "out"
+
+    operand = SyncOperand(tag="b", shape=(1, 8), value=value)
+    transport = SyncTransport(operands=(operand,), slab_dtype="half", cta=CtaTile(Literal(0, "int"), 1), elem_bytes=2)
+    fill = Body(tuple(transport.fill(k0=Literal(0, "int"), slot=Literal(0, "int"), k0_cur=Literal(0, "int"))))
+
+    mixed = next(assign for assign in fill.iter_of_type(Assign) if assign.name == "mixed__c0")
+    assert mixed.args == ("cell__c0", "scale")
+
+
 def test_software_swizzle_shifts_by_the_slab_row_not_the_atom() -> None:
     """A software-filled slab's XOR reads its ROW index — which needs the slab's OWN stride once a
     row is wider than one swizzle atom.

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -123,6 +123,35 @@ def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:
     assert materialized == []
 
 
+def test_schedule_pick_ignores_feature_keys_in_measured_row_descent() -> None:
+    rows = [
+        {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "slow"},
+        {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "measured"},
+        {"S_warp_eligible": 1.0, "RASTER": "gm8", "TILE": "other"},
+    ]
+    tree = build_fork_tree(
+        params=rows,
+        levels=(
+            Level(("S_warp_eligible", "RASTER"), lambda row: (row["S_warp_eligible"], row["RASTER"])),
+            Level(("TILE",), lambda row: (row["TILE"],)),
+        ),
+        materialize=lambda _row: None,
+    )
+    point = SimpleNamespace(
+        options=[tree],
+        node_id="node",
+        root_op=SimpleNamespace(knobs={"S_warp_eligible": 1.0}),
+        ctx=SimpleNamespace(features=lambda: {"H_opt": 3.0}),
+    )
+    index = {frozenset({("S_warp_eligible", "1.0")}): [({"RASTER": "", "TILE": "measured"}, 1.25)]}
+
+    leaf, knobs, price = _direct_measured_pick(point, None, index)
+
+    assert leaf_knobs(leaf) == rows[1]
+    assert knobs == rows[1]
+    assert price == 1.25
+
+
 def test_verified_pick_ignores_feature_keys_in_schedule_branches(monkeypatch) -> None:
     rows = [
         {"S_warp_eligible": 1.0, "RASTER": "", "TILE": "slow"},

--- a/tests/compiler/pipeline/test_fork.py
+++ b/tests/compiler/pipeline/test_fork.py
@@ -10,10 +10,12 @@ directly because graph-building must remain lazy.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass, replace
 
 import pytest
 
-from emmy.compiler.pipeline.fork import DeferredFork, Fork, Level, build_fork_tree
+from emmy.compiler.ir.schedule import Schedule, ScheduleContext
+from emmy.compiler.pipeline.fork import DeferredFork, Fork, Level, build_fork_tree, schedule_forks
 
 
 def _row(a: int, b: int, c: int) -> dict:
@@ -70,6 +72,47 @@ def test_deferred_structural_leaf_materializes_only_when_selected() -> None:
     assert made == []
     assert leaf.expand() == ["graph"]
     assert made == ["built"]
+
+
+def test_schedule_prefix_expansion_is_derived_once_and_returns_fresh_lists() -> None:
+    calls: list[tuple] = []
+
+    @dataclass(frozen=True)
+    class Context(ScheduleContext):
+        _assignment: Schedule
+
+        @property
+        def assignment(self):
+            return self._assignment
+
+        def extensions(self):
+            calls.append(tuple(self.assignment.nodes.items()))
+            if not self.assignment.nodes:
+                yield Schedule(None, {0: "node"}, {})
+            else:
+                yield Schedule("kernel", {}, {})
+
+        def extend(self, pick):
+            if pick.kernel is not None:
+                return replace(self, _assignment=Schedule(pick.kernel, self.assignment.nodes, self.assignment.edges))
+            return replace(self, _assignment=Schedule(None, {**self.assignment.nodes, **pick.nodes}, self.assignment.edges))
+
+    (branch,) = schedule_forks(
+        Context(Schedule(None, {}, {})),
+        branch_knobs={},
+        row_delta=lambda before, after: {},
+        leaf=lambda assignment: DeferredFork(lambda: assignment),
+        pool_id="test",
+        pool_bound=1,
+        pool_descent_bound=1,
+    )
+    first = branch.expand()
+    second = branch.expand()
+
+    assert calls == [(), ((0, "node"),)]
+    assert first == second and first is not second
+    first.clear()
+    assert branch.expand() == second
 
 
 def test_empty_params_raises():

--- a/tests/compiler/pipeline/test_fork.py
+++ b/tests/compiler/pipeline/test_fork.py
@@ -113,6 +113,7 @@ def test_schedule_prefix_expansion_is_derived_once_and_returns_fresh_lists() -> 
     assert first == second and first is not second
     first.clear()
     assert branch.expand() == second
+    assert "_memo_expansion" not in branch.__getstate__()
 
 
 def test_empty_params_raises():

--- a/tests/compiler/pipeline/test_knob.py
+++ b/tests/compiler/pipeline/test_knob.py
@@ -622,6 +622,7 @@ def test_complete_kernel_row_requires_the_emitted_exact_schedule():
     assert out["TILE"] == "mma_m16n8k16_f16_f32/f1x1"
     assert "S_ext_free_prod" not in out
     assert complete_kernel_row(out) == out
+    assert complete_kernel_row({"WORK": "", "RASTER": ""}) == {"WORK": "", "RASTER": ""}
 
     with pytest.raises(ValueError, match="missing RASTER"):
         complete_kernel_row({"WORK": "", "REDUCE": ""})

--- a/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma.yaml
@@ -36,16 +36,15 @@ configs:
     - linear
     - scaled_dot_product_attention
   realizations:
-  - name: k_sdpa_linear_reduce_8aa445.5e80ec3cf5a9
+  - name: k_sdpa_linear_reduce_896c1a.b24284af9e79
     bindings: {}
     pins:
       FAST_MATH: false
       PLACE@a7: cut
     knobs:
-      TILE@n3: mma_m16n8k16_f16_f32/f1x2
-      TILE@n4: mma_m16n8k16_f16_f32/f1x1
-      STAGE@n4: d1/smem
+      TILE: mma_m16n8k16_f16_f32/f1x1
+      STAGE: ''
       WORK: w1x1
       REDUCE: ''
       RASTER: ''
-    identity: 42592f5d4a4e2cb1f7a23326d0b3900a34b5fc6f408211a8c6e7b31821fe5b46
+    identity: 6129e4fbd1e944f8f14d65d392329774ea4e75ab5177f32236f14d98831fbe51

--- a/tests/compiler/realization/cases/matmul/f16-mma-broadcast-batched-pv-transpose.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-mma-broadcast-batched-pv-transpose.yaml
@@ -58,7 +58,7 @@ configs:
     - matmul
     - transpose
   realizations:
-  - name: k_matmul_8ceacc.35b04e6120a9
+  - name: k_matmul_82c46f.c9dc2f7bdc25
     bindings: {}
     pins:
       FAST_MATH: false
@@ -69,4 +69,4 @@ configs:
       STAGE: d1/smem-async
       LOOPIFY: '0'
       RASTER: ''
-    identity: 42e1e6e2745ac13b5918a329e4c1faf73e0f78a9ae04abbe9653db1798be3925
+    identity: cc270304488e2b5b4937832c7baa6ffd96f6d5ca60e800d1a0355e74eea7fa12

--- a/tests/compiler/realization/cases/matmul/f16-volta-warp-mma-sm70.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-volta-warp-mma-sm70.yaml
@@ -34,7 +34,11 @@ configs:
       FAST_MATH: false
     knobs:
       WORK: w4x2
-      TILE: mma_m8n8k4_f16_f32/f2x2/k8
+      TILE: mma_m8n8k4_f16_f32/f2x4/k4
       STAGE: d1/smem
       REDUCE: ''
     identity: 66167c3d632716ba03898c6a789b13ef98debd7a080f608ee4b92e1ed1113fb0
+    latency:
+      NVIDIA Tesla V100 SXM3 32GB:
+        emmy_us: 1868.8000440597534
+        tcompile_us: 756.7359805107117


### PR DESCRIPTION
## Summary

- rebase the corpus qualification onto generic schedule composition in main `b93a86c2`
- preserve independent kernel, node, and operand-edge domains with one compatibility authority and one generic traversal
- refresh 78 verified experiment rows whose only drift was the current empty-family schedule vocabulary
- fix nested SSA capture in synchronous compute fills exposed by a forced child schedule
- memoize immutable generic schedule-prefix expansion through the sanctioned per-instance memo table
- retain the faster qualified Volta schedule and the measured-row descent and benchmark-worker recovery fixes

## Qualification

- `make test`: 4214 passed, 1030 skipped, 2 xfailed in 185.78 seconds
- `make lint`: clean
- all 210 realization cases have current derived data and unchanged verdicts
- exact sm_120 systemd sandbox slice: 19 closed build/correct passes and 5 expected correctness gaps
- fresh RTX 5090 Qwen3-0.6B s512 small boundary: Emmy 1.390 us vs `torch.compile` 2.051 us, strict correctness passed
- large fused compile: 95.26 to 88.57 seconds after prefix memoization, with row order and target selection unchanged
- forced-cut probe: 12 child schedules exposed; the first child now lowers without undefined suffixed SSA names
- core `emmy/` diff is line-neutral: 48 additions and 48 deletions

## Architectural finding

An edge-first traversal prototype reduced the profiled fused compile to 45.77 seconds by avoiding repeated node x transport support checks, but changed complete-row emission order. A tied structural price then selected a different placement route, so the prototype was fully rejected. Factorizing enumeration safely first needs canonical structural tie-breaking that is independent of traversal order; this PR does not conflate that scoring change with the safe prefix cache.

## Remaining gap

Current-head parity is not established. The full forced-cut route still exceeded the bounded 180-second replay, so no unqualified latency or replacement golden was recorded. The next work is traversal-order-independent structural tie-breaking, then edge/node traversal factorization, plus tuning or compiler investigation for 15 nontrivial golden mismatches. The Volta schedule also needs an exact V100 timing refresh after the schedule rewrite.

This remains a draft while qualification continues. The retained A100 VM remains running; the kenshin host was not rebooted or stopped.