### PR TITLE
Attribute failures to the kernel that failed; put the composed cut on the ballot; make it compile

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -84,6 +84,17 @@ These are term operations spelled the same way so one canonicalizer and one deep
 vocabularies; they are not statement behaviour, and `Fold` has no `render`. Impure computation stays
 in Loop IR until total lift; there is no impure `Lambda` construction path.
 
+**`nested()` is the STATEMENT protocol, and it deliberately does not reach a Fold's operand edges**
+— it yields the lift body, and nothing at all for a contraction, whose algebra is meant to read as
+edges rather than body deps. Every walk built on it (`Body.iter`, and so `Body.loads` /
+`Body.writes`) therefore answers for a fully flattened stream only. A lowered body is not always
+one: a term survives lowering wherever a region kept it (`ProjectionRegion` holds its cones as
+terms), and a walk over `Fold.lower()` then silently under-reports everything beneath such an edge.
+Ask `loaded_buffers` instead whenever the answer must cover what a consumer of the STORED tree will
+reach — the kernel materializer walks that tree, so anything deciding a node's graph inputs has to
+see what it sees. Asking the lowered view there is what let a cut declare fewer inputs than the
+kernel it produced went on to read.
+
 ## Invariants by stage
 
 - **Frontend → tensor** (after `decomposition`): `LinearOp`, `MatmulOp`,

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -875,6 +875,42 @@ def deep_reads(stmts: list[Stmt]) -> set[str]:
     return out
 
 
+def loaded_buffers(node) -> set[str]:
+    """Every graph BUFFER loaded under ``node`` — a term, a stmt, or a body of them.
+
+    ``Body.loads`` walks ``Stmt.nested()``, and a Fold's operand EDGES are not nested statements:
+    :meth:`Fold.nested` yields the lift body, and nothing at all for a contraction, whose algebra
+    is meant to read as edges rather than body deps. That is fine for a fully flattened stream,
+    but a lowered body still carries Folds as TERMS wherever a region kept them
+    (:class:`~emmy.compiler.ir.tile.ir.ProjectionRegion` holds its cones as terms), so asking the
+    lowered body alone silently under-reports every buffer beneath such an edge.
+
+    Ask this whenever the answer must cover what a consumer of the STORED tree will reach — the
+    cut declaring a piece's graph inputs, ordering pieces by the workspaces they read. A cut that
+    declared the lowered view instead named fewer inputs than the kernel the materializer built
+    from the same tree went on to read, and the workspace producers, unreferenced, were pruned as
+    orphans."""
+    out: set[str] = set()
+    seen: set[int] = set()
+    stack = [node]
+    while stack:
+        item = stack.pop()
+        if id(item) in seen:
+            continue
+        seen.add(id(item))
+        if isinstance(item, Load):
+            out.add(item.input)
+        elif isinstance(item, Fold):
+            stack.extend(item.operands)
+            stack.extend(item.lift.body)
+        elif isinstance(item, (list, tuple, Body)):
+            stack.extend(item)
+        else:
+            for body in item.nested():
+                stack.extend(body)
+    return out
+
+
 def stmt_axis_names(stmts) -> set[str]:
     """Every loop induction variable bound anywhere in ``stmts`` (deep). A composed structural node
     sitting in the body needs no special case — it is a ``Stmt``, so its children are reached through
@@ -1047,11 +1083,12 @@ def _(s: Fold, rename, sigma, axis_fn):
 
 __all__ = [
     "Channel",
-    "Fold",
     "deep_defines",
     "deep_reads",
     "edge_refs_axis",
+    "Fold",
     "is_contraction",
+    "loaded_buffers",
     "operand_body",
     "operand_name",
     "refs_axis",

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -156,6 +156,14 @@ member: hoisting it onto an operand edge would lower it outside the sweep loop, 
 identifier (DeepSeek-V4 post16's per-column sum was the live case). A contraction is exempt because post-init
 promotes a sweep its operands read into a real free axis right after normalization.
 
+A fold FED by the body — one whose subtree captures a name a plain body member defines — is likewise never hoisted,
+no matter what kind: a projection evaluates its operands before its scalar body, so the capture would read a value
+that does not exist yet. The `closed` gate reads only the fold's own lift and cannot see a nested capture; the
+composed placement cut builds exactly this shape (the consumer piece's workspace loads and rsqrt chain feed the
+retained reduce — DeepSeek-V4 post4096's two-cut piece was the live case, every capture an undefined identifier at
+nvcc). The schedule walk mirrors the fact: every fold under such a chain-form root offers only the serial fold,
+since the materializer binds the projection body whole.
+
 A matrix row that Loop IR elided because its static extent is one remains algebraic information when every output
 specification starts with one or more literal-zero coordinates followed by the dense `n` coordinate, directly or
 split into row-major quotient/remainder coordinates by a pure reshape. The `n` coordinate may already be free or may

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -312,6 +312,18 @@ def _normalize_body(body: Body, axes: tuple[str, ...], implicit_axes: frozenset[
     return Body(out)
 
 
+def fed_by_body(fold: Fold, body) -> bool:
+    """Whether ``fold``'s subtree captures a name a plain (non-Fold) member of ``body`` defines.
+
+    A projection evaluates its operands before its scalar body, so such a fold can never move onto
+    an operand edge — the names it captures would not exist yet. ``Fold.deps()`` is the memoized
+    deep capture set (its own lift's free names plus every operand edge's, recursively), so the
+    check costs one set intersection. Read by the hoist below and by the schedule walk's
+    serial-only gate, so the two cannot drift."""
+    feeds = {name for stmt in body if not isinstance(stmt, Fold) for name in stmt.defines()}
+    return bool(feeds) and not feeds.isdisjoint(fold.deps())
+
+
 def _hoist_closed_folds(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset[str]) -> Fold:
     """Move closed child Folds from a zero-axis body onto operand edges.
 
