### PR TITLE
Retain one row per kept signature, not every row that carries it

### DIFF
--- a/emmy/compiler/pipeline/search/pool.py
+++ b/emmy/compiler/pipeline/search/pool.py
@@ -16,11 +16,15 @@ deterministic and the reservoir never reads a row, so two byte-identical pools d
 samples — which is what keeps the fit reproducible and keeps two goldens over one pool mergeable
 into one training group.
 
-**Membership survives the draw exactly.** ``keep`` is the set of :func:`~.features.tile_signature`
-values that must be retained whatever the draw picks. The reservoir visits every candidate by
-construction, and a row whose signature is in the set is retained beside the draw: a golden that is
-genuinely absent from its pool still reads as absent, which is a real defect class (a pin or dtype
-mismatch) the fit and ``eval golden`` both detect by exactly that miss.
+**Membership survives the draw exactly, at ONE row per signature.** ``keep`` is the set of
+:func:`~.features.tile_signature` values the draw may not lose, and the reservoir visits every
+candidate, so a golden that is genuinely absent from its pool still reads as absent — a real defect
+class (a pin or dtype mismatch) the fit and ``eval golden`` both detect by exactly that miss. One row
+discharges that: both consumers locate a golden with ``next(... == want ...)`` and read the first
+match. The cap is load-bearing, not tidy — a signature is a coarse stamp many schedules share, so
+retaining every match scaled the keep-set with the POOL instead of the corpus: 34 signatures pulled
+77,279 rows out of a 1,950,625-row V100 ``k_linear_matmul_reduce`` pool, 99.8% of its sample, burying
+the uniform draw under the golden's own signature class.
 
 **Reported rank is the RAW sample rank with the exact total beside it, never scaled**
 (:class:`Candidates`). A sample's rank resolution floor is ``n / size``; pretending otherwise would
@@ -69,7 +73,7 @@ class PoolSample:
     #: Candidates to draw. ``0`` (or a pool no larger than it) means the whole pool.
     rows: int
     seed: int = 0
-    #: The ``tile_signature`` values the draw may not drop.
+    #: The ``tile_signature`` values the draw may not drop. One row per value — the first carrying it.
     keep: frozenset = frozenset()
     #: Where each drawn pool reports its EXACT size, keyed by that pool's schedule-space stamp. The sampled
     #: rows cannot carry it and the fork tree has no channel for it, so the enumerator writes here
@@ -92,7 +96,8 @@ class PoolSample:
         One pass, O(size) retained: the first ``size`` candidates fill the reservoir and each later
         one displaces a uniformly chosen slot, so the draw is uniform without knowing the count up
         front — the property that lets a lazy walk be sampled at all. The kept-signature rows ride
