### PR TITLE
Declare the block-scaled cell's scale registers once

### DIFF
--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1413,7 +1413,7 @@ class RegFragment(Stmt):
     byte-identical."""
 
     name: str
-    role: str  # "a" / "b" / "c"
+    role: str  # "a" / "b" / "c" / "sf"
     shape: tuple[int, int, int]
     dtype: DataType
     count: int = 1  # >1 arrays the fragment family: ``<ty> name[count][n_regs]`` (loopify only)
@@ -1437,6 +1437,12 @@ class RegFragment(Stmt):
     def render(self, ctx: RenderCtx) -> list[str]:
         n_regs = self._nregs()
         ctx.ssa_dtypes[self.name] = self.dtype.name
+        if self.role == "sf":
+            # A block scale is ONE register the instruction takes by value, not an array — but it
+            # is declared here like every other fragment so :class:`BlockScaleLoad` ASSIGNS it.
+            # The register ring re-enters slot ``s`` every ``depth`` steps, so a load that declared
+            # its own destination redeclared it in the same C scope.
+            return [f"{_pad(ctx.indent)}unsigned {self.name};"]
         dims = f"[{self.count}][{n_regs}]" if self.count > 1 else f"[{n_regs}]"
         if self.role == "c" and self.dtype.nbytes != 2:
             # Brace-init zeros the whole (arrayed) accumulator; ``= {0.0f, ...}`` stays the flat form.
@@ -1565,7 +1571,9 @@ class BlockScaleLoad(Stmt):
         # slab changing type — a byte-typed slab would lose that the bytes ARE e4m3 to every other
         # reader of ``ctx.buffer_dtypes``.
         src = f"reinterpret_cast<const unsigned char*>(&{self.src_buffer}[{flat}])"
-        return [f"{_pad(ctx.indent)}unsigned {self.frag} = emmy_mma_load_sf{self.role}_f4({src}, {self.ldm});"]
+        # ASSIGNS — the fragment is declared once by its ``RegFragment`` (role ``sf``). Declaring
+        # it here redeclared it every time the register ring re-entered the slot.
+        return [f"{_pad(ctx.indent)}{self.frag} = emmy_mma_load_sf{self.role}_f4({src}, {self.ldm});"]
 
 
 @dataclass(frozen=True)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field, replace
 
 from emmy.compiler.backend.cuda.dtype import cuda_name
 from emmy.compiler.dim import Dim
-from emmy.compiler.dtype import F32
+from emmy.compiler.dtype import F32, U32
 from emmy.compiler.ir.address import BYTE_SLAB_PAD
 from emmy.compiler.ir.atom import AtomKind
 from emmy.compiler.ir.axis import Axis
@@ -1797,6 +1797,21 @@ class _MmaOps(_AtomOps):
             for i in range(m.reg)
             for j in range(n.reg)
         ]
+        if block_scaled_atom(atom):
+            # The block-scaled cell's two scale operands are per-lane registers like the
+            # multiplicands, so they are declared here and ASSIGNED per K step. Slotted with the
+            # data fragments they ride beside: the register ring re-enters slot ``s`` every
+            # ``depth`` steps, and a load that declared its own destination redeclared it there.
+            # Named exactly as :func:`mma_leaves` spells them — A shares one name across channels,
+            # B carries the per-channel fold suffix.
+            decls += [
+                RegFragment(name=nm, role="sf", shape=atom.ptx_shape, dtype=U32, nregs=1) for nm in frags(lambda i: f"_sfa{i}", m.reg)
+            ]
+            for f in range(n_folds):
+                decls += [
+                    RegFragment(name=nm, role="sf", shape=atom.ptx_shape, dtype=U32, nregs=1)
+                    for nm in frags(lambda i, ff=f: _fold_frag(f"_sfb{i}", ff), n.reg)
+                ]
         if _f16acc(atom):
             # The f32 shadow accumulators — they keep the ``_c{i}_{j}`` names the store reads;
             # the packed f16 mma targets above are the ``_ch{i}_{j}`` family FragmentPromote folds.

--- a/tests/compiler/passes/test_nvfp4_w4a4.py
+++ b/tests/compiler/passes/test_nvfp4_w4a4.py
@@ -300,51 +300,13 @@ def test_the_block_scaled_cell_runs_and_holds_its_declared_tolerance(tmp_path):
         assert float(rel.max()) < 2e-3, f"{out}: past one fused-scale rounding per side"
 
 
-@requires_cuda
-@pytest.mark.xdist_group("cuda")
-def test_a_one_consumer_block_scaled_linear_reads_its_codes_from_memory(tmp_path):
-    """Coverage's other half. A linear with ONE consumer reaches the same shape as the shared one
-    above: the activation quantize is a kernel of its own writing the packed codes, the matmul
-    copies those codes into its slab, and the cell still fires against the numeric oracle.
-
-    Consumer count decides nothing here. Loop fusion stops at a computed packed buffer whether one
-    linear reads it or three, because splicing it away would leave the codes as a value with no
-    stored extent — see ``_packed_readers`` in the merge rule.
-    """
-    from emmy.compiler.backend.cuda.backend import CudaBackend
-    from emmy.compiler.backend.numpy import NumpyBackend
-    from emmy.compiler.loader.safetensors import load_constants_from_safetensors
-
-    m, n, k = 16, 128, 256
-    g = _w4a4_linear(tmp_path, m=m, n=n, k=k)
-    x = (np.random.default_rng(23).standard_normal((m, k)) * 0.5).astype(np.float16)
-    data = load_constants_from_safetensors(g, str(tmp_path))
-    ref, _ = NumpyBackend().run(g, input_data={**data, "x": x})
-    backend = CudaBackend()
-    compiled = backend.compile(g)
-    sources = [s for node in compiled.nodes.values() if (s := getattr(node.op, "kernel_source", None))]
-    native = [s for s in sources if "emmy_mma_m16n8k64_e2m1_f32(" in s]
-    assert native, "the block-scaled cell was never selected on a one-consumer linear"
-    assert "emmy_to_f4e2m1" not in native[0], "the quantize belongs in its own kernel, not inside the matmul"
-    assert any("emmy_to_f4e2m1" in s for s in sources if s not in native), "no kernel encodes the activation at all"
-    assert "EMMY_F4_LUT" not in native[0], "a native cell must not decode either operand through the value table"
-
-    got, _ = backend.run(compiled, input_data={**data, "x": x})
-    r = ref.outputs["y"].astype(np.float32).reshape(-1)
-    c = np.asarray(got.outputs["y"]).astype(np.float32).reshape(-1)
-    rel = np.abs(c - r) / max(float(np.abs(r).max()), 1e-9)
-    assert float(np.median(rel)) < 1e-4, "a systematic shift, not the fused-scale rounding"
-    assert float(rel.max()) < 2e-3, "past one fused-scale rounding per side"
-
-
 @pytest.mark.parametrize("consumers", [1, 3])
 def test_the_quantized_activation_survives_loop_fusion_whatever_its_consumer_count(tmp_path, consumers):
     """The packed activation buffer is a fusion boundary: the merge leaves it standing whether one
     linear reads it or three, so both reach the block-scaled cell with the codes in memory.
 
     Structural and deliberately GPU-free — the shape this pins is decided in the loop dialect,
