### PR TITLE
Bind a sweep-reading reduce inside its output sweep; offer it only the serial fold

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -104,7 +104,11 @@ kernel-boundary `TileOp.output_specs` are reconstituted at their owning projecti
 (a STREAMED store — one whose values are an observed fold's observer results — rides the recursion down to the leaf
 instead and splices into the reduce loop after the observer stmts), so everything below the peel — the sinks,
 cooperative loop distribution, and split realizers — consumes the identical statement stream that entered total
-lift. The
+lift. An output sweep whose axis the peeled root's cone reads cannot wrap at the peel (the root binds outside the
+projection, so no wrap position encloses it): the serial fold binds the projection UNPEELED so the sweep loop wraps
+operand and projection together, and a cooperative / ILP row — whose lanes the sweep would be distributed across —
+declines via `UnbindableProjection` (`RuleSkipped(reject=True)` at the pass boundary; the greedy retries the next
+row). The
 recursion, the binder, the reduce-axis tiling, and the shared-row staging apply live in `_factor.py`; the four tiling
 levels every tier seals through are `_tiling.py`, which knows a `Side` pair, integer counts and three callables — no
 node kinds, no algebra, no `Ctx`. That is the decide/realize seam: the tile schedule picks the plan, `_tiling` is

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -53,13 +53,13 @@ from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.kernel import Tile
 from emmy.compiler.ir.kernel.ir import Smem, Sync, TreeHalve, WarpShuffle
-from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, _unique_edges, is_contraction, operand_body
+from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, _unique_edges, edge_refs_axis, is_contraction, operand_body
 from emmy.compiler.ir.schedule import Raster
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
 from emmy.compiler.ir.tile import FoldMove, Level, ReducePlan, ReduceStage
 from emmy.compiler.ir.tile.ir import ProjectionRegion, _projection_results, apply_output_specs, observed_result_names