-        beside the reservoir (the keep-set ADDS to the draw, it never displaces it), and the whole
+        beside the reservoir (the keep-set ADDS to the draw, it never displaces it) at one row per
+        signature, so what they add is bounded by the keep-set rather than by the pool, and the whole
         stream is returned when ``size`` is 0 or the stream is no larger."""
         stream = iter(rows)
         if self.rows <= 0:
@@ -101,10 +106,12 @@ class PoolSample:
         rng = np.random.default_rng(self.seed)
         reservoir: list[tuple[int, dict]] = []
         kept: dict[int, dict] = {}
+        found: set = set()
         count = 0
         for index, row in enumerate(stream):
             count = index + 1
-            if self.keep and features.tile_signature(row) in self.keep:
+            if self.keep and (sig := features.tile_signature(row)) in self.keep and sig not in found:
+                found.add(sig)
                 kept[index] = row
             if index < self.rows:
                 reservoir.append((index, row))

--- a/tests/compiler/pipeline/search/test_pool_sample.py
+++ b/tests/compiler/pipeline/search/test_pool_sample.py
@@ -68,6 +68,21 @@ def test_every_candidate_is_visited_even_though_most_are_dropped(by_id) -> None:
     assert PoolSample(rows=10, keep=frozenset({12345})).take(space) == PoolSample(rows=10).take(space)
 
 
+def test_a_kept_signature_retains_one_row_however_many_carry_it(monkeypatch) -> None:
+    """A signature is a coarse structural stamp, so a big pool can hold thousands of rows under one
+    of them. Both consumers read the FIRST match and no more, so the keep-set must scale with the
+    corpus that recorded it, never with the pool it is applied to — retaining every match is what
+    let 34 signatures pull 77,279 rows out of a 1.95M-row pool and swamp the draw."""
+    monkeypatch.setattr(features, "tile_signature", lambda row: row["id"] % 4)
+    space = _space(500)  # 125 rows carry each of the four signatures
+    kept = PoolSample(rows=10, seed=0, keep=frozenset({1, 3})).take(space)
+    ids = [row["id"] for row in kept.rows]
+    assert 1 in ids and 3 in ids, "the first row carrying each kept signature is retained"
+    drawn = {row["id"] for row in PoolSample(rows=10, seed=0).take(space).rows}
+    assert set(ids) - drawn == {1, 3}, "and it adds exactly those two rows to the draw, not 250"
+    assert kept.total == 500, "the exact pool size is unchanged by what the keep-set retains"
+
+
 def test_a_pool_no_larger_than_the_draw_is_taken_whole() -> None:
     space = _space(10)
     assert PoolSample(rows=10).take(space) == Candidates(space, 10)


### PR DESCRIPTION
## What

`PoolSample.take` retained **every** row whose `tile_signature` was in the keep-set. It now retains
the **first** row per signature.

```python
if self.keep and (sig := features.tile_signature(row)) in self.keep and sig not in found:
    found.add(sig)
    kept[index] = row
```

## Why

The keep-set's job is to guarantee that a sampled pool never loses a recorded golden's own row, so
that "golden not in N candidates" always means a real defect — a pin or dtype mismatch — rather than
a sampling accident. Both `emmy fit` and `eval golden` read that miss exactly that way.

One row per signature discharges that obligation completely: both consumers locate the golden with
`next(... tile_signature(row) == want ...)` and read the first match only
(`commands/fit.py`, `search/golden_eval.py`).

Retaining every match instead made the keep-set's contribution scale with the **pool** rather than
with the corpus that recorded it. A tile signature is a coarse structural stamp — free-axis slots,
reduce decomposition, atom — that many distinct schedules share, and the coarser the tier the more
they share it.

Measured on the V100 `k_linear_matmul_reduce` goldens:

| | rows retained | signatures | rows per signature |
| --- | ---: | ---: | ---: |
| V100 `k_linear_matmul_reduce` (1,950,625 candidates) | 77,279 | 34 | ~2,270 |
| RTX 5090 `matmul.mlp_gate_up.h4096` (57,811 candidates) | 348 | 61 | ~3.6 |

99.8% of that pool's sample was keep-set rows, so the uniform draw was buried under the golden's own
signature class — the sample had stopped being a sample. `emmy fit` then featurized all 77,279 rows
per pool, four such pools in the corpus. The fit did not finish: it was still climbing past 13 GB on
that one pool after 20 minutes.

## Result

Same pool, after the change: **77,279 rows -> 147** (the 128-row draw plus the 19 recorded signatures
actually present). The golden is still retained and the defect signal is byte-identical.

A full linear fit over the golden corpus now **completes**, which it did not before:

| | before | after |
| --- | ---: | ---: |
| peak RSS | 13 GB, climbing when killed | **0.79 GB** |
| largest pool's rows | 77,279 | **2,044** |
| outcome | never reached training | wrote `metrics.json` + `weights.json` |

Rank quality is unchanged, which is the intended outcome for a sampling fix — it makes the fit
runnable, it does not change what is learned:

| | baseline `d5455b46` | this branch |
| --- | --- | --- |
| holdout median rank | 6 | 6 |
| holdout top-1 | 14% | 15% |
| goldens unranked (unmatched) | 67 | 174 |

The unranked jump is NOT caused by this change — it is a pre-existing HEAD regression this fit merely
made visible: 121 goldens recording a cross-CTA split (`REDUCE=g<n>`) no longer match any row, because the
enumeration offers no `g<n>` rows in the ordinary candidate pool. They are 95% of the 127 distinct goldens
skipped (4090 3 -> 95, 5090 4 -> 46). Filed as a separate concern; nothing in this PR touches it.

(`feat_ver` differs between those two runs, 3 vs 4, so the comparison is indicative rather than
like-for-like. The full-train median moves 3 -> 9 because the degenerate 5-row V100 pools that used
to hand out free rank-0 hits are real pools at HEAD.)

## Line balance

`git diff --stat main -- emmy/` is +15/-8, net **+7**, of which **+2 lines are executable code**
(`found: set = set()` and `found.add(sig)`). The remainder documents why the cap is load-bearing
rather than tidy — the invariant is not recoverable from the three lines that enforce it.

## Tests

`tests/compiler/pipeline/search/test_pool_sample.py::test_a_kept_signature_retains_one_row_however_many_carry_it`
— every existing test in that file gives each row a unique signature, so none of them could catch
this. The new test fails on the parent commit and passes here.

`make test`: 4227 passed, 1 pre-existing failure
(`test_golden_bench_2026.py::test_neptune_emmy_runner_fails_when_one_setup_is_incomplete`, a shell
harness exiting 127 on this machine) verified to fail identically on a clean tree. `make lint` clean.

## Not addressed here

Two separate defects surfaced while diagnosing this, both left alone:

1. **The `O(pool)` enumeration walk.** Bounding memory was never meant to bound time; those four
   pools still take minutes each to walk. The corpus now holds a 9,128,859-candidate pool.
2. **Three stale goldens record an all-empty schedule for a large pool.** An empty schedule
   (`TILE`/`WORK`/`STAGE`/`REDUCE` all `""`) is normal and correct for pointwise / slice / div / mul kernels —
   there is nothing to schedule — and 38 of the 46 empty goldens reaching the fit sit in pools of <=10 rows and
   rank at median 2. Only three pair an empty schedule with a real schedule space, and they are the same fused
   kernels as (1): `pre-sym.k_linear_dad69a...dynamic.fm` (28,921 rows, rank 1500),
   `layer0.i048.k_linear_matmul_reduce` (1,950,625, rank 1373) and `layer0.i076.k_linear_matmul_reduce`
   (9,128,859, rank 1465). They were recorded when those kernels offered ~5 degenerate options, so the record
   was accurate then and is stale now. The fix is to re-record those three on a V100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxbNDQNmsJXoHqdQ6KFWVF


