### PR TITLE
Closure: one scoped-lambda concept; sharing strengthened to unification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,12 +256,17 @@ You MUST audit the complete diff after the before-committing checks and before r
 16. **Keep reasoning and reports out of code**: Which logic should become concise agent instructions? Code may
     transform structural data, but scripts must not interpret results or assemble human-readable reports.
 17. **Minimize the diff**: Can the same outcome be achieved with fewer changed lines, files, flags, and abstractions?
-18. **Apply the audit findings**: perform the removals and consolidation before requesting review. Tests must protect
+18. **Check the core line balance**: run `git diff --stat main -- emmy/`. A PR that introduces no new functionality
+    (a refactor, a cleanup, a fix) must NOT increase the line count under `emmy/` — net growth there without new
+    capability is the typical sign of architectural creep: another special case, helper, or early return layered onto
+    a design that no longer fits. If the balance is positive, do not shave lines cosmetically to pass the check —
+    restructure so the layering disappears, or say explicitly in the PR body why the growth is justified.
+19. **Apply the audit findings**: perform the removals and consolidation before requesting review. Tests must protect
     the smaller contract, not preserve unnecessary machinery.
 
 ### Submitting
 
-19. Push and open a PR
+20. Push and open a PR
 
 # Behavioral Guidelines:
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -114,6 +114,10 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
   earlier compiler pass wrote onto the operation.
 - **Mutable / immutable** — A mutable object can be changed after creation. An immutable object cannot; code creates
   a replacement instead. Emmy's graph is mutable, while many nested compiler statements are immutable.
+- **Closure** — A pure lambda paired with the enclosing iteration axes it may read. In Emmy the environment is an
+  index space: a normalized term captures only iteration axes, never data values, which arrive through operand
+  edges. Alpha-equivalent closures with equal captures denote one value; under different captures they are one
+  function with distinct values. Defined in `ir/pure/closure.py`.
 - **Structural identity / structural key** — A fingerprint based on computation and data flow rather than cosmetic
   names. It lets Emmy recognize equivalent compiler candidates.
 - **Idempotent rule** — A rule that does not keep changing its own output when applied again. Compiler rewrite rules

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -346,7 +346,7 @@ never do — no
 isinstance whitelist), with results-defined checked there too and α-invariance by canonical renumbering
 (`Lambda.canonical` — free names never renumbered). The scope-aware half lives in `ir/pure/closure.py`: a `Closure`
 pairs a lambda with the enclosing iteration axes it may capture — an INDEX-SPACE environment, never values — and its
-`canonical`/`alpha_eq`/`equivalent_clusters` are the one cross-scope equivalence the Tile canonical forms and the
+alpha-invariant equality (with `canonical`/`equivalent_clusters`) is the one cross-scope equivalence the Tile canonical forms and the
 lowering passes (semiring A-merge, twisted-pair recognition, seam value clustering) all consult.
 `Lambda.__post_init__` invokes `ir/pure/normalize.py` to install a
 dependency-safe body order and commutative argument order, so these context-independent storage invariants do not

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -344,7 +344,11 @@ binder kind over the reused stmt vocabulary — a `Body` of PURE stmts only (ANF
 `Load`/`Assign`/`Select` and the structural `Fold` and `ProjectionRegion` nodes opt in; `Accum`/`Write`/`Init`/`Loop`
 never do — no
 isinstance whitelist), with results-defined checked there too and α-invariance by canonical renumbering
-(`Lambda.canonical` — free names never renumbered). `Lambda.__post_init__` invokes `ir/pure/normalize.py` to install a
+(`Lambda.canonical` — free names never renumbered). The scope-aware half lives in `ir/pure/closure.py`: a `Closure`
+pairs a lambda with the enclosing iteration axes it may capture — an INDEX-SPACE environment, never values — and its
+`canonical`/`alpha_eq`/`equivalent_clusters` are the one cross-scope equivalence the Tile canonical forms and the
+lowering passes (semiring A-merge, twisted-pair recognition, seam value clustering) all consult.
+`Lambda.__post_init__` invokes `ir/pure/normalize.py` to install a
 dependency-safe body order and commutative argument order, so these context-independent storage invariants do not
 belong to `Fold`, `TileOp`, or the structural-key path. Contraction operand roles live on Fold edges, so sorting a
 commutative product's arguments does not change them. Formation is strict: a kernel's writes ride

--- a/emmy/compiler/ir/pure/closure.py
+++ b/emmy/compiler/ir/pure/closure.py
@@ -118,6 +118,18 @@ class Closure:
         """Alpha-invariant equality across scopes — canonical forms compared structurally."""
         return isinstance(other, Closure) and self.canonical() == other.canonical()
 
