### PR TITLE
Let every prior declare the columns it reads

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -690,8 +690,13 @@ pools it is given and therefore selects nothing.
 
 Shared: `--seed`, `--folds N` (default 5; `0` skips cross-validation), `--out DIR`, and `--features SPEC` — the
 feature view, comma-separated names with a trailing `*` for a prefix glob and a leading `-` to exclude, recorded in
-the metrics header and artifact provenance so two fits are only compared under matching views. **The default view is
-the trainer's own**: `search/data/group.DEFAULT_FEATURES` (`D_*,MMA_tier,MMA_acc_bits`) for `linear`, and
+the metrics header and artifact provenance so two fits are only compared under matching views. The spec is the whole
+rule — the filter keeps what the spec names and nothing else — so the recorded view is exactly what was trained on,
+and a view feeding a model that routes on `S_ext_n_symbolic_axis` names that column. The flag is the fit's alone: a
+fit DEFINES a not-yet-existing model's columns, while `eval prior --dataset golden` consumes models it already holds
+and derives its view from what they declare (`Prior.columns`), recording it under the same `features` header key.
+**The default view is the trainer's own**: `search/data/group.DEFAULT_FEATURES`
+(`D_*,MMA_tier,MMA_acc_bits,S_ext_n_symbolic_axis`) for `linear`, and
 `prior/fit/catboost.TREE_FEATURES` for `catboost` — that set minus every feature that exists only because an
 additive model cannot form it (monotone duplicates, `-|x - target|` folds, threshold flags, the `D_tma_*`
 interaction mirrors), each of which a tree re-derives by splitting on columns the view keeps.

--- a/emmy/commands/eval.py
+++ b/emmy/commands/eval.py
@@ -11,6 +11,9 @@ Five subcommands:
   The summaries are assembled by ``search/prior/report.py`` and rendered here; ``emmy fit``
   writes the same summaries into its ``metrics.json``, so a fit and an eval state the golden
   screen with one implementation rather than two that agree by coincidence.
+  ``--dataset golden`` builds its candidate pools over the columns those halves DECLARE
+  (``Prior.columns``, the routing stamp included), and records the resulting view under the same
+  ``features`` header key the fit records its ``--features`` under.
 - ``eval golden``    — validate one canonical golden YAML against the pinned serving
   configuration and live GPU, then reproduce its rows and audit the exact serving matrix.
 - ``eval variants``  — per-kernel leaderboard of the tune DB's measured variants
@@ -293,19 +296,45 @@ def _measured_report(args, halves):
 def _golden_report(args, halves):
     """``eval prior --dataset golden`` — the report over the recorded golden corpus.
 
-    Built by ``emmy fit``'s own case builder over the FULL featurization, not the fit's ``D_*`` view. The view
-    is a property of the model being fitted, and this command scores two model classes: the linear half reads
-    only its own weight names, so its ranks are identical either way, while the online half regresses on the
-    ``S_*`` / ``H_*`` columns a narrow view drops and would otherwise be asked about a kernel with no shape."""
+    Built by ``emmy fit``'s own case builder, over the union of the columns the halves about to score DECLARE
+    (:attr:`~...search.prior.base.Prior.columns`) rather than a view named here. A view is a property of a
+    model, and this command holds the models: the linear half reads only its own weight names, and the online
+    half regresses on the ``S_*`` / ``H_*`` columns a fit's ``D_*`` view drops and would otherwise be asked
+    about a kernel with no shape. Both facts are in their artifacts, so neither has to be restated — the
+    command previously enumerated every column the featurizer can spell because it had no way to ask.
+
+    Narrowing is safe for SCORES: an absent column and a column outside a model's own list are the same thing
+    to ``score_rows``, which projects the pool onto its own names either way. Verified over the
+    ``matmul.square.512`` pools on four cards, both weight sets — scores bit-identical against the full
+    featurization.
+
+    It is NOT neutral for pool formation, which a reader comparing two reports has to know. Pool identity is a
+    digest of the packed matrix, so two enumerations separated only by columns no scoring model reads fold into
+    one group under a narrower view — 27 softmax groups under ``"*"``, 26 under the shipped offline half's
+    declaration — and ``groups``, ``positives`` and the merged pool's rank move with it. A merged group is one
+    candidate pool competed over by two goldens, which is what a group means here; the ``features`` header key
+    is what says which view produced the numbers.
+
+    Narrowing keeps the pools ROUTABLE for the same reason: the routing stamp is a column the halves declare,
+    so it lands in the spec like any other name (why that matters:
+    :mod:`~emmy.compiler.pipeline.search.prior.linear_model`).
+
+    Every half in ``halves`` can answer — ``_prior_halves`` has already dropped an unfit one, and a fitted one
+    always has columns — so there is no widen-and-warn path to get wrong."""
     from emmy.commands.fit import build_golden_groups  # noqa: PLC0415
     from emmy.compiler.pipeline.search.prior.report import EvalReport, golden_summaries  # noqa: PLC0415
 
+    view = ",".join(sorted({col for _half, prior in halves for col in prior.columns}))
     logger.info("Building golden pools (each golden under its own card's context) ...")
-    groups, skipped = build_golden_groups("*", sample=args.pool_sample, kernel=args.kernel)
+    groups, skipped = build_golden_groups(view, sample=args.pool_sample, kernel=args.kernel)
     header = {
         "dataset": "golden",
         "source": "recorded golden corpus",
         "kernel": args.kernel,
+        # The same key ``emmy fit`` records in its metrics file, holding the same thing — a feature-view spec.
+        # The two commands state the golden screen with one implementation, so they must also say what they
+        # scored in one vocabulary, or a reader comparing the files reads one word two ways.
+        "features": view,
         "pool_sample": args.pool_sample,
         "groups": len(groups),
         "positives": sum(len(g.golden_ids) for g in groups),
@@ -388,6 +417,15 @@ _REPORT_CAPTIONS = {
 }
 
 
+def _elide(value) -> str:
+    """A header value for the console line, shortened with its full length named.
+
+    The count is kept because it is the readable part of a long value: a feature-view spec's WIDTH is what a
+    reader compares between two runs, and the names themselves are in the JSON."""
+    text = str(value)
+    return text if len(text) <= 60 else f"{text[:60]}… ({len(text)} chars)"
+
+
 def _emit_report(report) -> None:
     """Print an :class:`EvalReport` — the provenance header, then one table of summaries.
 
@@ -400,8 +438,10 @@ def _emit_report(report) -> None:
     logger.info("[prior] %s dataset — %s", head.get("dataset", "?"), head.get("source", ""))
     # Every remaining header key, whatever the dataset put there. Printed generically so a builder that starts
     # recording a new provenance field does not also have to teach this about it — a count nobody prints is a
-    # count nobody checks.
-    provenance = ", ".join(f"{k}={head[k]}" for k in head if k not in ("dataset", "source", "dropped") and head[k] is not None)
+    # count nobody checks. Long values are elided HERE rather than shortened at the builder: the JSON is what
+    # two runs are diffed by and must stay exact, and the golden dataset's feature-view spec is ~60 column
+    # names, which would bury every other field on this line.
+    provenance = ", ".join(f"{k}={_elide(head[k])}" for k in head if k not in ("dataset", "source", "dropped") and head[k] is not None)
     if provenance:
         logger.info("  %s", provenance)
     if dropped := head.get("dropped"):

--- a/emmy/commands/fit.py
+++ b/emmy/commands/fit.py
@@ -42,7 +42,7 @@ from emmy.compiler.pipeline.search.prior.fit import catboost as fit_catboost
 from emmy.compiler.pipeline.search.prior.fit import cv as fit_cv
 from emmy.compiler.pipeline.search.prior.fit import linear as fit_linear
 from emmy.compiler.pipeline.search.prior.fit.run import run_fit
-from emmy.compiler.pipeline.search.prior.linear_model import LinearModel
+from emmy.compiler.pipeline.search.prior.linear_model import LinearModel, unweighted_cols
 
 logger = logging.getLogger(__name__)
 
@@ -374,10 +374,10 @@ def _linear_trainers(args, names: list[str]):
     from emmy.compiler.pipeline.search.prior.offline import _DEFAULT_FILE  # noqa: PLC0415
 
     raw = storage.read_json(config.offline_path() or _DEFAULT_FILE)
-    if not isinstance(raw, dict) or "scale" not in (raw.get("params") or {}):
+    if not isinstance(raw, dict) or "scale" not in (raw.get("params") or {}) or "unweighted_cols" not in raw:
         raise SystemExit(
             f"no usable incumbent weights artifact to seed from at {config.offline_path() or _DEFAULT_FILE} "
-            f"(needs a 'params' block carrying 'scale')"
+            f"(needs a 'params' block carrying 'scale', and an 'unweighted_cols' declaration)"
         )
     # Lenient read (``LinearModel.from_artifact`` does not version-gate): a refit after a featurizer
     # change is exactly when versions mismatch, and a stale key simply seeds 0.0. A pre-2026-08-05
@@ -517,7 +517,8 @@ def handle_fit(args) -> None:
         # coordinate carries an EMPTY set, and that is still its answer, not a missing one.
         carried = incumbent.weights_dynamic if incumbent.weights_dynamic is not None else model.weights
         source = "incumbent" if incumbent.weights_dynamic is not None else "the static fit"