@@ -321,12 +333,20 @@ def _hoist_closed_folds(root: Fold, axes: tuple[str, ...], sweep_axes: frozenset
     at kernel scope, where the axis is an undefined identifier (``head``'s sweep case — the fold
     must stay the projection's body member; found live on DeepSeek-V4 post16's per-column sum,
     ``k_div_36``). A CONTRACTION is exempt: ``TileOp.__post_init__`` promotes a sweep its operands
-    read into a real free axis right after normalization, so the hoisted edge stays bound."""
+    read into a real free axis right after normalization, so the hoisted edge stays bound.
+
+    A fold FED by the body is never hoisted either — no matter what kind: the ``closed`` gate
+    reads only the fold's own lift, but hoisting moves the whole subtree, and a subtree capturing
+    a name the remaining body defines (:func:`fed_by_body`) would evaluate before its provider.
+    The composed placement cut builds exactly this shape — the consumer piece's workspace loads
+    and their rsqrt chain feed the retained reduce — and hoisting it emitted every capture as an
+    undefined identifier at nvcc (DeepSeek-V4 post4096's two-cut ``…mean_reduce`` piece)."""
     candidates = [
         stmt
         for stmt in root.body
         if isinstance(stmt, Fold)
         and Closure(stmt.lift, axes).closed
+        and not fed_by_body(stmt, root.body)
         and (is_contraction(stmt) or not any(edge_refs_axis(stmt, name) for name in sweep_axes))
     ]
     if not candidates:

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -94,6 +94,18 @@ def cone_stat_dtypes(pro: tuple, stats: tuple[str, ...], inputs) -> dict[str, ob
     return {nm: dt for nm in stats if (dt := env.get(nm)) is not None}
 
 
+def _dtype_key(edge, scope: dict | None) -> tuple:
+    """An edge's cache key: its identity plus the dtypes its CAPTURES resolve to at this
+    occurrence. Captures are what make the answer occurrence-dependent; an edge with none keys the
+    same with or without a scope, so the unscoped and scoped walks share their entries."""
+    # Identity keying is only valid while the tree is alive — which it is for every caller, who
+    # holds the root across the walk.
+    captures = sorted(edge.deps()) if isinstance(edge, Fold) else ()
+    if not captures or not scope:
+        return (id(edge), ())
+    return (id(edge), tuple((name, getattr(scope.get(name), "name", None)) for name in captures))
+
+
 def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict | None = None) -> tuple:
     """Infer an edge's result dtypes in the lexical scope where the edge occurs.
 
@@ -104,16 +116,17 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict
     capturing seam whose occurrences resolve to equal providers, and equal providers type equally.
     """
     cache = {} if cache is None else cache
-    if id(edge) in cache:
-        return cache[id(edge)]
+    key = _dtype_key(edge, scope)
+    if key in cache:
+        return cache[key]
     if isinstance(edge, Load):
         tensor = inputs.get(edge.input) if inputs else None
         result = (tensor.dtype if tensor is not None else None,) * len(edge.names)
-        cache[id(edge)] = result
+        cache[key] = result
         return result
     if not isinstance(edge, Fold):
         result = (None,) * len(_operand_result_names(edge))
-        cache[id(edge)] = result
+        cache[key] = result
         return result
 
     env = dict(scope or {})
@@ -142,7 +155,7 @@ def edge_dtypes(edge, inputs, cache: dict[int, tuple] | None = None, scope: dict
     else:
         carried = lifted[: len(edge.combine.results)]
         result = carried + tuple(env.get(name) for name in _operand_result_names(edge)[len(carried) :])
-    cache[id(edge)] = result
+    cache[key] = result
     return result
 
 

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -89,10 +89,14 @@ pure `Load`/`Assign` chain joins the produced piece verbatim, while a Fold produ
 reads the name through that producer's workspace, so cutting it composes the producer's cut in. Dtypes for capturing
 seams come from inference rooted at the Tile tree, where the enclosing bindings are visible. This is what lets row
 statistics materialize once per query row instead of being copied into a contraction's evaluation domain.
-Provider-closed and dependent seams are SCOPED-PIN-ONLY: the unpinned fork and bare `PLACE=cut` never select them,
-because nearly every kernel — and every fresh cut piece, which copies its providers — hosts some, so offering them
-would make recursive placement inexhaustible and the candidate walk explode. A route through them is spelled by
-authored or golden-decoded pins.
+Provider-closed and dependent seams join the UNPINNED fork as principal closures: each seam is offered with its
+transitively required producers as ONE composed structural arm, built by the same composition walk the pin path
+uses, so the evidence-driven route through a dependent seam is on the ballot (DeepSeek-V4 post4096's only working
+placement was a dependent seam's closure — the previous plain-only ballot could never elect it, however the
+evidence ranked). Two seams whose closures coincide are one arm. Bare `PLACE=cut` still resolves among the PLAIN
+seams only — it names one deterministic decision, and its recursion terminates because pieces run out of plain
+seams. Recursive placement over composed arms converges in practice — pieces collapse onto shared identities as
+the tree shrinks — rather than being cut off by any count or depth guard.
 Scoped `PLACE@path=cut` pins are authoritative and COMPOSE: every pin that resolves on
 one kernel joins a single realization — one producer per seam, one consumer, a producer reading another seam's
 workspace when its value nests inside (attention's statistics cone contains the score dots whose operand cones are
@@ -477,8 +481,8 @@ Maximal Loop fusion remains canonical. Tile lowering may expose two kinds of gra
 that canonical input:
 
 - **`030_cut`** offers the maximal fused Fold tree and every closed stored child-Fold seam — body-member folds
-  closed at offer time by provider closure and dependent seams stay scoped-pin-only (see the placement discussion
-  above). A cut writes one workspace
+  closed at offer time by provider closure, and dependent seams offered as principal closures (see the placement
+  discussion above). A cut writes one workspace
   per state component and replaces all occurrences of the same canonically shared Fold object with workspace loads.
   Closure and replaceability are semantic gates; operation family, expected speed, row order, and search-space size
   are not. Closure reads the complete lowered statement stream through `Body`'s scope-aware dependence analysis:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -904,8 +904,14 @@ def _tile_reduce_axis(op: Fold, plan, ctx: Ctx, tail: tuple, out_val: str) -> tu
     # offline-weights refit steering dynamic scalar SDPA onto the ILP fold).
     defined = {nm for s in rloop.body.iter() for nm in s.defines()}
     expr_external = {v for s in rloop.body.iter() for e in s.exprs() for v in e.free_vars()} - defined
+    # ... and the same for the SSA-deps channel: an ``Assign``'s args are name strings ``deps()``
+    # reports and ``exprs()`` does not, so a value defined ahead of the loop (a hoisted scalar
+    # load, a provider chain a cut left before the reduce) and read inside it is invisible to the
+    # Expr scan above. It is one value shared by every copy — renaming its uses (``in3__r1``)
+    # emits an undeclared identifier (surfaced by DeepSeek-V4 post4096's two-cut piece).
+    deps_external = {nm for s in rloop.body.iter() for nm in s.deps()} - defined
     protected = frozenset(
-        {axis.name, *(ax.name for ax in grid), *axis.extent_expr().free_vars(), *nested_axes, *expr_external}
+        {axis.name, *(ax.name for ax in grid), *axis.extent_expr().free_vars(), *nested_axes, *expr_external, *deps_external}
         | ({lane.name} if lane is not None else set())
     )
     # A twisted fold's masked tail clamps the STREAMED VALUE to the pivot fold's identity

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_cut.py
@@ -15,6 +15,31 @@ from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams, out
 PATTERN = [Pattern("root", TileOp)]
 
 
+def _seam_index(seams) -> dict[int, object]:
+    """``id(node) -> seam`` over every seam node AND its clustered siblings — a duplicate cone
+    folded into a cluster seam stays addressable: any member names the one shared decision."""
+    return {id(node): seam for seam in seams for node in (seam.node, *(sibling for sibling, _ in seam.siblings))}
+
+
+def _with_required(chosen, by_node: dict[int, object], refuse: frozenset = frozenset()) -> tuple:
+    """``chosen`` expanded with every transitively required producer seam — the ONE composition
+    walk the pin path and the unpinned fork share, so a dependent seam is the same composed
+    decision however it is reached. The requirement is structural (the dependent's piece reads
+    the producer's workspace), not a choice either route can decline; a requirement landing on a
+    ``refuse`` spelling (a pinned fuse) raises the contradiction."""
+    out = list(chosen)
+    queue = list(out)
+    while queue:
+        for _, producer in queue.pop().requires:
+            required = by_node[id(producer)]
+            if required.spelling in refuse:
+                raise ValueError(f"PLACE pins fuse {required.spelling!r}, the producer a pinned dependent cut requires")
+            if not any(member is required for member in out):
+                out.append(required)
+                queue.append(required)
+    return tuple(out)
+
+
 def _pin(tile: TileOp, seams) -> tuple[tuple, str, bool] | None:
     """The authoritative placement the live PLACE pins spell for THIS kernel, or ``None``.
 
@@ -34,9 +59,7 @@ def _pin(tile: TileOp, seams) -> tuple[tuple, str, bool] | None:
         if value not in {"fuse", "cut"}:
             raise ValueError(f"bad PLACE value {value!r}; expected 'fuse' or 'cut'")
     all_sites = sites(tile.op)
-    # A duplicate cone folded into a cluster seam stays addressable: pinning any
-    # member's site names the one shared decision.
-    by_node = {id(node): seam for seam in seams for node in (seam.node, *(sibling for sibling, _ in seam.siblings))}
+    by_node = _seam_index(seams)
     cut: list = []
     fused: list[str] = []
     missing = False
@@ -56,17 +79,7 @@ def _pin(tile: TileOp, seams) -> tuple[tuple, str, bool] | None:
         elif not any(chosen is seam for chosen in cut):
             cut.append(seam)
     cut = [seam for seam in cut if seam.spelling not in fused]
-    # A dependent seam's producers join the composed decision transitively: the requirement is
-    # structural (its piece reads the producer's workspace), not a choice a pin can decline.
-    queue = list(cut)
-    while queue:
-        for _, producer in queue.pop().requires:
-            required = by_node[id(producer)]
-            if required.spelling in fused:
-                raise ValueError(f"PLACE pins fuse {required.spelling!r}, the producer a pinned dependent cut requires")
-            if not any(chosen is required for chosen in cut):
-                cut.append(required)
-                queue.append(required)
+    cut = list(_with_required(cut, by_node, refuse=frozenset(fused)))
     if cut:
         return tuple(cut), "cut", True
     if fused:
@@ -119,13 +132,23 @@ def rewrite(match: Match, root: Node, ctx=None):
         )
 
     options = [DeferredFork(lambda: replace(tile, placement_decided=True), {"PLACE": "fuse"})]
+    # One structural arm per PRINCIPAL closure: a seam plus its transitively required producers,
+    # composed exactly as the pin path composes them (`_with_required`), so the evidence-driven
+    # route through a dependent seam is on the ballot — DeepSeek-V4 post4096's only working
+    # placement (33,000,000x fewer worst per-thread trips) was a dependent seam's closure, which
+    # the previous plain-only fork could never offer. Two seams whose closures coincide are one
+    # arm; a plain seam's closure is itself, so the plain arms are unchanged.
+    by_node = _seam_index(seams)
+    closures: dict[frozenset[str], tuple] = {}
+    for seam in seams:
+        closure = _with_required((seam,), by_node)
+        closures.setdefault(frozenset(member.spelling for member in closure), closure)
     options.extend(
-        # Provider-closed and dependent seams stay OUT of the unpinned fork: every kernel and
-        # every fresh piece hosts some (the piece copies its providers), so offering them makes
-        # recursive placement inexhaustible and the candidate walk explodes. A route through them
-        # is spelled by scoped pins, which realize every member in one composed decision.
-        DeferredFork(lambda seam=seam: realize(match, root, (seam,), renamed), {seam.spelling: "cut"}, structural=True)
-        for seam in seams
-        if not (seam.providers or seam.requires)
+        DeferredFork(
+            lambda closure=closure: realize(match, root, closure, renamed),
+            {member.spelling: "cut" for member in closure},
+            structural=True,
+        )
+        for closure in closures.values()
     )
     return options

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -20,7 +20,15 @@ from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
-from emmy.compiler.ir.pure.fold import Fold, _expectation_bindings, _operand_result_names, deep_defines, deep_reads, is_contraction
+from emmy.compiler.ir.pure.fold import (
+    Fold,
+    _expectation_bindings,
+    _operand_result_names,
+    deep_defines,
+    deep_reads,
+    is_contraction,
+    loaded_buffers,
+)
 from emmy.compiler.ir.stmt import Assign, Body, Load, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.ops import edge_dtypes
@@ -212,12 +220,27 @@ def _environments(root: Fold) -> dict[int, list[tuple[Fold, ...]]]:
     def visit(node: Fold, outer: tuple[Fold, ...]) -> None:
         inner = (node, *outer)
         for child in (*node.operands, *node.lift.body):
-            if isinstance(child, Fold):
-                environments.setdefault(id(child), []).append(inner)
-                visit(child, inner)
+            for stored in _stored_folds(child):
+                environments.setdefault(id(stored), []).append(inner)
+                visit(stored, inner)
 
     visit(root, ())
     return environments
+
+
+def _stored_folds(member):
+    """``member`` itself when it is a Fold, else every Fold stored in its nested bodies.
+
+    A plain statement binds axes, not SSA definitions, so it is not a resolution scope — but it can
+    HOLD a stored fold (a ``ProjectionRegion`` keeps its cones), and one reached only that way had
+    no environment at all, which drops its seam. ``_tree.walk`` alternates node-wise and
+    statement-wise for the same reason."""
+    if isinstance(member, Fold):
+        yield member
+        return
+    for body in member.nested():
+        for stmt in body:
+            yield from _stored_folds(stmt)
 
 
 def _closed_in(node: Fold, environment: tuple[Fold, ...], axis_names: set[str]) -> tuple[tuple, tuple] | None:
@@ -294,6 +317,23 @@ def _provider_closure(node: Fold, scopes, environments: list[tuple[Fold, ...]]) 
     return first_providers, first_requires
 
 
+def _dtype_table(tile: TileOp) -> dict[int, tuple]:
+    """Each stored edge's inferred result dtypes, typed in its own lexical scope — and only where
+    every occurrence agrees.
+
+    ``edge_dtypes`` keys its cache by edge identity AND the dtypes of that occurrence's captures,
+    because one shared cone under two scopes has two answers. A seam stands for ONE value, so a
+    node whose occurrences disagree has no determined workspace and simply does not appear here;
+    :func:`_workspace_dtypes` then declines to offer it, which is the same answer provider closure
+    gives when the occurrences spell different sources."""
+    cache: dict[tuple, tuple] = {}
+    edge_dtypes(tile.op, tile.inputs, cache)
+    answers: dict[int, set[tuple]] = {}
+    for (node_id, _captures), dtypes in cache.items():
+        answers.setdefault(node_id, set()).add(dtypes)
+    return {node_id: next(iter(seen)) for node_id, seen in answers.items() if len(seen) == 1}
+
+
 def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     """Every semantically closed stored Fold edge whose workspace dtypes are determined, grouped
     only by object sharing. A contraction's operand edges are seams too — cutting one materializes
@@ -327,7 +367,7 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     dtype_table: dict[int, tuple] = {}
     if isinstance(tile.op, Fold):
         environments = _environments(tile.op)
-        edge_dtypes(tile.op, tile.inputs, dtype_table)
+        dtype_table = _dtype_table(tile)
     out: list[CutSite] = []
     seen: set[int] = set()
     for site in family_sites("PLACE", all_sites):
@@ -379,6 +419,14 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     return _cluster_value_seams(out, {id(seam.node): seam.frontier is None and store_dtype_consumers.get(id(seam.node)) for seam in out})
 
 
+def _closure_key(seam: CutSite) -> tuple:
+    """What a seam closes over, as a comparable value: its provider stmts and the SOURCES its
+    requirements name. Two cones can be alpha-equivalent and still read different sources — a
+    capture is a free name, and one host may define ``x = sum(a)`` where the other defines
+    ``x = sum(b)`` — so the closure is part of the value, and clustering compares it."""
+    return (seam.providers, tuple((name, id(producer)) for name, producer in seam.requires))
+
+
 def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) -> tuple[CutSite, ...]:
     """Fold duplicate operand cones — alpha-equivalent up to captured axis names — into ONE seam per value.
 
@@ -391,7 +439,13 @@ def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) ->
     (:func:`~emmy.compiler.ir.pure.closure.equivalent_clusters`); a member joins only when its
     paired axes agree on extent and window, its workspace dtypes match, and every workspace axis
     is a mapped capture — otherwise it stays its own seam."""
-    eligible = [index for index, seam in enumerate(seams) if operand_of.get(id(seam.node))]
+    # A seam ANOTHER seam requires never joins a cluster, as representative or as member. A
+    # dependent's piece reads its producer's workspace by the name that producer binds, and
+    # clustering re-points a value at the representative — whose result names are its own. Leaving
+    # a required producer alone keeps the requirement pointing at a seam that still exists and
+    # still binds the name the dependent reads.
+    required = {id(producer) for seam in seams for _, producer in seam.requires}
+    eligible = [index for index, seam in enumerate(seams) if operand_of.get(id(seam.node)) and id(seam.node) not in required]
     if len(eligible) < 2:
         return tuple(seams)
     scoped = {index: Closure.over_edge(seams[index].node, tuple(axis.name for axis in seams[index].axes)) for index in eligible}
@@ -411,9 +465,13 @@ def _cluster_value_seams(seams: list[CutSite], operand_of: dict[int, object]) ->
             member = seams[member_index]
             member_params = scoped[member_index].axes
             member_axes = {axis.name: axis for axis in member.axes}
-            aligned = member.dtypes == rep.dtypes and all(
-                (a := rep_axes[rn]).extent == (b := member_axes[mn]).extent and a.window == b.window
-                for rn, mn in zip(rep_params, member_params, strict=True)
+            aligned = (
+                member.dtypes == rep.dtypes
+                and _closure_key(member) == _closure_key(rep)
+                and all(
+                    (a := rep_axes[rn]).extent == (b := member_axes[mn]).extent and a.window == b.window
+                    for rn, mn in zip(rep_params, member_params, strict=True)
+                )
             )
             if not aligned:
                 continue
@@ -472,7 +530,14 @@ def _workspace_axes(seam: CutSite, produced: Fold) -> tuple:
 
 
 def _piece_inputs(root: Node, fold: Fold, first: tuple[str, ...] = ()) -> list[str]:
-    reads = {load.input for load in Body.coerce(fold.lower()).loads}
+    """A piece's graph inputs: its workspaces, then every buffer of ``root``'s the piece reads.
+
+    The read set is the STORED tree's (:func:`loaded_buffers`), not the lowered body's, because the
+    kernel this node becomes is materialized from that tree. A Fold a region keeps as a term hides
+    its operand edges from a lowered-body walk, so declaring the lowered view named fewer inputs
+    than the kernel went on to read; the workspace producers then had no consumer edge, were pruned
+    as orphans, and the launch asked for a buffer nothing had allocated."""
+    reads = loaded_buffers(fold)
     return [*first, *(name for name in root.inputs if name in reads)]
 
 
@@ -517,7 +582,7 @@ def _producer_order(pieces) -> list:
     ordered = []
     available: set[str] = set()
     while remaining:
-        ready = [piece for piece in remaining if {load.input for load in Body.coerce(piece[1].lower()).loads} & workspaces <= available]
+        ready = [piece for piece in remaining if loaded_buffers(piece[1]) & workspaces <= available]
         assert ready, "strict Fold containment makes the cut-workspace dependency graph acyclic"
         ordered.extend(ready)
         available.update(buffer for *_, buffers in ready for buffer in buffers)
@@ -565,7 +630,14 @@ def realize(
                 producer_loads = workspace_loads.get(id(producer))
                 if producer_loads is None:
                     raise ValueError(f"seam {seam.spelling!r} requires {name!r} from a producer seam absent from this composed cut")
-                prefix.extend(load for load in producer_loads if isinstance(load, Load) and name in load.defines())
+                # Whatever binds the name, taken by the name it BINDS: a plain workspace ``Load``,
+                # or — when the producer cut at a storage frontier — the projection wrapping the
+                # raw load and its decode residue. Matching on ``Load`` alone skipped the frontier
+                # form and left the requirement unbound in the piece.
+                supplied = [entry for entry in producer_loads if name in _operand_result_names(entry)]
+                if not supplied:
+                    raise ValueError(f"seam {seam.spelling!r} requires {name!r}, which its producer seam does not bind")
+                prefix.extend(supplied)
             produced = Fold.projection(body=Body((*prefix, produced)), results=names)
         axes = _workspace_axes(seam, produced)
         index = tuple(Var(axis.name) for axis in axes)
@@ -621,7 +693,7 @@ def realize(
         producer = replace(producer, knobs=consume_kernel_row(producer.knobs))
         shape = tuple(axis.extent for axis in axes)
         workspace_tensors = tuple(Tensor(name=buffer, shape=shape, dtype=dtype) for buffer, dtype in zip(buffers, seam.dtypes, strict=True))
-        reads = {load.input for load in Body.coerce(produced.lower()).loads}
+        reads = loaded_buffers(produced)
         fragment.add_node(
             op=producer,
             inputs=_piece_inputs(root, produced, tuple(buffer for buffer in all_buffers if buffer in reads)),

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -768,8 +768,9 @@ def _reduce_catalog(state: _State, extent: int) -> list[ReducePlan]:
 
 def _reduce_moves(state: _State, node, key: str | None) -> list[ReducePlan]:
     """The reduce partitions this fold offers: the serial fold plus every :func:`coop_reduce_moves`
-    band the node admits — an observed fold (a scan), and a fold whose cone reads a boundary
-    store's sweep axis, offer exactly the serial fold — or, under a ``REDUCE`` pin, the ONE
+    band the node admits — an observed fold (a scan), a fold whose cone reads a boundary
+    store's sweep axis, and any fold under a chain-form root (a zero-axis projection with no
+    operand edges) offer exactly the serial fold — or, under a ``REDUCE`` pin, the ONE
     partition that pin names, read
     against the kernel's pinned inventory (the ``coop`` token's width lives in ``WORK``). A pin is
     authoritative over the value; it cannot make a band this node has no geometry for legal, and
@@ -810,6 +811,25 @@ def _reduce_moves(state: _State, node, key: str | None) -> list[ReducePlan]:
                 f"sweep axis {swept[0]!r} — the sweep loop must enclose the whole reduce, so only the "
                 f"serial fold realizes"
             )
+        return [ReducePlan()]
+    root = state.tile.op
+    if isinstance(root, Fold) and root.axis is None and not root.operands:
+        # The chain form — a zero-axis root with no operand edges (a sweep-reading or body-FED
+        # member the normalize hoist must keep in place) — binds without a peel: the materializer
+        # emits the whole body in order through the schedule-blind body recursion, so no fold
+        # under it can realize a cooperative/ILP partition. Same contract as the swept branch:
+        # only the serial fold is offered, and a pin naming one is a recorded refusal, never a
+        # silent drop. The cross-CTA ``g`` half stays the split fork's decision — a split piece IS
+        # a chain-form root carrying its captured prologue, so the pin resolves through the
+        # ordinary receipt consumption first and only a SURVIVING partition refuses.
+        if pin is not None:
+            plan = _parsed_reduce_pin(state, pin, key)
+            if plan.stages:
+                raise PinRefused(
+                    f"REDUCE pin {pin!r} at {key or 'REDUCE'} names a partition, but this kernel's root binds "
+                    f"its projection body whole — a chain-form member realizes only the serial fold"
+                )
+            return [plan]
         return [ReducePlan()]
     if pin is None:
         return _reduce_catalog(state, extent)

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -31,15 +31,28 @@ degenerates to the enumeration's first leaf, which carries no meaning and can
 be arbitrarily slow. That is the accepted cost of the rule, not a defect to
 patch: a bad unmeasured pick is fixed by measuring (a tune, a recorded golden)
 or by fitting the prior better, never by teaching this module a preference.
+
+**A measurement can also DISQUALIFY.** The three tiers above all RANK, and a
+ranking needs a latency — which a ``bench_fail`` row does not have, only the
+watchdog's timeout sentinel. Those rows are still a recording of something that
+ran (or failed to), so they are read, but as an elimination rather than a score:
+where every measured variant of one structural signature failed, a slice
+containing that kernel prices ``inf`` (:func:`_resolved_price`) and any
+structural arm holding it loses the kernel-set argmin. Still evidence, still no
+preference — the alternative is that an all-failed kernel has no ``ok`` row,
+therefore no evidence at all, and falls through to the prior as though nothing
+were known about it. That is how DeepSeek-V4's post block kept a fused arm whose
+every benched variant hung.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Callable
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from emmy.compiler.graph import Graph
 from emmy.compiler.pipeline.fork import Fork, flatten_leaves, iter_leaves, leaf_knobs
@@ -194,8 +207,15 @@ def _decision_key(fp: ForkPoint, blocked: dict | None) -> tuple | None:
     )
 
 
-def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior) -> float | None:
+def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: dict | None = None) -> float | None:
     """Σ over a resolved slice's kernels of each one's estimated µs — the ONE cost rule.
+
+    ``failed`` is the measured DISQUALIFICATION (:class:`_Measured`): the structural signatures
+    whose every benched variant failed. A slice containing one prices ``inf``, so a structural arm
+    holding a kernel the tune watched hang loses the argmin to any arm that does not. That is not
+    a preference, it is the measurement — and without it those rows are invisible at deploy,
+    because the ranking index carries ``ok`` rows only, so an all-failed kernel has NO evidence
+    and falls through to the prior.
 
     Per kernel: the price the resolution's own fork stamped (the winning leaf's µs, which the
     deploy evidence hierarchy chose), or — where the trace carries no score for it: a decide that
@@ -220,6 +240,11 @@ def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior) -> float 
     for nid, node in terminal.nodes.items():
         if node.op.identity_key(with_io=True, with_knobs=True) is None:
             continue
+        if failed:
+            knobs = getattr(node.op, "knobs", None) or {}
+            sig = frozenset((k, str(v)) for k, v in knobs.items() if k.startswith("S_"))
+            if _sig_groups(failed, sig):
+                return math.inf
         us = scored.get(nid)
         if us is None:
             rows = [{**ctx.features(), **(getattr(node.op, "knobs", None) or {})}]
@@ -263,7 +288,8 @@ def _price_kernel(
 
             ctx = _replace(ctx, kernel_cache=None)  # a replayed kernel offers no fork to price
         terminal, trace = Run(pipeline=_tile_pipeline(), ctx=ctx).resolve(single_node_graph(graph, nid), nested)
-        us = _resolved_price(terminal, trace, ctx, prior)
+        failed = _db_measured_index(db, ctx).failed if db is not None else None
+        us = _resolved_price(terminal, trace, ctx, prior, failed=failed)
     except Exception:  # noqa: BLE001 — a price-probe failure must never break compile
         us = None
     memo[key] = us
@@ -352,7 +378,7 @@ def _priced_pick(
 _DB_INDEX_CACHE: dict = {}
 
 
-def _db_measured_index(db, ctx) -> dict[frozenset, list[tuple[dict, float]]]:
+def _db_measured_index(db, ctx) -> _Measured:
     """Caching wrapper over :func:`_db_measured_index_build` — memoizes the built
     index per process on ``(db path, mtime, context keys)``, invalidated when the
     DB file's mtime changes. An in-memory DB (no ``_path``) or an unstatable file
@@ -380,23 +406,49 @@ def _db_measured_index(db, ctx) -> dict[frozenset, list[tuple[dict, float]]]:
     return index
 
 
-def _db_measured_index_build(db, ctx) -> dict[frozenset, list[tuple[dict, float]]]:
-    """The tune DB's measured ``ok`` CUDA perf rows for this compile's regime.
+class _Measured(NamedTuple):
+    """One DB scan's two answers, because the scan is expensive and both come from the same rows.
+
+    ``ok`` RANKS — the measured rows a pick argmins over. ``failed`` DISQUALIFIES — the structural
+    signatures whose every measured variant failed, which is a different kind of answer and cannot
+    be expressed as a latency: a watchdog kill has no meaningful µs to rank with, only a sentinel."""
+
+    ok: dict[frozenset, list[tuple[dict, float]]]
+    failed: dict[frozenset, list[float]]
+
+
+def _db_measured_index_build(db, ctx) -> _Measured:
+    """The tune DB's measured CUDA perf rows for this compile's regime, split into what ranks and
+    what disqualifies.
 
     Rows are indexed by their ``S_*`` structural signature (stringified values because perf knobs
     round-trip JSON). One context key is sufficient: tune measures in the deployable regime, and
     ``Context.structural_key`` gives that regime one key however its flags are spelled. Rows from a
     deliberately non-deployable compile key elsewhere and are not consulted.
 
+    A non-``ok`` row is evidence too — the bench watchdog measured that variant not finishing — but
+    it is evidence a ranker cannot use, since its sentinel latency is a timeout constant rather
+    than a speed. It lands in ``failed`` instead, and only where NO variant of that signature was
+    measured ``ok``: one surviving row means the shape is realizable and merely has bad rows.
+    Failures are collected BEFORE the placement-route filter below, because a route's latency is
+    unattributable without a child-schedule receipt while a kernel that hung is attributable to
+    the kernel whatever route produced it.
+
     Best-effort: any failure returns an empty index so deploy falls back to the prior.
     """
 
     index: dict[frozenset, list[tuple[dict, float]]] = {}
+    survived: set[frozenset] = set()
+    failures: dict[frozenset, list[float]] = {}
     try:
         for row in db.iter_perf(ctx.structural_key(), backend="cuda"):
-            if row.status != "ok" or row.stats.median <= 0:
-                continue
             sig = frozenset((k, str(v)) for k, v in row.knobs.items() if k.startswith("S_"))
+            if row.status != "ok":
+                failures.setdefault(sig, []).append(float(getattr(row.stats, "median", 0.0) or 0.0))
+                continue
+            survived.add(sig)
+            if row.stats.median <= 0:
+                continue
             tun = {k: str(v) for k, v in row.knobs.items() if not k.startswith(("S_", "H_"))}
             # A placement route's latency belongs to the exact ordered child schedule tree that
             # ran. The perf schema carries no such receipt, so legacy route rows cannot be direct
@@ -405,8 +457,8 @@ def _db_measured_index_build(db, ctx) -> dict[frozenset, list[tuple[dict, float]
                 continue
             index.setdefault(sig, []).append((tun, float(row.stats.median)))
     except Exception:  # noqa: BLE001 — a DB consult failure must never break compile
-        return {}
-    return index
+        return _Measured({}, {})
+    return _Measured(index, {sig: us for sig, us in failures.items() if sig not in survived})
 
 
 def _sig_groups(index: dict[frozenset, list[tuple[dict, float]]], sig: frozenset) -> list[list[tuple[dict, float]]]:
@@ -1002,7 +1054,7 @@ def greedy_decide(
     verified_state: list = [None]
 
     def db_index() -> dict:
-        return db_state[0] or {}
+        return (db_state[0].ok if db_state[0] is not None else None) or {}
 
     def decide(fp: ForkPoint) -> object:
         nonlocal loaded, the_prior

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -243,7 +243,14 @@ def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: d
         if failed:
             knobs = getattr(node.op, "knobs", None) or {}
             sig = frozenset((k, str(v)) for k, v in knobs.items() if k.startswith("S_"))
-            if _sig_groups(failed, sig):
+            # EXACT signature, deliberately not the drift-tolerant :func:`_sig_groups` the ranking
+            # tier uses. There, a loose match only widens the candidate pool and a second filter
+            # (``evidence_row_vouches``) still has to agree on the tunable knobs; here there is no
+            # second filter, so agreeing on merely the SHARED keys would condemn every shape that
+            # happens not to contradict one recorded failure — measured on DeepSeek-V4's post
+            # block, where it priced all 17 leaves of a fork ``inf`` and thereby decided nothing.
+            # An elimination must fail safe: a failure condemns the shape that was measured.
+            if sig in failed:
                 return math.inf
         us = scored.get(nid)
         if us is None:

--- a/emmy/compiler/pipeline/search/policy/terminal_bench.py
+++ b/emmy/compiler/pipeline/search/policy/terminal_bench.py
@@ -269,15 +269,16 @@ class TerminalBench:
             )
             return self._point_stats(0.0), "compile_timeout"
         fail_us = float(self.backend.bench_run_timeout_s) * 1_000_000.0
+        blamed = self._blamed(exc)
         logger.warning(
-            "[tune] backend.benchmark failed (%s) — pinning bench_fail @ %.1f us for %d kernel(s)",
+            "[tune] backend.benchmark failed (%s) — pinning bench_fail @ %.1f us for %d of %d kernel(s)",
             exc,
             fail_us,
+            len(blamed),
             len(self.cuda_nodes),
         )
         s = self._point_stats(fail_us)
         agg = None
-        blamed = self._blamed(exc)
         for node in self.cuda_nodes:
             if id(node) in blamed:
                 self._persist(node.op, stats=s, status="bench_fail", error=f"{type(exc).__name__}: {exc}")

--- a/emmy/compiler/pipeline/search/policy/terminal_bench.py
+++ b/emmy/compiler/pipeline/search/policy/terminal_bench.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import statistics
 
 from emmy.compiler.backend.cuda.program import compile_budget_overrun
@@ -52,6 +53,31 @@ class TerminalBench:
         #: fork made it several, they hold DIFFERENT rows and there is no single row to attribute
         #: the total to. Each kernel carries its own decisions and earns its own sample.
         self.per_kernel: list[tuple[dict, float, str]] = []
+
+    #: The kernel a watchdog message NAMES — ``kernel 'k_foo (iter 0)' did not complete …``. The
+    #: exception class does not survive the bench worker's pipe (it arrives wrapped in a
+    #: ``BenchWorkerJobError``), so the label is recovered from the text.
+    _NAMED_KERNEL = re.compile(r"kernel '([A-Za-z_][A-Za-z0-9_]*)")
+
+    def _blamed(self, exc) -> set[int]:
+        """``id()``s of the nodes a failure is EVIDENCE ABOUT — usually not every kernel benched.
+
+        A terminal benches many kernels together and one of them hanging fails the whole run, so
+        blaming all of them records a failure for kernels that were never shown to fail. That is
+        not a cosmetic mislabel: those rows are read as deploy evidence, and on DeepSeek-V4's post
+        block 70 recorded failures carried only 7 distinct errors — 20 kernels condemned by one
+        hang, and 21 by a bench-worker startup timeout that is not a property of any kernel.
+
+        So blame is recorded only where it is unambiguous: the kernel the watchdog named, or the
+        single kernel of a one-kernel terminal. Otherwise nothing is persisted — the run failed,
+        but which kernel failed is unknown, and unknown is not the same as failed. The terminal
+        still reports ``bench_fail`` either way, so the search treats the candidate as failed and
+        moves on; only the durable per-kernel evidence is narrowed to what was actually observed."""
+        named = self._NAMED_KERNEL.search(str(exc))
+        if named is not None:
+            culprit = named.group(1)
+            return {id(n) for n in self.cuda_nodes if getattr(n.op, "kernel_name", "") == culprit}
+        return {id(self.cuda_nodes[0])} if len(self.cuda_nodes) == 1 else set()
 
     def _note(self, op, stats, status: str) -> None:
         self.per_kernel.append((dict(getattr(op, "knobs", None) or {}), float(stats.median), status))
@@ -251,9 +277,11 @@ class TerminalBench:
         )
         s = self._point_stats(fail_us)
         agg = None
+        blamed = self._blamed(exc)
         for node in self.cuda_nodes:
-            self._persist(node.op, stats=s, status="bench_fail", error=f"{type(exc).__name__}: {exc}")
-            self._note(node.op, s, "bench_fail")
+            if id(node) in blamed:
+                self._persist(node.op, stats=s, status="bench_fail", error=f"{type(exc).__name__}: {exc}")
+                self._note(node.op, s, "bench_fail")
             agg = self._accumulate(agg, s)
         return agg or self._point_stats(0.0), "bench_fail"
 

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -73,10 +73,12 @@ CUDA-12 `libnvrtc` preload only if that probe fails, using the path present in t
 - The emmy wheel + `cupy-cuda12x` install into the image cleanly beside vLLM's pins, and `emmy.serving.register` is
   importable there.
 
-## Stage 0 — unblock the twins (compiler; hard prerequisite) — **REOPENED; `pre16` blocks serving on current main**
+## Stage 0 — unblock the twins (compiler; hard prerequisite) — **all three twins COMPILE; `post4096` RUNTIME blocks**
 
 The first round closed (2026-08-25, below). Loop fusion was then rewritten under it, and the same class of pathology
-came back on both twins — see "Round two" after the original diagnosis.
+came back on both twins ("Round two"). Round two is now closed too — `pre16` runs in 8.18 s and `post4096` compiles,
+builds and launches — but round three found the remaining blocker one layer down: the plan the greedy selects for
+`post4096` contains a serially-impractical kernel, so a boot still stalls in the first prefill forward.
 
 ### Round one — the `post` twin (2026-08-25) — closed
 
@@ -114,33 +116,58 @@ does not inherit the workaround and dies with "invalid value for --gpu-architect
 must run inside the 1Cat image (NVRTC 12.9 native, verified) or in a venv without the NVRTC-13 pin. The inventory is
 untuned (no knobs or timings) and is therefore NOT promoted to the canonical path; it regenerates in ~60 s.
 
-### Round two — fusion rewritten under the twins (2026-08-28/29) — `post` closed, `pre` OPEN
+### Round two — fusion rewritten under the twins (2026-08-28/29) — CLOSED
 
 **Make loop fusion maximal and multi-output (#648, `bff3e3444`) landed after gate (c) passed** and broke both remaining
-twins. Two of the three defects are fixed; the third blocks serving on current main.
+twins. All three defects are now fixed:
 
 | twin | at `ab1ad4592` (pre-#648) | at `bff3e3444` (#648) | now |
 | --- | --- | --- | --- |
 | `expert16` | compiles | 11 same-scope redeclarations, nvcc rejects | fixed by #671 |
 | `post16` | compiles | lowering never terminates | fixed by #676, ~57 s on the V100 |
-| `pre16` | 3 kernels, 0.001 s | 1 kernel, never returns | **OPEN** |
+| `pre16` | 3 kernels, 0.001 s | 1 kernel, never returns | fixed; **8.18 s verified at main+#692** |
 
-`pre16` lowers to a single kernel holding two 4-deep nests, each `a2<4096 × a3<4 × a4<16384 × a1<16384` ≈ 4.4 × 10¹²
-iterations per thread. The inner `a1` reduce is the loop-invariant RMSNorm sum-of-squares, recomputed under the full
-crossed product instead of once. Re-measured on `324ebfe93` (#684): unchanged, so #682/#683/#684 do not address it.
+`pre16` lowered to a single kernel recomputing the loop-invariant RMSNorm sum-of-squares under a crossed product
+(≈ 4.4 × 10¹² iterations/thread) because `_close_projection` sank the sibling reduce into a nested contraction's
+evaluation domain. The fix needed provider closure generalized from "direct body-member host" to lexical environments
+for every `Fold` occurrence, so an operand-edge capture closes into a dependent seam (`CutSite.requires`) — landed via
+#682 (provider-closed statistics seams) and #688 (one scoped-lambda `Closure` concept); the residual placement-cut
+correctness bugs ride #692 (also PR #686's standalone form). Re-verified 2026-08-31 on `claude/attr-v100`
+(main + #692): `pre16` builds 1 kernel and `run_once` returns in 8.182 s.
 
-Localized: Loop IR is correct through stages 04–06 (the reduce is a sibling); Tile IR stage 07 sinks it into an operand
-edge at depth 4, in `_close_projection` (`emmy/compiler/ir/tile/normalize.py`). A scope guard refusing to attach a
-provider beneath a fold binder takes `pre16` from never-returning to **8.192 s on the V100**, but regresses 7
-`attention/*.yaml` realization cases: with the guard the statistics cone stays an operand-edge capture, and `_cut.py`
-records seam hosts only for direct lift-body members, so the capture is hostless and its seam is silently dropped.
-Closing it needs provider closure generalized from "direct body-member host" to lexical environments for every `Fold`
-occurrence, so an operand-edge capture closes into a dependent seam (`CutSite.requires`). WIP, explicitly not for merge:
-branch `fix/close-projection-multiplicity`.
+### Round three — `post4096`'s placement (2026-08-30/31) — compile CLOSED by #692, runtime OPEN
 
-**Consequence for the stages below.** Gate (c) passed at `ab1ad4592` and does NOT reproduce on current main — a boot
-there stalls in the first kernel that executes (observed: 2 h 37 min, no progress). Stage 4 cannot warm or bake until
-`pre16` compiles to something executable.
+With `pre16` fixed, the TP8×PP2 boot got past compile and died in whole-program capture on a cut-workspace
+`KeyError`; fixing that (piece inputs declared from the lossy lowered view — `loaded_buffers` is the honest reader)
+exposed the real problem: `post4096`'s fused monster `k_linear_softmax_matmul_mean_reduce_3052e1` does **2⁵⁵ worst
+per-thread serial trips** (`block_threads=1`) — the recomputation blowup of maximal fusion — and no evidence could
+steer placement away from it. PR #692 fixes the whole chain, each step verified on the host:
+
+- **Attribution**: one hang condemned every kernel in the terminal (70 failures / 7 distinct errors); the watchdog
+  names the culprit, so only that kernel earns the `bench_fail` row (re-tune: 15/15 rows correct).
+- **Disqualification**: a kernel whose every measured variant failed prices its structural arm at `inf`, matched
+  exactly.
+- **The composed cut compiles**: the consumer piece's IR was scope-inverted (normalize hoisted a fold whose subtree
+  captures body-defined names; ILP replication renamed `deps()`-channel reads) — 17 nvcc errors → 0; the two-cut
+  plan builds and launches at 2³⁰ trips.
+- **The composed cut is on the ballot**: the unpinned fork offered plain seams only (2 of the monster's 33); now
+  every seam is offered with its transitive `requires` closure as one composed arm, and the feared recursion
+  explosion is measured convergent.
+
+**Measured (2026-08-31, V100): an unpinned `post4096` compile with clean attributed evidence selects a composed cut
+on its own — 52 kernels, worst 2³⁷ (was 2⁵⁵), placement terminating in 327 s.** Still not servable: 2³⁷ serial
+trips is hours per launch (the 2³⁰ two-cut variant ran 2.6 h without completing before being killed). Two named
+gaps stand between here and a boot that serves, both follow-ups to #692:
+
+1. **Partition the monster** — the selected route is serial (`block_threads=1`). The reduce tier must emit a
+   sibling-provider chain (the piece's workspace-rsqrt captures) ahead of a cooperative/ILP loop; today such folds
+   legally offer only the serial fold. This is where actual serving latency comes from.
+2. **Let evidence elect the deeper route** — a tune pass over the new ballot so composed arms carry measured
+   latencies (today the 2³⁷-vs-2³⁰ choice is prior-guessed), or the monotone serial-work prior feature.
+
+**Consequence for the stages below.** Gate (c) passed at `ab1ad4592` and still does not reproduce: a boot compiles
+but stalls in the first `post4096` prefill forward. Stage 4 cannot warm or bake until the partitioned route exists
+(gap 1 above), and the golden re-record should follow it, not precede it.
 
 ## Stage 1 — loader lane: read the published checkpoint (CPU-testable) — **DONE (#651)**
 
@@ -232,8 +259,9 @@ expert destinations, PP transport, and mixed scheduling — token IDs either agr
 
 ### Gate (c) — PASSED (2026-08-26, real checkpoint at TP8 × PP2, at `ab1ad4592`)
 
-**Does not reproduce on current main** — see Stage 0 round two. The result below stands as evidence that the seam,
-the loader and the plugin are correct; re-running it needs `pre16` to compile to something executable again.
+**Does not reproduce on current main** — see Stage 0 round three. The result below stands as evidence that the seam,
+the loader and the plugin are correct; re-running it needs `post4096`'s selected plan to be executable at serving
+speed (the partitioned composed-cut route).
 
 `deepseek-ai/DeepSeek-V4-Flash-0731` serves through `EmmyGenModel` on the 16× V100 SXM3 host, in the pinned 1Cat
 image, at TP8 × PP2 with `--max-model-len 4096 --kv-cache-dtype fp8 --block-size 256` and eager execution:
@@ -290,7 +318,7 @@ recorded expert program is the one serving binds.
 The golden re-record is NOT done: `golden/v100_sm70.yaml` is still the #558 recording from before any of this, so it
 covers the routed-expert kernels not at all and they resolve from reservoir/prior evidence instead. Correctness is
 unaffected, but Stage 4 must not warm, bake or seal until the re-record happens on the host — which is itself blocked
-behind Stage 0 round two.
+behind Stage 0 round three's runtime gap.
 
 ## Stage 4 — image + release plumbing
 
@@ -349,8 +377,10 @@ shows expert weight streaming dominates and the fused-unpack GEMM can plausibly 
 Stage −1: DONE (~2 h). Stage 0 round one: DONE (fixed upstream by #602). Stage 1: DONE (#651). Stage 2: DONE (#656).
 Stage 3 in-repo: DONE (#662); gate (c) passed once at `ab1ad4592`, gate (d)'s token-ID half with it.
 
-**Stage 0 round two is the critical path.** `expert16` and `post16` are closed (#671, #676); `pre16` is open and holds
-everything behind it. The measured guard says the fix works; landing it is the seam-machinery change described above —
-call it 2–5 days, and it lands in a subsystem three other PRs (#677/#678/#682) touched inside a week, so coordinate.
-Then Stage 4: 2–4 days on-host (re-run gate (c), re-record the golden, warm/bake/verify). Stage 5: 1–2 days.
-Adding stage 6 (MXFP4 + tuning) is a further 1–3 weeks. The compiler, not the fork ABI, is now the dominant uncertainty.
+**Stage 0 round three's runtime gap is the critical path.** All three twins compile (`expert16` #671, `post16` #676,
+`pre16` #682/#688, `post4096`'s placement #692 — merge #692, and close #686 as superseded by it). What holds
+everything behind it now is partitioning `post4096`'s composed-cut consumer: the reduce tier emitting a
+sibling-provider chain ahead of a cooperative/ILP loop — a scoped codegen capability, call it 2–5 days — plus a tune
+pass over the new placement ballot so evidence, not the prior, elects the route. Then Stage 4: 2–4 days on-host
+(re-run gate (c), re-record the golden, warm/bake/verify). Stage 5: 1–2 days. Adding stage 6 (MXFP4 + tuning) is a
+further 1–3 weeks. The compiler, not the fork ABI, remains the dominant uncertainty.

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -480,7 +480,7 @@ def test_structural_multi_cuda_proposal_keeps_ranking_and_nodes_without_parent_p
     lowering = reloaded_db.lookup_lowering(original_loop.identity_key(with_io=True, with_knobs=True))
     assert lowering is not None and lowering.child_key == fallback_key
     candidates = [{**live_features, **fallback}, {**live_features, **route}]
-    assert _db_measured_pick(_db_measured_index(reloaded_db, ctx), candidates) == (0, 153.45)
+    assert _db_measured_pick(_db_measured_index(reloaded_db, ctx).ok, candidates) == (0, 153.45)
     reloaded_db.close()
     persist_proposal_rankings(path, document, targets[0], rankings)
     reloaded, reloaded_targets = load_working_targets(path)

--- a/tests/compiler/ir/pure/test_loaded_buffers.py
+++ b/tests/compiler/ir/pure/test_loaded_buffers.py
@@ -1,0 +1,52 @@
+"""``loaded_buffers`` — every buffer a stored term reads, operand edges included."""
+
+from __future__ import annotations
+
+from emmy.compiler.dim import Dim
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.pure import Fold, Lambda
+from emmy.compiler.ir.pure.fold import loaded_buffers
+from emmy.compiler.ir.stmt import Assign, Body, Load
+from emmy.compiler.ir.tile.ir import ProjectionRegion
+
+
+def _region_holding_a_cone() -> Fold:
+    """A cone whose OPERAND edge loads ``ws``, kept as a TERM inside a ``ProjectionRegion``.
+
+    This is DeepSeek-V4 ``post4096``'s shape, minimized: repeated placement leaves the fused root
+    holding its cut cones inside output regions, and each cone reads its workspace through an
+    operand edge."""
+    source = Fold.projection(body=Body((Load(name="w", input="ws", index=(Var("j"),)),)), results=("w",))
+    cone = Fold.projection(operands=(source,), body=Body((Assign(name="c", op="relu", args=("w",)),)), results=("c",))
+    region = ProjectionRegion(axis=Axis("j", Dim(4)), lift=Lambda(params=("j",), body=Body((cone,)), results=("c",)))
+    return Fold.projection(body=Body((region, Assign(name="out", op="copy", args=("c",)))), results=("out",))
+
+
+def test_a_cone_kept_as_a_term_still_reports_its_operand_buffers() -> None:
+    """The lowered body cannot answer this, which is why the cut may not ask it.
+
+    ``Body.loads`` walks ``Stmt.nested()``, and a Fold's operand edges are not nested statements —
+    so a region that keeps its cone as a term hides every buffer beneath that edge. A cut that
+    declared the lowered view named fewer graph inputs than the kernel the materializer built from
+    the same tree went on to read; the workspace producers lost their only consumer edge, were
+    pruned as orphans, and the launch asked for a buffer nothing had allocated
+    (``KeyError: '<node>__place_<token>_0'`` on DeepSeek-V4's TP8xPP2 boot)."""
+    root = _region_holding_a_cone()
+
+    assert {load.input for load in Body.coerce(root.lower()).loads} == set()
+    assert loaded_buffers(root) == {"ws"}
+
+
+def test_loaded_buffers_reads_a_contraction_through_its_edges() -> None:
+    """A contraction's ``nested()`` is empty by design — its algebra IS its operand edges."""
+    from emmy.compiler.ir.pure import Channel
+
+    contraction = Fold.contraction(
+        k_axis=Axis("k", Dim(8)),
+        a=Load(name="av", input="x", index=(Var("m"), Var("k"))),
+        channels=(Channel(b=Load(name="bv", input="w", index=(Var("n"), Var("k"))), acc="acc"),),
+    )
+
+    assert contraction.nested() == ()
+    assert loaded_buffers(contraction) == {"x", "w"}

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -15,7 +15,7 @@ from emmy.compiler.ir.pure.closure import Closure, equivalent_clusters
 from emmy.compiler.ir.schedule import TilePlan
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
 from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
-from emmy.compiler.ir.tile.normalize import _share_common_cones
+from emmy.compiler.ir.tile.normalize import _share_common_cones, normalize_fold_tree
 from emmy.compiler.ir.tile.path import family_sites, sites
 from emmy.compiler.pipeline import Pipeline
 from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams
@@ -856,3 +856,43 @@ def test_total_lift_produces_canonical_contraction() -> None:
 
     assert tile.op.role is AxisRole.CONTRACTION
     assert tile.op.loop.role is AxisRole.CONTRACTION
+
+
+def _fed_chain_root(feed: bool) -> Fold:
+    """A zero-axis root whose body holds a scalar chain and a reduce; ``feed`` wires the reduce's
+    nested cone to CAPTURE the chain's result (the composed placement cut's consumer shape)."""
+    scale_arg = "v25" if feed else "left"
+    inner = Fold.projection(
+        operands=(Load(name="left", input="x", index=(Var("k"),)),),
+        body=Body((Assign(name="scaled", op="multiply", args=("left", scale_arg)),)),
+        results=("scaled",),
+    )
+    init, combine = M(ElementwiseImpl("add"), names=("acc",))
+    fold = Fold(
+        axis=Axis("k", Dim(8)),
+        operands=(inner,),
+        init=init,
+        lift=Lambda(params=("k", "scaled"), body=Body((Assign(name="acc__v", op="copy", args=("scaled",)),)), results=("acc__v",)),
+        combine=combine,
+    )
+    chain = (Load(name="ws", input="cutbuf", index=()), Assign(name="v25", op="rsqrt", args=("ws",)))
+    return Fold.projection(body=Body((*chain, fold)), results=("acc",))
+
+
+def test_a_body_fed_fold_is_never_hoisted_onto_an_operand_edge() -> None:
+    """A projection evaluates its operands before its scalar body, so a member fold whose SUBTREE
+    captures a body-defined name must stay a member — ``Closure(...).closed`` reads only the
+    fold's own lift and cannot see the nested capture. Hoisting it emitted every capture as an
+    undefined identifier at nvcc (DeepSeek-V4 post4096's two-cut consumer piece)."""
+    out = normalize_fold_tree(_fed_chain_root(feed=True))
+
+    assert not out.operands, "the fed fold must stay a body member"
+    assert any(isinstance(s, Fold) for s in out.lift.body)
+
+
+def test_an_unfed_closed_fold_still_hoists() -> None:
+    """The guard narrows by the capture alone: the same shape with the cone reading only its own
+    operand keeps the hoist (and the dead chain stays in the body for later passes to judge)."""
+    out = normalize_fold_tree(_fed_chain_root(feed=False))
+
+    assert any(isinstance(e, Fold) and e.axis is not None for e in out.operands), "an unfed closed fold hoists"

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -225,3 +225,32 @@ def test_iteration_variables_are_not_captures() -> None:
 
 
 # --- the projection binder ----------------------------------------------------------------------- #
+
+
+def test_a_shared_cone_is_typed_in_each_occurrence_scope() -> None:
+    """``edge_dtypes`` answers per OCCURRENCE, not per object.
+
+    Normalization shares one Fold object between structurally identical cones, so the same cone
+    can sit under an f16 capture in one host and an f32 capture in another. Its result dtype is a
+    property of the occurrence, and a cache keyed on identity alone handed every occurrence the
+    first one's answer — which a cut then believes when it sizes the seam's workspace."""
+    from emmy.compiler.dtype import get as get_dtype
+    from emmy.compiler.ir.tile.ops import edge_dtypes
+    from emmy.compiler.tensor import Tensor
+
+    shared = Fold.projection(body=Body((Assign(name="y", op="relu", args=("x",)),)), results=("y",))
+    inputs = {"a": Tensor("a", (4,), get_dtype("f16")), "b": Tensor("b", (4,), get_dtype("f32"))}
+
+    def host(buf: str, out: str) -> Fold:
+        source = Fold.projection(body=Body((Load(name="x", input=buf, index=(Var("i"),)),)), results=("x",))
+        return Fold.projection(operands=(source, shared), body=Body((Assign(name=out, op="copy", args=("y",)),)), results=(out,))
+
+    # Both hosts stay referenced for the whole check: the cache keys on object identity, which is
+    # only stable while the keyed objects are alive.
+    narrow_host, wide_host = host("a", "z0"), host("b", "z1")
+    cache: dict = {}
+    narrow = edge_dtypes(narrow_host, inputs, cache)
+    wide = edge_dtypes(wide_host, inputs, cache)
+
+    assert [dtype.name for dtype in narrow] == ["f16"]
+    assert [dtype.name for dtype in wide] == ["f32"]

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -668,3 +668,25 @@ def test_a_required_producer_keeps_its_own_seam() -> None:
 
     assert any(seam.node is producer.node for seam in kept), "the required producer must survive as its own seam"
     assert not any(sibling is producer.node for seam in kept for sibling, _ in seam.siblings)
+
+
+def test_a_dependent_seam_is_an_unpinned_composed_arm() -> None:
+    """The unpinned fork offers a dependent seam WITH its transitive producer closure — one arm,
+    composed exactly as the pin path composes it. The plain-only ballot could never elect the one
+    placement measured to work on DeepSeek-V4 post4096 (a dependent seam's closure), however the
+    evidence ranked: the arm was not offered."""
+    match, graph = _composed_case_match()
+    node = next(node for node in graph.nodes.values() if isinstance(node.op, TileOp))
+    with pinned_knobs(_OFF):
+        options = _CUT.rewrite(match, node)
+    arms = [dict(option.knobs) for option in options if "cut" in option.knobs.values()]
+    dependent = {
+        "PLACE@map.fold.a.map.fold.a32": "cut",
+        "PLACE@map.fold.a.map.fold.a31": "cut",
+        "PLACE@map.fold.a21": "cut",
+    }
+    assert dependent in arms, f"the dependent seam's closure must be one composed arm, got {arms}"
+    seams = cuttable_seams(node.op)
+    offered = {spelling for arm in arms for spelling in arm}
+    missing = {seam.spelling for seam in seams} - offered
+    assert not missing, f"every seam must appear on the ballot through some closure: {missing}"

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -24,7 +24,13 @@ from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
 from emmy.compiler.loop_wire import loop_graph_to_wire
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, TILE_PASSES, Match, Pipeline, Rule, RuleSkipped
 from emmy.compiler.pipeline.fork import Fork
-from emmy.compiler.pipeline.passes.lowering.tile._cut import CutSite, _producer_order, _workspace_axes, cuttable_seams
+from emmy.compiler.pipeline.passes.lowering.tile._cut import (
+    CutSite,
+    _environments,
+    _producer_order,
+    _workspace_axes,
+    cuttable_seams,
+)
 from emmy.compiler.pipeline.pipeline import Run, _is_structural_option
 from emmy.compiler.pipeline.search.golden import (
     GoldenRecord,
@@ -592,3 +598,71 @@ def test_pool_group_fuses_node_id_respellings_and_keys_on_pins() -> None:
 
     unpinned = GoldenRecord(knobs={}, **{**fields, "pins": ()})
     assert unpinned.pool_group != a.pool_group, "the pin regime is a group-key term"
+def test_a_fold_held_by_a_plain_statement_still_gets_an_environment() -> None:
+    """A plain statement binds axes, not SSA definitions — but it can HOLD a stored fold.
+
+    ``ProjectionRegion`` keeps its cones as terms, and a fold reached only that way had no lexical
+    environment at all, so provider closure could not resolve its captures and silently dropped its
+    seam. The canonical tree walk alternates node-wise and statement-wise for the same reason."""
+    from emmy.compiler.ir.pure import Lambda
+    from emmy.compiler.ir.tile.ir import ProjectionRegion
+
+    cone = Fold.projection(body=Body((Assign(name="c", op="relu", args=("x",)),)), results=("c",))
+    region = ProjectionRegion(axis=Axis("j", 4), lift=Lambda(params=("j",), body=Body((cone,)), results=("c",)))
+    root = Fold.projection(
+        body=Body((Load(name="x", input="a", index=(Var("j"),)), region, Assign(name="out", op="copy", args=("c",)))),
+        results=("out",),
+    )
+
+    assert id(cone) in _environments(root), "a cone a region holds must still resolve its captures"
+    assert _environments(root)[id(cone)] == [(root,)]
+
+
+def _cone_seam(providers: tuple = (), requires: tuple = ()) -> CutSite:
+    """A bare seam record standing in for a clustered operand cone."""
+    node = Fold.projection(body=Body((Load(name="w", input="w", index=(Var("n"), Var("k"))),)), results=("w",))
+    return CutSite(node=node, spelling="PLACE@b", axes=(Axis("n", 8), Axis("k", 8)), dtypes=(F16,), providers=providers, requires=requires)
+
+
+def test_two_cones_that_close_over_different_sources_are_not_one_value() -> None:
+    """Clustering merges cones that are alpha-equivalent — but a capture is a FREE name.
+
+    Two B cones can spell ``w[n,k] * x`` identically while one host defines ``x = sum(a)`` and the
+    other ``x = sum(b)``; normalization refuses to sink either reduce, so both cones keep the same
+    free name. Merging them materializes one and lets the other read it, which silently hands the
+    second contraction the first's value. The closure is part of the value."""
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import _cluster_value_seams
+
+    first_source = Fold.projection(body=Body((Load(name="x", input="a", index=(Var("k"),)),)), results=("x",))
+    second_source = Fold.projection(body=Body((Load(name="x", input="b", index=(Var("k"),)),)), results=("x",))
+    consumer = object()
+
+    same = [_cone_seam(requires=(("x", first_source),)), _cone_seam(requires=(("x", first_source),))]
+    differing = [_cone_seam(requires=(("x", first_source),)), _cone_seam(requires=(("x", second_source),))]
+
+    clustered = _cluster_value_seams(same, {id(seam.node): consumer for seam in same})
+    assert len(clustered) == 1 and len(clustered[0].siblings) == 1
+
+    kept = _cluster_value_seams(differing, {id(seam.node): consumer for seam in differing})
+    assert len(kept) == 2 and not any(seam.siblings for seam in kept)
+
+
+def test_a_required_producer_keeps_its_own_seam() -> None:
+    """A dependent reads its producer's workspace by the name that producer BINDS.
+
+    Clustering re-points a value at its representative, whose result names are its own, so folding
+    a required producer into somebody else's cluster leaves the requirement naming a seam that no
+    longer exists — or, worse, one that binds a different name."""
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import _cluster_value_seams
+
+    # The producer is deliberately NOT first: the cluster representative is whoever leads, so a
+    # required producer that trails would be folded away as a sibling.
+    twin, producer = _cone_seam(), _cone_seam()
+    dependent = _cone_seam(requires=(("w", producer.node),))
+    consumer = object()
+    seams = [twin, producer, dependent]
+
+    kept = _cluster_value_seams(seams, {id(seam.node): consumer for seam in seams})
+
+    assert any(seam.node is producer.node for seam in kept), "the required producer must survive as its own seam"
+    assert not any(sibling is producer.node for seam in kept for sibling, _ in seam.siblings)

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -598,6 +598,8 @@ def test_pool_group_fuses_node_id_respellings_and_keys_on_pins() -> None:
 
     unpinned = GoldenRecord(knobs={}, **{**fields, "pins": ()})
     assert unpinned.pool_group != a.pool_group, "the pin regime is a group-key term"
+
+
 def test_a_fold_held_by_a_plain_statement_still_gets_an_environment() -> None:
     """A plain statement binds axes, not SSA definitions — but it can HOLD a stored fold.
 

--- a/tests/compiler/passes/test_reduce_tier_ilp.py
+++ b/tests/compiler/passes/test_reduce_tier_ilp.py
@@ -1,0 +1,52 @@
+"""The reduce tier's ILP replication and the names it must NOT rename.
+
+``_tile_reduce_axis`` copies the reduce body once per register chain, suffixing per-copy SSA
+names. A name the body READS but does not DEFINE is one shared value (a hoisted scalar load, a
+provider chain emitted ahead of the loop) — renaming its uses emits an undefined identifier at
+nvcc. The Expr channel (``s.exprs()``) was already protected; ``Assign`` args travel the
+SSA-deps channel (``s.deps()``), surfaced by DeepSeek-V4 post4096's two-cut piece
+(``identifier "in3__r1" is undefined``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from emmy.compiler.ir.axis import Axis, AxisRole
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.schedule import ReducePlan
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
+from emmy.compiler.pipeline.passes.lowering.kernel._factor import Ctx, _tile_reduce_axis
+from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
+
+
+def _names_read(stmts) -> set[str]:
+    out: set[str] = set()
+    for s in stmts:
+        out.update(s.deps())
+        for e in s.exprs():
+            out.update(e.free_vars())
+        for b in s.nested():
+            out |= _names_read(b)
+    return out
+
+
+def test_an_external_ssa_read_is_shared_by_every_ilp_copy() -> None:
+    body = Body(
+        (
+            Load(name="x_e", input="x", index=(Var("m"), Var("k"))),
+            Assign(name="scaled", op="multiply", args=("x_e", "alpha")),  # ``alpha`` defined ahead of the loop
+            Accum(name="acc", value="scaled", op="add", axes=("k",)),
+        )
+    )
+    red = fold_from_loop(Loop(axis=Axis("k", 128), body=body, role=AxisRole.PLANAR))
+    assert red is not None
+    sched = SimpleNamespace(get=lambda *_: None)
+    ctx = Ctx(grid=(Axis("m", 4),), inputs={}, output="o", sched=sched)
+
+    _state, fold, _close, _lane = _tile_reduce_axis(red, ReducePlan.of(reg=2), ctx, tail=(), out_val="acc")
+
+    read = _names_read(fold)
+    assert "alpha__r1" not in read, "the shared external value must not be renamed per copy"
+    assert "alpha" in read
+    assert any(name.endswith("__r1") for name in read), "the per-copy chains themselves still rename"

--- a/tests/compiler/passes/test_schedule_walk.py
+++ b/tests/compiler/passes/test_schedule_walk.py
@@ -282,8 +282,44 @@ def test_a_sweep_reading_fold_offers_only_the_serial_reduce(unpinned) -> None:
     sweep_spec = OutputSpec(write=Write(output="o", index=(Var("m"), Var("j")), value="v"), sweep=Axis("j", 4))
 
     def state(specs):
-        return SimpleNamespace(tile=SimpleNamespace(output_specs=specs), work_pin=None, transposed_ok=False)
+        return SimpleNamespace(tile=SimpleNamespace(output_specs=specs, op=red), work_pin=None, transposed_ok=False)
 
     assert _schedule._reduce_moves(state((sweep_spec,)), red, None) == [ReducePlan()]
     # Without the sweep read the catalog stays whole.
     assert len(_schedule._reduce_moves(state(()), red, None)) > 1
+
+
+def test_a_fold_under_a_chain_form_root_offers_only_the_serial_reduce(unpinned) -> None:
+    """A chain-form root — a zero-axis projection with NO operand edges (a body-FED or
+    sweep-reading member the normalize hoist keeps in place) — binds without a peel: the
+    materializer emits the whole body in order through the schedule-blind body recursion, so a
+    partitioned REDUCE row stamped under it would be a partition the kernel never emits. The
+    serial fold is the whole catalog (DeepSeek-V4 post4096's two-cut consumer piece)."""
+    from types import SimpleNamespace
+
+    from emmy.compiler.ir.axis import Axis, AxisRole
+    from emmy.compiler.ir.expr import Var
+    from emmy.compiler.ir.pure import Fold
+    from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
+    from emmy.compiler.ir.tile import ReducePlan
+    from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
+
+    body = Body(
+        (
+            Load(name="x_e", input="x", index=(Var("m"), Var("k"))),
+            Assign(name="scaled", op="multiply", args=("x_e", "v25")),
+            Accum(name="acc", value="scaled", op="add", axes=("k",)),
+        )
+    )
+    red = fold_from_loop(Loop(axis=Axis("k", 128), body=body, role=AxisRole.PLANAR))
+    assert red is not None
+    chain = (Load(name="ws", input="cutbuf", index=()), Assign(name="v25", op="rsqrt", args=("ws",)))
+    root = Fold.projection(body=Body((*chain, red)), results=("acc",))
+    assert not root.operands, "the fed member must remain in the body for this shape to be under test"
+
+    def state(op):
+        return SimpleNamespace(tile=SimpleNamespace(output_specs=(), op=op), work_pin=None, transposed_ok=False)
+
+    assert _schedule._reduce_moves(state(root), red, None) == [ReducePlan()]
+    # The same fold bound as the kernel root keeps the whole catalog.
+    assert len(_schedule._reduce_moves(state(red), red, None)) > 1

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -77,6 +77,27 @@ def test_a_shape_whose_every_variant_failed_prices_as_infeasible() -> None:
     assert greedy._resolved_price(terminal, trace, ctx, None, failed={doomed: [2_000_000.0]}) == math.inf
 
 
+def test_a_disqualification_condemns_only_the_shape_that_was_measured() -> None:
+    """Elimination matches the signature EXACTLY, unlike the ranking tier's drift-tolerant
+    :func:`_sig_groups`. There a loose match only widens the candidate pool and a second filter
+    still has to agree on the tunable knobs; here nothing follows the match, so condemning every
+    shape that merely does not contradict a recorded failure disqualifies the whole program.
+    Measured: on DeepSeek-V4's post block the tolerant form priced all 17 leaves of one fork
+    ``inf``, which decides nothing at all."""
+    recorded = frozenset({("S_shape", "4096"), ("S_dtype_f16", "1.0")})
+    # Agrees on every SHARED key, so the drift-tolerant matcher would call it a hit; it is a
+    # different shape and must still be priced.
+    other = SimpleNamespace(knobs={"S_shape": 4096, "S_n_loop": 9}, identity_key=lambda **_kw: "k")
+    terminal = SimpleNamespace(nodes={"n": SimpleNamespace(op=other)})
+    trace = [SimpleNamespace(node_id="n", score=5.0)]
+    ctx = SimpleNamespace(features=lambda: {})
+
+    assert greedy._sig_groups({recorded: [1.0]}, frozenset({("S_shape", "4096"), ("S_n_loop", "9")})), (
+        "the tolerant matcher does hit here — which is exactly why elimination must not use it"
+    )
+    assert greedy._resolved_price(terminal, trace, ctx, None, failed={recorded: [2_000_000.0]}) == 5.0
+
+
 def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:
     materialized = []
     rows = [{"TILE": str(tile), "STAGE": str(stage)} for tile in range(100) for stage in range(100)]

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -1,5 +1,6 @@
 """Focused tests for greedy schedule-space traversal."""
 
+import math
 from types import SimpleNamespace
 
 import pytest
@@ -30,7 +31,50 @@ def test_db_measured_index_excludes_placement_route_totals(route) -> None:
     db = SimpleNamespace(iter_perf=lambda *_args, **_kwargs: rows)
     ctx = SimpleNamespace(structural_key=lambda: "ctx")
 
-    assert _db_measured_index_build(db, ctx) == {signature: [({"WORK": "t64"}, 7.0)]}
+    assert _db_measured_index_build(db, ctx).ok == {signature: [({"WORK": "t64"}, 7.0)]}
+
+
+def test_db_measured_index_collects_shapes_whose_every_measured_variant_failed() -> None:
+    """A ``bench_fail`` row is evidence too — the watchdog measured that variant not finishing.
+    When EVERY measured variant of one structural shape failed, the shape itself is disqualified;
+    one surviving ``ok`` variant means only some rows are bad and the shape stays rankable.
+
+    Failures are collected before the placement-route filter the ``ok`` tier applies: a route's
+    LATENCY is unattributable without a child-schedule receipt, but a kernel that hung is
+    attributable to the kernel whatever route produced it."""
+    doomed = frozenset({("S_shape", "4096")})
+    mixed = frozenset({("S_shape", "128")})
+    rows = [
+        SimpleNamespace(status="bench_fail", stats=SimpleNamespace(median=2_000_000.0), knobs={"S_shape": 4096, "WORK": "t32"}),
+        SimpleNamespace(status="bench_fail", stats=SimpleNamespace(median=2_000_000.0), knobs={"S_shape": 4096, "PLACE": "fuse"}),
+        SimpleNamespace(status="bench_fail", stats=SimpleNamespace(median=2_000_000.0), knobs={"S_shape": 128, "WORK": "t32"}),
+        SimpleNamespace(status="ok", stats=SimpleNamespace(median=7.0), knobs={"S_shape": 128, "WORK": "t64"}),
+    ]
+    db = SimpleNamespace(iter_perf=lambda *_args, **_kwargs: rows)
+    ctx = SimpleNamespace(structural_key=lambda: "ctx")
+
+    measured = _db_measured_index_build(db, ctx)
+    assert doomed in measured.failed, "every measured variant of this shape hit the watchdog"
+    assert mixed not in measured.failed, "a shape with one ok variant is not disqualified"
+    assert measured.ok == {mixed: [({"WORK": "t64"}, 7.0)]}
+
+
+def test_a_shape_whose_every_variant_failed_prices_as_infeasible() -> None:
+    """The disqualification's teeth: a slice containing a known-failed kernel prices ``inf``, so
+    any structural arm holding it loses the ``_priced_pick`` argmin to an arm that does not.
+
+    Without this the failures are invisible at deploy — the measured index carries ``ok`` rows
+    only, so a kernel every one of whose variants hung simply has no evidence and falls through to
+    the prior, which is exactly how DeepSeek-V4's post block kept its hanging fused arm across a
+    30-minute tune that recorded 40 failures for it."""
+    doomed = frozenset({("S_shape", "4096")})
+    op = SimpleNamespace(knobs={"S_shape": 4096}, identity_key=lambda **_kw: "k")
+    terminal = SimpleNamespace(nodes={"n": SimpleNamespace(op=op)})
+    trace = [SimpleNamespace(node_id="n", score=5.0)]
+    ctx = SimpleNamespace(features=lambda: {})
+
+    assert greedy._resolved_price(terminal, trace, ctx, None) == 5.0
+    assert greedy._resolved_price(terminal, trace, ctx, None, failed={doomed: [2_000_000.0]}) == math.inf
 
 
 def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:

--- a/tests/compiler/pipeline/search/policy/test_terminal_bench.py
+++ b/tests/compiler/pipeline/search/policy/test_terminal_bench.py
@@ -132,3 +132,66 @@ async def test_a_real_bench_failure_still_records_bench_fail() -> None:
     assert status == "bench_fail"
     assert stats.median == 2_000_000.0
     assert _perf_row(db, cand).status == "bench_fail"
+
+
+def _candidate_pair():
+    """A terminal with TWO kernels — the shape one hang used to condemn wholesale."""
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (1,)), node_id="x")
+    # The bodies must differ materially: ``CudaOp`` identity normalizes the kernel NAME away, so
+    # two kernels differing only in name are one identity and would share a single perf row.
+    for nid, name, body in (("mid", "k_innocent", "out[0] = 1.0f;"), ("out", "k_culprit", "out[0] = 2.0f;")):
+        graph.add_node(
+            CudaOp(
+                kernel_source=f'extern "C" __global__ void {name}(float* out) {{ {body} }}',
+                kernel_name=name,
+                arg_order=("out",),
+            ),
+            [],
+            Tensor(nid, (1,)),
+            node_id=nid,
+        )
+    graph.inputs, graph.outputs = ["x"], ["out"]
+    return SimpleNamespace(graph=graph, ctx=Context.from_target((8, 0)))
+
+
+def _fail_rows(db: SearchDB, cand) -> dict[str, str]:
+    """``kernel_name -> status`` for every kernel of ``cand`` that has a perf row."""
+    out = {}
+    for nid in ("mid", "out"):
+        op = cand.graph.nodes[nid].op
+        row = db.lookup_perf(cand.ctx.structural_key(), op.identity_key(with_io=True, with_knobs=True), backend="cuda")
+        if row is not None:
+            out[op.kernel_name] = row.status
+    return out
+
+
+async def test_a_hung_kernel_is_blamed_alone() -> None:
+    """The watchdog NAMES the kernel that hung, so only that kernel earns the ``bench_fail`` row.
+
+    A terminal benches its kernels together and one hang fails the whole run; recording the
+    failure against all of them manufactures evidence about kernels never shown to fail. Measured
+    on DeepSeek-V4's post block: 70 recorded failures carrying only 7 distinct errors, 20 kernels
+    condemned by a single hang."""
+    db, cand = SearchDB(), _candidate_pair()
+    exc = BenchWorkerJobError("bench worker error: HungKernelError(\"kernel 'k_culprit (iter 0)' did not complete within 60000 ms\")")
+
+    _stats, status, _measured, per_kernel = await bench_terminal_async(cand, backend=_RaisingBackend(exc), db=db)
+
+    assert status == "bench_fail", "the terminal still failed — the search must move on"
+    assert _fail_rows(db, cand) == {"k_culprit": "bench_fail"}, "the innocent kernel must carry no failure"
+    assert len(per_kernel) == 1, "only the culprit trains the prior on this failure"
+
+
+async def test_an_unattributable_failure_blames_no_kernel() -> None:
+    """A bench-worker startup timeout is not a property of any kernel — it names none, and with
+    several kernels in the terminal there is no unambiguous culprit. Unknown is not failed, so
+    nothing is persisted; the terminal still reports ``bench_fail`` and the candidate is spent."""
+    db, cand = SearchDB(), _candidate_pair()
+    exc = RuntimeError("bench worker did not accept the request within 74.0s wall budget — SIGKILL'd, stream cleaned")
+
+    _stats, status, _measured, per_kernel = await bench_terminal_async(cand, backend=_RaisingBackend(exc), db=db)
+
+    assert status == "bench_fail"
+    assert _fail_rows(db, cand) == {}
+    assert per_kernel == []


### PR DESCRIPTION
## What

DeepSeek-V4 `post4096` fuses a chain of wide contractions into one kernel doing **3.6e16 = 2^55 worst per-thread
serial trips** (`block_threads=1`), which wedges the TP8xPP2 serve boot on a 16xV100 host. This PR fixes every
defect found between the greedy and that kernel, in evidence order:

1. **Failure attribution** (`2af3abf65`, `59577521e`): a terminal benches its kernels together, and one hang
   condemned all of them — 70 recorded failures carrying 7 distinct errors, 20 kernels condemned by a single hang.
   The watchdog NAMES the hung kernel, so only that kernel earns the `bench_fail` row; an unattributable failure
   (a worker startup timeout) blames no kernel. Re-tuned on the V100: 15/15 rows name the real culprit.

2. **Measured-failure disqualification** (`c41ce6d6e`, `b2573ebed`): a kernel every one of whose measured variants
   failed now disqualifies the structural arm holding it (`math.inf` price), instead of merely failing to rank.
   Disqualification matches a failure signature EXACTLY — the drift-tolerant matcher belongs to ranking, where the
   worst outcome is a mediocre pick, not to condemnation.

3. **Placement-cut correctness** (`cb061d118`): five bugs in the composed cut, four found by review — piece inputs
   declared from the lossy lowered view (the `KeyError` that killed the TP8xPP2 boot), an occurrence-dependent
   dtype cache, a statement holding a stored fold having no lexical environment, clustering that compared cone
   syntax but not what a seam closes over, and requirement injection matching `Load` only.

4. **The composed cut now COMPILES** (`9ebc46cb4`): the consumer piece's IR was scope-inverted — the normalize
   hoist moved a fold onto an operand edge while its subtree captured names the remaining body defines (the
   `closed` gate reads only the fold's own lift), and ILP replication renamed reads of values defined ahead of the
   loop (the `deps()` channel is invisible to the `exprs()` scan). Verified on the V100: the two-cut plan went
   **17 nvcc errors ("identifier \"v55__r3\" is undefined") to 0 failing kernels**, builds, and launches, with the
   monster at 2^30 trips instead of 2^55.

5. **The composed cut is now ON THE BALLOT** (`776c9b049`): the unpinned fork offered PLAIN seams only — 2 of the
   monster's 33 — so the only route measured to work (a dependent seam's closure) could never be elected by any
   evidence. Now every seam is offered with its transitive `requires` closure as one composed structural arm,
   built by the same walk the pin path uses. The feared recursion explosion is refuted by measurement: the
   identity-deduped placement walk on the deepest dependent-chain fixture converges
   (36 -> 173 -> 322 -> 285 -> 117 -> 25 new pieces per generation).

## Measured result

Unpinned `post4096` compile on the V100 with clean attributed evidence: the greedy selects a composed cut on its
own — **52 kernels, worst per-thread trips 2^37 (down from 2^55)**, placement terminating in 327s (~4.4x compile
time). No human pin involved.

Known gaps, deliberately out of scope (recorded for follow-up): the 2^37 plan is still serially impractical to
RUN; electing the deeper 2^30 route needs a tune pass over the new ballot or a monotone serial-work prior feature,
and partitioning the two-cut consumer needs the reduce tier to emit sibling-provider chains ahead of the loop.

## Line balance

`git diff --stat main -- emmy/`: +366/-64. Every commit adds capability or fixes a correctness defect (attribution,
disqualification, five cut fixes, three codegen fixes, the ballot) — none is a refactor; each carries a test that
fails on main.

## Verification

- `make test` green at every commit (4010 passed), `make lint` clean.
- Hardware: V100 verification for attribution (15/15 rows), the two-cut compile (17 nvcc errors -> 0, launches),
  and the unpinned evidence compile (2^55 -> 2^37, no pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)