### PR TITLE
post4096: bound a launch by its blocks — the launch-total serial floor (stacked on #706)

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -409,7 +409,14 @@ reduce-partition coverage, at a per-issue constant conservative for any GPU cloc
 `post4096`'s fused 2^30-trip recomputation nest priced 4.29e-37 µs and beat every recomputation-free
 composed-cut arm until the bound priced it honestly — and its successor dominant piece (2^23 trips, 839 µs on
 trips alone, 16 % inside the guard, 13.21 s measured) rode that escape until the issue count priced its
-~16-statement weight-column-walk trips honestly. The guard is jurisdiction, not tuning —
+~16-statement weight-column-walk trips honestly. The same summand also carries a LAUNCH-TOTAL floor
+(`features.launch_floor_us`): every block evaluates the kernel's worst nest at least once, so a launch retires at
+least `blocks × S_ext_serial_cell_issues` issues — blocks read off the terminal placement's grid over the row's
+per-CTA output tile (or one cell per thread over the largest block a GPU runs) — at an issue rate no GPU reaches
+across all its schedulers (1e5 issues/ns). It is what separates two arms whose per-thread floors tie:
+`post4096`'s contribution producer recomputing the mHC statistics once per (row, a28) block against its
+statistics cut computing them once per row — 2000× apart per launch. Counting per output cell instead of per
+block was rejected as not a bound; `launch_floor_us` carries the record. The guard is jurisdiction, not tuning —
 the bound ignores launch overhead and memory traffic, so at ordinary magnitudes the model's ranking stands
 untouched, while a bound past the guard is un-servable whatever those effects are. A measured µs is never below
 the bound, so the clamp only ever lifts model garbage; the prior's own scoring surfaces are untouched, because

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -475,6 +475,66 @@ def serial_floor_us(knobs: dict) -> float:
     return _covered_serial(knobs, "S_ext_serial_cell_issues") * SERIAL_ISSUE_FLOOR_US
 
 
+#: Launch-total calibration bound, µs per serial issue summed over a launch's blocks: 1e5 issues
+#: per ns (1e8 per µs) is a rate no GPU reaches across all its schedulers (a V100 issues ~500 per
+#: ns; the largest current part ~2000), so it is a bound, not a model. Its jurisdiction is the
+#: same enforcement guard as the per-thread floor. The calibration line: at ~1e4 per ns the
+#: qwen3emb ``gated-mlp-s512`` corpus kernel (1,572,864 blocks × 7168 issues, the largest
+#: legitimate launch total) would cross the guard — that is the rate not to cross.
+LAUNCH_ISSUE_FLOOR_US = 1e-8
+
+#: The most output cells one block can hold when the row spells no output tile: every cell takes
+#: at least one thread, and no block has more threads than this.
+_MAX_BLOCK_THREADS = 1024
+
+
+def _launch_blocks(knobs: dict, cells: float) -> float:
+    """A lower bound on the blocks one launch of the row's kernel runs over ``cells`` output
+    cells: the cells divided by the most cells one block covers — the widest per-CTA output tile
+    (``tile_m × tile_n``) among the row's ``TILE`` sites when it spells one (the pooled family
+    read is diagnostic; the widest site is the safe one whichever is the root's), else one cell
+    per thread over the largest block a GPU runs (:data:`_MAX_BLOCK_THREADS`). Over-counting a
+    block's cells only under-counts blocks, the safe direction; a spelled tile that does not
+    resolve bounds nothing (``0.0``) rather than borrowing the per-cell cap. A cross-CTA split
+    multiplies the blocks and divides each block's nest by the same factor, so neither side
+    applies it."""
+    if not cells:
+        return 0.0
+    work, _tile, _stage, reduce = _row_values(knobs)
+    spelled = [str(value) for name, value in knobs.items() if (name == "TILE" or name.startswith("TILE@")) and value]
+    tiles = [_resolved_tile(work, value, reduce) for value in spelled]
+    if any(tile is None for tile in tiles):
+        return 0.0
+    tiled = [tile.tile_m * tile.tile_n for tile in tiles if tile.is_tiled]
+    return math.ceil(cells / float(max(tiled) if tiled else _MAX_BLOCK_THREADS))
+
+
+def launch_floor_us(knobs: dict, cells: float) -> float:
+    """A physical lower bound, in µs, on one launch of the row's kernel from its LAUNCH-TOTAL
+    serial issues: every block evaluates the kernel's worst serial nest at least once, so the
+    launch retires at least ``blocks × S_ext_serial_cell_issues`` issues, at an issue rate no GPU
+    reaches (:data:`LAUNCH_ISSUE_FLOOR_US`). ``cells`` is the launch's output cells — the
+    placement's grid extents, sweeps excluded (a sweep is a loop a thread walks, not grid
+    parallelism). No reduce-partition coverage divide: partitioning moves a nest's trips between
+    threads, not out of the launch. The one assumption past the per-thread floor's: every block
+    runs the worst nest — a nest under a data-dependent ``Cond`` counts toward it, so a block that
+    skips it is over-priced; slack the guard's margin absorbs. Beside the per-thread floor
+    (:func:`serial_floor_us`) this is what separates a kernel that recomputes a statistic once
+    per block from one that computes it once per row — the two tie per thread (DeepSeek-V4
+    ``post4096``'s contribution producer against its statistics cut: 2^23 blocks against 4096,
+    priced at ≥ 2^13 against ≥ 4 — the untiled cap over-states a coop block's cells 1024×, the
+    safe direction, and the 2000× ratio survives).
+
+    Counting per OUTPUT CELL instead of per block — cells × per-cell issues — was rejected because
+    it is not a bound: a serial nest that is an operand cone of an outer contraction is shared
+    across every cell of a block that does not read its coordinates, and the tile chooses how
+    many. On post4096's measured dominant piece (13.21 s) it charged 2^24 cells × 2^27 issues =
+    2^51 → 22.5 s at this rate, above the measurement; per block the same kernel prices 0.67 µs
+    (its per-thread floor is what catches it). A bound a measurement refutes must not be
+    tightened back."""
+    return _launch_blocks(knobs, cells) * float(knobs.get("S_ext_serial_cell_issues") or 0.0) * LAUNCH_ISSUE_FLOOR_US
+
+
 def _free_slots(knobs: dict) -> tuple[int, int, int, int] | None:
     """The ``(par_n, reg_n, par_m, reg_m)`` slot widths for the (≤2) tiled free axes.
 

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -44,7 +44,7 @@ therefore no evidence at all, and falls through to the prior as though nothing
 were known about it. That is how DeepSeek-V4's post block kept a fused arm whose
 every benched variant hung.
 
-**One physical bound, and it is not a preference.** The kernel-set Σ
+**The physical bound, and it is not a preference.** The kernel-set Σ
 (:func:`_resolved_price`) clamps a summand to its serial-work lower bound where
 that bound is decisively large (:data:`_SERIAL_FLOOR_ENFORCE_US`). This is the
 one exception to "no hand-written tier", and it is an exception in the same
@@ -68,7 +68,7 @@ from typing import TYPE_CHECKING, NamedTuple
 from emmy.compiler.graph import Graph
 from emmy.compiler.pipeline.fork import Fork, flatten_leaves, iter_leaves, leaf_knobs
 from emmy.compiler.pipeline.knob import schedule_pin_fingerprint
-from emmy.compiler.pipeline.search.features import serial_floor_us
+from emmy.compiler.pipeline.search.features import launch_floor_us, serial_floor_us
 
 logger = logging.getLogger(__name__)
 
@@ -261,9 +261,11 @@ def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: d
     the known cost of comparing kernel SETS with a per-kernel ranker — the exposure the module
     docstring names, and the prior's to fix by being calibrated, not this function's to paper
     over. What this Σ DOES enforce is the physical bound no calibration could relax: a summand
-    whose serial-work lower bound (:func:`~..features.serial_floor_us` — the kernel's per-thread
-    serial issues, each trip priced at the statements it re-executes, at a per-issue time
-    conservative for any GPU clock) exceeds
+    whose serial-work lower bound — the larger of its per-thread floor
+    (:func:`~..features.serial_floor_us`: the kernel's per-thread serial issues, each trip priced
+    at the statements it re-executes, at a per-issue time conservative for any GPU clock) and its
+    launch-total floor (:func:`~..features.launch_floor_us`: every block evaluates the worst nest
+    at least once, at an issue rate no GPU reaches across all its schedulers) — exceeds
     :data:`_SERIAL_FLOOR_ENFORCE_US` is clamped to that bound. A measured µs is never below the
     bound, so the clamp only ever lifts model garbage: the cold proxy priced DeepSeek-V4
     ``post4096``'s fused 2^30-trip recomputation nest at 4.29e-37 µs, under every one of its
@@ -309,9 +311,21 @@ def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: d
             us = prior.mean_scores(rows)[0] if prior is not None else None
         if us is None:
             return None
-        floor = serial_floor_us(knobs)
+        floor = max(serial_floor_us(knobs), launch_floor_us(knobs, _grid_cells(node.op)))
         total += max(us, floor) if floor > _SERIAL_FLOOR_ENFORCE_US else us
     return total
+
+
+def _grid_cells(op) -> float:
+    """The output cells one launch of ``op`` runs: its placement's static grid extents, or ``0.0``
+    (no launch-total bound) when the op carries no grid or a symbolic extent."""
+    grid = getattr(getattr(op, "place", None), "grid", None)
+    if not grid or any(not axis.extent.is_static for axis in grid):
+        return 0.0
+    cells = 1.0
+    for axis in grid:
+        cells *= float(axis.extent.as_static())
+    return cells
 
 
 def _price_kernel(

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -218,9 +218,17 @@ gaps stand between here and a boot that serves, both follow-ups to #692:
    contributions is a pure staged mma with no serial hidden-dim walk — the shape this item asked for — but the
    contribution producer now carries the mHC statistics recompute per (row, a28) cell (~2^20 trips per lane
    after its 1024-way cta×coop coverage, 2^53 total), and that per-thread floor is honestly 839 µs: the piece is
-   un-servable through grid-TOTAL serial work, which a per-thread bound cannot see. Open, as a design decision
-   for the next round: a launch-total bound (per-cell issues × output cells at a machine-width constant), or
-   measured evidence for the statistics seams on this piece. The host measurement of this route is still owed.
+   un-servable through grid-TOTAL serial work, which a per-thread bound cannot see. **Landed next (the stacked
+   PR): a launch-total floor beside the per-thread one** — every block evaluates the worst nest at least once,
+   so `blocks × per-cell issues` at an issue rate no GPU reaches (1e5 issues/ns) bounds the launch, with blocks read
+   off the terminal placement's grid over the row's per-CTA output tile. It separates the producer tie 2000×
+   (2^23 blocks vs 4096), keeps the corpus ~8.9× inside the guard (largest legitimate launch total 112.7 µs,
+   `gated-mlp-s512`), and needs no stamp or restamp. Counting per output cell × cells was rejected as not a
+   bound: on the measured 13.21 s piece it priced 22.5 s (the tile shares the operand cone across 64 output
+   columns per block). The tighter follow-up, not taken: per-nest evaluations — blocks × the block's cells
+   projected onto the coordinates the worst nest READS × per-evaluation issues — which needs a structural stamp
+   of the nest's read free axes plus the codec's m/n slot mapping (`_free_slots` canonicalizes wide-is-n; the
+   warp fragment keeps codec axes), the error-prone part. The host measurement of this route is still owed.
 
 **Consequence for the stages below.** Gate (c) passed at `ab1ad4592` and still does not reproduce: a boot now
 compiles end to end and the elected route is a measured 23.2 s per `post4096` prefill forward (no longer a

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -143,10 +143,22 @@ def _stamped(trips: int, issues_per_trip: int) -> dict:
     return {"S_ext_serial_cell_work": float(trips), "S_ext_serial_cell_issues": float(trips) * issues_per_trip}
 
 
-def _priced(kernels: dict[str, tuple[dict, float]]) -> float:
-    """``_resolved_price`` over SimpleNamespace kernels: ``{node_id: (knobs, traced score)}``."""
+def _grid(*extents: int):
+    """A mapped placement over static grid axes — what ``_grid_cells`` reads off a terminal op."""
+    from emmy.compiler.dim import Dim
+    from emmy.compiler.ir.axis import Axis
+
+    return SimpleNamespace(grid=tuple(Axis(f"g{i}", Dim(extent)) for i, extent in enumerate(extents)))
+
+
+def _priced(kernels: dict[str, tuple[dict, float]], grids: dict[str, object] | None = None) -> float:
+    """``_resolved_price`` over SimpleNamespace kernels: ``{node_id: (knobs, traced score)}``;
+    ``grids`` maps a node to its placement (none → no launch-total bound)."""
     terminal = SimpleNamespace(
-        nodes={nid: SimpleNamespace(op=SimpleNamespace(knobs=knobs, identity_key=lambda **_kw: "k")) for nid, (knobs, _) in kernels.items()}
+        nodes={
+            nid: SimpleNamespace(op=SimpleNamespace(knobs=knobs, identity_key=lambda **_kw: "k", place=(grids or {}).get(nid)))
+            for nid, (knobs, _) in kernels.items()
+        }
     )
     trace = [SimpleNamespace(node_id=nid, score=score) for nid, (_, score) in kernels.items()]
     return greedy._resolved_price(terminal, trace, SimpleNamespace(features=lambda: {}), None)
@@ -201,6 +213,36 @@ def test_the_issues_stamp_closes_the_sub_guard_trip_escape():
     assert fused == pytest.approx(float(2**23) * 16.0 * 1e-4, rel=1e-6)
     cut = _priced({"p": (_stamped(2**12, 16), 1.37e-3), "c": (_stamped(2**11, 10), 1.3e-5)})
     assert cut < fused  # the per-output-element weight-column walk loses on its issue bound
+
+
+def test_the_launch_total_bound_separates_a_per_block_recompute_from_a_per_row_one():
+    """The tie the per-thread floor cannot break, measured on post4096's contribution producer:
+    the fused producer recomputes the mHC statistics once per (row, a28) block — 2^23 blocks over
+    a 2^33-issue nest — while the statistics cut computes them once per row (4096 blocks) and
+    leaves the consumer its own carrier nest. Per thread both arms floor at the same nest (the
+    fused arm's coverage divides it the same way); per launch they are 2000× apart — priced at
+    ≥ 2^13 blocks against ≥ 4, the untiled cap over-stating a coop block's cells 1024× in the safe
+    direction — so the Σ elects the cut."""
+    from emmy.compiler.pipeline.search.features import LAUNCH_ISSUE_FLOOR_US
+
+    coop = {"WORK": "t256", "REDUCE": "coop"}  # 256 lanes share one cell's nest: the per-thread divide
+    fused_row, cut_stat, cut_consumer = {**_stamped(2**30, 8), **coop}, {**_stamped(2**30, 8), **coop}, _stamped(2**22, 8)
+    fused = _priced({"n": (fused_row, 2516.58)}, {"n": _grid(4096, 2048)})
+    cut = _priced({"p": (cut_stat, 2516.58), "c": (cut_consumer, 20.0)}, {"p": _grid(4096), "c": _grid(4096, 2048)})
+    assert fused == pytest.approx(2**13 * 2**33 * LAUNCH_ISSUE_FLOOR_US)  # ≥ 2^13 blocks × 2^33 issues
+    assert cut < fused / 50
+
+
+def test_the_launch_total_guard_margin_is_pinned_by_the_corpus():
+    """The largest legitimate launch total across the realization corpus (every case lowered
+    under its pins, blocks from the emitted launch grid): ``gated-mlp-s512``'s fused kernel,
+    1,572,864 blocks × 7168 issues — 112.7 µs, ~8.9× inside the guard. Lowering the guard or
+    raising the rate within that margin breaks this test before it breaks the corpus."""
+    from emmy.compiler.pipeline.search.features import LAUNCH_ISSUE_FLOOR_US
+
+    gated_mlp_s512 = 1_572_864 * 7168 * LAUNCH_ISSUE_FLOOR_US
+    assert gated_mlp_s512 == pytest.approx(112.7, rel=0.01)
+    assert gated_mlp_s512 < greedy._SERIAL_FLOOR_ENFORCE_US / 8
 
 
 def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:

--- a/tests/compiler/pipeline/test_knob.py
+++ b/tests/compiler/pipeline/test_knob.py
@@ -346,6 +346,40 @@ def test_knob_features_serial_cell_work_divides_by_reduce_coverage():
     assert "D_serial_cell_work" not in knob_features({"S_n_load": 3.0})
 
 
+def test_launch_floor_counts_blocks_not_cells_and_ignores_reduce_coverage():
+    """``launch_floor_us``: blocks × the per-cell issues stamp at a rate no GPU reaches. Blocks
+    are the launch's cells over the most cells a block covers — the widest output tile among the
+    row's ``TILE`` sites when it spells one, else one cell per thread over the largest block a
+    GPU runs — and a coop/cta reduce partition moves trips between threads, never out of the
+    launch, so it does not divide. A spelled tile that does not resolve bounds nothing."""
+    from emmy.compiler.pipeline.search.features import LAUNCH_ISSUE_FLOOR_US, _launch_blocks, launch_floor_us
+
+    untiled = {"S_ext_serial_cell_issues": float(2**33)}
+    assert _launch_blocks(untiled, 2.0**23) == 2**13  # 1024 cells per block at most
+    assert launch_floor_us(untiled, 2.0**23) == pytest.approx(2**13 * 2**33 * LAUNCH_ISSUE_FLOOR_US)
+    assert launch_floor_us({**untiled, "WORK": "t256", "REDUCE": "coop"}, 2.0**23) == launch_floor_us(untiled, 2.0**23)
+    assert launch_floor_us({**untiled, "WORK": "t64", "REDUCE": "g4k"}, 2.0**23) == launch_floor_us(untiled, 2.0**23)
+    assert launch_floor_us(untiled, 0.0) == 0.0  # no grid, no launch-total bound
+    # The measured dominant piece's row: its codec tile is 256 × 64 output cells per block, so a
+    # 4096 × 4096 output launches exactly the 1024 blocks its emitted kernel decodes.
+    tiled = {**untiled, "WORK": "w4x4", "TILE": "mma_m8n8k4_f16_f32/f4x1/k8"}
+    assert _launch_blocks(tiled, 2.0**24) == 1024
+    two_sites = {**tiled, "TILE@map.1/inner": "f4x4"}  # the widest site bounds the blocks
+    assert _launch_blocks(two_sites, 2.0**24) == 1024
+    assert _launch_blocks({**untiled, "WORK": "w4x4", "TILE": "not-a-tile"}, 2.0**24) == 0.0
+
+
+def test_launch_floor_stays_below_the_measured_dominant_piece():
+    """The refutation, pinned: post4096's dominant piece (measured 13.21 s) runs 1024 blocks over
+    a 2^16-issue nest, so its launch floor is 0.67 µs — below the measurement, as a bound must
+    be. Counting per output cell (2^24 cells × 2^27 issues) priced 22.5 s and was rejected."""
+    from emmy.compiler.pipeline.search.features import LAUNCH_ISSUE_FLOOR_US
+
+    assert 1024 * 2**16 * LAUNCH_ISSUE_FLOOR_US == pytest.approx(0.671, rel=0.01)
+    assert 1024 * 2**16 * LAUNCH_ISSUE_FLOOR_US < 13_210_000.0
+    assert 2**24 * 2**27 * LAUNCH_ISSUE_FLOOR_US > 13_210_000.0  # what the rejected count would claim
+
+
 def test_serial_floor_is_the_covered_issues_at_the_per_issue_bound():
     """``serial_floor_us``: a physical lower bound on one kernel-launch — the row's per-thread
     serial issues (the issues stamp ÷ reduce-partition coverage, the same rule as the trips


### PR DESCRIPTION
Stacked on #706 (`feature/materialize-ffn-matmul-contributions`); base retargets to `main` once #706 merges.

## What this is

The per-thread serial floor (#702, refined per issue in #706) prices what ONE thread must retire. On DeepSeek-V4
`post4096`'s route it left a tie it cannot see: the contribution producer recomputing the mHC statistics once per
(row, a28) block (2^23 blocks) and its statistics cut computing them once per row (4096 blocks) floor at the same
~2.5 ms per thread — the fused arm's 1024-way cta×coop coverage divides the same nest — while they differ 2000×
in what the LAUNCH retires. The greedy kept the tie's fused side.

This adds a launch-total floor beside the per-thread one, under the same 1 ms guard (`_resolved_price` clamps a
summand to the larger of the two floors once either passes it):

- `features.launch_floor_us(knobs, cells)` = `launch_blocks × S_ext_serial_cell_issues × 1e-8 µs` — every
  block evaluates the kernel's worst serial nest at least once, at 1e5 issues/ns, a machine-width rate no GPU
  reaches (a V100 issues ~500/ns). No reduce-partition coverage divide and no cta multiply: partitioning moves a
  nest's trips between threads or blocks, never out of the launch.
- `features.launch_blocks(knobs, cells)` = the launch's output cells ÷ the most cells one block covers: the
  row's codec output tile `tile_m × tile_n` when it spells one, else one cell per thread over the largest block
  a GPU runs. Over-counting a block's cells only under-counts blocks — the safe direction. The codec tile for
  the measured dominant piece's row is 256 × 64 cells, exactly the 1024 blocks its emitted kernel decodes
  (pinned by test).
- `greedy._grid_cells(op)`: the terminal placement's static grid extents (sweeps are loops a thread walks, not
  grid parallelism, so they are excluded by construction; a symbolic extent → no launch bound).

No new stamp, no schema bump, no corpus restamp: the featurizer is unchanged, so every sub-guard election is
untouched by construction, and the freeze prior eval is unchanged (rho +0.51, regret@1 1.00x, 176 pools).

## What was rejected, and why it is written down

Counting per OUTPUT CELL (per-cell issues × cells) was the first design and is not a bound: a serial nest that
is an operand cone of an outer contraction is shared across every cell of a block that does not read its
coordinates, and the tile chooses how many. On `post4096`'s measured dominant piece (13.21 s) it charged
2^24 cells × 2^27 issues → 22.5 s at this rate — above the measurement. Per block the same kernel prices
0.67 µs (its per-thread floor is what catches it). The refutation is a test, and `launch_floor_us`'s docstring
says why, so nobody tightens it back. The tighter honest follow-up — per-nest evaluations projected onto the
axes the nest reads — is recorded in the serving plan with its cost (a structural stamp of the nest's read free
axes plus the codec's m/n slot mapping).

## Acceptance (all GPU-free; full table in the session report)

- Corpus margin, measured from every case's emitted launch grid: largest legitimate launch total 112.7 µs
  (`qwen3emb/gated-mlp-s512`, 1,572,864 blocks × 7168 issues), ~8.9× inside the guard; at 1e4/ns it would
  cross — pinned by test beside the per-thread 26.21 µs pin.
- The deterministic `post4096` replay (pinned twins + host-DB copy) elects **the statistics cut**: 9 kernels;
  the contribution producer's per-cell issues fall from ~2^34.6 to ~2^32.6 (the mHC statistics nest leaves it
  for two per-row `f4x4` pieces; only the carrier chain remains — launch floor 0.53 s, the next seam to elect);
  the contribution consumer stays a pure `w8x1` mma with no serial hidden-dim walk; the two 16384×256 `f4`
  sweep pieces of the measured 23.24 s route (5.3 s + 4.0 s) do not survive — two pieces two orders lighter
  per thread carry their role.
- Unit tests: blocks not cells; coverage does not divide the launch total; the refutation pin; the tie case
  (per-thread floors tie, the Σ elects the cut); the corpus margin pin.
- `make test` 4173 passed / 0 failed; `make lint` clean.

## Not claimed, and one new finding

The route is still not servable: the producer's carrier recompute stands, and — found while building the
per-piece table — **the post-#699 residual is emitted over a 2^56-thread linear grid** (every output sweep the
root's contractions read is promoted into its placement), so it cannot launch. That pathology is in #706's
election too and absent pre-#699; it is independent of both PRs and recorded in the serving plan as its own
item. The host measurement remains owed.

Core line balance (`git diff --stat 5ceb7118 -- emmy/`) is the two floor functions and the cell reader — the
capability this PR adds — plus their docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