+    @property
+    def value_captures(self) -> frozenset[str]:
+        """Free names that are NOT environment axes — data the term still reads from sibling
+        definitions. Empty in normal form: the closing rewrites in ``tile/normalize`` exist to
+        drain these into operand edges."""
+        return self.fn.free_names() - frozenset(self.axes)
+
+    @property
+    def closed(self) -> bool:
+        """Whether the lambda captures nothing beyond its environment axes."""
+        return not self.value_captures
+
 
 def equivalent_clusters(closures: Iterable[Closure]) -> tuple[tuple[int, ...], ...]:
     """Partition closures into alpha-equivalent clusters, in input order.

--- a/emmy/compiler/ir/pure/closure.py
+++ b/emmy/compiler/ir/pure/closure.py
@@ -47,12 +47,25 @@ def _lambda_members(body: Body):
                 yield from _lambda_members(nested)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class Closure:
-    """A pure lambda scoped by the enclosing iteration axes it may capture, in binding order."""
+    """A pure lambda scoped by the enclosing iteration axes it may capture, in binding order.
+
+    Equality and hash are ALPHA-INVARIANT — two closures are equal when their canonical forms
+    coincide — while the stored spelling is preserved: correspondence uses (the seam clustering's
+    sibling axis pairing, a drain's real capture names) read the original ``fn`` and ``axes``.
+    """
 
     fn: Lambda
     axes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.axes, tuple):
+            object.__setattr__(self, "axes", tuple(self.axes))
+        # ``fn`` purity is Lambda's own formation invariant; only the environment needs checking.
+        stray = [axis for axis in self.axes if not isinstance(axis, str)]
+        if stray:
+            raise ValueError(f"Closure axes must be iteration-axis names, got {stray}")
 
     @classmethod
     def over_edge(cls, operand, axes: Iterable[str]) -> Closure:
@@ -76,9 +89,6 @@ class Closure:
     @cached_property
     def _canonical(self) -> Lambda:
         fn = self.fn
-        if any(not stmt.pure for stmt in fn.body):
-            raise ValueError("closure canonicalization requires a pure body")
-
         members = tuple(_lambda_members(fn.body))
         reads = {name for stmt in members for name in _member_reads(stmt)}
         bound_axes = tuple(name for stmt in members for name in stmt.binds_axes())
@@ -114,9 +124,11 @@ class Closure:
             results=tuple(rename(result) if isinstance(result, str) else result for result in fn.results),
         )
 
-    def alpha_eq(self, other: Closure) -> bool:
-        """Alpha-invariant equality across scopes — canonical forms compared structurally."""
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, Closure) and self.canonical() == other.canonical()
+
+    def __hash__(self) -> int:
+        return hash(self.canonical())
 
     @property
     def value_captures(self) -> frozenset[str]:
@@ -137,9 +149,9 @@ def equivalent_clusters(closures: Iterable[Closure]) -> tuple[tuple[int, ...], .
     The returned indices let a later pass keep its own Fold or graph metadata beside this general
     equivalence analysis.
     """
-    clusters: dict[Lambda, list[int]] = {}
+    clusters: dict[Closure, list[int]] = {}
     for index, closure in enumerate(closures):
-        clusters.setdefault(closure.canonical(), []).append(index)
+        clusters.setdefault(closure, []).append(index)
     return tuple(tuple(cluster) for cluster in clusters.values())
 
 

--- a/emmy/compiler/ir/pure/closure.py
+++ b/emmy/compiler/ir/pure/closure.py
@@ -1,0 +1,134 @@
+"""``Closure`` — a pure :class:`Lambda` paired with the enclosing iteration axes it may read.
+
+The one scoped-lambda concept shared by the Tile-level canonical forms and the lowering passes.
+Unlike a conventional closure, the environment is an INDEX SPACE: ``axes`` names enclosing
+iteration variables, never data values — a normalized term's values arrive through operand
+edges, and the only names its lift may capture are axes bound by its ancestors. That restriction
+is what keeps equivalence tractable (:meth:`Closure.canonical` renames the environment
+positionally) and what makes a tree position an instantiation: alpha-equal closures under EQUAL
+captures denote one value, while the same form under different captures stays distinct values of
+one function.
+
+Equivalence is a comparison-time VIEW, never a stored normal form — canonicalizing in place
+would clobber meaningful axis names in the tree. And it is a property, not a sharing mechanism:
+a rewrite may merge equivalent closures only where it supplies the binder that unifies their
+names (the contraction's single A slot in the semiring canonicalization) or where the captures
+already coincide (``tile/normalize._share_common_cones``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+from functools import cached_property
+
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.pure.fold import Fold, edge_refs_axis, operand_name
+from emmy.compiler.ir.pure.lam import Lambda
+from emmy.compiler.ir.sigma import Sigma
+from emmy.compiler.ir.stmt import Body
+from emmy.compiler.ir.stmt.body import _member_reads
+
+
+def _lambda_members(body: Body):
+    """Walk every binding inside a lambda, including Fold operand edges and algebra bodies."""
+    for stmt in body:
+        yield stmt
+        if isinstance(stmt, Fold):
+            for edge in stmt.operands:
+                if isinstance(edge, Fold):
+                    yield from _lambda_members(Body((edge,)))
+                else:
+                    yield edge
+            yield from _lambda_members(stmt.lift.body)
+        else:
+            for nested in stmt.nested():
+                yield from _lambda_members(nested)
+
+
+@dataclass(frozen=True)
+class Closure:
+    """A pure lambda scoped by the enclosing iteration axes it may capture, in binding order."""
+
+    fn: Lambda
+    axes: tuple[str, ...]
+
+    @classmethod
+    def over_edge(cls, operand, axes: Iterable[str]) -> Closure:
+        """Wrap one operand edge as a closure over the axes it references, kept in ``axes`` order.
+
+        The wrapping lambda binds exactly the referenced axes, so :attr:`axes` doubles as the
+        edge's positional capture correspondence (what the seam clustering pairs siblings by).
+        """
+        params = tuple(axis for axis in axes if edge_refs_axis(operand, axis))
+        return cls(Lambda(params=params, body=Body((operand,)), results=(operand_name(operand),)), params)
+
+    def canonical(self) -> Lambda:
+        """The alpha-canonical form, the enclosing iteration axes included.
+
+        :meth:`Lambda.canonical` handles names bound by the lambda itself. A Fold tree also needs
+        captured axes canonicalized so equivalent lifts at different tree positions compare
+        equal. Unused enclosing axes do not affect the result.
+        """
+        return self._canonical
+
+    @cached_property
+    def _canonical(self) -> Lambda:
+        fn = self.fn
+        if any(not stmt.pure for stmt in fn.body):
+            raise ValueError("closure canonicalization requires a pure body")
+
+        members = tuple(_lambda_members(fn.body))
+        reads = {name for stmt in members for name in _member_reads(stmt)}
+        bound_axes = tuple(name for stmt in members for name in stmt.binds_axes())
+        axis_order = tuple(dict.fromkeys((*self.axes, *bound_axes)))
+        active_axes = tuple(name for name in axis_order if name in reads or name in fn.params or name in bound_axes)
+        names = {name: f"_a{i}" for i, name in enumerate(active_axes)}
+
+        p = 0
+        for name in fn.params:
+            if name not in names:
+                names[name] = f"_p{p}"
+                p += 1
+        v = 0
+        for stmt in members:
+            for name in stmt.defines():
+                if name not in names:
+                    names[name] = f"_v{v}"
+                    v += 1
+
+        def rename(name: str) -> str:
+            return names.get(name, name)
+
+        sigma = Sigma({name: Var(names[name]) for name in active_axes})
+
+        def rename_axis(axis: Axis) -> Axis:
+            name = names.get(axis.name)
+            return replace(axis, name=name) if name is not None else axis
+
+        renamed = Body(stmt.rewrite(rename, sigma, rename_axis) for stmt in fn.body)
+        return Lambda(
+            params=tuple(rename(name) for name in fn.params),
+            body=renamed,
+            results=tuple(rename(result) if isinstance(result, str) else result for result in fn.results),
+        )
+
+    def alpha_eq(self, other: Closure) -> bool:
+        """Alpha-invariant equality across scopes — canonical forms compared structurally."""
+        return isinstance(other, Closure) and self.canonical() == other.canonical()
+
+
+def equivalent_clusters(closures: Iterable[Closure]) -> tuple[tuple[int, ...], ...]:
+    """Partition closures into alpha-equivalent clusters, in input order.
+
+    The returned indices let a later pass keep its own Fold or graph metadata beside this general
+    equivalence analysis.
+    """
+    clusters: dict[Lambda, list[int]] = {}
+    for index, closure in enumerate(closures):
+        clusters.setdefault(closure.canonical(), []).append(index)
+    return tuple(tuple(cluster) for cluster in clusters.values())
+
+
+__all__ = ["Closure", "equivalent_clusters"]

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -98,8 +98,9 @@ projection is formed or revisited. That is not cosmetic: a pass-through is what 
 computation compare unequal, and the placement fork's value clustering (`lowering/tile/_cut.py`) relies on
 alpha-equivalent cones converging to one canonical shape.
 
-Normalization ends by restoring OBJECT SHARING: structurally equal cones with the same captures collapse onto one
-Fold object (`_share_common_cones`), so a value fusion inlined into several consumption sites — attention's softmax
+Normalization ends by restoring OBJECT SHARING: same-value cones — alpha-equal with identical captures and exposed
+result names, so a copy differing only in internal binder spelling still qualifies — collapse onto one Fold object
+(`_share_common_cones`), so a value fusion inlined into several consumption sites — attention's softmax
 statistics, read by the weight cone and by the epilogue — is one node again. This is an invariant, not an
 optimization: seam grouping and cut realization key on object identity, so severed sharing silently turns one value
 into per-site recompute that no schedule can undo (the class PR #679 measured at three orders of magnitude). A

--- a/emmy/compiler/ir/tile/__init__.py
+++ b/emmy/compiler/ir/tile/__init__.py
@@ -19,7 +19,7 @@ from emmy.compiler.ir.tile.ir import (
     lower_with_output_specs,
     observed_result_names,
 )
-from emmy.compiler.ir.tile.normalize import lambda_equivalent_clusters, normalize_fold_tree
+from emmy.compiler.ir.tile.normalize import normalize_fold_tree
 
 __all__ = [
     "Channel",
@@ -33,7 +33,6 @@ __all__ = [
     "ProjectionRegion",
     "TileOp",
     "apply_output_specs",
-    "lambda_equivalent_clusters",
     "lower_with_output_specs",
     "observed_result_names",
     "normalize_fold_tree",

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 
-from emmy.compiler.ir.axis import Axis
-from emmy.compiler.ir.expr import Var, affine_form
+from emmy.compiler.ir.expr import affine_form
 from emmy.compiler.ir.pure import (
     Channel,
     Fold,
@@ -28,93 +27,11 @@ from emmy.compiler.ir.pure import (
     is_contraction,
 )
 from emmy.compiler.ir.pure.algebra import product_spine
+from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
 from emmy.compiler.ir.pure.fold import _operand_result_names, edge_refs_axis, operand_name, refs_axis
-from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body, Load
 from emmy.compiler.ir.stmt.body import _member_reads
 from emmy.compiler.structural import instance_memo
-
-
-def _lambda_members(body: Body):
-    """Walk every binding inside a lambda, including Fold operand edges and algebra bodies."""
-    for stmt in body:
-        yield stmt
-        if isinstance(stmt, Fold):
-            for edge in stmt.operands:
-                if isinstance(edge, Fold):
-                    yield from _lambda_members(Body((edge,)))
-                else:
-                    yield edge
-            yield from _lambda_members(stmt.lift.body)
-        else:
-            for nested in stmt.nested():
-                yield from _lambda_members(nested)
-
-
-def _canonical_lambda(fn: Lambda, axes: Iterable[str] = ()) -> Lambda:
-    """Return an alpha-canonical lambda, including its enclosing iteration axes.
-
-    :meth:`Lambda.canonical` handles names bound by the lambda itself.  A Fold tree also needs
-    captured axes canonicalized so equivalent lifts at different tree positions compare equal.
-    Unused enclosing axes do not affect the result.
-    """
-    if any(not stmt.pure for stmt in fn.body):
-        raise ValueError("lambda canonicalization requires a pure body")
-
-    body = fn.body
-    members = tuple(_lambda_members(body))
-    reads = {name for stmt in members for name in _member_reads(stmt)}
-    bound_axes = tuple(name for stmt in members for name in stmt.binds_axes())
-    axis_order = tuple(dict.fromkeys((*axes, *bound_axes)))
-    active_axes = tuple(name for name in axis_order if name in reads or name in fn.params or name in bound_axes)
-    names = {name: f"_a{i}" for i, name in enumerate(active_axes)}
-
-    p = 0
-    for name in fn.params:
-        if name not in names:
-            names[name] = f"_p{p}"
-            p += 1
-    v = 0
-    for stmt in members:
-        for name in stmt.defines():
-            if name not in names:
-                names[name] = f"_v{v}"
-                v += 1
-
-    def rename(name: str) -> str:
-        return names.get(name, name)
-
-    sigma = Sigma({name: Var(names[name]) for name in active_axes})
-
-    def rename_axis(axis: Axis) -> Axis:
-        name = names.get(axis.name)
-        return replace(axis, name=name) if name is not None else axis
-
-    renamed = Body(stmt.rewrite(rename, sigma, rename_axis) for stmt in body)
-    return Lambda(
-        params=tuple(rename(name) for name in fn.params),
-        body=renamed,
-        results=tuple(rename(result) if isinstance(result, str) else result for result in fn.results),
-    )
-
-
-def lambda_equivalent_clusters(
-    items: Iterable[tuple[Lambda, Iterable[str]]],
-) -> tuple[tuple[int, ...], ...]:
-    """Partition scoped lambdas into alpha-equivalent clusters, in input order.
-
-    Each item is ``(lambda, enclosing-axis-names)``.  The returned indices let a later pass keep
-    its own Fold or graph metadata beside this general equivalence analysis.
-    """
-    clusters: dict[Lambda, list[int]] = {}
-    for index, (fn, axes) in enumerate(items):
-        clusters.setdefault(_canonical_lambda(fn, axes), []).append(index)
-    return tuple(tuple(cluster) for cluster in clusters.values())
-
-
-def _operand_lambda(operand, axes: tuple[str, ...]) -> tuple[Lambda, tuple[str, ...]]:
-    params = tuple(axis for axis in axes if edge_refs_axis(operand, axis))
-    return Lambda(params=params, body=Body((operand,)), results=(operand_name(operand),)), params
 
 
 def _operand_roles(operand, axes: tuple[str, ...]) -> frozenset[str]:
@@ -259,7 +176,7 @@ def _orient_shared(pairs: list[tuple], product, axes: tuple[str, ...]) -> list[t
         return pairs
 
     candidates = tuple(edge for pair in pairs for edge in pair)
-    clusters = lambda_equivalent_clusters(_operand_lambda(edge, axes) for edge in candidates)
+    clusters = equivalent_clusters(Closure.over_edge(edge, axes) for edge in candidates)
     complete = [cluster for cluster in clusters if {index // 2 for index in cluster} == set(range(len(pairs)))]
     if not complete:
         return pairs
@@ -339,7 +256,7 @@ def _canonical_semiring(fold: Fold, axes: tuple[str, ...], implicit_axes: frozen
     if not body.defs_die_at(members, roots=roots, allowed=form.products):
         return fold
 
-    a_clusters = lambda_equivalent_clusters(_operand_lambda(candidate, all_axes) for candidate, _ in pairs)
+    a_clusters = equivalent_clusters(Closure.over_edge(candidate, all_axes) for candidate, _ in pairs)
     member_sets = {name: {id(stmt) for stmt in cone_members} for name, (_, cone_members) in extracted.items()}
     names = tuple(member_sets)
     shared_names = {operand_name(candidate) for candidate, _ in pairs}
@@ -900,6 +817,5 @@ def normalize_fold_tree(root, axes: Iterable[str] = (), implicit_axes: Iterable[
 
 
 __all__ = [
-    "lambda_equivalent_clusters",
     "normalize_fold_tree",
 ]

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -326,7 +326,7 @@ def _hoist_closed_folds(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset
         stmt
         for stmt in root.body
         if isinstance(stmt, Fold)
-        and not (set(stmt.lift.free_names()) - set(axes))
+        and Closure(stmt.lift, axes).closed
         and (is_contraction(stmt) or not any(edge_refs_axis(stmt, name) for name in sweep_axes))
     ]
     if not candidates:
@@ -367,6 +367,51 @@ def _carries_iteration(node) -> bool:
     return any(_carries_iteration(child) for child in children)
 
 
+def _close_tree(root: Fold, provider) -> tuple[tuple, Body]:
+    """The shared walk of both closing rewrites: establish the closure invariant on contractions.
+
+    A contraction's computed zero-axis operand may still carry value captures
+    (:attr:`~emmy.compiler.ir.pure.closure.Closure.value_captures` — sibling-defined data rather
+    than axes); ``provider(edge, binders)`` returns the source edge that supplies them, or
+    ``None`` to leave the operand open. ``binders`` counts only the iteration domains crossed
+    BELOW ``root`` — a reducing root already evaluates inside its own axis, and a projection root
+    has none — and each caller owns what a provider may take and what happens to the drained
+    chain afterwards."""
+
+    def close(node: Fold, binders: tuple[str, ...] = ()) -> Fold:
+        inner = (*binders, node.axis.name) if node.axis is not None else binders
+        operands = tuple(close(edge, inner) if isinstance(edge, Fold) else edge for edge in node.operands)
+        body = Body(close(stmt, inner) if isinstance(stmt, Fold) else stmt for stmt in node.body)
+        current = replace(node, operands=operands) if operands != node.operands else node
+        if body != current.body:
+            current = current.with_bodies((body,))
+        if not is_contraction(current):
+            return current
+
+        changed = False
+        closed = []
+        for edge in current.operands:
+            if not isinstance(edge, Fold) or edge.axis is not None:
+                closed.append(edge)
+                continue
+            source = provider(edge, binders)
+            if source is None:
+                closed.append(edge)
+                continue
+            closed.append(Fold.projection(operands=(source, *edge.operands), body=edge.body, results=edge.lift.results))
+            changed = True
+        return replace(current, operands=tuple(closed)) if changed else current
+
+    rewritten_operands = tuple(close(edge) if isinstance(edge, Fold) else edge for edge in root.operands)
+    rewritten_body = Body(close(stmt) if isinstance(stmt, Fold) else stmt for stmt in root.body)
+    return rewritten_operands, rewritten_body
+
+
+def _provider_needs(edge, provider_order: tuple[str, ...], provider_names: frozenset[str]) -> tuple[str, ...]:
+    """The provider names an operand edge captures, in provider order."""
+    return tuple(name for name in provider_order if name in (_edge_free_names(edge) & provider_names))
+
+
 def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[str]) -> Fold:
     """Move an enclosing projection's dependencies onto captured contraction operands."""
     assert root.axis is None
@@ -383,7 +428,10 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
     moved_members: set[int] = set()
     moved_edges: set[int] = set()
 
-    def provider(names: tuple[str, ...], binders: tuple[str, ...]):
+    def provider(edge, binders: tuple[str, ...]):
+        names = _provider_needs(edge, provider_order, provider_names)
+        if not names:
+            return None
         cone = root.body.backward_cone(names)
         required = set(cone.external_reads) | set(names)
         edges = tuple(dict.fromkeys(edge_by_name[name] for name in provider_order if name in required and name in edge_by_name))
@@ -408,33 +456,7 @@ def _close_projection(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[s
         hoisted = _hoist_closed_folds(Fold.projection(operands=edges, body=Body(cone.members), results=names), axes, sweep_axes)
         return _passthrough(hoisted) or hoisted
 
-    def close(node: Fold, binders: tuple[str, ...] = ()) -> Fold:
-        inner = (*binders, node.axis.name) if node.axis is not None else binders
-        operands = tuple(close(edge, inner) if isinstance(edge, Fold) else edge for edge in node.operands)
-        body = Body(close(stmt, inner) if isinstance(stmt, Fold) else stmt for stmt in node.body)
-        current = replace(node, operands=operands) if operands != node.operands else node
-        if body != current.body:
-            current = current.with_bodies((body,))
-        if not is_contraction(current):
-            return current
-
-        changed = False
-        closed = []
-        for edge in current.operands:
-            if not isinstance(edge, Fold) or edge.axis is not None:
-                closed.append(edge)
-                continue
-            needed = tuple(name for name in provider_order if name in (_edge_free_names(edge) & provider_names))
-            source = provider(needed, binders) if needed else None
-            if source is None:
-                closed.append(edge)
-                continue
-            closed.append(Fold.projection(operands=(source, *edge.operands), body=edge.body, results=edge.lift.results))
-            changed = True
-        return replace(current, operands=tuple(closed)) if changed else current
-
-    rewritten_operands = tuple(close(edge) if isinstance(edge, Fold) else edge for edge in root.operands)
-    rewritten_body = Body(close(stmt) if isinstance(stmt, Fold) else stmt for stmt in root.body)
+    rewritten_operands, rewritten_body = _close_tree(root, provider)
     if not moved_members and not moved_edges:
         if rewritten_operands == root.operands and rewritten_body == root.body:
             return root
@@ -474,7 +496,10 @@ def _close_reduce_body(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[
     provider_names = frozenset(provider_order)
     moved: set[int] = set()
 
-    def source(names: tuple[str, ...], binders: tuple[str, ...]) -> Fold | None:
+    def provider(edge, binders: tuple[str, ...]) -> Fold | None:
+        names = _provider_needs(edge, provider_order, provider_names)
+        if not names:
+            return None
         cone = body.backward_cone(names)
         defined = {name for stmt in cone.members for name in stmt.defines()}
         if not set(names) <= defined:
@@ -484,34 +509,7 @@ def _close_reduce_body(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[
         moved.update(id(stmt) for stmt in cone.members)
         return _hoist_closed_folds(Fold.projection(body=Body(cone.members), results=names), axes, sweep_axes)
 
-    def close(node: Fold, binders: tuple[str, ...] = ()) -> Fold:
-        # ``root`` already evaluates inside its own axis; only descendants add a new domain.
-        inner = (*binders, node.axis.name) if node.axis is not None else binders
-        operands = tuple(close(edge, inner) if isinstance(edge, Fold) else edge for edge in node.operands)
-        stmts = Body(close(stmt, inner) if isinstance(stmt, Fold) else stmt for stmt in node.lift.body)
-        current = replace(node, operands=operands) if operands != node.operands else node
-        if stmts != current.lift.body:
-            current = current.with_bodies((stmts,))
-        if not is_contraction(current):
-            return current
-
-        changed = False
-        closed = []
-        for edge in current.operands:
-            if not isinstance(edge, Fold) or edge.axis is not None:
-                closed.append(edge)
-                continue
-            needed = tuple(name for name in provider_order if name in (_edge_free_names(edge) & provider_names))
-            provided = source(needed, binders) if needed else None
-            if provided is None:
-                closed.append(edge)
-                continue
-            closed.append(Fold.projection(operands=(provided, *edge.operands), body=edge.body, results=edge.lift.results))
-            changed = True
-        return replace(current, operands=tuple(closed)) if changed else current
-
-    rewritten_operands = tuple(close(edge) if isinstance(edge, Fold) else edge for edge in root.operands)
-    rewritten_body = Body(close(stmt) if isinstance(stmt, Fold) else stmt for stmt in body)
+    rewritten_operands, rewritten_body = _close_tree(root, provider)
     if not moved:
         return root
 

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -3,10 +3,11 @@
 Each :class:`Fold` already owns context-independent lambda-body ordering. The rewrites here need
 the enclosing Tile axes or parent Fold.
 
-INVARIANT — normalization ends with structurally identical cones as ONE shared object
-(:func:`_share_common_cones`). Object identity is how the placement machinery recognizes that two
-consumption sites read one value, so a rewrite that copies a cone (the close rewrites do, by
-design) is only sound because this final pass restores the sharing. Recompute elimination is a
+INVARIANT — normalization ends with same-value cones (alpha-equal, identical captures and
+interface names) as ONE shared object (:func:`_share_common_cones`). Object identity is how the
+placement machinery recognizes that two consumption sites read one value, so a rewrite that
+copies a cone (the close rewrites do, by design) is only sound because this final pass restores
+the sharing. Recompute elimination is a
 Tile-level placement concern built on that identity: a duplicated value becomes one seam, and a
 composed cut materializes it once for every reader. Do NOT patch recompute downstream — a Loop IR
 fusion or emission workaround sees one kernel at a time and cannot know two kernels re-derive the
@@ -729,21 +730,32 @@ def _normalize_fold(fold: Fold, axes: tuple[str, ...], implicit_axes: frozenset[
 
 
 def _share_common_cones(root: Fold) -> Fold:
-    """Restore object sharing between structurally identical cones — the tree-wide half of
-    canonicalization.
+    """Restore object sharing between same-value cones — the tree-wide half of canonicalization.
 
     Fusion and the close rewrites inline one value into every consumption site, so a traced value
     consumed twice (attention's softmax statistics, read by the weight cone and the epilogue)
     reappears as equal-but-distinct copies. Everything downstream keys on object identity —
     ``cuttable_seams`` groups occurrences by it, ``realize`` replaces cut values by it — so a
     severed sharing silently turns one value into per-site recompute that no schedule can undo.
-    This walk hash-conses every Fold bottom-up: copies that are structurally EQUAL (same captured
-    names included — the bucket key adds ``deps`` so α-equivalent cones under different captures,
-    the K-cone family, stay value clustering's job) collapse onto the first occurrence in walk
-    order. Emission is untouched: lowering walks tree positions, and every position still holds
-    an equal term. Identity-preserving off the replacement spine, like ``_replace_fold``."""
+    This walk hash-conses every Fold bottom-up: copies UNIFY onto the first occurrence in walk
+    order when they are alpha-equal with identical captures (the bucket key adds ``deps`` — the
+    K-cone family, alpha-equal under DIFFERENT captures, stays value clustering's job) and
+    identical interface names (``defines`` — what sibling members and the consuming lift read),
+    so a copy that differs only in internal binder spelling still collapses where plain
+    structural equality would silently sever the sharing. Emission is untouched in shape:
+    lowering walks tree positions, and every position holds a term of the same value (a unified
+    representative may change internal spelling). Identity-preserving off the replacement spine,
+    like ``_replace_fold``."""
     canon: dict[tuple, list[Fold]] = {}
     seen: dict[int, Fold] = {}
+    unify_keys: dict[int, Lambda] = {}
+
+    def unify_key(fold: Fold) -> Lambda:
+        # The whole-term alpha-quotient under an empty environment: free names (the captures) and
+        # the bucket-pinned interface names make canonical equality mean equal VALUE.
+        if id(fold) not in unify_keys:
+            unify_keys[id(fold)] = Closure(Lambda(params=(), body=Body((fold,)), results=fold.defines()), ()).canonical()
+        return unify_keys[id(fold)]
 
     def member(stmt):
         if isinstance(stmt, Fold):
@@ -768,9 +780,9 @@ def _share_common_cones(root: Fold) -> Fold:
             current = replace(current, operands=operands)
         if any(piece is not stmt for piece, stmt in zip(body, node.lift.body, strict=True)):
             current = current.with_bodies((Body(body),))
-        bucket = canon.setdefault((current.structural_key(), current.deps()), [])
+        bucket = canon.setdefault((current.structural_key(), current.deps(), current.defines()), [])
         for prior in bucket:
-            if prior == current:
+            if prior == current or unify_key(prior) == unify_key(current):
                 seen[id(node)] = prior
                 return prior
         bucket.append(current)

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -19,10 +19,10 @@ from emmy.compiler.dtype import get as get_dtype
 from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
 from emmy.compiler.ir.pure.fold import Fold, _expectation_bindings, _operand_result_names, deep_defines, deep_reads, is_contraction
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
-from emmy.compiler.ir.tile.normalize import _operand_lambda, lambda_equivalent_clusters
 from emmy.compiler.ir.tile.ops import edge_dtypes
 from emmy.compiler.ir.tile.path import family_sites, sites, spell
 from emmy.compiler.pipeline import Match
@@ -387,29 +387,29 @@ def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) ->
     attention's normalized K cone appears once per score contraction. Those copies are one VALUE:
     the cluster's first seam becomes the decision for all of them, carrying each duplicate as a
     sibling with its positional capture correspondence (:class:`CutSite`). Membership reuses the
-    scoped lambda alpha-equivalence the semiring canonicalization already trusts
-    (:func:`lambda_equivalent_clusters`); a member joins only when its paired axes agree on
-    extent and window, its workspace dtypes match, and every workspace axis is a mapped capture —
-    otherwise it stays its own seam."""
+    closure alpha-equivalence the semiring canonicalization already trusts
+    (:func:`~emmy.compiler.ir.pure.closure.equivalent_clusters`); a member joins only when its
+    paired axes agree on extent and window, its workspace dtypes match, and every workspace axis
+    is a mapped capture — otherwise it stays its own seam."""
     eligible = [index for index, seam in enumerate(seams) if operand_of.get(id(seam.node))]
     if len(eligible) < 2:
         return tuple(seams)
-    scoped = {index: _operand_lambda(seams[index].node, tuple(axis.name for axis in seams[index].axes)) for index in eligible}
+    scoped = {index: Closure.over_edge(seams[index].node, tuple(axis.name for axis in seams[index].axes)) for index in eligible}
     drop: set[int] = set()
     merged: dict[int, CutSite] = {}
-    for cluster in lambda_equivalent_clusters(scoped[index] for index in eligible):
+    for cluster in equivalent_clusters(scoped[index] for index in eligible):
         rep_index, *rest = (eligible[position] for position in cluster)
         if not rest:
             continue
         rep = seams[rep_index]
-        rep_params = scoped[rep_index][1]
+        rep_params = scoped[rep_index].axes
         rep_axes = {axis.name: axis for axis in rep.axes}
         if {axis.name for axis in _workspace_axes(rep, rep.node)} - set(rep_params):
             continue  # a workspace axis with no capture to map has no sibling spelling
         siblings = []
         for member_index in rest:
             member = seams[member_index]
-            member_params = scoped[member_index][1]
+            member_params = scoped[member_index].axes
             member_axes = {axis.name: axis for axis in member.axes}
             aligned = member.dtypes == rep.dtypes and all(
                 (a := rep_axes[rn]).extent == (b := member_axes[mn]).extent and a.window == b.window

--- a/emmy/compiler/pipeline/passes/lowering/tile/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_twist.py
@@ -9,11 +9,11 @@ from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure import Fold, Lambda, component_ops, is_contraction
 from emmy.compiler.ir.pure.algebra import product_spine
 from emmy.compiler.ir.pure.carrier import EXP_FAMILY, exp_combine_states
+from emmy.compiler.ir.pure.closure import Closure
 from emmy.compiler.ir.pure.fold import _operand_result_names, edge_refs_axis, operand_name, refs_axis
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body, Load, Select
 from emmy.compiler.ir.stmt.body import _member_reads
-from emmy.compiler.ir.tile.normalize import lambda_equivalent_clusters
 
 logger = logging.getLogger(__name__)
 
@@ -31,12 +31,6 @@ def _decline(what: str, why: str) -> None:
 
 
 @dataclass(frozen=True)
-class _Score:
-    fn: Lambda
-    axes: tuple[str, ...]
-
-
-@dataclass(frozen=True)
 class _NormalizedExp:
     statistic: Fold
     provider: Fold | None
@@ -47,7 +41,7 @@ def _bindings(fold: Fold) -> dict[str, object]:
     return {name: edge for edge in fold.operands for name in _operand_result_names(edge)}
 
 
-def _score(fold: Fold, result: str, axes: tuple[str, ...]) -> _Score | None:
+def _score(fold: Fold, result: str, axes: tuple[str, ...]) -> Closure | None:
     """A fold's one-source pure score cone, scoped by its streaming axis."""
     bindings = _bindings(fold)
     members = (bindings[result],) if result in bindings else fold.body.backward_cone((result,)).members
@@ -59,11 +53,7 @@ def _score(fold: Fold, result: str, axes: tuple[str, ...]) -> _Score | None:
     nodes = tuple(stmt for stmt in members if isinstance(stmt, Fold))
     if len({id(source) for source in (*used_edges, *indexed_loads, *nodes)}) != 1:
         return None
-    return _Score(Lambda(params=(fold.axis.name,), body=Body(members), results=(result,)), (*axes, fold.axis.name))
-
-
-def _same_score(left: _Score, right: _Score) -> bool:
-    return lambda_equivalent_clusters(((left.fn, left.axes), (right.fn, right.axes))) == ((0, 1),)
+    return Closure(Lambda(params=(fold.axis.name,), body=Body(members), results=(result,)), (*axes, fold.axis.name))
 
 
 def _same_axis(left: Fold, right: Fold) -> bool:
@@ -84,7 +74,7 @@ def _exp_score(defs: dict[str, object], name: str, pivots: frozenset[str]) -> st
     return None
 
 
-def _maximum(fold: Fold, axes: tuple[str, ...]) -> tuple[str, _Score] | None:
+def _maximum(fold: Fold, axes: tuple[str, ...]) -> tuple[str, Closure] | None:
     if fold.axis is None:
         return None
     ops = component_ops(fold.combine)
@@ -100,7 +90,7 @@ def _maximum(fold: Fold, axes: tuple[str, ...]) -> tuple[str, _Score] | None:
     return fold.combine.results[0], score
 
 
-def _denominator(fold: Fold, pivots: frozenset[str], score: _Score, axes: tuple[str, ...]) -> bool:
+def _denominator(fold: Fold, pivots: frozenset[str], score: Closure, axes: tuple[str, ...]) -> bool:
     if fold.axis is None:
         return False
     ops = component_ops(fold.combine)
@@ -114,7 +104,7 @@ def _denominator(fold: Fold, pivots: frozenset[str], score: _Score, axes: tuple[
     cone = fold.body.backward_cone((result,))
     return (
         candidate_score is not None
-        and _same_score(score, candidate_score)
+        and score.alpha_eq(candidate_score)
         and {id(stmt) for stmt in cone.members} == {id(stmt) for stmt in fold.body}
     )
 
@@ -234,7 +224,7 @@ def _inverse_leaf(defs: dict[str, object], leaves: tuple[str, ...], denominator:
     return f"{denominator}__inv" if len(divisors) == 1 and not bound else None
 
 
-def _varying_score(body: Body, result: str, axis: str, axes: tuple[str, ...]) -> tuple[_Score, Body] | None:
+def _varying_score(body: Body, result: str, axis: str, axes: tuple[str, ...]) -> tuple[Closure, Body] | None:
     cone = body.backward_cone((result,))
     varying = {axis}
     members = []
@@ -246,7 +236,7 @@ def _varying_score(body: Body, result: str, axis: str, axes: tuple[str, ...]) ->
     if not members:
         return None
     fn = Lambda(params=(axis,), body=Body(members), results=(result,))
-    return _Score(fn, (*axes, axis)), Body(members)
+    return Closure(fn, (*axes, axis)), Body(members)
 
 
 def _assign_cone(defs: dict[str, object], root: str, stops: frozenset[str]) -> frozenset[int]:
@@ -307,7 +297,7 @@ def _normalized_exp(edge: Fold, axis: str, axes: tuple[str, ...]) -> _Normalized
     score_name = weights[0][1]
     current = _varying_score(body, score_name, axis, axes)
     reference = _score(statistic, statistic.lift.results[0], axes)
-    if current is None or reference is None or not _same_score(reference, current[0]):
+    if current is None or reference is None or not reference.alpha_eq(current[0]):
         return _decline("normalized exponential", f"the weight's score {score_name!r} is not the statistic's own score")
 
     free = set(statistic.lift.free_names()) - {*axes, statistic.axis.name}

--- a/emmy/compiler/pipeline/passes/lowering/tile/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_twist.py
@@ -103,9 +103,7 @@ def _denominator(fold: Fold, pivots: frozenset[str], score: Closure, axes: tuple
     candidate_score = _score(fold, candidate, axes) if candidate is not None else None
     cone = fold.body.backward_cone((result,))
     return (
-        candidate_score is not None
-        and score.alpha_eq(candidate_score)
-        and {id(stmt) for stmt in cone.members} == {id(stmt) for stmt in fold.body}
+        candidate_score is not None and score == candidate_score and {id(stmt) for stmt in cone.members} == {id(stmt) for stmt in fold.body}
     )
 
 
@@ -297,7 +295,7 @@ def _normalized_exp(edge: Fold, axis: str, axes: tuple[str, ...]) -> _Normalized
     score_name = weights[0][1]
     current = _varying_score(body, score_name, axis, axes)
     reference = _score(statistic, statistic.lift.results[0], axes)
-    if current is None or reference is None or not reference.alpha_eq(current[0]):
+    if current is None or reference is None or reference != current[0]:
         return _decline("normalized exponential", f"the weight's score {score_name!r} is not the statistic's own score")
 
     free = set(statistic.lift.free_names()) - {*axes, statistic.axis.name}

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -826,7 +826,9 @@ def test_equivalent_clusters_include_captured_axes() -> None:
         results=("value",),
     )
 
+    assert Closure(first, ("row", "k")) == Closure(second, ("unused", "query", "depth"))  # equality is alpha-invariant
     assert equivalent_clusters((Closure(first, ("row", "k")), Closure(second, ("unused", "query", "depth")))) == ((0, 1),)
+    assert Closure(first, ("row", "k")) != Closure(first, ("k", "row"))  # capture order is the positional identity
 
 
 def test_total_lift_produces_canonical_contraction() -> None:

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -11,9 +11,10 @@ from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import Literal, Var
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.pure import Channel, Fold, Lambda, M, is_contraction
+from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
 from emmy.compiler.ir.schedule import TilePlan
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
-from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp, lambda_equivalent_clusters
+from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.path import family_sites, sites
 from emmy.compiler.pipeline import Pipeline
 from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams
@@ -775,7 +776,7 @@ def test_contraction_preserves_computed_operand_statement_order() -> None:
     assert TileOp(op=tile.op, place=tile.place).op is tile.op
 
 
-def test_lambda_equivalent_clusters_include_captured_axes() -> None:
+def test_equivalent_clusters_include_captured_axes() -> None:
     first = Lambda(
         params=("k",),
         body=Body((Load(name="x", input="q", index=(Var("row"), Var("k"))),)),
@@ -787,7 +788,7 @@ def test_lambda_equivalent_clusters_include_captured_axes() -> None:
         results=("value",),
     )
 
-    assert lambda_equivalent_clusters(((first, ("row", "k")), (second, ("unused", "query", "depth")))) == ((0, 1),)
+    assert equivalent_clusters((Closure(first, ("row", "k")), Closure(second, ("unused", "query", "depth")))) == ((0, 1),)
 
 
 def test_total_lift_produces_canonical_contraction() -> None:

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -15,6 +15,7 @@ from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
 from emmy.compiler.ir.schedule import TilePlan
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
+from emmy.compiler.ir.tile.normalize import _share_common_cones
 from emmy.compiler.ir.tile.path import family_sites, sites
 from emmy.compiler.pipeline import Pipeline
 from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams
@@ -389,13 +390,16 @@ def test_normalization_shares_structurally_identical_cones() -> None:
                 folds(stmt, out)
         return out
 
+    def unify_key(node: Fold):
+        return Closure(Lambda(params=(), body=Body((node,)), results=node.defines()), ()).canonical()
+
     by_identity = folds(tile.op, {})
     by_value: dict[tuple, list[Fold]] = {}
     for node in by_identity.values():
-        by_value.setdefault((node.structural_key(), node.deps()), []).append(node)
+        by_value.setdefault((node.structural_key(), node.deps(), node.defines()), []).append(node)
     for twins in by_value.values():
-        distinct_equals = [(a, b) for index, a in enumerate(twins) for b in twins[index + 1 :] if a == b]
-        assert not distinct_equals, "normalization left structurally equal cones as distinct objects"
+        distinct_equals = [(a, b) for index, a in enumerate(twins) for b in twins[index + 1 :] if unify_key(a) == unify_key(b)]
+        assert not distinct_equals, "normalization left same-value cones as distinct objects"
 
 
 def test_reduced_qk_attention_offers_the_statistic_arm_b_seams_idempotently() -> None:
@@ -774,6 +778,40 @@ def test_contraction_preserves_computed_operand_statement_order() -> None:
     assert isinstance(lowered[1], Assign) and lowered[1].name == "inv"
     assert isinstance(lowered[2], Loop) and lowered[2].axis.name == "j"
     assert TileOp(op=tile.op, place=tile.place).op is tile.op
+
+
+def test_share_common_cones_unifies_internally_renamed_copies() -> None:
+    """Alpha-equal cones with identical captures and interface names collapse to one object even
+    when their internal binder spelling differs — plain structural equality would keep them
+    distinct and silently sever the sharing."""
+
+    def cone(load: str, product: str, row: str = "m") -> Fold:
+        body = Body(
+            (
+                Load(name=load, input="x", index=(Var(row), Var("k"))),
+                Assign(name=product, op="multiply", args=(load, load)),
+            )
+        )
+        init, combine = M(ElementwiseImpl("add"), names=("acc",))
+        return Fold(axis=Axis("k", Dim(8)), lift=Lambda(params=("k",), body=body, results=(product,)), init=init, combine=combine)
+
+    def consumer(inner: Fold, out: str) -> Fold:
+        return Fold.projection(operands=(inner,), body=Body((Assign(name=out, op="exp", args=("acc",)),)), results=(out,))
+
+    def rooted(second: Fold) -> Fold:
+        return _share_common_cones(
+            Fold.projection(
+                operands=(consumer(cone("l1", "p1"), "u"), consumer(second, "v")),
+                body=Body((Assign(name="w", op="add", args=("u", "v")),)),
+                results=("w",),
+            )
+        )
+
+    unified = rooted(cone("l2", "p2"))
+    assert unified.operands[0].operands[0] is unified.operands[1].operands[0]
+
+    distinct = rooted(cone("l2", "p2", row="q"))  # same form, different capture — a different value
+    assert distinct.operands[0].operands[0] is not distinct.operands[1].operands[0]
 
 
 def test_equivalent_clusters_include_captured_axes() -> None:


### PR DESCRIPTION
## What

Three commits, plus a new pre-submission audit rule this PR is the first to answer to.

1. **AGENTS.md — core line-balance check (step 18).** A PR that introduces no new functionality must not grow the line count under `emmy/`; net growth without new capability is the typical sign of architectural creep.

2. **Extract `Closure` into `ir/pure/closure.py`.** The scoped alpha-equivalence machinery lived as `tile/normalize.py` privates that `_cut.py` and `_twist.py` imported directly, and `_twist.py` hand-rolled the same `(lambda, axes)` pairing as its own `_Score` dataclass. `Closure` (an index-space environment: iteration axes only, never values) with `over_edge` / `canonical` / `alpha_eq` / `equivalent_clusters` replaces all of it. No behavior change; glossary and IR architecture notes added.

3. **Strengthen `_share_common_cones` from structural equality to closure unification.** The pass bucketed copies by the alpha-invariant structural key but collapsed them only under name-sensitive structural equality — a cone copy differing in internal binder spelling silently kept its own object: severed sharing, the per-site recompute class placement cannot undo (PR #679's three-orders-of-magnitude class). Copies now unify when alpha-equal with identical captures (`deps`) and interface names (`defines`). The tree-wide invariant test asserts the new strength; a unit test covers the renamed-copy and different-capture cases.

4. **Merge the closing rewrites onto one shared walk.** `_close_projection` / `_close_reduce_body` duplicated the same `close()` recursion; the shared `_close_tree` engine states the enabling condition — drain a contraction operand's value captures (`Closure.value_captures`) until the closure invariant holds — and each rewrite keeps only its provider extraction and drained-chain policy. Behavior unchanged.

## Line balance (step 18)

`emmy/` is +66 net. Justified: commit 3 adds capability (renamed copies now share, closing a latent missed-sharing hole), and the growth is the `Closure` contract documentation; the mechanical halves are net-negative (normalize.py −171 lines total, `_Score` and the duplicated close walk deleted).

## Verification

- Full suite green after each commit (4733–4734 passed; 2 xpassed are the pre-existing TMA-staging bit-parity flakes, reproducible on pristine origin/main).
- Commit 2 is digest-neutral by construction (pure code motion). Commit 3 can change which copy's spelling survives sharing, so it is verified by the realization corpus replay in the suite rather than byte digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8gTVj5hSLXuZQ5K5pQSHQ