### PR TITLE
Resolve seam captures in program order; stop read walks at a term's scoped rollup

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -457,7 +457,7 @@ The optional readable-source fold keeps a single-use `Assign` named when any arg
 the result dtype, so the target-aware `Assign.render` path remains responsible for conversions such as
 `__half2float`.
 
-Dependence cones (`ir/stmt/body.py`): `Body.backward_cone(roots)` / `Body.forward_cone(seeds)` build a `Cone` —
+Dependence cones (`ir/stmt/body.py`): `Body.backward_cone(roots)` builds a `Cone` —
 the subset of the body's immediate stmts closed under SSA dependence (a wrapper joins as a unit; internally-bound
 axes excluded), plus `external_reads`, the names read from outside (axis vars and enclosing/sibling scopes alike).
 Construction never fails: unresolved names are data, and chaining scope levels means seeding the next level's

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -347,7 +347,11 @@ identity with the knobs; and the deploy join key (the deploy identity (`identity
 schedule evidence.
 `Fold.deps()` exposes names captured outside the lift params, including captures reached recursively through operand
 edges. A contraction deliberately hides its pure lift body from generic nested-body walks, so this direct dependency
-surface is what keeps an operand's captured statistic ordered before the contraction that reads it.
+surface is what keeps an operand's captured statistic ordered before the contraction that reads it. A read walk
+STOPS at this rollup — the **`Stmt.deps_deep` trait** (a `Stmt`-protocol member beside `pure`, conservative `False`
+default; `Fold` opts in) tells `_member_reads` that `deps()` already answers for the whole subtree, scope-correctly.
+Re-walking the lift's flat namespace cannot see its params, so an operand-supplied name read inside the lift leaked
+out of every enclosing lambda as a phantom capture: an operand-supplied name is not an enclosing capture.
 
 A reduce is a contraction not by "two loads" but by the genuine algebra — the lift ⊗
 **distributes over** the fold ⊕ (`multiply` over `add`; *not* `add` over `add`, a sum of two

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -325,6 +325,7 @@ class Fold:
     whichever partition the fork picked. See the NO-schedule-fields note on ``operands`` below."""
 
     pure = True  # a term is a value — its internals are its own; legal inside a stored ``Lambda``
+    deps_deep = True  # :meth:`deps` is the memoized scoped rollup — read walks must not re-walk the lift
 
     # The reduce axis — ``None`` is the ZERO-AXIS node (what zero-axis ``Fold`` was): no iteration, no monoid,
     # its ``lift`` the per-cell projection. The BILINEAR reading is a READING of this one

--- a/emmy/compiler/ir/stmt/base.py
+++ b/emmy/compiler/ir/stmt/base.py
@@ -487,6 +487,13 @@ class Stmt(Structural):
     # declares itself. ``Lambda.__post_init__`` is the enforcing formation gate.
     pure: bool = False
 
+    # Rolled-deps trait — True iff :meth:`deps` already reports the ENTIRE subtree's reads,
+    # scope-correctly (every nested lambda's params subtracted). A read walk then takes ``deps()``
+    # and must not re-walk ``nested()``: the flat re-walk cannot see an inner lambda's params, so
+    # a factored operand cone's result read inside the lift leaks out as a phantom capture.
+    # Conservative default; ``Fold`` (the memoized scoped rollup) opts in.
+    deps_deep: bool = False
+
     def deps(self) -> tuple[str, ...]:
         """SSA names this stmt reads — its 'requirements'.
 

--- a/emmy/compiler/ir/stmt/body.py
+++ b/emmy/compiler/ir/stmt/body.py
@@ -89,6 +89,10 @@ def _member_reads(s: Stmt) -> frozenset[str]:
         for e in st.exprs():
             reads.update(e.free_vars() - bound)
         defs.update(st.defines())
+        if st.deps_deep:
+            return  # ``deps()`` already rolls up the subtree scope-correctly; the flat re-walk
+            # cannot see the lift's params, so a factored operand cone's result read inside the
+            # lift would leak out as a phantom capture
         inner_bound = bound | st.binds_axes()
         for body in st.nested():
             for c in body:

--- a/emmy/compiler/ir/stmt/body.py
+++ b/emmy/compiler/ir/stmt/body.py
@@ -16,7 +16,7 @@ as method-shaped wrappers around the existing free functions.
 Phase 2 surface: def-use queries (``definitions``, ``axis_dependencies``,
 ``deps_closure``, ``depends_on`` / ``independent``, ``deps_of``), type-filtered lookups
 (``loads``, ``writes``, ``accums``, …), and dependence cones
-(:class:`Cone`, :meth:`Body.backward_cone` / :meth:`Body.forward_cone`
+(:class:`Cone`, :meth:`Body.backward_cone`
 / :meth:`Body.defs_die_at`) — the shared substrate behind the rules
 that slice computed-operand cones. Region transforms (``replace_at``,
 ``partition_at``) remain follow-ups; add as needed.
@@ -36,8 +36,7 @@ class Cone:
     """A dependence cone over ONE scope level: the subset of a Body's
     immediate stmts closed under SSA dependence (in body order), plus every
     name the cone reads from outside itself — sibling/enclosing scopes and
-    axis vars alike. Built by :meth:`Body.backward_cone` /
-    :meth:`Body.forward_cone`.
+    axis vars alike. Built by :meth:`Body.backward_cone`.
 
     Construction never fails and applies no eligibility judgment: an
     unresolved name is data (``external_reads``), not an error. Which
@@ -561,32 +560,6 @@ class Body(tuple[Stmt, ...]):
             member_ids.add(id(s))
             pending.extend(_member_reads(s))
         return Cone(members=tuple(s for s in self if id(s) in member_ids), external_reads=frozenset(external))
-
-    def forward_cone(self, seeds: Iterable[Stmt]) -> Cone:
-        """The forward (taint) :class:`Cone` of the ``seeds`` — top-level
-        stmts of this body — over THIS body's immediate stmts: the seeds
-        plus every member transitively reading a name they expose, to
-        fixpoint, in body order. ``external_reads`` are the member reads not
-        produced inside the cone (reads of earlier non-member siblings
-        included)."""
-        member_ids = {id(s) for s in seeds}
-        names: set[str] = set()
-        for s in seeds:
-            names.update(_exposed_defines(s))
-        reads = {id(s): _member_reads(s) for s in self}
-        changed = True
-        while changed:
-            changed = False
-            for s in self:
-                if id(s) in member_ids:
-                    continue
-                if reads[id(s)] & names:
-                    member_ids.add(id(s))
-                    names.update(_exposed_defines(s))
-                    changed = True
-        members = tuple(s for s in self if id(s) in member_ids)
-        external = set().union(*(reads.get(id(s), _member_reads(s)) for s in members)) if members else set()
-        return Cone(members=members, external_reads=frozenset(external - names))
 
     def defs_die_at(self, members: Iterable[Stmt], *, roots: Iterable[str], allowed: Iterable[Stmt]) -> bool:
         """True iff no stmt in this body outside ``members`` reads a name

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -94,6 +94,7 @@ class ProjectionRegion:
     lift: Lambda
     unroll: bool = False
     pure = True
+    deps_deep = False  # :meth:`deps` names only the params — the body may read more; walks descend
 
     @property
     def body(self) -> Body:

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -86,7 +86,13 @@ their captured axis names (attention's normalized K cone, once per score contrac
 duplicate carried as a sibling with its capture correspondence, and the cut replaces every one with workspace loads
 spelled through its own axes. Any stored fold capturing enclosing-scope names — operand edge or body member — is
 cuttable through PROVIDER CLOSURE. Each occurrence resolves captures outward through its lexical environment,
-nearest scope first; every occurrence must resolve to equal straight-line providers and the same Fold producers. A
+nearest scope first; every occurrence must resolve to equal straight-line providers and the same Fold producers.
+A capture is detected in PROGRAM ORDER over the seam's reconstituted lowering — a definition covers only the reads
+that follow it. A stored tree may hold one value object at two positions (a projection member and, canonically
+shared, inside a contraction-operand cone whose position lowers inside the reduce loop, after a shallower sibling
+read of the same name); order-blind resolution let the deeper definition mask that read, offered the seam as closed,
+and cut a piece whose reader had no definition — nvcc's undefined identifier on DeepSeek-V4 post4096's composed-cut
+`mean_reduce` piece. Realization asserts every piece reads nothing before its definition beyond its own axes. A
 pure `Load`/`Assign` chain joins the produced piece verbatim, while a Fold producer makes the seam DEPENDENT: its piece
 reads the name through that producer's workspace, so cutting it composes the producer's cut in. Dtypes for capturing
 seams come from inference rooted at the Tile tree, where the enclosing bindings are visible. This is what lets row
@@ -362,7 +368,7 @@ How to comply:
 - **Bail conservatively on well-formedness, never on shape identity.** `return None` / `RuleSkipped` for a body
   the rule doesn't fully understand is fine; the conditions must be structural properties (escaping values,
   symbolic extents, mixed dtypes), not "is this the X kernel".
-- **Phrase dataflow conditions over cones, don't hand-roll the walk.** `Body.backward_cone` / `forward_cone` /
+- **Phrase dataflow conditions over cones, don't hand-roll the walk.** `Body.backward_cone` /
   `defs_die_at` (`ir/stmt/body.py`) are the shared slicing substrate: a rule asks for a cone and judges its
   *properties* (members, external reads, escapes) — construction never fails, so every bail stays a rule-side
   condition. See the dependence-cones section of `compiler/ir/ARCHITECTURE.md`.

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -30,8 +30,9 @@ from emmy.compiler.ir.pure.fold import (
     loaded_buffers,
 )
 from emmy.compiler.ir.pure.tree import walk
-from emmy.compiler.ir.stmt import Assign, Body, Load, Write
-from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Write
+from emmy.compiler.ir.stmt.body import _exposed_defines
+from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp, lower_with_output_specs
 from emmy.compiler.ir.tile.ops import carries_partition, edge_dtypes
 from emmy.compiler.ir.tile.path import family_sites, sites, spell
 from emmy.compiler.pipeline import Match
@@ -147,10 +148,38 @@ def storage_frontier(node: Fold) -> Frontier | None:
     return Frontier(name=frontier, producer=side(prefix), residue=side(residue), dtype=result)
 
 
+def _ordered_captures(stmts, scope: frozenset[str]) -> set[str]:
+    """Names read before any definition, walking nested bodies in program order. A definition
+    covers only the reads that FOLLOW it; loop-carried accumulators are live on entry."""
+    captured: set[str] = set()
+    seen = set(scope)
+    for stmt in stmts:
+        reads = set(stmt.deps())
+        for expr in stmt.exprs():
+            reads |= expr.free_vars()
+        captured |= reads - seen
+        inner = seen | stmt.binds_axes() | set(stmt.defines())
+        for body in stmt.nested():
+            carried = {child.name for child in Body(body).iter() if isinstance(child, Accum)}
+            captured |= _ordered_captures(body, frozenset(inner | carried))
+        seen |= _exposed_defines(stmt)
+    return captured
+
+
 def _external_reads(node: Fold) -> frozenset[str]:
-    """Every lowered statement's scope-aware SSA and axis captures."""
-    lowered = Body(node.lower())
-    return lowered.forward_cone(lowered).external_reads
+    """Every lowered statement's scope-aware SSA and axis captures, in PROGRAM ORDER: a definition
+    covers only the reads that follow it. A stored tree may hold one value object at two positions
+    (a projection member and, canonically shared, deep inside a contraction-operand cone); the
+    deeper position lowers inside its reduce loop, AFTER a shallower sibling read of the same
+    name. Order-blind resolution let that later definition mask the read, offered the seam as
+    closed over the name, and cut a piece whose reader had no definition — nvcc's undefined
+    identifier on DeepSeek-V4 post4096's composed-cut ``mean_reduce`` piece.
+
+    Through the ONE reconstitution spelling, so a ``ProjectionRegion`` expands as materialization
+    expands it: a stored Fold reached as a term answers with ``deps()``, whose accounting
+    over-approximates a factored operand cone's internal spellings as reads — the expansion
+    lowers those cones and their definitions instead of asking."""
+    return frozenset(_ordered_captures(Body.coerce(lower_with_output_specs(node, ())), frozenset()))
 
 
 def _closed_at(node: Fold, axes: tuple) -> bool:
@@ -673,7 +702,13 @@ def realize(
     produced_pieces = []
     for seam, produced, axes, index, token, names, buffers, replacements in pieces:
         others = {target: loads for target, loads in everything.items() if target not in replacements}
-        produced_pieces.append((seam, _replace_fold(produced, others) if others else produced, axes, index, token, names, buffers))
+        piece = _replace_fold(produced, others) if others else produced
+        dangling = _external_reads(piece) - {axis.name for axis in seam.axes}
+        assert not dangling, f"cut piece for seam {seam.spelling!r} reads {sorted(dangling)} before any definition"
+        produced_pieces.append((seam, piece, axes, index, token, names, buffers))
+    outer_names = {axis.name for axis in tile.place.free} | {store.sweep.name for store in tile.output_specs if store.sweep is not None}
+    dangling = _external_reads(parent_fold) - outer_names
+    assert not dangling, f"cut consumer of {tile.name!r} reads {sorted(dangling)} before any definition"
 
     fragment = _input_fragment(match, root)
     all_buffers = [buffer for *_, buffers in produced_pieces for buffer in buffers]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -150,7 +150,9 @@ def storage_frontier(node: Fold) -> Frontier | None:
 
 def _ordered_captures(stmts, scope: frozenset[str]) -> set[str]:
     """Names read before any definition, walking nested bodies in program order. A definition
-    covers only the reads that FOLLOW it; loop-carried accumulators are live on entry."""
+    covers only the reads that FOLLOW it; loop-carried accumulators are live on entry. The
+    mirror direction keeps `_exposed_defines`' documented over-approximation: a definition inside
+    an EARLIER sibling's body still covers a later outer-scope read."""
     captured: set[str] = set()
     seen = set(scope)
     for stmt in stmts:
@@ -158,10 +160,11 @@ def _ordered_captures(stmts, scope: frozenset[str]) -> set[str]:
         for expr in stmt.exprs():
             reads |= expr.free_vars()
         captured |= reads - seen
-        inner = seen | stmt.binds_axes() | set(stmt.defines())
-        for body in stmt.nested():
-            carried = {child.name for child in Body(body).iter() if isinstance(child, Accum)}
-            captured |= _ordered_captures(body, frozenset(inner | carried))
+        if not stmt.deps_deep:  # a term's ``deps()`` is already the scoped rollup — see ``Stmt.deps_deep``
+            inner = seen | stmt.binds_axes() | set(stmt.defines())
+            for body in stmt.nested():
+                carried = {child.name for child in Body(body).iter() if isinstance(child, Accum)}
+                captured |= _ordered_captures(body, frozenset(inner | carried))
         seen |= _exposed_defines(stmt)
     return captured
 
@@ -703,7 +706,11 @@ def realize(
     for seam, produced, axes, index, token, names, buffers, replacements in pieces:
         others = {target: loads for target, loads in everything.items() if target not in replacements}
         piece = _replace_fold(produced, others) if others else produced
-        dangling = _external_reads(piece) - {axis.name for axis in seam.axes}
+        # The bound is the piece's REAL placement (its workspace axes) — what the produced kernel
+        # binds — not the wider seam.axes. Two caveats on what this proves: the check reads the
+        # reconstituted lowering while ``_piece_inputs`` reads the stored tree's ``loaded_buffers``
+        # (two views of one piece), and observer-only captures sit outside both.
+        dangling = _external_reads(piece) - {axis.name for axis in axes}
         assert not dangling, f"cut piece for seam {seam.spelling!r} reads {sorted(dangling)} before any definition"
         produced_pieces.append((seam, piece, axes, index, token, names, buffers))
     outer_names = {axis.name for axis in tile.place.free} | {store.sweep.name for store in tile.output_specs if store.sweep is not None}

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -110,11 +110,12 @@ cannot adjudicate a Loop-IR fragment either way (no Torch twin and no independen
 "same-input greedy reference is unavailable"), so real correctness evidence comes from the CPU seam equivalence test
 today and from real-weight parity at Stage 3.
 
-Two environment notes for later stages: the host venv's torch pulls NVRTC 13, which cannot target sm_70 — the main
-process works around it with `LD_PRELOAD=/usr/local/cuda-12.9/lib64/libnvrtc.so.12`, but an isolated **bench worker**
-does not inherit the workaround and dies with "invalid value for --gpu-architecture", so any `--bench` / `tune` work
-must run inside the 1Cat image (NVRTC 12.9 native, verified) or in a venv without the NVRTC-13 pin. The inventory is
-untuned (no knobs or timings) and is therefore NOT promoted to the canonical path; it regenerates in ~60 s.
+Two environment notes for later stages — the first CORRECTED 2026-09-01: the old NVRTC-13 bench-worker constraint
+no longer applies (workers inherit the full environment, and the nvcc path dropped its NVRTC fallback). The real
+sm_70 trap is torch cu130 shipping no sm_70 kernels at all; `torch==2.13.0+cu126` fixes it, and `--bench` / `tune`
+then run fine in the plain host venv — no 1Cat image needed. The inventory is untuned (no knobs or timings) and is
+therefore NOT promoted to the canonical path; it regenerates in minutes (post-#691 rewrite: 12 graphs, 152 distinct
+kernels, 3 m 44 s on the host).
 
 ### Round two — fusion rewritten under the twins (2026-08-28/29) — CLOSED
 
@@ -159,22 +160,36 @@ on its own — 52 kernels, worst 2³⁷ (was 2⁵⁵), placement terminating in 
 trips is hours per launch (the 2³⁰ two-cut variant ran 2.6 h without completing before being killed). Two named
 gaps stand between here and a boot that serves, both follow-ups to #692:
 
-1. **Partition the monster — LANDED.** A chain-form root's DIRECT body members (the piece's workspace-rsqrt
-   captures feeding the retained reduce, exactly the monster's shape) now offer and realize cooperative/ILP
-   partitions: the reduce tier binds a provider chain ahead of a strided cooperative/ILP fold sharing one lane
-   axis, closing lane-distributed. A fold nested deeper, and any member of a sweep- or streamed-store-carrying
-   kernel, still keep the serial fold — an offer-side decision, not a remaining capability gap. Realization is
-   corpus-ratcheted (a cooperative reduce row on a composed-cut chain-form piece). Still owed on the V100 host: an
-   unpinned `post4096` compile with this ballot available, to see whether the greedy actually elects a partitioned
-   row for the monster kernel, or still elects serial (see gap 2).
-2. **Let evidence elect the deeper route** — a tune pass over the ballot, now including the monster's own
-   cooperative/ILP rows, so composed arms and partitioned members alike carry measured latencies (today the
-   2³⁷-vs-2³⁰ cut choice, and any partitioned row's win margin, is prior-guessed) — or the monotone serial-work
-   prior feature. This is the critical path still blocking serving latency.
+1. **Partition the monster — LANDED (#693/#694).** A chain-form root's DIRECT body members (the piece's
+   workspace-rsqrt captures feeding the retained reduce, exactly the monster's shape) now offer and realize
+   cooperative/ILP partitions: the reduce tier binds a provider chain ahead of a strided cooperative/ILP fold
+   sharing one lane axis, closing lane-distributed. A fold nested deeper, and any member of a sweep- or
+   streamed-store-carrying kernel, still keep the serial fold — an offer-side decision, not a remaining capability
+   gap. Realization is corpus-ratcheted (a cooperative reduce row on a composed-cut chain-form piece).
+2. **Evidence electing the route — MECHANISM PROVEN on the host (2026-09-01), measurement still owed.** The first
+   tune pass over the new ballot could not measure the monster (below), but its 9 attributed `bench_fail` rows
+   alone flipped the greedy: the worst piece dropped 2³⁸ → 2³⁰ per-thread serial trips (256×) and three
+   partitioned reduces were elected (placement 857 s vs 616 s baseline). The elected consumer piece then failed nvcc — an
+   order-blind seam-capture accounting bug in the composed cut (a deeper occurrence of the same workspace `Load`
+   masked the shallower read, so the piece read the name before any definition); fixed by resolving seam captures
+   in program order with a realize-time no-read-before-definition guardrail (PR #700; all 12 pieces of the real
+   plan now compile, plan name-identical). What still blocks a MEASURED election: the tune's hardcoded compile
+   budget (12 s/74 s) is far under the >160 s these variants need, the monster exposes 45 site-local `REDUCE@`
+   knobs, and `--dump-dir` crashes on these targets — so no successful measurement exists yet, only
+   disqualifications, and no online prior was written. The monotone serial-work prior feature remains the
+   cold-start answer. NOTE: the host's tune DB now carries those 9 rows, so any unpinned compile there elects the
+   partitioned route — intended, now that #700 makes it build.
+3. **NEW — make the elected route's work small enough to serve.** Even the elected 2³⁰ route runs past the 60 s
+   bench watchdog per launch: the dominant cost is re-evaluating the mHC statistics subtree ~16,384× inside the
+   shared-expert contraction — a recomputation blowup that partitioning distributes but does not remove. This is a
+   hoisting/placement-pricing gap (the compiler must materialize or hoist the statistics once, or the cut must
+   price the recomputation out), and it is now the critical path: gates below stay blocked until a `post4096`
+   route launches in seconds, not minutes.
 
-**Consequence for the stages below.** Gate (c) passed at `ab1ad4592` and still does not reproduce: a boot compiles
-but stalls in the first `post4096` prefill forward. Stage 4 cannot warm or bake until gap 2 lands and gate (c) is
-re-run on the host, and the golden re-record should follow it, not precede it.
+**Consequence for the stages below.** Gate (c) passed at `ab1ad4592` and still does not reproduce: a boot now
+compiles end to end (post-#700) but the first `post4096` prefill forward would take minutes-plus per launch.
+Stage 4 cannot warm or bake until gap 3 lands and gate (c) is re-run on the host, and the golden re-record should
+follow it, not precede it.
 
 ## Stage 1 — loader lane: read the published checkpoint (CPU-testable) — **DONE (#651)**
 
@@ -384,10 +399,11 @@ shows expert weight streaming dominates and the fused-unpack GEMM can plausibly 
 Stage −1: DONE (~2 h). Stage 0 round one: DONE (fixed upstream by #602). Stage 1: DONE (#651). Stage 2: DONE (#656).
 Stage 3 in-repo: DONE (#662); gate (c) passed once at `ab1ad4592`, gate (d)'s token-ID half with it.
 
-**Stage 0 round three's runtime gap is the critical path.** All three twins compile (`expert16` #671, `post16` #676,
-`pre16` #682/#688, `post4096`'s placement #692 — merge #692, and close #686 as superseded by it). What holds
-everything behind it now is partitioning `post4096`'s composed-cut consumer: the reduce tier emitting a
-sibling-provider chain ahead of a cooperative/ILP loop — a scoped codegen capability, call it 2–5 days — plus a tune
-pass over the new placement ballot so evidence, not the prior, elects the route. Then Stage 4: 2–4 days on-host
-(re-run gate (c), re-record the golden, warm/bake/verify). Stage 5: 1–2 days. Adding stage 6 (MXFP4 + tuning) is a
-further 1–3 weeks. The compiler, not the fork ABI, remains the dominant uncertainty.
+**Stage 0 round three, gap 3, is the critical path.** Partitioning landed (#693/#694), the election mechanism is
+proven on the host, and the elected plan compiles end to end (#700) — but its monster piece re-evaluates the mHC
+statistics subtree ~16,384× and launches past the 60 s watchdog. What holds everything now: the recomputation
+itself (hoist or materialize the statistics once — open-ended placement/fusion work), with the serial-work prior
+feature and the tune-harness fixes (compile budget, the 45-knob site space, `--dump-dir`) as the supporting lane.
+Then Stage 4: 2–4 days on-host (re-run gate (c), re-record the golden, warm/bake/verify). Stage 5: 1–2 days.
+Adding stage 6 (MXFP4 + tuning) is a further 1–3 weeks. The compiler, not the fork ABI, remains the dominant
+uncertainty.

--- a/tests/compiler/ir/test_body_cone.py
+++ b/tests/compiler/ir/test_body_cone.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``Body.backward_cone`` / ``forward_cone`` / ``defs_die_at``.
+"""Unit tests for ``Body.backward_cone`` / ``defs_die_at``.
 
 The cone API is the shared dataflow substrate behind the rules that used to
 hand-roll slicing (``_split_demoted``, ``021_hoist_staged_loads_above_mask``)
@@ -84,23 +84,6 @@ def test_backward_cone_select_predicate_axis_is_read():
     )
     cone = body.backward_cone(["v"])
     assert "n" in cone.external_reads
-
-
-# --- forward_cone -----------------------------------------------------
-
-
-def test_forward_cone_taints_transitive_readers():
-    body = _cell()
-    cone = body.forward_cone([body[0]])  # seed: the unsafe Load a0
-    assert [s.defines()[0] for s in cone.members] == ["a0", "a1", "p", "acc"]
-    # b is read by a member but produced outside the cone.
-    assert "b" in cone.external_reads
-
-
-def test_forward_cone_skips_independent_stmts():
-    body = _cell()
-    cone = body.forward_cone([body[2]])  # seed: the B-side Load
-    assert [s.defines()[0] for s in cone.members] == ["b", "p", "acc"]
 
 
 # --- defs_die_at ------------------------------------------------------

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -195,6 +195,29 @@ def test_an_operand_supplied_name_is_not_an_enclosing_capture() -> None:
     assert outer.deps() == (), "an operand-supplied read must not surface as an enclosing capture"
 
 
+def test_a_hoist_candidate_shadowing_a_body_define_is_not_fed_by_it() -> None:
+    """The three-level shape whose hoist verdict the scoped-rollup fix flips, REFUSED to ALLOWED.
+
+    A plain root member defines ``p``; the candidate fold's INNER fold takes its own ``p`` from a
+    factored operand edge, so the candidate never reads the body's ``p``. The phantom capture made
+    ``fed_by_body`` see a feed and refuse the hoist; with ``deps()`` honest, the candidate hoists
+    onto an operand edge — the semantically correct verdict, pinned here because it is a real
+    normalize behavior change, not only a reporting change."""
+    from emmy.compiler.ir.tile.normalize import _hoist_closed_folds, fed_by_body
+
+    cone = Fold.projection(body=Body((Load(name="p", input="eps", index=()),)), results=("p",))
+    inner = Fold.projection(operands=(cone,), body=Body((Assign(name="q", op="rsqrt", args=("p",)),)), results=("q",))
+    candidate = Fold.projection(body=Body((inner, Assign(name="r", op="rsqrt", args=("q",)))), results=("r",))
+    root = Fold.projection(
+        body=Body((Load(name="p", input="host", index=()), candidate, Assign(name="out", op="rsqrt", args=("r",)))),
+        results=("out",),
+    )
+
+    assert not fed_by_body(candidate, root.lift.body), "a shadowed name is not a feed"
+    hoisted = _hoist_closed_folds(root, (), frozenset())
+    assert any(edge is candidate for edge in hoisted.operands), "the closed candidate hoists onto an operand edge"
+
+
 def test_cut_closure_does_not_confuse_a_sibling_loop_axis_for_scope() -> None:
     """A loop binding ``k`` in one operand does not scope a sibling operand's ``x[k]`` load."""
     from emmy.compiler.pipeline.passes.lowering.tile._cut import _closed_at

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -181,6 +181,20 @@ def test_contraction_deps_include_inline_operand_captures() -> None:
     assert "m_run" in node.deps()
 
 
+def test_an_operand_supplied_name_is_not_an_enclosing_capture() -> None:
+    """A factored operand cone's result reaches the lift through a param, not from the enclosing
+    scope. The read walk used to re-walk a member fold's lift without seeing its params, so every
+    enclosing lambda reported the name as a phantom capture — misdiagnosed as dangling on
+    DeepSeek-V4 post4096's whole-kernel root, and blocking sharing unification for the copies
+    that carry it. ``deps()`` is the scoped rollup; the walk must stop there (``Stmt.deps_deep``)."""
+    cone = Fold.projection(body=Body((Load(name="p", input="eps", index=()),)), results=("p",))
+    member = Fold.projection(operands=(cone,), body=Body((Assign(name="q", op="rsqrt", args=("p",)),)), results=("q",))
+    outer = Fold.projection(body=Body((member, Assign(name="out", op="rsqrt", args=("q",)))), results=("out",))
+
+    assert member.deps() == ()
+    assert outer.deps() == (), "an operand-supplied read must not surface as an enclosing capture"
+
+
 def test_cut_closure_does_not_confuse_a_sibling_loop_axis_for_scope() -> None:
     """A loop binding ``k`` in one operand does not scope a sibling operand's ``x[k]`` load."""
     from emmy.compiler.pipeline.passes.lowering.tile._cut import _closed_at

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -27,6 +27,7 @@ from emmy.compiler.pipeline.fork import Fork
 from emmy.compiler.pipeline.passes.lowering.tile._cut import (
     CutSite,
     _environments,
+    _external_reads,
     _producer_order,
     _workspace_axes,
     cuttable_seams,
@@ -645,6 +646,33 @@ def test_pool_group_fuses_node_id_respellings_and_keys_on_pins() -> None:
 
     unpinned = GoldenRecord(knobs={}, **{**fields, "pins": ()})
     assert unpinned.pool_group != a.pool_group, "the pin regime is a group-key term"
+
+
+def test_lowered_captures_resolve_in_program_order() -> None:
+    """A definition covers only the reads that FOLLOW it.
+
+    A stored tree may hold one value object at two positions — a projection member and, canonically
+    shared, deep inside a contraction-operand cone. A seam that keeps only the deeper position
+    lowers the definition inside the reduce loop, AFTER a shallower sibling read of the same name:
+    the name is still a capture the piece must receive as a provider. Order-blind resolution let
+    the later definition mask the read, offered the seam as closed, and cut a piece whose reader
+    had no definition — nvcc's undefined identifier on DeepSeek-V4 post4096's composed-cut
+    ``mean_reduce`` piece."""
+    scalar = Load(name="x", input="eps", index=())
+    cone = Fold.projection(body=Body((scalar, Assign(name="v", op="rsqrt", args=("x",)))), results=("v",))
+    weight = Load(name="w_e", input="w", index=(Var("k"),))
+    b_edge = Fold.projection(operands=(cone,), body=Body((weight, Assign(name="b", op="multiply", args=("w_e", "v")))), results=("b",))
+    inner = Fold.contraction(
+        k_axis=Axis("k", 8),
+        a=Load(name="a_e", input="a", index=(Var("k"),)),
+        channels=(Channel(b=b_edge, acc="acc"),),
+    )
+    node = Fold.projection(
+        body=Body((Assign(name="r", op="rsqrt", args=("x",)), inner, Assign(name="out", op="multiply", args=("r", "acc")))),
+        results=("out",),
+    )
+    assert "x" in node.deps(), "the stored tree knows the shallow read is a capture"
+    assert "x" in _external_reads(node), "the lowered accounting must agree: a later, deeper definition covers nothing"
 
 
 def test_a_fold_held_by_a_plain_statement_still_gets_an_environment() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -675,6 +675,74 @@ def test_lowered_captures_resolve_in_program_order() -> None:
     assert "x" in _external_reads(node), "the lowered accounting must agree: a later, deeper definition covers nothing"
 
 
+def test_masked_capture_threads_into_the_piece_and_the_guardrail_fires_without_it() -> None:
+    """End to end at the cut: the recovered capture becomes a provider, and its absence is loud.
+
+    The seam is a reducing fold whose lift reads ``x`` ahead of a contraction holding the ``x``
+    cone on its b edge (the deeper position lowers inside the reduce loop). Provider closure must
+    NEED ``x``, resolve it in the host body, and prepend the ``Load`` to the produced piece; a
+    seam stripped of that provider must trip realization's read-before-definition assert instead
+    of reaching nvcc."""
+    j, k = Axis("j", 4), Axis("k", 16)
+    shared = Load(name="x", input="eps", index=())
+    cone = Fold.projection(body=Body((shared, Assign(name="v", op="rsqrt", args=("x",)))), results=("v",))
+    weight = Load(name="w_v", input="w", index=(Var("k"),))
+    b_edge = Fold.projection(
+        operands=(cone,),
+        body=Body((weight, Assign(name="bv", op="multiply", args=("w_v", "v")), Assign(name="bs", op="multiply", args=("bv", "s")))),
+        results=("bs",),
+    )
+    inner = Fold.contraction(
+        k_axis=k,
+        a=Load(name="a_v", input="a", index=(Var("j"), Var("k"))),
+        channels=(Channel(b=b_edge, acc="acc"),),
+    )
+    reducing = Fold(
+        axis=j,
+        lift=Lambda(
+            params=("j",),
+            body=Body(
+                (
+                    Assign(name="r", op="rsqrt", args=("x",)),
+                    Assign(name="s", op="rsqrt", args=("r",)),
+                    inner,
+                    Assign(name="step", op="multiply", args=("acc", "r")),
+                )
+            ),
+            results=("step",),
+        ),
+        init=(0.0,),
+        combine=Lambda(params=("acc6", "other"), body=Body((Assign(name="acc6", op="add", args=("acc6", "other")),)), results=("acc6",)),
+    )
+    host = Fold.projection(body=Body((shared, reducing, Assign(name="out", op="rsqrt", args=("acc6",)))), results=("out",))
+    tile = TileOp(
+        op=host,
+        name="host_kernel",
+        place=Placement(free=()),
+        output_specs=(OutputSpec(Write(output="out_buf", index=(), value="out")),),
+    )
+    assert tile.op is host, "the shape must survive construction normalization unchanged"
+
+    graph = Graph()
+    for name, shape in (("eps", (1,)), ("a", (4, 16)), ("w", (16,))):
+        _input(graph, name, shape, dtype="f32")
+    graph.add_node(tile, ["eps", "a", "w"], outputs=(Tensor("out_buf", (), "f32"),), node_id="host_kernel")
+    match = Match(graph=graph, root_node_id="host_kernel", rule=Rule(name="test", pattern=[]))
+    root = graph.nodes["host_kernel"]
+
+    seam = next(s for s in cuttable_seams(tile) if s.node is reducing)
+    assert [tuple(p.defines()) for p in seam.providers] == [("x",)], "the masked capture resolves to its host Load"
+
+    fragment = realize(match, root, (seam,), output_map(root))
+    piece = next(node.op for node in fragment.nodes.values() if isinstance(node.op, TileOp) and "__place_" in node.op.name)
+    assert piece.op.lift.body[0] is seam.providers[0], "the provider Load opens the piece"
+    assert not _external_reads(piece.op), "the produced piece reads nothing before its definition"
+
+    stripped = CutSite(node=seam.node, spelling=seam.spelling, axes=seam.axes, dtypes=seam.dtypes)
+    with pytest.raises(AssertionError, match=r"reads \['x'\] before any definition"):
+        realize(match, root, (stripped,), output_map(root))
+
+
 def test_a_fold_held_by_a_plain_statement_still_gets_an_environment() -> None:
     """A plain statement binds axes, not SSA definitions — but it can HOLD a stored fold.
 


### PR DESCRIPTION
## What

Two capture-accounting defects in the read-walk substrate, found when the DeepSeek-V4 gap-2 tune elected a
partitioned composed-cut route for `post4096` and the consumer piece failed nvcc (`identifier "in6__u0..u3" is
undefined`).

1. **The miscompile** (`Resolve seam captures in program order; a deeper same-name definition covers nothing`):
   `_cut.py::_external_reads` answered "what does this piece capture?" with an order-blind `forward_cone`, so a
   deeper contraction-operand occurrence of the same `Load` object masked a shallower read of the same name, and
   `_closed_at` skipped that provider — the produced piece read `in6` before any definition (the `__u` suffixes
   are ILP replication of the ONE unprovided read). The fix resolves captures in program order over the
   reconstituted lowering, removes `forward_cone` outright (its one remaining caller was this bug), and adds a
   realize-time guardrail: every produced piece must read nothing before definition, bounded by the piece's real
   placement axes. This class previously travelled all the way to nvcc unnoticed; the guardrail costs ~0.05 s
   across the full suite.
2. **The phantom captures** (`Stop read walks at a term's scoped rollup`): `_member_reads` re-walked a Fold
   member's nested lift body without subtracting the lift's params, so after normalization factors a definer onto
   an operand edge, `Fold.deps()` reported captures nothing actually reads (four such phantoms on the post4096
   root misdirected the first two debugging passes at normalize/emission, which are innocent). Fixed as a
   `Stmt.deps_deep` protocol trait — a read walk stops at a term's scoped rollup. Direction is strictly
   shrinking (over-approximation removed), so sharing can only improve.

## Disclosed behavior change

The deps precision fix relaxes `fed_by_body` / the normalize hoist for one three-level shape (root ⊃ member ⊃
inner fold whose name arrives through its own factored operand edge): hoist REFUSED → ALLOWED, semantically
correct, pinned by `test_a_hoist_candidate_shadowing_a_body_define_is_not_fed_by_it`. Zero flips across the
checked-in suite (3873 `fed_by_body` calls).

## Documented residual limits (pre-existing, now stated in code)

- Mirror-direction masking: a definition inside an EARLIER sibling's body still covers a later outer-scope read
  (inherited `_exposed_defines` over-approximation).
- Observer-only captures sit outside both the capture walk and the guardrail.

## Verification

- `make test` 4229 passed / lint clean / realization corpus zero stale; new units are RED against reconstructed
  pre-fix code (verified independently in review): program-order capture resolution, the operand-supplied-name
  precision case, the hoist-relaxation pin, and an end-to-end cut test where the recovered capture threads into
  the piece by object identity and a stripped seam makes the guardrail fire (message-matched).
- On the 16× V100 host: all 12 pieces of the real `post4096` composed-cut plan now compile through nvcc
  (previously 1 failed), plan name-identical, compile 1 m 35 s.
- A sharing/unification causal hypothesis was tested and refuted (the precision fix alone leaves the miscompile;
  repro CUDA byte-identical) — the two commits are independent fixes.
- No corpus case: the real shape's golden record is 261 KB against the 1–2 KB case norm; the four units plus the
  loud realize guardrail carry the regression.
- `git diff --stat origin/main -- emmy/`: net +38 — a miscompile fix with an always-on structural assert plus a
  declared protocol trait; justified as new checking, not architectural creep.

## What this unblocks / does not

Unblocks: evidence-elected composed-cut plans compile end to end, so gate (c) retries on the V100 no longer die
at nvcc, and the gap-2 tune can measure real launches. Does not: make the elected 2^30 route fast — it benches
past the 60 s watchdog (an honest runtime `bench_fail`); the serial-work prior feature and the mHC-statistics
hoisting remain the open performance work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