-from emmy.compiler.ir.tile.ops import cone_seam, projection_regions, sched_of
+from emmy.compiler.ir.tile.ops import UnbindableProjection, cone_seam, projection_regions, sched_of
 from emmy.compiler.pipeline.passes.lowering._reduction import Reduction, loop_state_head
 from emmy.compiler.pipeline.passes.lowering.kernel._atom import (
     clamp_last,
@@ -315,6 +315,23 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         streamed = tuple(spec for spec in root_specs if set(spec.write.values) <= observed)
         streamed_ids = {id(spec) for spec in streamed}
         plain = tuple(spec for spec in root_specs if id(spec) not in streamed_ids)
+        # An output sweep whose axis the peeled root's cone reads cannot wrap here: the peel binds
+        # the root OUTSIDE the projection, so no wrap position inside ``proj`` encloses the reduce
+        # and the sweep coordinate renders as an undefined identifier at nvcc (DeepSeek-V4's fused
+        # ``k_div_36_reduce``, whose per-column mean read the store sweep's column). The serial
+        # fold realizes the shape whole — bind the UNPEELED projection so ``apply_output_specs``
+        # wraps operand and projection together. A cooperative / ILP partition (or an output-tiled
+        # contraction root) has no such realization — the sweep is distributed across the lanes it
+        # would have to re-run on — so the row is declined and the greedy retries the next one.
+        swept = [spec.sweep.name for spec in plain if spec.sweep is not None and edge_refs_axis(root, spec.sweep.name)]
+        if swept:
+            plan = ctx.sched.get("REDUCE", root) if isinstance(root, Fold) and root.axis is not None else None
+            if (plan is not None and (plan.coop > 1 or plan.reg > 1)) or (is_contraction(root) and ctx.sched.tile_of(root) is not None):
+                raise UnbindableProjection(
+                    f"the bound reduce's cone reads output sweep axis {swept[0]!r} — a cooperative / ILP "
+                    f"partition cannot re-run the reduce per swept cell"
+                )
+            return _bind(op, ctx, tail, out_val, store, output_specs=output_specs)
         if plain:
             proj = apply_output_specs(proj, plain)
         return _factorize(root, ctx, tail=(*proj, *tail), out_val=out_val, store=store, output_specs=streamed, cell_op=closed_root)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -325,8 +325,16 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, output_specs
         # would have to re-run on — so the row is declined and the greedy retries the next one.
         swept = [spec.sweep.name for spec in plain if spec.sweep is not None and edge_refs_axis(root, spec.sweep.name)]
         if swept:
-            plan = ctx.sched.get("REDUCE", root) if isinstance(root, Fold) and root.axis is not None else None
-            if (plan is not None and (plan.coop > 1 or plan.reg > 1)) or (is_contraction(root) and ctx.sched.tile_of(root) is not None):
+            # The schedule at stake is the ITERATING node's, which a chain of zero-axis projections
+            # may sit above (``root`` is then a projection, carrying no ``REDUCE`` site of its
+            # own). Descend to it, or the decline reads an absent plan off the wrapper and binds a
+            # partitioned row as the serial fold — the emission is correct but silently drops the
+            # partition the row was priced on.
+            node = root
+            while isinstance(node, Fold) and node.axis is None and node.operands:
+                node = node.operands[0]
+            plan = ctx.sched.get("REDUCE", node) if isinstance(node, Fold) and node.axis is not None else None
+            if (plan is not None and (plan.coop > 1 or plan.reg > 1)) or (is_contraction(node) and ctx.sched.tile_of(node) is not None):
                 raise UnbindableProjection(
                     f"the bound reduce's cone reads output sweep axis {swept[0]!r} — a cooperative / ILP "
                     f"partition cannot re-run the reduce per swept cell"

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -703,7 +703,9 @@ def _reduce_catalog(state: _State, extent: int) -> list[ReducePlan]:
 
 def _reduce_moves(state: _State, node, key: str | None) -> list[ReducePlan]:
     """The reduce partitions this fold offers: the serial fold plus every :func:`coop_reduce_moves`
-    band the node admits, or — under a ``REDUCE`` pin — the ONE partition that pin names, read
+    band the node admits — an observed fold (a scan), and a fold whose cone reads a boundary
+    store's sweep axis, offer exactly the serial fold — or, under a ``REDUCE`` pin, the ONE
+    partition that pin names, read
     against the kernel's pinned inventory (the ``coop`` token's width lives in ``WORK``). A pin is
     authoritative over the value; it cannot make a band this node has no geometry for legal, and
     one that names no legal partition raises the refusal instead of silently emptying the
@@ -728,6 +730,21 @@ def _reduce_moves(state: _State, node, key: str | None) -> list[ReducePlan]:
         # fails loudly at the offered oracle, whose membership check sees the pin unsatisfied.
         if pin is not None and ReducePlan.parse(pin, state.work_pin).stages and logger.isEnabledFor(logging.DEBUG):
             logger.debug("REDUCE pin %r names a partition; an observed fold (a scan) realizes the serial fold only", pin)
+        return [ReducePlan()]
+    swept = tuple(spec.sweep.name for spec in state.tile.output_specs if spec.sweep is not None and edge_refs_axis(node, spec.sweep.name))
+    if swept:
+        # The boundary store's output sweep must ENCLOSE this fold — its cone reads the sweep
+        # coordinate, so the whole reduce re-runs per swept cell (the materializer binds the
+        # projection unpeeled). A partitioned combine cannot ride inside the per-lane sweep, so
+        # only the serial fold realizes; deciding it here keeps the greedy off the kernel binder's
+        # decline, which costs a full re-resolve per declined row. A pin naming a partition is a
+        # recorded refusal, never a silent drop.
+        if pin is not None and ReducePlan.parse(pin, state.work_pin).stages:
+            raise PinRefused(
+                f"REDUCE pin {pin!r} at {key or 'REDUCE'} names a partition, but this fold reads output "
+                f"sweep axis {swept[0]!r} — the sweep loop must enclose the whole reduce, so only the "
+                f"serial fold realizes"
+            )
         return [ReducePlan()]
     if pin is None:
         return _reduce_catalog(state, extent)

--- a/tests/compiler/ir/tile/test_structural_reduction.py
+++ b/tests/compiler/ir/tile/test_structural_reduction.py
@@ -567,10 +567,13 @@ def test_sealed_inventory_derives_off_the_schedule_dict() -> None:
 # --- an output sweep the bound reduce's cone reads ----------------------------------------------- #
 
 
-def _sweep_reading_reduce_tile(plan=None) -> TileOp:
+def _sweep_reading_reduce_tile(plan=None, chain: bool = False) -> TileOp:
     """The DeepSeek ``k_div_36_reduce`` shape: a zero-axis projection whose OPERAND reduce streams a
     load indexed by the boundary store's sweep axis (``acc = Σ_k x[m, k, j]`` under ``sweep(j)
-    o[m, j] = v``) — the reduce must re-run per swept cell, so the sweep loop has to enclose it."""
+    o[m, j] = v``) — the reduce must re-run per swept cell, so the sweep loop has to enclose it.
+
+    ``chain`` puts a second zero-axis projection between the root and the reduce, so the peeled
+    operand carries no ``REDUCE`` site of its own."""
     from emmy.compiler.ir.schedule import Placement
 
     body = Body(
@@ -581,14 +584,21 @@ def _sweep_reading_reduce_tile(plan=None) -> TileOp:
     )
     red = fold_from_loop(Loop(axis=Axis("k", 4), body=body, role=AxisRole.PLANAR))
     assert red is not None
-    node = Fold.projection(body=Body((Assign(name="v", op="sqrt", args=("acc",)),)), operands=(red,))
+    if chain:
+        inner = Fold.projection(body=Body((Assign(name="mid", op="copy", args=("acc",)),)), operands=(red,), results=("mid",))
+        node = Fold.projection(body=Body((Assign(name="v", op="sqrt", args=("mid",)),)), operands=(inner,))
+    else:
+        node = Fold.projection(body=Body((Assign(name="v", op="sqrt", args=("acc",)),)), operands=(red,))
     tile = TileOp(
         op=node,
         place=Placement(free=(Axis("m", 8),)),
         output_specs=(OutputSpec(write=Write(output="o", index=(Var("m"), Var("j")), value="v"), sweep=Axis("j", 4)),),
     )
     if plan is not None:
-        tile = _with_slice(tile, "REDUCE", tile.op.operands[0], plan)
+        scheduled = tile.op.operands[0]
+        while scheduled.axis is None and scheduled.operands:
+            scheduled = scheduled.operands[0]
+        tile = _with_slice(tile, "REDUCE", scheduled, plan)
     return tile
 
 
@@ -626,3 +636,20 @@ def test_partitioned_reduce_reading_the_output_sweep_refuses_the_row() -> None:
 
     with pytest.raises(UnbindableProjection):
         factorize(_sweep_reading_reduce_tile(ReducePlan.of(coop=4)), root=None)
+
+
+def test_a_projection_chain_does_not_hide_the_partition_from_the_refusal() -> None:
+    """The schedule at stake is the ITERATING node's, and a chain of zero-axis projections may sit
+    between it and the peeled operand. Reading the plan off the wrapper found none and bound the
+    row as the serial fold: the emission was correct but silently dropped the partition the row
+    was priced on, which is the phantom stamp the offer-side narrowing exists to prevent."""
+    import pytest
+
+    from emmy.compiler.ir.tile.ops import UnbindableProjection
+    from emmy.compiler.pipeline.passes.lowering.kernel._factor import factorize
+
+    # The serial chain still emits with every axis bound.
+    tile = factorize(_sweep_reading_reduce_tile(chain=True), root=None)
+    assert not _reads_axis_outside_its_loop(list(tile.body), "j")
+    with pytest.raises(UnbindableProjection):
+        factorize(_sweep_reading_reduce_tile(ReducePlan.of(coop=4), chain=True), root=None)

--- a/tests/compiler/ir/tile/test_structural_reduction.py
+++ b/tests/compiler/ir/tile/test_structural_reduction.py
@@ -562,3 +562,67 @@ def test_sealed_inventory_derives_off_the_schedule_dict() -> None:
     schedule: dict = {}
     Sched(t.op, schedule, place=t.place).put("TILE", c, TilePlan.parse("f2", Workers.parse("t2")))
     assert sealed_inventory(schedule, t.workers) == Workers(kind="thread", units=(2, 1))
+
+
+# --- an output sweep the bound reduce's cone reads ----------------------------------------------- #
+
+
+def _sweep_reading_reduce_tile(plan=None) -> TileOp:
+    """The DeepSeek ``k_div_36_reduce`` shape: a zero-axis projection whose OPERAND reduce streams a
+    load indexed by the boundary store's sweep axis (``acc = Σ_k x[m, k, j]`` under ``sweep(j)
+    o[m, j] = v``) — the reduce must re-run per swept cell, so the sweep loop has to enclose it."""
+    from emmy.compiler.ir.schedule import Placement
+
+    body = Body(
+        (
+            Load(name="x_e", input="x", index=(Var("m"), Var("k"), Var("j"))),
+            Accum(name="acc", value="x_e", op="add", axes=("k",)),
+        )
+    )
+    red = fold_from_loop(Loop(axis=Axis("k", 4), body=body, role=AxisRole.PLANAR))
+    assert red is not None
+    node = Fold.projection(body=Body((Assign(name="v", op="sqrt", args=("acc",)),)), operands=(red,))
+    tile = TileOp(
+        op=node,
+        place=Placement(free=(Axis("m", 8),)),
+        output_specs=(OutputSpec(write=Write(output="o", index=(Var("m"), Var("j")), value="v"), sweep=Axis("j", 4)),),
+    )
+    if plan is not None:
+        tile = _with_slice(tile, "REDUCE", tile.op.operands[0], plan)
+    return tile
+
+
+def _reads_axis_outside_its_loop(stmts, name: str) -> bool:
+    """A deep read of axis ``name`` not enclosed by a loop binding it — the undefined-identifier
+    shape nvcc rejects."""
+    for s in stmts:
+        if name in s.binds_axes():
+            continue
+        if any(name in e.free_vars() for e in s.exprs()):
+            return True
+        if any(_reads_axis_outside_its_loop(list(b), name) for b in s.nested()):
+            return True
+    return False
+
+
+def test_serial_reduce_reading_the_output_sweep_emits_inside_the_sweep_loop() -> None:
+    """The serial fold realizes the shape whole: the projection is not peeled off its operand, so
+    the output sweep ``Loop`` wraps the reduce and the sweep axis is bound everywhere it is read."""
+    from emmy.compiler.pipeline.passes.lowering.kernel._factor import factorize
+
+    tile = factorize(_sweep_reading_reduce_tile(), root=None)
+    assert not _reads_axis_outside_its_loop(list(tile.body), "j")
+
+
+def test_partitioned_reduce_reading_the_output_sweep_refuses_the_row() -> None:
+    """A cooperative / ILP partition cannot re-run per swept cell — the materializer distributes the
+    output sweep across the cooperating lanes, and a cross-lane combine inside a lane-local sweep
+    folds different swept cells. The row is declined (``RuleSkipped(reject=True)`` at the pass
+    boundary), and the greedy blocklist retry resolves onto the serial fold."""
+    import pytest
+
+    from emmy.compiler.ir.tile.ops import UnbindableProjection
+    from emmy.compiler.pipeline.passes.lowering.kernel._factor import factorize
+
+    with pytest.raises(UnbindableProjection):
+        factorize(_sweep_reading_reduce_tile(ReducePlan.of(coop=4)), root=None)

--- a/tests/compiler/passes/test_schedule_walk.py
+++ b/tests/compiler/passes/test_schedule_walk.py
@@ -255,3 +255,35 @@ def test_computed_b_statistic_is_a_keyed_schedule_site(unpinned, monkeypatch) ->
     assert rows, "the fused attention kernel must still enumerate"
     keyed_under_b = [key for row in rows for key in row if key.split("@", 1)[0] == "REDUCE" and "b" in key.split("@", 1)[-1].split(".")]
     assert keyed_under_b, "no REDUCE site was keyed inside a computed B operand cone"
+
+
+def test_a_sweep_reading_fold_offers_only_the_serial_reduce(unpinned) -> None:
+    """A fold whose cone reads a boundary store's sweep axis must be ENCLOSED by the output sweep
+    loop (the materializer binds the projection unpeeled), and a partitioned combine cannot ride
+    inside the per-lane sweep — so the serial fold is the whole catalog, decided at the offer.
+    Offering a band and declining it at the kernel binder instead costs one full greedy
+    re-resolve per declined row (DeepSeek-V4's fused ``k_div_36_reduce`` on the live V100)."""
+    from types import SimpleNamespace
+
+    from emmy.compiler.ir.axis import Axis, AxisRole
+    from emmy.compiler.ir.expr import Var
+    from emmy.compiler.ir.stmt import Accum, Body, Load, Loop, Write
+    from emmy.compiler.ir.tile import OutputSpec, ReducePlan
+    from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
+
+    body = Body(
+        (
+            Load(name="x_e", input="x", index=(Var("m"), Var("k"), Var("j"))),
+            Accum(name="acc", value="x_e", op="add", axes=("k",)),
+        )
+    )
+    red = fold_from_loop(Loop(axis=Axis("k", 128), body=body, role=AxisRole.PLANAR))
+    assert red is not None
+    sweep_spec = OutputSpec(write=Write(output="o", index=(Var("m"), Var("j")), value="v"), sweep=Axis("j", 4))
+
+    def state(specs):
+        return SimpleNamespace(tile=SimpleNamespace(output_specs=specs), work_pin=None, transposed_ok=False)
+
+    assert _schedule._reduce_moves(state((sweep_spec,)), red, None) == [ReducePlan()]
+    # Without the sweep read the catalog stays whole.
+    assert len(_schedule._reduce_moves(state(()), red, None)) > 1


### PR DESCRIPTION
## What

[#677](https://github.com/cloudrift-ai/deplodock/pull/677) stopped the normalize hoist from *moving* a sweep-reading fold onto an operand edge — the route by which DeepSeek-V4's `k_div_36_reduce` got an unbound sweep axis. This closes the same hole one layer down: a stored term whose operand edge **already** carries such a fold is directly expressible, and the materializer still emits the sweep coordinate as an undefined identifier for it, under every row.

The peel is the reason. `_factorize` binds the root operand *outside* the projection, so no wrap position inside the projection body encloses the reduce, and `apply_output_specs` can never put the sweep loop around it.

## Changes

- **`_factorize`** detects a plain output sweep whose axis the peeled root's cone reads (`edge_refs_axis`). The serial fold realizes the shape whole, so the projection binds **unpeeled** through the zero-axis `_bind` arm and the sweep loop wraps operand and projection together. A cooperative / ILP row (or an output-tiled contraction root) has no such realization — the sweep is distributed across the very lanes the reduce would have to re-run on — so it declines via `UnbindableProjection` (`RuleSkipped(reject=True)`) and the greedy retries the next row.
- **`_reduce_moves`** offers such a fold exactly the serial fold, beside the existing scan rule and with the same pin refusal. Deciding it at the offer keeps the greedy off the binder's decline, which costs a full re-resolve per declined row and retires structural pricing as collateral — the DeepSeek V100 serve compile spent **382 s** on those retries where the narrowed offer resolves once, in **40 s**. The binder decline stays as the backstop.

## Tests

Two at `factorize` (serial emission keeps the sweep axis bound everywhere it is read; a coop row refuses) and one on the narrowed catalog at `_reduce_moves`. All three **fail on main without this change**.

## Verification

- `make test`: **3983 passed**. The two `tests/serving` failures (Laguna gate, GLM4 MoE tail) reproduce unchanged on clean main at 1498d6ac7 — local Transformers drift, not this branch.
- `make lint`: clean.
- Realization corpus: green, no case verdicts changed.
- On-card (16× V100, sm_70): with this change on the branch it was authored against, DeepSeek-V4 `post16` nvcc-compiled 54/54 (was 53/54, `a15` undefined), and `k_div_36_reduce` emitted the sweep loop enclosing the mean reduce.

## Not included

A follow-up commit on the branch this came from generalizes the same idea to an **enclosure gate** — any fold nested inside another fold's reduce axis is emitted serially by `_factor._emit`, which reads no schedule, so the bands offered there are partitions the kernel never realizes. That work predates [#679](https://github.com/cloudrift-ai/deplodock/pull/679) and is **not** in this PR: #679 added `attention/rmsnorm-*` corpus cases whose pinned rows record `REDUCE@<enclosed site>: coop`, and the gate refuses those pins, so 5 cases fail. Deciding whether those stamps are phantom (corpus regeneration) or the gate is over-broad (compiler fix) is its own change with its own evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)