-        model = replace(model, weights_dynamic=carried)
+        # Re-declared with the carried set: a name the carried weights price is no longer unweighted.
+        model = replace(model, weights_dynamic=carried, unweighted_cols=unweighted_cols(model.weights, carried))
         notes = f"{notes}; dynamic set carried from {source}"
     provenance = {
         "fitted": datetime.date.today().isoformat(),

--- a/emmy/commands/fit.py
+++ b/emmy/commands/fit.py
@@ -298,8 +298,9 @@ def build_golden_groups(
         # The feature view (default ``DEFAULT_FEATURES``: ``D_*`` geometry/occupancy plus
         # ``MMA_tier`` — see its rationale in ``search/data/group.py``) filters here, before
         # the pool is packed, so the trained-under view is exactly what the Group stores.
-        # ``feature_view`` keeps the routing features whatever the spec says, so a narrower
-        # ``--features`` cannot silently misroute a symbolic-axis pool.
+        # The view is the whole rule, routing stamp included: a spec that drops it packs pools that
+        # ``pack_features`` labels static, which ``GoldenGroup.from_dicts`` and ``LinearModel.score_rows``
+        # refuse rather than misroute.
         feats = [{k: v for k, v in features.knob_features({**base, **r}).items() if keep(k)} for r in rows]
         packed = pack_features(feats)
         # Second stage: two enumerations can still land on one pool — the same program recorded in different

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -168,7 +168,7 @@ Everything in this table recurs on nearly every page below. The rest of the docu
 | `search/strategy/` | The search shapes: `base.SearchStrategy`, `greedy.GreedyStrategy`, `two_level.TwoLevelStrategy`. |
 | `search/prior/` | The ONE ranking path: a `Prior` ABC with the cold `OfflinePrior` and the `OnlinePrior` composed behind `FallbackPrior` (`load_prior`). `linear_model.py` holds `LinearModel`, the offline prior's scoring function as a value object — the one definition the fitter optimizes and the deploy path ranks by. `diagnostics.py` backs the `eval` reachability / calibration reports; `fit/` is the offline fitter, split by responsibility — `linear.py` trainer, `cv.py` fold harness, `tables.py` the rank-table rendering, `run.py` the pure `emmy fit` run harness. The candidate pool it all trains over is `search/data/group.Group`, one layer down: a pool is data, not a fitter detail. |
 | `search/metrics.py` | What a scored candidate pool is worth, as pure functions over numbers: golden ranks and their tie conventions, `topk_pick` / `topk_regret` against measured latencies, and Spearman ρ. No model, no I/O, no strings, so the callers cannot each hold a slightly different definition — the rank metrics, the three calibration paths and the reachability ratio all resolve here. Rendering lives with the caller (`prior/fit/tables.py` for the fit's rank tables; the other top-k summaries have not been unified yet). |
-| `search/data/` | The harmonized read-view over the three data sources (golden records / DB `perf` rows / prior reservoir): `Sample`, `Dataset`, the derived `ShapeKey` index, and `group.py`'s `Group` — one candidate pool packed as a matrix plus one label per row. The base says nothing about what the labels mean, which is all a ranking metric needs; `GoldenGroup` is the subclass whose labels MARK rows (`golden_ids`) rather than measure them, and only it can be asked which rows are the answer. `group_measured` builds base groups from benched node rows, labelled with measured µs. Nothing here imports `search/prior/`: a group carries every column it was given, and each model class narrows to the ones it wants when it asks for the matrix — `TREE_FEATURES`, the view argued entirely from what a tree can re-derive, lives with the CatBoost trainer for the same reason. |
+| `search/data/` | The harmonized read-view over the three data sources (golden records / DB `perf` rows / prior reservoir): `Sample`, `Dataset`, the derived `ShapeKey` index, and `group.py`'s `Group` — one candidate pool packed as a matrix plus one label per row. The base says nothing about what the labels mean, which is all a ranking metric needs; `GoldenGroup` is the subclass whose labels MARK rows (`golden_ids`) rather than measure them, and only it can be asked which rows are the answer. `group_measured` builds base groups from benched node rows, labelled with measured µs. Nothing here imports `search/prior/`: a group carries every column it was given, and each model class narrows to the ones it wants when it asks for the matrix — `TREE_FEATURES`, the view argued entirely from what a tree can re-derive, lives with the CatBoost trainer for the same reason. The dependency runs the other way for the column set itself: `Prior.columns` publishes what a model reads — weights, the interaction's inputs and the routing stamp — so a BUILDER can pack for the models it is about to score instead of restating their columns or widening to everything the featurizer can spell. `feature_view` filters on its spec alone, so a view feeding a model that routes names the routing column like any other. |
 | `search/golden.py` | Generic program-backed records, a repository corpus loaded on first evidence access, stable-format validation, and lazy provenance-derived structural indexes (see Part 7). |
 | `search/audit.py` | The verified-tier drift audit: one MATCH / DRIFT / GAP verdict per consultation, collected off a whole card's graphs under isolated evidence. Backs the `emmy eval golden --serving-config` release gate. |
 | `slice.py` | Isolates one finalized kernel into a standalone graph (used by the inner tune and structural pricing). |
@@ -1477,10 +1477,46 @@ same corpus, the same sampling draw and the same rows. Each golden's compile con
 count and smem specs — never the host's. Building them for the host's context makes golden ranks machine-dependent,
 because the occupancy features then describe tiles for a GPU that is not the one the row came from.
 
-The eval builds its pools over the FULL featurization while a fit trains under its trainer's feature view. The view is
-a property of the model being fitted, and the eval scores two model classes: the linear half reads only its own weight
-names, so its ranks are identical either way, while the online half regresses on the `S_*` / `H_*` columns a narrow
-view drops and would otherwise be asked about a kernel with no shape.
+**The eval builds its pools over the columns its halves declare; a fit trains under its trainer's feature view.** The
+asymmetry is the two commands' opposite relation to the model. A fit DEFINES the columns of a model that does not exist
+yet — its view is an input and the artifact's weight names are an output — so it keeps `--features`, and deriving that
+view from the incumbent artifact would freeze the vocabulary against ever gaining a feature. An eval CONSUMES models it
+already holds, so it asks them (`Prior.columns`) instead of naming a view: the linear half declares both weight sets
+plus the atomic-free gate's inputs, and the online half declares the `S_*` / `H_*` columns it regressed on, which a
+narrow view would drop and leave it asked about a kernel with no shape.
+
+Narrowing cannot move a rank WITHIN a pool: an absent column and a column outside a model's own list are the same
+thing to `score_rows` — it projects the pool onto its own names either way, and `Group.matrix` builds column `j` from
+`feat_names[j]` regardless of how wide the stored matrix is.
+
+It can change which POOLS THERE ARE, and that is the part to know before comparing two reports. A golden pool's
+identity is a digest of its packed matrix (`_pool_identity` in `commands/fit.py`), so two enumerations separated only
+by columns the scoring models do not read — `H_*`, every `S_*` but the routing stamp, the unweighted `D_*` — pack
+identically under a derived view and fold into ONE group. Measured over the `softmax` goldens against the shipped
+offline half's declaration: 27 groups under `"*"` and 26 under it, where the V100's `layer3.i020` and `layer3.i028`
+softmax-reduce pools (32 rows each, same pinned row) become one. `positives` follows, 27 to 26, because a group's
+label set is a set of row indices.
+
+Merging is the per-group semantic doing its job — a group IS a candidate pool, and two goldens that compete over the
+same candidates with the same answer are one question, which is why a group's rank is the best over its goldens. What
+it is not is invisible: `groups`, `positives` and a merged pool's rank all move, and the view is derived from the
+halves being scored, so a run with an online checkpoint present can form different pools than one without. The eval
+records the view it used under the same `features` header key the fit records `--features` under; two reports are
+comparable when that key matches, and not otherwise.
+
+The union is a superset of what any one `score_rows` call packs, never the exact list: see `LinearModel.cols_for`
+for why scoring the static weight set over the union would perturb a reported rank, and why the routing stamp is
+declared but not packed into the matmul.
+
+**A feature view keeps what its spec names, and nothing else.** `feature_view` used to exempt the routing stamp from
+every spec, which put model knowledge — that one column selects a weight set — inside a column filter, and made the
+recorded spec a lie: a fit whose provenance said `D_*,MMA_tier,MMA_acc_bits` had trained on one more column than
+that. Two fits are only comparable when their recorded specs match, so the spec has to be the truth about what was
+kept. Each shipped view now names the stamp (`DEFAULT_FEATURES`, `MATMUL_FEATURES`, `TREE_FEATURES` — the tree's
+is an exclusion-style view over `D_*` / `MMA_*`, which never covered the stamp by construction), the eval derives
+its view from what the models declare, and a view that forgets is caught three ways: by the test over the shipped
+specs, by `GoldenGroup.from_dicts` refusing a `dyn`-tier case whose packed rows say static, and by
+`LinearModel.score_rows` refusing a pool that carries no stamp.
 
 **The per-fork view is retired.** Until 2026-08 this part also documented three node-tree diagnostics: fork-sibling
 regret (what following the prior's pick at each fork cost, bucketed by knob family), a golden-anchored descent (how

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -389,7 +389,11 @@ one because it is what answers on a machine that has no local measurements yet �
 `OfflinePrior` scores a candidate with a linear formula over the `D_*` features — hand-designed descriptions of a
 tile's geometry and its occupancy — fitted ahead of time. It never falls back on the order the rule emitted its
 options in. The complete scoring function lives in the repo-checked artifact `search/prior/offline_weights.json`:
-both weight sets plus the scalar params, carrying a `feat_ver` version and a `provenance` block. The offline fitter
+both weight sets, the scalar params, a `feat_ver` version, a `provenance` block, and `unweighted_cols`. That last
+one is what makes the artifact say what it READS: `Prior.columns` is the weight keys unioned with it, and the part
+no weight key can spell is the routing stamp, which selects the weight set instead of contributing a term. A caller
+rebuilding the column set from the weight keys alone therefore always missed it — and packed pools that route every
+candidate to the static weight set with no symptom. The offline fitter
 writes it (`search/prior/fit/`, driven by `emmy fit`). Building the training cases from the goldens lives in
 `emmy/commands/fit.py`, because reconstructing the set of candidates a golden competed against needs the command
 layer's tracer for the golden's little PyTorch snippet, which `pipeline/` never imports.
@@ -441,8 +445,11 @@ What a newcomer needs to know about the fit:
   golden-rank metrics and catastrophic when scoring a fork, where a not-yet-decided knob scores such a feature 0.0.
   The penalty must be in raw units (`w_z/sd`), because after de-standardizing, the inflated weight looks like an
   ordinary O(1) weight.
-- **Loading is strict.** A missing artifact, or one whose `feat_ver` does not match, is a hard error — refit it, never
-  a silent fallback. The error comes from the artifact loader, and it surfaces in `tune` / `eval`, which load the
+- **Loading is strict.** A missing artifact, one whose `feat_ver` does not match, or one that does not say what it
+  reads (`unweighted_cols` here, the booster's `cols` in a tree artifact), is a hard error — refit it, never a silent
+  fallback. `feat_ver` is untouched by that requirement: it versions the FEATURIZER's column vocabulary, which this
+  did not change, and bumping it would discard every persisted reservoir and node row over an artifact schema change.
+  The error comes from the artifact loader, and it surfaces in `tune` / `eval`, which load the
   prior directly. A greedy compile wraps `load_prior` best-effort, so there a bad artifact does not abort the compile:
   it produces the no-prior resolve described under the hierarchy below (first leaf, with the DB tier lost along with
   the prior object). A weight key that is no longer used, inside an artifact of the current version, is
@@ -450,7 +457,10 @@ What a newcomer needs to know about the fit:
 - A separate `weights_dynamic` set ranks kernels whose tiles are masked because an axis is symbolic; it is selected on
   the stamped `S_ext_n_symbolic_axis`. That stamp **routes and never carries a weight**: the dataset packs it like
   any other column, and the linear fit narrows it out of its own descent coordinates (`descent_cols`) while a tree
-  splits on it to price both regimes in one model. The reason is identifiability: the stamp is constant
+  splits on it to price both regimes in one model. It is still a column the model READS, so the artifact declares
+  it, every training view names it, and `LinearModel.score_rows` refuses a pool that arrives without it — a pool
+  with no stamp is labelled static, and nothing downstream could tell that from a genuinely static one.
+  The reason it carries no weight is identifiability: the stamp is constant
   across a candidate pool, so a linear term on it shifts every candidate equally and cancels out of the within-pool
   ranking. The rank objective cannot see such a term at all, which makes whatever value a descent lands on there
   noise rather than a fitted quantity.

--- a/emmy/compiler/pipeline/search/data/group.py
+++ b/emmy/compiler/pipeline/search/data/group.py
@@ -35,7 +35,9 @@ constructs anything, so a group is built once, already knowing every verified ro
 fit's case tier (``thread`` / ``warp`` / ``dyn`` / ``reduce`` / ``pointwise``) and is a REPORT LABEL only — it
 decides nothing.
 The weight set a group scores under is ``dynamic``, read off the routing stamp exactly as the deployed prior
-reads it. ``shape`` is the cross-validation fold group, and is the one identity here that decides something
+reads it — which is why the stamp has to survive whatever view packed the rows, and why every view that feeds a
+routing model names it (:func:`feature_view`).
+``shape`` is the cross-validation fold group, and is the one identity here that decides something
 structural: two goldens sharing it enumerate the same candidates, so a fold that separated them would train on
 the answer.
 """
@@ -49,7 +51,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from emmy.compiler.pipeline.search.data.freeze import freeze_reason
-from emmy.compiler.pipeline.search.features import ROUTING_FEATURES, is_dynamic_row, knob_features
+from emmy.compiler.pipeline.search.features import is_dynamic_row, knob_features
 from emmy.compiler.structural import digest
 
 # The default feature view: the ``D_*`` geometry/occupancy features plus the two ``MMA_*`` atom features that
@@ -60,15 +62,20 @@ from emmy.compiler.structural import digest
 # routing stamp is the same kind of quantity, which is why the LINEAR model narrows it out of its own
 # coordinates (:func:`~..prior.linear_model.descent_cols`) while the matrix still carries it for a tree to split on.
 #
+# ``S_ext_n_symbolic_axis`` is the exception, named because that carrying is neither optional nor automatic any
+# more: a pool's weight set is read off the stamp when its rows are packed, so a view without it labels every
+# pool static and the fit reports zero dynamic cases rather than an error.
+#
 # ``MMA_acc_bits`` is load-bearing: the f16-accumulate fork is spelled in the TILE codec's atom token, so a row
 # taking it is identical under every ``D_*`` feature to its f32-accumulate sibling. While the view dropped it,
 # 93% of a fast-math pool's rows sat in a tied pair no weight vector could separate, and 125 of the 280 RTX 5090
 # matmul goldens had a tied candidate ahead of them in emission order — unrankable at top-1 by construction.
 # The remaining ``MMA_*`` (``MMA_atom_m/n/k``, ``MMA_a_bits``) measured exactly neutral, so they stay out.
-DEFAULT_FEATURES = "D_*,MMA_tier,MMA_acc_bits"
+DEFAULT_FEATURES = "D_*,MMA_tier,MMA_acc_bits,S_ext_n_symbolic_axis"
 
-# The matmul view: every feature that can actually move a matmul candidate's rank, and no other. An
-# ordinary spec for :func:`feature_view` — pass it as ``--features``; nothing else filters.
+# The matmul view: every feature that can actually move a matmul candidate's rank, plus the routing stamp,
+# which moves no rank but decides which weight set does the ranking. An ordinary spec for :func:`feature_view` —
+# pass it as ``--features``; nothing else filters.
 #
 # Two classes are excluded, both provably free to drop rather than judged uninteresting. Measured over
 # the RTX 5090 matmul goldens (286 pools, 36.6 M candidates):
@@ -76,8 +83,9 @@ DEFAULT_FEATURES = "D_*,MMA_tier,MMA_acc_bits"
 # CONSTANT WITHIN EVERY POOL — the feature never varies between a pool's candidates, so a linear model
 # adds the same contribution to all of them and the term cancels out of the ranking exactly. Dropped:
 # ``D_bk_ge32``, ``D_l2_bk``, ``D_neg_masked_k/m/n``, ``D_pow2_threads``, ``D_raster_gn``,
-# ``D_stage_split`` (nothing enumerates it yet), and the four ``S_ext_*`` shape stamps (constant within
-# a shape by construction). ``D_pow2_threads`` is the striking one: it carries the shipped artifact's
+# ``D_stage_split`` (nothing enumerates it yet), and every ``S_ext_*`` shape stamp except the routing one
+# (constant within a shape by construction; the routing stamp is kept for the reason below, and is not a
+# coordinate either). ``D_pow2_threads`` is the striking one: it carries the shipped artifact's
 # LARGEST weight (+136.5, the cold-deploy incident weight) and cannot change a matmul ranking at all.
 #
 # GLOBALLY AFFINE DUPLICATES — a scaled copy of a kept feature (verified exact, residual at float
@@ -89,9 +97,9 @@ DEFAULT_FEATURES = "D_*,MMA_tier,MMA_acc_bits"
 #
 # Both exclusions are expressiveness-neutral by construction — the model can express exactly the same
 # ranking functions with these 53 coordinates as with all 72 — so this buys a smaller, faster,
-# better-identified fit, not a different model. (Naming no ``S_ext_*`` stamp costs the view nothing on the
-# weight-set choice either: :attr:`Group.dynamic` carries the answer, and the linear fit narrows the stamp
-# out of its coordinates regardless of the view.)
+# better-identified fit, not a different model. The routing stamp is the one ``S_ext_*`` the view keeps, and it
+# is not a coordinate either: :attr:`Group.dynamic` is read off it when the pool is packed, and the linear fit
+# narrows it back out of its descent (:func:`~..prior.linear_model.descent_cols`).
 #
 # ``D_stage_prefetch`` is the one feature here that is a step rather than a measurement — see its
 # definition in ``search/features.py`` for why the linear model cannot form it from ``D_stage_depth``.
@@ -104,7 +112,7 @@ MATMUL_FEATURES = (
     "D_stage_reg_depth,D_stage_tma,"
     "D_threads,D_tile_m,D_tile_n,D_tilen_clean,D_tma_aspect,D_tma_grid_m,D_tma_grid_n,D_tma_l2_splitk,"
     "D_tma_log2_area,D_w_grid_aspect,D_w_grid_m,D_w_grid_n,D_w_l2_bk,D_w_near_bk,D_wspec_warps,"
-    "MMA_a_bits,MMA_acc_bits"
+    "MMA_a_bits,MMA_acc_bits,S_ext_n_symbolic_axis"
 )
 
 
@@ -139,17 +147,24 @@ def feature_view(spec: str):
     drop it. Excluding is the safe direction: an unforeseen feature arrives in the view, where at worst the
     model ignores it.
 
-    :data:`~..features.ROUTING_FEATURES` are kept by EVERY view, named or not, and cannot be excluded.
-    They select a weight set rather than contribute a term, and the packed column is what a tree splits the
-    two regimes on, so keeping them costs a view nothing. A view that could drop them would instead route
-    every pool to the static weight set and report a fit with zero dynamic cases — silently, since nothing
-    downstream can tell an unfittable dynamic set from a genuinely static dataset. What keeps the stamp out
-    of a LINEAR descent is the model class narrowing its own coordinates
+    The spec is the whole rule. This filter knows two things — the patterns it was given and the name it is
+    asked about — and nothing about what any column MEANS. It used to exempt
+    :data:`~..features.ROUTING_FEATURES` from every spec, which is model knowledge (that one column selects a
+    weight set) living in the data layer, and it made the recorded spec a lie: a fit whose provenance said
+    ``"D_*,MMA_tier,MMA_acc_bits"`` had in fact trained on one more column. Two fits are only comparable when
+    the recorded specs match, so the spec has to be the truth about what was kept.
+
+    A view that feeds a model which routes therefore NAMES the routing stamp: :data:`DEFAULT_FEATURES`,
+    :data:`MATMUL_FEATURES` and the tree's ``TREE_FEATURES`` all do, and ``eval prior --dataset golden``
+    derives its spec from what the models declare (``Prior.columns``). Forgetting it is caught twice — at
+    commit time by the test over the shipped specs, and at scoring time by ``LinearModel.score_rows``, which
+    refuses a pool that carries no stamp rather than routing all of it to the static weight set. What keeps the
+    stamp out of a LINEAR descent is still the model class narrowing its own coordinates
     (:func:`~..prior.linear_model.descent_cols`), not the dataset withholding the column."""
     pats = [p.strip() for p in spec.split(",") if p.strip()]
     keep = _matcher([p for p in pats if not p.startswith("-")])
     drop = _matcher([p[1:] for p in pats if p.startswith("-")])
-    return lambda name: name in ROUTING_FEATURES or (keep(name) and not drop(name))
+    return lambda name: keep(name) and not drop(name)
 
 
 def feature_matrix(feats: list[dict[str, float]], names: list[str], *, fill: float = 0.0) -> np.ndarray:
@@ -336,8 +351,9 @@ class GoldenGroup(Group):
         _, matrix, dynamic = packed
         if dynamic != (tier == "dyn"):
             raise ValueError(
-                f"{key}: the routing stamp says dynamic={dynamic} but the case tier says {tier!r} — "
-                f"the source record's flag and its featurized rows disagree about the weight set"
+                f"{key}: the routing stamp says dynamic={dynamic} but the case tier says {tier!r} — either the "
+                f"source record's flag disagrees with its featurized rows, or the feature view these rows were "
+                f"packed under does not name the stamp"
             )
         rows = (goldens,) if isinstance(goldens, int) else goldens
         ids = tuple(sorted({int(i) for i in rows}))

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -47,13 +47,21 @@ from emmy.compiler.pipeline.knob import (
 # meaning. The shipped linear artifacts were schema-migrated with the bump: their retired
 # ``D_stage_ring`` coefficient moved to ``D_stage_prefetch``, the identical ``depth >= 2`` signal,
 # so the scoring function did not change and no synthetic refit was needed.
+#
+# Retirements like that one are now ENFORCED rather than only described: an artifact declares
+# the columns it reads (``Prior.columns``), and a test asserts the shipped artifact declares no
+# column this featurizer has stopped producing. A weight on a retired column is dead — the pool
+# never stamps the name, so the term can only ever score ``0.0``.
 FEATURIZER_VERSION = 4
 
 # The features that SELECT a weight set rather than describe a candidate — the ``S_ext_n_symbolic_axis`` stamp
 # a masked-tile (symbolic-axis) kernel carries. The stamp VOCABULARY belongs here with the rest of the feature
-# spelling, so a dataset can read it without importing a model; what to DO with it stays with the model classes
-# (``prior/linear_model.py``: the two weight sets, and ``descent_cols``, which keeps the stamp out of the linear
-# descent because a pool-constant term cancels out of a within-pool ranking).
+# spelling; what to DO with it stays with the model classes (``prior/linear_model.py``: the two weight sets, and
+# ``descent_cols``, which keeps the stamp out of the linear descent because a pool-constant term cancels out of
+# a within-pool ranking).
+#
+# The data layer knows this name through :func:`is_dynamic_row` alone, which labels a packed pool: a feature
+# view filters on its spec and nothing else, so a view that feeds a routing model names the stamp itself.
 #: The ``H_opt`` value of the DEPLOYABLE regime — the nvcc opt level ``compile`` / ``run`` / ``tune``
 #: all compile at, and therefore the only one a measurement is worth anything under. Rows carrying
 #: any other value came from a deliberately pinned sweep or from the era when tuning ranked at

--- a/emmy/compiler/pipeline/search/prior/base.py
+++ b/emmy/compiler/pipeline/search/prior/base.py
@@ -269,8 +269,30 @@ class Prior(ABC):
         The pool must carry every column the model reads. A group packed under a narrow feature view — the fit's
         ``D_*`` view, say — answers the linear model correctly, because its weight names are inside that view,
         while the online model's ``S_*`` / ``H_*`` columns would all fill absent and its predictions would be
-        about a kernel with no shape. Which columns a group carries is the BUILDER's decision, so an evaluation
-        that scores both halves builds its pools over the full featurization."""
+        about a kernel with no shape. Which columns a group carries is the BUILDER's decision, and :attr:`columns`
+        is how a builder asks instead of guessing."""
+
+    @property
+    @abstractmethod
+    def columns(self) -> tuple[str, ...]:
+        """Every column this model reads — what a builder must pack for :meth:`score_rows` to answer about the
+        kernel it was asked about rather than about a kernel with no shape. That includes columns the model
+        reads without weighting, the routing stamp above all; ``prior/linear_model.py``'s module docstring is
+        where the consequences of getting that wrong are written down.
+
+        This is a ``Prior``'s contract, NOT ``score_rows``'s: the fit-side scorers answer ``score_rows`` without
+        being ``Prior``\\ s (``fit/linear.LinearFit``, ``fit/catboost.CatBoostFit``) and are handed pools their own
+        trainer already packed to its own view, so they have nothing to ask and nobody to ask them. What this adds
+        is the ability to ASK. The column set was always there — a weight dict's keys, a booster's stored order —
+        but until it was published a caller could only restate it as a glob or widen to every column the featurizer
+        can spell.
+
+        A SUPERSET of what any single :meth:`score_rows` call packs, never the exact list: the linear model
+        reads one weight set at a time and this unions both, so a caller cannot under-request. Order is the
+        model's own; take a set if you need one.
+
+        Non-empty whenever :attr:`fitted`. An unfitted model has nothing to declare and is never asked — a report
+        drops such a half instead of showing it ranking at chance."""
 
     # --- deployable-evidence pick ------------------------------------------
 

--- a/emmy/compiler/pipeline/search/prior/catboost_model.py
+++ b/emmy/compiler/pipeline/search/prior/catboost_model.py
@@ -139,6 +139,13 @@ class CatBoostModel:
         """Feature dicts packed into this model's own column order, absent key = :data:`ABSENT`."""
         return np.array([[f.get(c, ABSENT) for c in self.cols] for f in feats_list], dtype=float)
 
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """:attr:`cols` under the shared protocol name (``Prior.columns``), so a pool builder can ask this model
+        class and the linear one the same question. Two spellings of one concept because ``cols`` is also the
+        artifact's schema key (:meth:`to_artifact`) and cannot move without breaking every written file."""
+        return self.cols
+
     def score_rows(self, group: Group) -> np.ndarray:
         """:meth:`quality_rows` over a whole packed pool — the pool-shaped entry point :class:`~..linear_model.LinearModel`
         also answers, and the ONE place the tree's column choice is made: :attr:`cols` in its own order,

--- a/emmy/compiler/pipeline/search/prior/fallback.py
+++ b/emmy/compiler/pipeline/search/prior/fallback.py
@@ -99,6 +99,16 @@ class FallbackPrior(Prior):
     def score_rows(self, group):
         return self._deploy.score_rows(group)
 
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """The columns of whichever half owns deploys, matching :meth:`score_rows` exactly — a pool packed from
+        this must be the pool that half can score.
+
+        Spelled out rather than left to :meth:`__getattr__`, which forwards to the ONLINE half: it would answer
+        the online half's columns while ``score_rows`` scored the offline one, and the mismatch would look like
+        a correct answer."""
+        return self._deploy.columns
+
     def pick(self, rows: list[dict]) -> tuple[int, float]:
         # Measured -O3 evidence lives in the ONLINE half's reservoir (the
         # offline prior has no dataset), and applies even while the model is

--- a/emmy/compiler/pipeline/search/prior/fit/catboost.py
+++ b/emmy/compiler/pipeline/search/prior/fit/catboost.py
@@ -76,8 +76,11 @@ logger = logging.getLogger(__name__)
 # ``D_splitk_deficit`` / ``D_splitk_roundtrip`` / ``D_near_kchunks`` / ``D_scalar_on_warp_eligible`` —
 # whose state operand (the needed split count, the reduce extent, the warp-eligibility stamp) is not a
 # candidate column at all, so no split on the pool can recover it.
+#
+# ``S_ext_n_symbolic_axis`` is the one kept column outside the ``D_*`` / ``MMA_*`` families, and is named
+# because nothing else here would keep it: splitting on the stamp is how ONE tree prices both regimes.
 TREE_FEATURES = (
-    "D_*,MMA_tier,MMA_acc_bits,"
+    "D_*,MMA_tier,MMA_acc_bits,S_ext_n_symbolic_axis,"
     "-D_l2_threads,-D_l2_reuse,-D_cells_cap,"
     "-D_near_threads,-D_near_area,-D_near_cells,-D_near_intensity,-D_near_tilen,-D_near_waves,-D_w_near_bk,-D_square,"
     "-D_stage_prefetch,-D_bk_ge32,-D_splitk_le2,-D_ctas_ge_sm,-D_bn_band,-D_bm_band,-D_tilen_clean,"

--- a/emmy/compiler/pipeline/search/prior/fit/linear.py
+++ b/emmy/compiler/pipeline/search/prior/fit/linear.py
@@ -38,10 +38,12 @@ from emmy.compiler.pipeline.search.metrics import best_rank
 from emmy.compiler.pipeline.search.prior.fit.tables import topk_table
 from emmy.compiler.pipeline.search.prior.linear_model import (
     FITTED_PARAMS,
+    GATE_FEATURES,
     LinearModel,
     descent_cols,
     gate_columns,
     quality_columns,
+    unweighted_cols,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,7 +146,8 @@ def fit_weights(
     sd[sd == 0] = 1.0
     # BEFORE the scaling, and as copies: the interaction compares a raw split COUNT against a raw
     # threshold, and the in-place pass below would otherwise both standardize those values and
-    # write through the column views.
+    # write through the column views. ``names`` carries the interaction's inputs — :meth:`LinearTrainer.fit`
+    # refuses a view without them — so this reads real columns rather than defaulting any.
     gates = [gate_columns(m, names) for m in mats]
     for m in mats:
         m -= mu
@@ -250,8 +253,22 @@ class LinearTrainer:
         be fit against the pair that will actually deploy.
 
         The static group list must be non-empty — the dynamic stage seeds from it. Callers guard
-        that; this does not."""
+        that; this does not.
+
+        Refuses a view that drops an interaction input the POOLS carry. The descent fits that term's weight
+        and threshold as coordinates, so without its columns it would search them against a term that is 0.0 for
+        every candidate and report the result as fitted. Asked against what the pools stamp rather than against
+        :data:`GATE_FEATURES` flatly, because the two absences are different: a corpus with no split-K finalize
+        anywhere (an all-pointwise slice) has nothing to price and is fit normally, while a view that hides a
+        finalize the pools do carry is the mistake worth refusing. One check here, at the entry point, rather
+        than a defaulted column deep in the scoring loop — which is what used to hide it."""
         names = list(descent_cols(self.feature_names))
+        stamped = {c for g in groups for c in GATE_FEATURES if c in g.feat_names}
+        if blind := sorted(stamped - set(names)):
+            raise ValueError(
+                f"the feature view drops {blind}, which the pools stamp and the atomic-free interaction reads — "
+                f"its fitted weight and threshold would be searched against a term that is 0.0 for every candidate"
+            )
         static_groups = [g for g in groups if not g.dynamic]
         dyn_groups = [g for g in groups if g.dynamic]
         rng = np.random.default_rng(self.random_state)
@@ -269,8 +286,13 @@ class LinearTrainer:
             l2=self.l2,
             objective=self.objective,
         )
+        static_weights = raw_weights(names, static_w, static_sd)
         model = LinearModel(
-            weights=raw_weights(names, static_w, static_sd),
+            # What this fit's model reads beyond its weights, written down once here and carried into the
+            # artifact. The dynamic stage below re-declares: a second weight set can price a name this one did
+            # not.
+            unweighted_cols=unweighted_cols(static_weights, None),
+            weights=static_weights,
             weights_dynamic=None,
             scale=self.init.scale,  # carried from the incumbent: rank-neutral, so the fit has no opinion on it
             **{n: float(v) for n, v in zip(FITTED_PARAMS, params, strict=True)},
@@ -291,7 +313,12 @@ class LinearTrainer:
             fit_params=False,
             objective=self.objective,
         )
-        return LinearFit(replace(model, weights_dynamic=raw_weights(names, dyn_w, dyn_sd)), static_ranks, dyn_ranks)
+        dyn_weights = raw_weights(names, dyn_w, dyn_sd)
+        return LinearFit(
+            replace(model, weights_dynamic=dyn_weights, unweighted_cols=unweighted_cols(model.weights, dyn_weights)),
+            static_ranks,
+            dyn_ranks,
+        )
 
 
 @dataclass(frozen=True)

--- a/emmy/compiler/pipeline/search/prior/linear_model.py
+++ b/emmy/compiler/pipeline/search/prior/linear_model.py
@@ -7,7 +7,20 @@ descends on — one fp16 golden enumerates ~78k rows, so the per-dict path is no
 module the two were separate transcriptions of the same formula kept in step by a parity test; drift between them
 would mean the fitter optimizing something other than what deploys. :meth:`LinearModel.score_rows` is the front
 door onto the matrix shape rather than a third shape: it takes a whole candidate pool and decides, once and here,
-which columns this model class wants out of it.
+which columns this model class wants out of it — through :meth:`LinearModel.cols_for`.
+
+**What a model reads is declared by its artifact.** This is the canonical statement of it; everything else
+points here. :attr:`LinearModel.columns` is the answer a pool BUILDER packs for, and it covers all three things
+this arithmetic touches: both weight sets, the interaction's two inputs (:data:`GATE_FEATURES`), and the routing
+stamp. The weight names are already in the artifact as dict keys, so only the rest is stored — the
+``unweighted_cols`` field — and :attr:`~LinearModel.columns` unions the two.
+
+The routing stamp is why the declaration could not be left implicit. It selects the weight set rather than
+entering the sum, so it is NOT among the columns packed into the matrix (:meth:`LinearModel.cols_for`) and it may
+never carry a weight — which means nothing derived from the weight keys can ever name it. A builder trusting such
+a derivation packs a pool with no stamp, and every candidate is then priced by the static weight set with no
+symptom at all, a pool without a stamp being exactly what a genuinely static pool looks like.
+:meth:`LinearModel.score_rows` refuses a pool that carries no stamp for that reason.
 
 The public scoring methods borrow ``Prior``'s own featurized surface — ``mean_score_features`` and
 ``mean_scores_features`` (``quality`` / ``quality_rows`` / ``score_rows`` are this module's own vocabulary, not
@@ -27,7 +40,8 @@ staged prologues locked out, occupancy over a free-dim product that excludes the
 under ``weights_dynamic``. That stamp must never ALSO be a fitted weight: it is constant across a candidate
 pool, so a linear term on it adds the same constant to every candidate and cancels exactly out of the
 within-pool ranking. The rank objective cannot see it, and whatever value a descent lands on
-there is decided by the regularizer and noise. It routes; it is never a coordinate.
+there is decided by the regularizer and noise. It routes; it is never a coordinate — but it is a column this
+model reads, so it is declared, and a feature view that feeds this model names it.
 """
 
 from __future__ import annotations
@@ -74,11 +88,18 @@ FITTED_PARAMS = ("atomic_free_weight", "atomic_free_split_threshold")
 # two lines once. Reordering to match the shipped file would instead change what a refit emits.
 PARAM_ORDER = ("scale", *FITTED_PARAMS)
 
-# The two features :func:`atomic_free_term` reads, each with the value an omitted featurization implies: no
-# deferred combine kernel, and a split count of 1. Spelled once — the dict path (:func:`gate_values`), the
-# matrix path (:func:`gate_columns`) and the fit-side column selection all read them from here, and a
-# disagreement between those would silently price the interaction differently on the two sides.
-GATE_DEFAULTS = {"D_finalize_kernel": 0.0, "D_splitk": 1.0}
+# The two features :func:`atomic_free_term` reads, in the order it takes them — the INTERACTION's input list,
+# not a column set. Which column is the finalize flag and which is the split count is the formula's business, and
+# the fitted pair in ``params`` prices exactly this formula. Spelled once so the dict path (:func:`gate_values`),
+# the matrix path (:func:`gate_columns`) and :meth:`LinearModel.cols_for` cannot disagree.
+#
+# ONE absent value, 0.0, on both access shapes — what :meth:`Group.matrix` fills a missing column with, so an
+# absent finalize flag zeroes the term because the formula says so at ``finalize == 0``. Each name used to carry
+# a default of its own instead (finalize 0.0, split count 1.0 — a count no featurization produces), applied when
+# the NAME was missing from the packed columns, which made "the view dropped this column" indistinguishable from
+# "the pool never stamped it". Neither reader can tell those apart, so the view case is checked where both are
+# visible: ``LinearTrainer.fit``, which sees the view and what the pools stamp.
+GATE_FEATURES = ("D_finalize_kernel", "D_splitk")
 
 
 def atomic_free_term(finalize_kernel, splitk, *, weight: float, threshold: float):
@@ -94,29 +115,29 @@ def atomic_free_term(finalize_kernel, splitk, *, weight: float, threshold: float
 
 
 def gate_values(feats: dict) -> tuple[float, ...]:
-    """:data:`GATE_DEFAULTS` read off one feature dict — the per-row twin of :func:`gate_columns`."""
-    return tuple(feats.get(name, default) for name, default in GATE_DEFAULTS.items())
+    """The interaction's inputs read off one feature dict — the per-row twin of :func:`gate_columns`, absent
+    key = 0.0 (:data:`GATE_FEATURES`)."""
+    return tuple(feats.get(name, 0.0) for name in GATE_FEATURES)
 
 
 def gate_columns(mat: np.ndarray, names) -> tuple[np.ndarray, ...]:
-    """:data:`GATE_DEFAULTS` read off a packed pool, one column each, defaulted exactly as
-    :func:`gate_values` defaults the dict path.
-
-    The default applies when the NAME is absent from ``names``, which is the matrix-side spelling of the dict
-    path's "key absent from the row". It cannot key off the VALUE: :meth:`Group.matrix` fills a name the pool
-    never stamped with a zeros column, so by then "unstamped" and "stamped 0.0" are the same bits, and defaulting
-    a present zero would rewrite a genuine ``D_splitk=0`` into a 1. The fitter also cannot trim the gate names
-    out per pool, because one ``names`` list indexes the weight vector for every pool in the fit.
-
-    So the two paths read a pool differently in exactly one situation: a gate name in ``names`` that the pool
-    never stamped. That does not arise — the featurizer stamps the split count alongside the finalize flag, and
-    over 1.33 M enumerated candidate rows the 536 917 carrying a nonzero finalize all carry ``D_splitk`` too.
-    Rows without a finalize are unaffected regardless, since it zeroes the whole term.
+    """The interaction's inputs read off a packed pool, one column each — the matrix twin of
+    :func:`gate_values`, a name ``names`` does not carry reading as the same 0.0 (:data:`GATE_FEATURES`).
 
     Copies, never column views: the fitter z-scores its pools IN PLACE, and these values must stay in raw units —
     the interaction compares a split COUNT against its threshold."""
     idx = {n: j for j, n in enumerate(names)}
-    return tuple(mat[:, idx[name]].copy() if name in idx else np.full(len(mat), default) for name, default in GATE_DEFAULTS.items())
+    return tuple(mat[:, idx[name]].copy() if name in idx else np.zeros(len(mat)) for name in GATE_FEATURES)
+
+
+def unweighted_cols(weights: dict[str, float], weights_dynamic: dict[str, float] | None) -> tuple[str, ...]:
+    """The columns a model with these weights reads WITHOUT weighting them: the routing stamp, plus any
+    interaction input a fit pruned out of both weight sets — :attr:`LinearModel.unweighted_cols`.
+
+    The WRITER's expression, called where a fit decides what its model reads (and again where the ship path
+    carries a dynamic set forward). A reader unions two artifact fields instead, and needs neither
+    :data:`GATE_FEATURES` nor ``ROUTING_FEATURES`` to do it."""
+    return tuple(sorted((set(GATE_FEATURES) | set(ROUTING_FEATURES)) - set(weights) - set(weights_dynamic or {})))
 
 
 def quality_columns(mat: np.ndarray, w: np.ndarray, gates: tuple[np.ndarray, np.ndarray], *, weight: float, threshold: float):
@@ -131,13 +152,17 @@ def quality_columns(mat: np.ndarray, w: np.ndarray, gates: tuple[np.ndarray, np.
 
 @dataclass(frozen=True)
 class LinearModel:
-    """A fitted linear ranker over ``features.knob_features`` — two weight sets, the scalar scoring params, and
-    nothing else. Immutable and comparable, so a fit result is a value the caller can diff, swap and serialize.
+    """A fitted linear ranker over ``features.knob_features`` — the columns it reads, two weight sets, the scalar
+    scoring params, and nothing else. Immutable and comparable, so a fit result is a value the caller can diff,
+    swap and serialize.
 
     ``weights_dynamic`` is ``None`` only inside an incomplete fit (a training slice with no symbolic-axis cases).
     A deploy artifact always carries both sets — :meth:`to_artifact` refuses to write a model that does not, and
     the caller substitutes its fallback set first."""
 
+    # The declared columns that are not weight keys — the routing stamp, and any interaction input pruned out
+    # of both weight sets. The other half of :attr:`columns`; :func:`unweighted_cols` is where a fit forms it.
+    unweighted_cols: tuple[str, ...]
     weights: dict[str, float]
     weights_dynamic: dict[str, float] | None
     # exp() argument scale — keeps the deployed proxy in a finite, sane range. Rank-neutral (a monotone
@@ -242,18 +267,57 @@ class LinearModel:
         without knowing which one they hold.
 
         Two things a caller must not re-derive, which is why they live here rather than at each call site.
-        The COLUMNS are the weight set's names UNION :data:`GATE_DEFAULTS`: the interaction's two inputs have
-        to be present whether or not the weight dict names them, since a pruned zero weight drops the key.
-        The WEIGHT SET comes from :meth:`weight_set`, so the static-vs-dynamic choice is made once, here,
-        and a second copy of that routing cannot drift from it.
+        The COLUMNS come from :meth:`cols_for`. The WEIGHT SET comes from :meth:`weight_set`, so the
+        static-vs-dynamic choice is made once, here, and a second copy of that routing cannot drift from it.
+
+        The pool must CARRY the routing stamp: ``Group.dynamic`` is read off it when the rows are packed, so a
+        pool that lost it arrives labelled static and would be priced entirely by the static weight set, whatever
+        its regime and with nothing in the result to say so (module docstring). Refusing makes that a failure
+        rather than a silence, for every builder — a feature view that stopped naming the stamp, a golden pool,
+        or measured rows recorded before the featurizer stamped it.
+
+        Nothing else about the pool is required. A column this model weights but the pool never stamped is the
+        ordinary absent case and scores 0.0 (:meth:`Group.matrix`'s fill for this model class), which is what a
+        reduce or pointwise pool legitimately looks like against an artifact fitted over every regime.
 
         ``None`` when the group needs the dynamic set and this model has none — the unfittable
         cross-validation fold. Asking :meth:`weight_set` instead would raise, and a fold harness wants an
         answer it can skip on, not an exception."""
+        if unstamped := [c for c in ROUTING_FEATURES if c not in group.feat_names]:
+            raise ValueError(
+                f"pool {group.key!r} carries no {unstamped} column: this model reads the routing stamp to pick a "
+                f"weight set, and without it every candidate would be priced as static whatever its regime"
+            )
         if group.dynamic and self.weights_dynamic is None:
             return None
-        names = sorted(set(self.weight_set(group.dynamic)) | set(GATE_DEFAULTS))
+        names = self.cols_for(group.dynamic)
         return self.quality_rows(group.matrix(names), names, dynamic=group.dynamic)
+
+    def cols_for(self, dynamic: bool) -> list[str]:
+        """The columns to PACK for one weight set's score: that set's names UNION :data:`GATE_FEATURES`. The
+        interaction's two inputs have to be present whether or not the weight dict names them, since a pruned
+        zero weight drops the key.
+
+        A subset of :attr:`columns`, without the routing stamp: the stamp selects this list rather than
+        entering the arithmetic (module docstring), and widening the matmul by a weightless column is exactly
+        what the next paragraph says not to do.
+
+        Per weight set rather than one list for both, which the declaration covers jointly. Scoring the static
+        set over the union of both would add a column carrying weight ``0.0`` — arithmetically nothing, but
+        ``mat @ w`` blocks differently at 60 columns than at 59 and the result moves in the last bits (measured:
+        up to 5.7e-14 on qualities of order 10^2, over the shipped artifact). That is not absorbable noise here:
+        :func:`~..metrics.dual_rank` counts EXACT float equality to build the pessimistic rank, so a
+        perturbation that splits a genuine score plateau moves a reported rank by the whole plateau's width, and
+        a rank is an integer no rounding can smooth."""
+        return sorted(set(self.weight_set(dynamic)) | set(GATE_FEATURES))
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """Every column this model reads, from the artifact's two halves: the weight keys, plus
+        :attr:`unweighted_cols` for what carries no weight. Pack a pool over this and it is a pool this model can
+        score, without knowing anything else about it — see the module docstring for why that includes the
+        routing stamp."""
+        return tuple(sorted(set(self.weights) | set(self.weights_dynamic or {}) | set(self.unweighted_cols)))
 
     def weight_set(self, dynamic: bool) -> dict[str, float]:
         """The weight dict a row of this kind scores under — the ONE place the two sets are chosen between.
@@ -278,6 +342,7 @@ class LinearModel:
         params = obj.get("params", {})
         dyn = obj.get("weights_dynamic")
         return cls(
+            unweighted_cols=tuple(obj["unweighted_cols"]),
             weights=dict(obj.get("weights", {})),
             weights_dynamic=None if dyn is None else dict(dyn),
             scale=float(params["scale"]),
@@ -297,6 +362,9 @@ class LinearModel:
         return {
             "feat_ver": FEATURIZER_VERSION,
             "kind": "linear",
+            # Leads the weights: a reader meets the columns that carry no weight before the ones that do, and
+            # ``Prior.columns`` is this field unioned with the weight keys.
+            "unweighted_cols": list(self.unweighted_cols),
             "weights": self.weights,
             "weights_dynamic": self.weights_dynamic,
             "params": {name: float(getattr(self, name)) for name in PARAM_ORDER},

--- a/emmy/compiler/pipeline/search/prior/offline.py
+++ b/emmy/compiler/pipeline/search/prior/offline.py
@@ -49,7 +49,10 @@ _DEFAULT_FILE = Path(__file__).parent / "offline_weights.json"
 # ``kind`` has always been written; this is where it is finally read. A file naming an unknown kind is a
 # hard error, not a fallback to linear — see :func:`_load_artifact`.
 _KINDS = {
-    "linear": (LinearModel, ("weights", "weights_dynamic", "params"), linear_model.PARAM_ORDER),
+    # Each kind must say what it reads: ``unweighted_cols`` here (unioned with the weight keys — see
+    # ``LinearModel.columns``), the booster's positional ``cols`` for the tree. ``feat_ver`` is untouched by the
+    # requirement, because the featurizer's vocabulary did not change.
+    "linear": (LinearModel, ("unweighted_cols", "weights", "weights_dynamic", "params"), linear_model.PARAM_ORDER),
     # ``model_file`` (the sidecar path) is the current spelling; the inline base64 ``model`` is the pre-split
     # one, still readable so run artifacts written before the split keep loading. Either satisfies the check.
     "catboost": (CatBoostModel, ("cols", "params"), catboost_model.PARAM_ORDER),
@@ -115,6 +118,7 @@ class OfflinePrior(Prior):
         self,
         *,
         model=None,
+        unweighted_cols: tuple[str, ...] | None = None,
         weights: dict[str, float] | None = None,
         weights_dynamic: dict[str, float] | None = None,
         scale: float | None = None,
@@ -124,6 +128,7 @@ class OfflinePrior(Prior):
         super().__init__()
         # Keyed by LinearModel's own field names, which is what lets the merge below be a ``replace``.
         overrides = {
+            "unweighted_cols": unweighted_cols,
             "weights": weights,
             "weights_dynamic": weights_dynamic,
             "scale": scale,
@@ -159,6 +164,14 @@ class OfflinePrior(Prior):
     def model(self):
         """The scoring function this prior ranks with — a :class:`LinearModel` or a ``CatBoostModel``."""
         return self._model
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """The artifact's own declared columns — straight through to the model, for the same reason
+        :meth:`score_rows` is: the model is the object that holds the declaration, and this adapter would only be
+        a second place to get it wrong. Always non-empty, so a caller never has to handle an offline half that
+        cannot say what it reads."""
+        return self._model.columns
 
     @property
     def fitted(self) -> bool:

--- a/emmy/compiler/pipeline/search/prior/offline_weights.json
+++ b/emmy/compiler/pipeline/search/prior/offline_weights.json
@@ -1,6 +1,9 @@
 {
   "feat_ver": 4,
   "kind": "linear",
+  "unweighted_cols": [
+    "S_ext_n_symbolic_axis"
+  ],
   "weights": {
     "D_aspect": 0.12744471745958774,
     "D_bk_ge32": -0.2506127603794619,

--- a/emmy/compiler/pipeline/search/prior/offline_weights_matmul_rtx5090.json
+++ b/emmy/compiler/pipeline/search/prior/offline_weights_matmul_rtx5090.json
@@ -1,6 +1,9 @@
 {
   "feat_ver": 4,
   "kind": "linear",
+  "unweighted_cols": [
+    "S_ext_n_symbolic_axis"
+  ],
   "weights": {
     "D_aspect": -1.6678268333456214,
     "D_bm_band": -0.8901032742830086,

--- a/emmy/compiler/pipeline/search/prior/online.py
+++ b/emmy/compiler/pipeline/search/prior/online.py
@@ -45,6 +45,15 @@ class OnlinePrior(Prior):
     def fitted(self) -> bool:
         return self._model is not None
 
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """The columns the last :meth:`fit` regressed on, in the order the booster indexes them — already
+        persisted as the checkpoint's ``cols`` (:meth:`to_json`), so this publishes state rather than adding it.
+
+        Empty until the first fit: :meth:`fit` returns before assigning the model when the dataset yields no
+        columns, so a fitted half always has columns to declare."""
+        return tuple(self._cols or ())
+
     def fit(self) -> None:
         """Refit a fresh CatBoostRegressor on the whole bounded dataset (RMSE on
         ``log(latency µs)``). Columns are the sorted union of feature keys; an

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -605,7 +605,10 @@ def test_prior_reports_both_halves_over_benched_pools(run_cli, tmp_path):
 
     db_path = tmp_path / "n.db"
     db = SearchDB(db_path)
-    s = {"S_ext_free_prod": 1024.0, "S_ext_reduce_max": 512.0, "S_loop_depth": 2.0, "H_cc": 120.0, "H_opt": 3.0}
+    # ``S_ext_n_symbolic_axis`` is on every recorded row (the featurizer emits it unconditionally) and the
+    # linear half refuses a pool that cannot be routed, so a fixture row carries it too.
+    s = {"S_ext_free_prod": 1024.0, "S_ext_reduce_max": 512.0, "S_loop_depth": 2.0, "S_ext_n_symbolic_axis": 0.0}
+    s |= {"H_cc": 120.0, "H_opt": 3.0}
     db.record_nodes(
         [
             NodeRow("P", None, "ctx", "mm", s, 1.0, 1, gpu=_GPU, is_leaf=False),
@@ -671,7 +674,10 @@ def test_prior_writes_the_report_as_json(run_cli, tmp_path):
 
     db_path = tmp_path / "n.db"
     db = SearchDB(db_path)
-    s = {"S_ext_free_prod": 1024.0, "S_ext_reduce_max": 512.0, "S_loop_depth": 2.0, "H_cc": 120.0, "H_opt": 3.0}
+    # ``S_ext_n_symbolic_axis`` is on every recorded row (the featurizer emits it unconditionally) and the
+    # linear half refuses a pool that cannot be routed, so a fixture row carries it too.
+    s = {"S_ext_free_prod": 1024.0, "S_ext_reduce_max": 512.0, "S_loop_depth": 2.0, "S_ext_n_symbolic_axis": 0.0}
+    s |= {"H_cc": 120.0, "H_opt": 3.0}
     db.record_nodes(
         [
             NodeRow("c8", None, "ctx", "mm", {**s, "BM": 8}, 3.0, 2, gpu=_GPU, is_leaf=True),

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -698,6 +698,48 @@ def test_prior_writes_the_report_as_json(run_cli, tmp_path):
     assert summary["metrics"]["regret1"]["groups"] == 1
 
 
+def test_the_golden_dataset_builds_pools_over_the_columns_its_halves_declare(tmp_path, monkeypatch, caplog):
+    """``--dataset golden`` asks the models it is about to score which columns they read, instead of
+    enumerating every column the featurizer can spell. The spec it builds with is exactly the union of the
+    halves' declarations, and it lands in the header under the same ``features`` key ``emmy fit`` uses.
+
+    In-process rather than through ``run_cli``: the real builder traces and enumerates the whole golden
+    corpus, which is minutes to hours, so the builder is patched the way ``emmy fit``'s own command test
+    patches it. What is under test is which spec reaches it."""
+    import argparse
+    import logging
+
+    from emmy.commands import eval as eval_cmd
+    from emmy.compiler.pipeline.search.data.group import GoldenGroup
+    from emmy.compiler.pipeline.search.prior import OfflinePrior
+
+    seen: dict[str, str] = {}
+
+    def fake_build(spec, **_kwargs):
+        seen["spec"] = spec
+        rows = [{"S_ext_n_symbolic_axis": 0.0, "H_opt": 3.0, "D_threads": float(t)} for t in (128, 256)]
+        return [GoldenGroup.from_dicts(f"{_GPU}/k", "k", "thread", _GPU, "k", 0, rows)], []
+
+    monkeypatch.setattr("emmy.commands.fit.build_golden_groups", fake_build)
+    monkeypatch.setattr(eval_cmd, "_emit_golden_deploy_check", lambda *_args, **_kwargs: None)
+
+    parser = argparse.ArgumentParser()
+    eval_cmd.register_eval_command(parser.add_subparsers())
+    out = tmp_path / "report.json"
+    args = parser.parse_args(["eval", "prior", "--dataset", "golden", "--json", str(out), "--online-file", str(tmp_path / "absent.json")])
+    with caplog.at_level(logging.INFO, logger="emmy.commands.eval"):
+        args.func(args)
+
+    # The offline half alone, because the online one is absent and therefore dropped before scoring.
+    declared = ",".join(sorted(OfflinePrior().columns))
+    assert seen["spec"] == declared
+    assert seen["spec"] != "*"
+    assert json.loads(out.read_text())["header"]["features"] == declared
+    # The console keeps the width, not 60 column names: the spec is what the JSON is for.
+    provenance = next(line for line in caplog.messages if "pool_sample=" in line)
+    assert declared not in provenance and f"({len(declared)} chars)" in provenance
+
+
 def test_nodes_dataset_rejected_by_db_only_subcommand(run_cli, tmp_path):
     """Widening the ``--dataset`` vocabulary with ``nodes`` must not leak into the
     db-only subcommands — ``eval variants`` still exits 2 on it."""

--- a/tests/compiler/pipeline/search/prior/test_fit_cv.py
+++ b/tests/compiler/pipeline/search/prior/test_fit_cv.py
@@ -21,7 +21,7 @@ from emmy.compiler.pipeline.search.prior.fit import LinearFit, LinearTrainer
 from emmy.compiler.pipeline.search.prior.fit import cv as fit_cv
 from emmy.compiler.pipeline.search.prior.fit.catboost import TREE_FEATURES
 from emmy.compiler.pipeline.search.prior.fit.run import run_fit
-from emmy.compiler.pipeline.search.prior.linear_model import LinearModel, descent_cols
+from emmy.compiler.pipeline.search.prior.linear_model import LinearModel, descent_cols, unweighted_cols
 
 # --- feature view ------------------------------------------------------------------
 
@@ -64,7 +64,7 @@ def test_a_merged_case_reports_its_positive_count():
     two. ``positives`` is what makes that visible: without it a metrics file with fewer groups looks like lost
     data rather than a pool that gained a second verified answer."""
     groups = [_case("m.512", "warp", "gpuA", pinned=1), _case("m.1024", "warp", "gpuA", pinned=(0, 2))]
-    model = LinearFit(LinearModel(weights={"D_a": -1.0}, weights_dynamic=None, scale=0.1, **SEED_PARAMS), [0], None)
+    model = LinearFit(_model({"D_a": -1.0}, None), [0], None)
     rows = fit_cv.evaluate_full_train(groups, model)["per_golden"]
     assert rows["gpuA/m.512"]["positives"] == 1
     assert rows["gpuA/m.1024"]["positives"] == 2
@@ -298,7 +298,7 @@ def test_a_routing_feature_may_never_carry_a_fitted_weight():
         sets = {"weights": {"D_a": 1.0}, "weights_dynamic": {"D_a": 1.0}}
         sets[field] = {**sets[field], "S_ext_n_symbolic_axis": 0.5}
         with pytest.raises(ValueError, match="never contributes a term"):
-            LinearModel(scale=0.1, atomic_free_weight=0.0, atomic_free_split_threshold=4.0, **sets)
+            LinearModel(unweighted_cols=unweighted_cols(**sets), scale=0.1, atomic_free_weight=0.0, atomic_free_split_threshold=4.0, **sets)
 
 
 def test_matrix_fill_declares_the_absent_semantics():
@@ -385,11 +385,22 @@ NAMES = ["D_a", "D_b"]
 SEED_PARAMS = {"atomic_free_weight": 0.0, "atomic_free_split_threshold": 4.0}
 
 
+def _model(weights, weights_dynamic) -> LinearModel:
+    """A model declaring exactly what it reads, the way a fit writes one."""
+    return LinearModel(
+        unweighted_cols=unweighted_cols(weights, weights_dynamic),
+        weights=weights,
+        weights_dynamic=weights_dynamic,
+        scale=0.1,
+        **SEED_PARAMS,
+    )
+
+
 # The fold trainer the command layer wires up: zero-seeded weights, samples=0. One instance serves
 # every fold — the trainer is immutable and its fit is pure.
 FOLD_TRAINER = LinearTrainer(
     feature_names=tuple(NAMES),
-    init=LinearModel(weights={}, weights_dynamic=None, scale=0.1, **SEED_PARAMS),
+    init=_model({}, None),
     samples=0,
     warm_start=False,
 )
@@ -486,7 +497,7 @@ def test_fittability_guard_excludes_fold_loudly():
 
 def _metrics():
     groups = _cases()
-    model = LinearFit(LinearModel(weights={"D_a": -1.0, "D_b": 0.25}, weights_dynamic={"D_a": -0.5}, scale=0.1, **SEED_PARAMS), [0], [0])
+    model = LinearFit(_model({"D_a": -1.0, "D_b": 0.25}, {"D_a": -0.5}), [0], [0])
     cv = fit_cv.run_folds(groups, trainer=FOLD_TRAINER, k=3)
     skipped = [
         ("gpuA", "attention.hd128", fit_cv.OUT_OF_SCOPE),

--- a/tests/compiler/pipeline/search/prior/test_fit_cv.py
+++ b/tests/compiler/pipeline/search/prior/test_fit_cv.py
@@ -33,7 +33,8 @@ def test_default_feature_view_keeps_the_geometry_and_atom_features():
     f32 sibling. Everything else (the shape/hardware pass-throughs) is constant within a pool."""
     keep = feature_view(DEFAULT_FEATURES)
     sample = {"D_waves": 1.0, "D_bk_gap": 2.0, "MMA_tier": 3.0, "MMA_acc_bits": 4.0, "MMA_atom_m": 5.0, "S_ext_free_prod": 6.0, "D_": 7.0}
-    assert {k for k in sample if keep(k)} == {"D_waves", "D_bk_gap", "D_", "MMA_tier", "MMA_acc_bits"}
+    sample["S_ext_n_symbolic_axis"] = 0.0  # named by the view: the pool's weight set is read off it
+    assert {k for k in sample if keep(k)} == {"D_waves", "D_bk_gap", "D_", "MMA_tier", "MMA_acc_bits", "S_ext_n_symbolic_axis"}
 
 
 def test_matmul_view_is_exact_names_through_the_one_parser():
@@ -282,10 +283,11 @@ def test_routing_stamp_selects_the_weight_set_and_never_becomes_a_coordinate():
         assert "S_ext_n_symbolic_axis" not in descent_cols(group.feat_names)
     # The tier decides nothing, but it still has to AGREE: it and the stamp are the same fact arriving
     # by two routes, so a disagreement means one of them is wrong and the pool would otherwise train
-    # under the wrong weight set with nothing reporting it.
-    with pytest.raises(ValueError, match="disagree about the weight set"):
+    # under the wrong weight set with nothing reporting it. The second case is also what a feature view
+    # that stopped naming the stamp produces, which is why the message names both causes.
+    with pytest.raises(ValueError, match="the case tier says"):
         GoldenGroup.from_dicts("gpuA/x", "x", "warp", "gpuA", "x", 0, [{"D_a": 1.0, "S_ext_n_symbolic_axis": 1.0}])
-    with pytest.raises(ValueError, match="disagree about the weight set"):
+    with pytest.raises(ValueError, match="does not name the stamp"):
         GoldenGroup.from_dicts("gpuA/x", "x", "dyn", "gpuA", "x", 0, [{"D_a": 1.0}])
 
 
@@ -344,13 +346,22 @@ def test_matrix_is_memoized_and_read_only():
     assert other.shape == (2, 1) and g.matrix(["D_a", "D_b"]).shape == (2, 2)
 
 
-def test_no_feature_view_can_drop_the_routing_stamp():
-    """Routing is not a view choice. A spec that names neither the stamp nor a prefix covering it still
-    keeps it — otherwise every pool would route to the static weight set and the run would report a
-    dataset with zero dynamic groups rather than an error."""
-    for spec in (DEFAULT_FEATURES, MATMUL_FEATURES, "D_waves"):
+def test_every_shipped_view_names_the_routing_stamp():
+    """A view that drops the routing stamp labels every pool static: the weight set is read off the stamp when
+    the rows are packed, so the run reports a dataset with zero dynamic groups rather than an error, and nothing
+    downstream can tell that from a genuinely static corpus.
+
+    The filter no longer protects against that by exempting the stamp from every spec — a column filter knows
+    its patterns and the name it is asked about, and an exemption made the recorded spec a lie about what was
+    kept. So each shipped view NAMES the stamp, and this is the check that catches one that forgets. The eval's
+    view is not here because it is not a constant: it is the union of what the models declare
+    (``Prior.columns``), which names the stamp for the same reason."""
+    for spec in (DEFAULT_FEATURES, MATMUL_FEATURES, TREE_FEATURES):
         assert feature_view(spec)("S_ext_n_symbolic_axis"), spec
-    assert not feature_view("D_waves")("S_ext_free_prod")  # only the routing features are exempt
+    # And the filter keeps nothing it was not given: an unnamed stamp drops like any other column, which is
+    # what ``LinearModel.score_rows`` refuses a pool over.
+    assert not feature_view("D_waves")("S_ext_n_symbolic_axis")
+    assert not feature_view("D_waves")("S_ext_free_prod")
 
 
 def test_tree_view_drops_only_what_a_tree_re_derives():
@@ -365,7 +376,9 @@ def test_tree_view_drops_only_what_a_tree_re_derives():
     # a relation BETWEEN two columns, and the knob x state block whose state operand is not a column.
     for name in ("D_threads", "D_cells", "D_aspect", "D_stage_depth", "D_splitk", "D_pow2_threads", "D_bn_ge_bm", "D_splitk_excess"):
         assert keep(name), name
-    assert keep("S_ext_n_symbolic_axis"), "the routing stamp is exempt from every view, exclusions included"
+    # The one kept column outside the D_*/MMA_* families: one tree prices both regimes by splitting on the
+    # stamp, where the linear model needs a second weight vector.
+    assert keep("S_ext_n_symbolic_axis") and not default("S_ext_free_prod")
 
 
 def test_feature_view_exclusions_apply_to_names_and_globs():

--- a/tests/compiler/pipeline/search/prior/test_prior_fit.py
+++ b/tests/compiler/pipeline/search/prior/test_prior_fit.py
@@ -149,6 +149,68 @@ def test_built_artifact_loads_through_offline_prior(tmp_path, monkeypatch):
     assert json.loads(path.read_text())["feat_ver"] == FEATURIZER_VERSION
 
 
+@pytest.mark.parametrize("path", sorted(_DEFAULT_FILE.parent.glob("offline_weights*.json")), ids=lambda p: p.stem)
+def test_every_shipped_artifact_declares_the_columns_it_cannot_weight(path):
+    """Every checked-in linear artifact must declare the columns it reads that no weight key can spell: the
+    routing stamp it picks a weight set with, and the interaction's two inputs wherever a fit pruned their
+    weights away. ``columns`` is the weight keys unioned with ``unweighted_cols``, so this is the whole of what
+    the second field is for — a model whose declaration missed one would hand a pool builder a short list and be
+    handed back a pool that silently misroutes, or prices the interaction off a zeros column.
+
+    Both files, because both are reachable: the sibling is a scoped experiment selected with
+    ``EMMY_OFFLINE_FILE`` / ``--offline-file``, and it is hand-maintained, which is exactly when a schema check
+    earns its place."""
+    art = json.loads(path.read_text())
+    declared = set(OfflinePrior(model=LinearModel.from_artifact(art)).columns)
+
+    assert set(GATE_FEATURES) <= declared
+    assert set(features.ROUTING_FEATURES) <= declared
+    # And the stored half is only ever the part the weights cannot carry.
+    assert set(art["unweighted_cols"]) == declared - set(art["weights"]) - set(art["weights_dynamic"] or {})
+
+
+def test_every_column_the_shipped_artifact_declares_is_still_produced():
+    """A weight for a column the featurizer no longer spells is a DEAD term — it can never be anything but
+    ``0.0``, because the pool never stamps the name and ``Group.matrix`` fills it with the linear model's
+    absent value. Nothing used to notice, because nothing could ask an artifact which columns it read.
+
+    This is not hypothetical drift. Retiring ``D_stage_ring`` is what collapsed the RTX 5090 matmul fit's
+    top-1 from 54 of 242 goldens to 4, and the shipped artifact carried that dead weight — its fourth-largest
+    by magnitude — for months, documented but unenforced. The ``FEATURIZER_VERSION`` 4 bump finally migrated
+    the coefficient onto ``D_stage_prefetch``, the identical ``depth >= 2`` signal, so the artifact now
+    declares nothing the featurizer has stopped producing.
+
+    What counts as "still produced" is measured by re-featurizing every recorded golden's OWN knobs: no
+    enumeration, no ``Context``, no GPU, and it enters through ``knob_features``, the same door the golden
+    group builder feeds. A column no recorded configuration exhibits is exactly as dead as one the featurizer
+    cannot spell."""
+    declared = set(OfflinePrior().columns)
+    produced: set[str] = set()
+    for record in GOLDEN_RECORDS:
+        if record.knobs:
+            produced |= set(features.knob_features({**record.structural_features, **record.knobs}))
+        if declared <= produced:
+            break  # every remaining record can only widen ``produced``, so the verdict is already fixed
+
+    assert declared - produced == set()
+
+
+def test_a_view_that_hides_a_stamped_interaction_input_is_refused():
+    """The fit searches the interaction's weight and threshold as descent coordinates. A view that drops
+    ``D_finalize_kernel`` while the pools carry it leaves the term at 0.0 for every candidate, so the search
+    walks two coordinates that cannot move the objective and the artifact ships whatever they landed on.
+
+    Refused at the trainer, which is the one place that sees both the view and what the pools stamp. A corpus
+    that never stamps the column at all is a different thing — nothing to price — and still fits: that is the
+    case the synthetic pools above are."""
+    cases, names = _synthetic_cases()
+    stamped = [replace(c, feat_names=(*c.feat_names, "D_finalize_kernel")) for c in cases]
+
+    _trainer(names).fit(cases)  # no finalize anywhere: nothing to hide, fits normally
+    with pytest.raises(ValueError, match="D_finalize_kernel"):
+        _trainer(names).fit(stamped)
+
+
 # --- incumbent rank agreement: fit-time eval vs deployed scoring -------------------
 
 

--- a/tests/compiler/pipeline/search/prior/test_prior_fit.py
+++ b/tests/compiler/pipeline/search/prior/test_prior_fit.py
@@ -19,8 +19,10 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from emmy.compiler.pipeline.search import features
 from emmy.compiler.pipeline.search.data.group import GoldenGroup, feature_matrix
 from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
+from emmy.compiler.pipeline.search.golden import GOLDEN_RECORDS
 from emmy.compiler.pipeline.search.metrics import rank_of_golden
 from emmy.compiler.pipeline.search.prior.fit import (
     DEFAULT_L2,
@@ -31,16 +33,16 @@ from emmy.compiler.pipeline.search.prior.fit import (
     mean_log_rank,
     raw_weights,
 )
-from emmy.compiler.pipeline.search.prior.linear_model import GATE_DEFAULTS, LinearModel, gate_values
+from emmy.compiler.pipeline.search.prior.linear_model import GATE_FEATURES, LinearModel, gate_values, unweighted_cols
 from emmy.compiler.pipeline.search.prior.offline import _DEFAULT_FILE, OfflinePrior
 
 # Seed for the fitted scalar params — the interaction OFF at the shipped threshold, the state a
 # fresh fit starts from.
 SEED_PARAMS = np.array([0.0, 4.0])
 
-# The two features the OfflinePrior reads through the atomic-free interaction rather than as plain
-# linear terms — kept out of the synthetic rows below so that comparison isolates the linear part.
-_INTERACTION_FEATURES = {"D_finalize_kernel", "D_splitk"}
+# The interaction's inputs (:data:`GATE_FEATURES`) are kept out of the synthetic rows below, so that
+# comparison isolates the linear part.
+_INTERACTION_FEATURES = set(GATE_FEATURES)
 
 
 def _synthetic_cases(n_cases=6, n_rows=40, n_feats=8, seed=1234):
@@ -69,7 +71,12 @@ def _synthetic_cases(n_cases=6, n_rows=40, n_feats=8, seed=1234):
 # ``warm_start=False`` anyway), the interaction seeded OFF at the shipped threshold, and the shipped
 # exp scale — which the trainer carries into the fitted model rather than fitting.
 SEED_MODEL = LinearModel(
-    weights={}, weights_dynamic=None, scale=0.1, atomic_free_weight=float(SEED_PARAMS[0]), atomic_free_split_threshold=float(SEED_PARAMS[1])
+    unweighted_cols=unweighted_cols({}, None),
+    weights={},
+    weights_dynamic=None,
+    scale=0.1,
+    atomic_free_weight=float(SEED_PARAMS[0]),
+    atomic_free_split_threshold=float(SEED_PARAMS[1]),
 )
 
 
@@ -171,7 +178,9 @@ def test_incumbent_weights_rank_identically_through_fit_eval_and_prior(dynamic):
 
     prior = OfflinePrior()
     linear_scores = feature_matrix(rows, names) @ w_vec
-    stamp = {"S_ext_n_symbolic_axis": 1.0} if dynamic else {}
+    # On every row either way: the featurizer emits the stamp unconditionally, 0.0 when no axis is symbolic,
+    # and a pool without it is one no model can route.
+    stamp = {"S_ext_n_symbolic_axis": 1.0 if dynamic else 0.0}
     proxies = np.array([prior.mean_score_features({**row, **stamp}) for row in rows])
 
     for i in range(len(rows)):
@@ -191,12 +200,20 @@ def test_dict_and_matrix_paths_score_identically(dynamic):
     art = json.loads(_DEFAULT_FILE.read_text())
     params = {"atomic_free_weight": 5.0, "atomic_free_split_threshold": 4.0}
     # ONE model object behind both paths — the prior scores dicts through it, the fit scores matrices.
-    model = LinearModel(weights=art["weights"], weights_dynamic=art["weights_dynamic"], scale=0.1, **params)
+    model = LinearModel(
+        unweighted_cols=tuple(art["unweighted_cols"]),
+        weights=art["weights"],
+        weights_dynamic=art["weights_dynamic"],
+        scale=0.1,
+        **params,
+    )
     prior, fit = OfflinePrior(model=model), LinearFit(model, [], [])
 
     rng = np.random.default_rng(11)
     names = sorted(set(art["weights"]) | _INTERACTION_FEATURES)
-    stamp = {"S_ext_n_symbolic_axis": 1.0} if dynamic else {}
+    # On every row either way: the featurizer emits the stamp unconditionally, 0.0 when no axis is symbolic,
+    # and a pool without it is one no model can route.
+    stamp = {"S_ext_n_symbolic_axis": 1.0 if dynamic else 0.0}
     rows = [
         {
             **{n: float(rng.integers(-2, 3)) for n in names if rng.random() > 0.3},
@@ -225,6 +242,7 @@ def test_an_unfittable_dynamic_fold_scores_as_none_rather_than_raising():
     Static pools still score normally on the same model: it is the missing WEIGHT SET that is the limit,
     not the model."""
     static_only = LinearModel(
+        unweighted_cols=unweighted_cols({"D_threads": 1.0}, None),
         weights={"D_threads": 1.0},
         weights_dynamic=None,
         scale=0.1,
@@ -233,7 +251,8 @@ def test_an_unfittable_dynamic_fold_scores_as_none_rather_than_raising():
     )
     rows = [{"D_threads": float(i), "S_ext_n_symbolic_axis": 1.0} for i in range(5)]
     dyn = GoldenGroup.from_dicts("x/d", "d", "dyn", "x", "d", 0, rows)
-    static = GoldenGroup.from_dicts("x/s", "s", "warp", "x", "s", 0, [{"D_threads": float(i)} for i in range(5)])
+    static_rows = [{"D_threads": float(i), "S_ext_n_symbolic_axis": 0.0} for i in range(5)]
+    static = GoldenGroup.from_dicts("x/s", "s", "warp", "x", "s", 0, static_rows)
 
     assert dyn.dynamic and not static.dynamic
     for caller in (static_only, LinearFit(static_only, [], [])):  # the model, and the fit that forwards to it
@@ -273,22 +292,26 @@ def test_model_artifact_round_trips():
     assert model.to_artifact(provenance={})["params"] == art["params"]
 
 
-def test_gate_values_and_gate_columns_agree_including_the_defaults():
-    """The interaction's two inputs are read one way for a dict and another for a matrix, and both
-    must yield the same numbers — including for a featurization that omits them, where the defaults
-    are the whole answer. Both now read :data:`GATE_DEFAULTS`, so this pins that they stay in step,
-    and that its ORDER is the order ``atomic_free_term`` takes its positional arguments in."""
-    assert tuple(GATE_DEFAULTS) == ("D_finalize_kernel", "D_splitk")  # finalize first, as the term reads them
+def test_gate_values_and_gate_columns_agree_on_the_one_absent_value():
+    """The interaction's two inputs are read one way for a dict and another for a matrix, and both must yield
+    the same numbers. There is one absent value now, 0.0 — the same one an absent weight feature scores and the
+    same one ``Group.matrix`` fills a column with — so the two shapes cannot disagree the way they could while
+    each name carried a default of its own (a fabricated split count of 1, and a finalize zero that silently
+    switched the whole term off).
 
-    present = {"D_finalize_kernel": 1.0, "D_splitk": 8.0}
-    absent: dict[str, float] = {"D_other": 3.0}
-    for feats in (present, absent):
-        # Like for like: a pool's column list IS its rows' feature names, which is what makes "the
-        # name is missing" and "the key is missing" the same condition on the two sides.
-        names = sorted(feats)
-        cols = gate_columns(feature_matrix([feats], names), names)
-        assert [float(c[0]) for c in cols] == list(gate_values(feats))
-    assert gate_values(absent) == tuple(GATE_DEFAULTS.values())  # nothing stamped → the declared defaults
+    :data:`GATE_FEATURES` is the order ``atomic_free_term`` takes its positional arguments in, so that is
+    pinned here too."""
+    assert GATE_FEATURES == ("D_finalize_kernel", "D_splitk")  # finalize first, as the term reads them
+
+    feats = {"D_finalize_kernel": 1.0, "D_splitk": 8.0, "D_other": 3.0}
+    names = sorted(feats)
+    # Like for like: a pool's column list IS its rows' feature names.
+    cols = gate_columns(feature_matrix([feats], names), names)
+    assert [float(c[0]) for c in cols] == list(gate_values(feats))
+    # A row inside the pool that lacks the keys its siblings carry: 0.0 on both sides, and the term is off
+    # because the formula says so at ``finalize == 0``, not because a default stood in for a value.
+    assert gate_values({"D_other": 3.0}) == (0.0, 0.0)
+    assert [float(c[0]) for c in gate_columns(feature_matrix([{"D_other": 3.0}], names), names)] == [0.0, 0.0]
 
 
 def test_gate_columns_survive_the_in_place_z_scoring():

--- a/tests/compiler/pipeline/search/prior/test_regime_admission.py
+++ b/tests/compiler/pipeline/search/prior/test_regime_admission.py
@@ -33,6 +33,10 @@ class _P(Prior):
     def score_rows(self, group):
         return None
 
+    @property
+    def columns(self) -> tuple[str, ...]:
+        return ()  # never fitted, so nothing to declare
+
 
 def _prior() -> _P:
     return _P()

--- a/tests/compiler/pipeline/search/prior/test_score_rows.py
+++ b/tests/compiler/pipeline/search/prior/test_score_rows.py
@@ -5,15 +5,23 @@ is actually asked over: a matmul enumeration runs to ~10^5 rows and the per-row 
 made the fit OOM. This one takes the packed pool. What each implementation must get right is its OWN column
 list and its OWN absent-value fill — which is why it cannot be one shared function — and one polarity, since
 the fitted model classes compute quality (higher = faster) while the online model regresses latency.
+
+``Prior.columns`` is the other half of that: each implementation PUBLISHES the complete column list it reads —
+weights, the interaction's inputs and the routing stamp — so a pool builder can pack for the models it is about
+to score instead of restating their columns or widening to every column the featurizer can spell.
 """
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import numpy as np
+import pytest
 
 from emmy.compiler.pipeline.search.data.group import GoldenGroup
+from emmy.compiler.pipeline.search.features import ROUTING_FEATURES
 from emmy.compiler.pipeline.search.prior.fallback import FallbackPrior
-from emmy.compiler.pipeline.search.prior.linear_model import LinearModel
+from emmy.compiler.pipeline.search.prior.linear_model import GATE_FEATURES, LinearModel, gate_columns, unweighted_cols
 from emmy.compiler.pipeline.search.prior.offline import OfflinePrior
 from emmy.compiler.pipeline.search.prior.online import OnlinePrior
 
@@ -23,10 +31,17 @@ def _group(feats: list[dict], *, tier: str = "thread") -> GoldenGroup:
 
 
 def _linear(**weights) -> OfflinePrior:
-    return OfflinePrior(
-        model=LinearModel(
-            weights=dict(weights), weights_dynamic=dict(weights), scale=1.0, atomic_free_weight=0.0, atomic_free_split_threshold=4.0
-        )
+    return OfflinePrior(model=_model(dict(weights), dict(weights)))
+
+
+def _model(weights, weights_dynamic, **params) -> LinearModel:
+    """A model declaring exactly what it reads, the way a fit writes one."""
+    return LinearModel(
+        unweighted_cols=unweighted_cols(weights, weights_dynamic),
+        weights=weights,
+        weights_dynamic=weights_dynamic,
+        scale=1.0,
+        **{"atomic_free_weight": 0.0, "atomic_free_split_threshold": 4.0, **params},
     )
 
 
@@ -46,9 +61,9 @@ def test_the_linear_half_scores_a_whole_pool_by_its_own_weights():
 
 
 def test_a_narrower_feature_view_does_not_move_the_linear_halfs_ranks():
-    """Why ``eval prior --dataset golden`` may build its pools over the FULL featurization while ``emmy fit``
-    trains under a narrow ``D_*`` view, and still report the same rank: the model projects the pool onto its
-    own weight names, so every column outside them is inert."""
+    """Why ``eval prior --dataset golden`` may build its pools over just the columns its halves declare, while
+    ``emmy fit`` trains under a narrow ``D_*`` view, and both still report the same rank: the model projects the
+    pool onto its own weight names, so every column outside them is inert."""
     prior = _linear(D_a=2.0)
     narrow = [{**_stamp(), "D_a": 1.0}, {**_stamp(), "D_a": 3.0}]
     wide = [{**row, "S_ext_free_prod": 4096.0, "H_opt": 3.0, "MMA_a_bits": 16.0} for row in narrow]
@@ -56,12 +71,73 @@ def test_a_narrower_feature_view_does_not_move_the_linear_halfs_ranks():
     assert prior.score_rows(_group(narrow)).tolist() == prior.score_rows(_group(wide)).tolist()
 
 
+def test_the_linear_half_declares_every_column_it_reads():
+    """:attr:`LinearModel.columns` must cover what ``score_rows`` reads under BOTH weight sets — a builder packs
+    one pool without knowing which set it will route to. It also covers the interaction's two inputs whether or
+    not a weight names them (a pruned zero weight drops the key, and ``gate_columns`` still reads it), and the
+    routing stamp, which the model reads through the pool's own ``dynamic`` label rather than out of the matrix.
+
+    The stamp is the one that used to be missing, and the reason the artifact stores an ``unweighted_cols``
+    field at all: it is the part of the answer no weight key can spell."""
+    model = _model(
+        {"D_a": 1.0},  # no D_finalize_kernel / D_splitk weight — the pruned-gate case
+        {"D_a": 1.0, "D_dyn_only": 2.0},
+    )
+
+    assert set(model.cols_for(False)) <= set(model.columns)
+    assert set(model.cols_for(True)) <= set(model.columns)
+    assert set(GATE_FEATURES) <= set(model.columns)
+    assert set(ROUTING_FEATURES) <= set(model.columns)
+    assert not set(ROUTING_FEATURES) & set(model.cols_for(True))  # it routes; it is not packed into the matmul
+    assert "D_dyn_only" in model.columns  # the dynamic set's own column, declared even when scoring a static pool
+
+
+def test_a_model_with_no_dynamic_weight_set_still_declares_its_static_columns():
+    """An incomplete fit (no symbolic-axis cases) declines a dynamic pool but is still a usable static scorer,
+    so its declaration is the static set rather than empty. It still declares the routing stamp: reading the
+    stamp is how it knows to decline."""
+    static_only = _model({"D_a": 1.0}, None)
+
+    assert set(static_only.columns) == {"D_a", *GATE_FEATURES, *ROUTING_FEATURES}
+
+
+def test_a_pool_that_cannot_route_is_refused_rather_than_scored_as_static():
+    """The stamp is not optional. A pool packed under a view that dropped it arrives labelled static — every
+    candidate would then be priced by the static weight set whatever its regime, and nothing downstream could
+    tell that from a genuinely static pool. So the model refuses it.
+
+    This is the check that replaces the feature view's old exemption of the stamp from every spec: the filter
+    now keeps only what its spec names, and the model says so when a builder gets it wrong."""
+    prior = _linear(D_a=2.0)
+    unstamped = _group([{"D_a": 1.0}, {"D_a": 3.0}])  # no S_ext_n_symbolic_axis anywhere in the pool
+
+    with pytest.raises(ValueError, match="routing stamp"):
+        prior.score_rows(unstamped)
+
+
+def test_the_interaction_is_computed_from_the_pool_not_from_a_default():
+    """The atomic-free term is the one part of the score that is not a linear weight, and a per-name default
+    used to let it vanish: an absent ``D_finalize_kernel`` read 0.0, which zeroes ``weight · finalize · (…)``
+    for every row, while an absent ``D_splitk`` read 1.0, a split count no featurization produces.
+
+    The pool's own values reach the term now — a split count above the threshold rewards the deferred combine
+    kernel, one below penalizes it — and an unstamped column reads this model's one absent value, so a pool
+    with no finalize kernel prices the term at the formula's own zero rather than at a substituted one."""
+    prior = _linear(D_a=0.0)  # weights contribute nothing, so the score IS the interaction
+    model = replace(prior.model, atomic_free_weight=3.0)
+    rows = [{**_stamp(), "D_finalize_kernel": 1.0, "D_splitk": splitk} for splitk in (2.0, 8.0)]
+
+    assert OfflinePrior(model=model).score_rows(_group(rows)).tolist() == [-3.0, 3.0]
+    assert prior.score_rows(_group(rows)).tolist() == [0.0, 0.0]  # a zero interaction weight is a real zero
+    # A pool that stamps neither input: 0.0 on both, which is the term's value at ``finalize == 0``.
+    assert OfflinePrior(model=model).score_rows(_group([{**_stamp(), "D_a": 5.0}])).tolist() == [0.0]
+    assert [float(c[0]) for c in gate_columns(np.zeros((1, 1)), ["D_a"])] == [0.0, 0.0]
+
+
 def test_the_linear_half_declines_a_pool_it_fitted_no_weight_set_for():
     """``None``, not an exception and not a silent zero: an unfittable cross-validation fold and an
     all-static fit both hit this, and a report has to count the pools rather than average them in."""
-    static_only = LinearModel(
-        weights={"D_a": 1.0}, weights_dynamic=None, scale=1.0, atomic_free_weight=0.0, atomic_free_split_threshold=4.0
-    )
+    static_only = _model({"D_a": 1.0}, None)
     prior = OfflinePrior(model=static_only)
 
     assert prior.score_rows(_group([{**_stamp(), "D_a": 1.0}])) is not None
@@ -79,6 +155,18 @@ def test_the_online_half_returns_quality_not_latency():
     scores = prior.score_rows(_group([{**_stamp(), "BM": 8.0}, {**_stamp(), "BM": 64.0}]))
     assert scores[1] > scores[0]  # the faster config scores HIGHER quality
     assert prior.mean_score({**_stamp(), "BM": 64.0}) < prior.mean_score({**_stamp(), "BM": 8.0})  # µs: lower is better
+
+
+def test_the_online_half_declares_the_columns_it_regressed_on():
+    """The tree indexes features by POSITION, so its column list is as load-bearing as a weight dict's keys.
+    Empty until the first fit — an unfit half is dropped by a report rather than asked."""
+    prior = OnlinePrior(iterations=40)
+    assert prior.columns == ()
+
+    prior.add_rows([({**_stamp(), "BM": 8.0}, 100.0)] * 40 + [({**_stamp(), "BM": 64.0}, 5.0)] * 40)
+    prior.fit()
+
+    assert prior.fitted and "BM" in prior.columns
 
 
 def test_an_unfit_online_half_answers_a_constant_rather_than_failing():
@@ -109,3 +197,12 @@ def test_the_composite_answers_with_the_half_that_owns_deploys():
 
     assert not composite.trustworthy
     assert np.array_equal(composite.score_rows(group), offline.score_rows(group))
+
+
+def test_the_composite_declares_the_columns_of_the_half_that_owns_deploys():
+    """``columns`` must agree with ``score_rows`` about WHICH half answers. ``__getattr__`` forwards to the
+    online half, so leaving this to it would declare one half's columns and score with the other's."""
+    offline = _linear(D_a=2.0)
+    composite = FallbackPrior(OnlinePrior(), offline)  # online unfit → not trustworthy → offline owns deploys
+
+    assert composite.columns == offline.columns

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -413,6 +413,7 @@
  "tests/compiler/pipeline/search/prior/test_catboost_model.py::test_the_tree_prices_the_two_regimes_from_the_routing_column": 0.05,
  "tests/compiler/pipeline/search/prior/test_catboost_model.py::test_two_artifacts_in_one_directory_do_not_collide": 0.08,
  "tests/compiler/pipeline/search/prior/test_fit_cv.py::test_handle_fit_writes_metrics_and_a_loadable_artifact": 0.05,
+ "tests/compiler/pipeline/search/prior/test_prior_fit.py::test_every_column_the_shipped_artifact_declares_is_still_produced": 3.26,
  "tests/compiler/pipeline/search/prior/test_prior_fit.py::test_fit_twice_is_byte_identical": 0.07,
  "tests/compiler/pipeline/search/prior/test_prior_fit.py::test_l2_default_is_rank_neutral_on_random_restart": 0.06,
  "tests/compiler/pipeline/search/prior/test_report.py::test_a_pool_too_small_for_a_metric_is_excluded_and_the_count_says_so": 0.38,


### PR DESCRIPTION
## What

A prior model's columns lived in its artifact only in pieces — the keys of `LinearModel`'s weight dicts,
`CatBoostModel`'s stored order — and nothing published them, so callers restated the set by hand: `emmy fit` as
a glob, and `emmy eval prior --dataset golden`, unable to ask, as `"*"` — every column the featurizer can spell.

The branch makes each artifact say what it reads, and takes the same knowledge out of the two other places it was
hiding:

1. **The artifact declares what no weight key can spell.** A linear artifact gains `unweighted_cols` — the
   routing stamp `S_ext_n_symbolic_axis`, plus any interaction input a fit pruned out of both weight sets — and
   `Prior.columns` is the weight keys unioned with it. One name per shipped file today — three lines of JSON,
   not sixty — the loader demands the field, and both checked-in artifacts are migrated.
2. **`GATE_DEFAULTS` is gone**, values and all. What remains is `GATE_FEATURES` (the names the formula reads) and
   one absent value, 0.0 — the same one `Group.matrix` fills a missing column with.
3. **`feature_view` keeps only what its spec names.** No more exempting the routing stamp from every spec; each
   shipped view names it, so a recorded view is the truth about what a fit trained on.
4. `eval prior --dataset golden` builds its pools from what its halves declare, and tests pin both properties of
   a shipped declaration: no retired column, and every column it cannot weight.

`emmy fit` keeps `--features`: a fit DEFINES the columns of a model that does not exist yet, while an eval
CONSUMES one it already holds.

## The defect the declaration exposed

`LinearModel.columns` documented itself as "every column ANY pool can make this model read" and returned weight
keys ∪ gate names. It omitted `S_ext_n_symbolic_axis` — the column that decides WHICH weight set prices the
pool. The model reads it (through `Group.dynamic`, taken off the rows when they are packed), but a routing stamp
may never carry a weight, so nothing derived from the weight keys could ever name it.

A caller packing from that declaration would have got every candidate priced by the static weight set — with no
symptom, because a pool with no stamp is exactly what a genuinely static pool looks like. It never happened only
because the one caller that packs from a declaration went through `feature_view`, which exempted the stamp from
every spec. The artifact and the filter each held half of one rule, and neither said so.

## Decisions worth reviewing

**`feat_ver` is NOT bumped.** It versions the featurizer's column vocabulary — what a persisted feature name
MEANS — and nothing was renamed. A bump would discard every reservoir and node row over an artifact schema
change.

**The unconditional routing keep is replaced, not deleted.** It was protecting the training path, whose view is
authored by a flag rather than derived from a model; `TREE_FEATURES` is the sharp case (an exclusion view over
`D_*` / `MMA_*` that never covered an `S_*` name, feeding the one model class that prices both regimes by
splitting on the stamp). Three catches replace it: the shipped-spec test, `GoldenGroup.from_dicts`' existing
tier-vs-stamp check, and `LinearModel.score_rows` refusing a pool that carries no stamp.

**One check where both halves are visible.** `gate_columns` cannot tell "the view dropped this column" from "the
pool never stamped it", and refusing the second would refuse a legitimate corpus (4 of the 8 recorded `pointwise`
goldens featurize with no `D_finalize_kernel` at all). So `LinearTrainer.fit` refuses a view that hides an
interaction input the POOLS carry — once, at the entry point, leaving `fit_weights`' one-projection cache
untouched.

## ⚠️ Narrowing the eval's view changes pool FORMATION

Scores do not move: `score_rows` projects a pool onto its own names either way. But a golden pool's identity is a
blake2b digest of its packed matrix, so two enumerations separated only by columns no scoring model reads fold
into ONE group under a narrower view.

Measured over the `softmax` goldens against the shipped offline half's declaration: **27 groups under `"*"`, 26
under it** — the V100's `layer3.i020` and `layer3.i028` softmax-reduce pools (32 rows each, same pinned row)
become one, and `positives` follows 27 → 26 because a group's label set is a set of row indices. `rms_norm` is
unchanged (20/20 both ways). The families holding most such buckets (matmul, attention, `gemma4_12b`, `pre-sym`
— 267 of 556 buckets carry more than one pool group) do not finish building here, so they are unverified.

A merged group is one candidate pool two goldens compete over, which is what a group means here, and its rank is
the best over them. It is still a reported-number change: `groups`, `positives` and that pool's rank move, and
since the view is derived from the halves being scored, a run with an online checkpoint present can form
different pools than one without. Both `ARCHITECTURE.md` and the `_golden_report` docstring now say this instead
of claiming nothing moves, and the `features` header key is what makes two reports comparable.

## Evidence

- **Bit-identical scoring across the migration**: all 176 pools of the checked-in measurement freeze (143 static
  / 33 dynamic, 1916 rows, both weight sets) score to byte-identical float vectors.
- **Both trainers refit** over the same scoped slice (the 38 `rms_norm` / `softmax` / `reduce` / `pointwise`
  records → 38 pools), each reporting **19 static / 19 dynamic** cases, each writing an artifact whose `columns`
  is exactly what it declares.
- Full suite: 4236 passed, 1 pre-existing failure (`test_neptune_emmy_runner_...`, exit 127, a missing binary).
  `make lint` clean.

## Line balance

`emmy/` grows 276 lines net (361 added, 85 removed, artifacts excluded). The PR adds functionality — a
declaration field, its writer, two refusals, a loader requirement — but the growth is mostly prose: roughly six
of every seven added lines are comments and docstrings. The routing-stamp argument is stated once in `prior/linear_model.py`'s module docstring
and once in `pipeline/ARCHITECTURE.md`; every other site points at those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfZqg1hitW3F8yKmZXcWt