-    long before a kernel exists. ``test_a_one_consumer_block_scaled_linear_reads_its_codes_from_memory``
-    carries the same contract down to emitted CUDA and holds it to the numeric oracle.
+    long before a kernel exists.
 
     A merge that spliced this buffer away would still compute the declared program. What it would
     lose is the object the packed dtype describes: the stored byte whose extent is half the

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -316,7 +316,6 @@
  "tests/compiler/passes/test_nvfp4_staged.py::test_the_row_features_the_width_the_weight_really_moves[d1/smem-False]": 5.53,
  "tests/compiler/passes/test_nvfp4_staged.py::test_the_row_features_the_width_the_weight_really_moves[d2/smem-async-True]": 5.56,
  "tests/compiler/passes/test_nvfp4_staged.py::test_the_spelled_checkpoint_lowers_to_the_packed_drain": 5.55,
- "tests/compiler/passes/test_nvfp4_w4a4.py::test_a_one_consumer_block_scaled_linear_reads_its_codes_from_memory@cuda": 7.0,
  "tests/compiler/passes/test_nvfp4_w4a4.py::test_a_shared_activation_reaches_its_matmuls_as_packed_codes": 0.63,
  "tests/compiler/passes/test_nvfp4_w4a4.py::test_a_shared_quantized_activation_behind_a_norm_compiles_and_holds_flip_bounded_parity@cuda": 8.7,
  "tests/compiler/passes/test_nvfp4_w4a4.py::test_the_block_scaled_cell_runs_and_holds_its_declared_tolerance@cuda": 10.0,


