### PR TITLE
CI: raise the test step cap from 12 to 25 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on:
       group: ubuntu-runners
     # The outer job includes dependency and cache setup; the test step below owns the stricter
-    # twelve-minute execution cap.
-    timeout-minutes: 20
+    # twenty-five-minute execution cap.
+    timeout-minutes: 33
     steps:
       - uses: actions/checkout@v4
 
@@ -67,7 +67,7 @@ jobs:
           key: hf-models-v1
 
       - name: Run tests
-        timeout-minutes: 12
+        timeout-minutes: 25
         run: make test
 
   package:


### PR DESCRIPTION
`Run tests` step: `timeout-minutes: 12` → `25`.

The outer `test` job cap moves with it, `20` → `33`. That cap bounds dependency/cache setup *plus* the test step, so
leaving it at 20 would have killed the run before the step's own cap could ever apply — the effective limit would have
stayed 20, not 25. Kept the same ~8 minutes of setup headroom the previous pair had.

Comment above the job updated (it named the twelve-minute cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)