### PR DESCRIPTION
Three `tests/compiler/passes/test_nvfp4_w4a4.py` tests were failing on the RTX 5090. Two were one
codegen bug; the third is a separate regression, described below.

## The bug

`BlockScaleLoad.render` emitted `unsigned <frag> = emmy_mma_load_sf{a,b}_f4(...);` — a
**declaration** — at every occurrence. Every other mma fragment is declared once by its
`RegFragment` and merely *assigned* by its loader. With the register double-buffer
(`reg_depth >= 2 and n_steps >= 2`) the slot suffix cycles `slot = step % depth`, so the second
visit to a slot redeclared its own destination in the same C scope:

```
k.cu(616): error: "_sfa0_s0" has already been declared in the current scope
k.cu(618): error: "_sfb0_s0" has already been declared in the current scope
...
10 errors detected in the compilation of "k.cu".
```

The emitted source shows it directly — `n_steps=4`, `depth=2`, so the ring re-enters `_s0` at
step 1 and `_s1` at step 2:

```cuda
unsigned _a0_s0[4];                                    // declared once, at kernel scope
...
unsigned _sfa0_s0 = emmy_mma_load_sfa_f4(&_as_smem[...      ], 16);   // prologue
unsigned _sfa0_s1 = emmy_mma_load_sfa_f4(&_as_smem[... +  4], 16);
unsigned _sfa0_s0 = emmy_mma_load_sfa_f4(&_as_smem[... +  8], 16);   // <-- redeclares
unsigned _sfa0_s1 = emmy_mma_load_sfa_f4(&_as_smem[... + 12], 16);   // <-- redeclares
```

Only the `_sf*` names collided, never the data fragments — that asymmetry is what pointed at the
declaration rather than at the ring.

## The fix

The scale operand takes the same shape as every other fragment. A `RegFragment` with role `sf`
declares it beside the multiplicands it rides with — slotted through the same `frags()` helper, so
it follows the ring automatically — and `BlockScaleLoad` assigns. `sf` renders a bare `unsigned`
rather than an array because the instruction takes the scale by value, not by pointer.

Reachable only when both multiplicands are packed pairs (`block_scaled_atom`), so nothing outside
the NVFP4 block-scaled cell changes shape.

## Verification

`tests/compiler/passes/test_nvfp4_{w4a4,staged,atom,encode}.py` — **68 passed, exit 0**, on an
RTX 5090 (sm_120a, `-Xcicc -O1`), run under `-n 4 --dist=loadgroup` so the `@cuda` group suffixes
the `durations.json` gate looks up are stamped.

## The deleted test, and the regression it was holding

`test_a_one_consumer_block_scaled_linear_reads_its_codes_from_memory` is removed at the repo
owner's direction. **It was failing for a different, live reason, and that reason is not fixed
here** — recording it so the signal is not lost:

- With this fix applied it gets past codegen and then fails
  `assert native, "the block-scaled cell was never selected on a one-consumer linear"`.
- At `m,n,k = 16,128,256` the schedule now takes a **split-K** (`k_y__partial` + `k_y`) and decodes
  through the pair-value tables (`x_static_fp4_r1_f4_pairs`, `layer_w_f4_pairs`) — **no mma at all**
  in the emitted kernels, native cell or otherwise.
- Bisected: the whole file was **green at `af972a10`** ("NVFP4 support in the emmy compiler", #499,
  12 passed) and **red at `3bb68cda`**. The test file itself only changed by an import move in
  `b93a86c2`, so the behaviour regressed — it did not land red. The culprit is `5719f823` or
  `b93a86c2`, both classic-scheduling rebuilds; I was bisecting between them when the test was cut.

Its `tests/durations.json` entry is removed with it, and the dangling docstring cross-reference in
`test_the_quantized_activation_survives_loop_fusion_whatever_its_consumer_count` is dropped.

## Line balance

`git diff --stat main -- emmy/`: **26 insertions, 3 deletions**. Net positive because the fix adds a
declaration path that did not exist — the `sf` render arm plus the six lines in `_AtomOps.state`
that emit the declarations. There is no smaller correct form: the loader cannot both declare once
and assign per step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrpvLp4vv1aAdFimnQkyHT
