### PR TITLE
Key measurements on kernel identity, unpack the store's columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ relevant `ARCHITECTURE.md` before answering.
 - `EMMY_TUNE_DB` environment variable (optional) — overrides the default tuning SQLite cache path
   (`~/.cache/emmy/autotune.db`). `emmy tune` reads from / writes to this path. NOTE: greedy `compile` / `run`
   resolve forks through the deploy evidence hierarchy — the live card's recorded goldens first (the repo-shipped
-  verified tier; consulted, never trained on), then measured reservoir/DB evidence, then the global `Prior` (the
+  verified tier; consulted, never trained on), then measured reservoir evidence (the tune DB's own tier is off until
+  the per-fork identity query lands), then the global `Prior` (the
   online prior with its offline cold-start fallback; the old `_best_fork` DB→fork replay was removed). The online prior
   is a separate JSON checkpoint (`EMMY_ONLINE_FILE` → `~/.cache/emmy/online.json`; legacy `EMMY_PRIOR_FILE` still
   accepted) that `tune` writes and `compile` / `run` read. Use the README architecture index for the prior and

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -247,11 +247,11 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
 - **Realize** — A recorded configuration *realizes* when the compiler, at the point where it makes that choice, offers
   a candidate matching the recording. A configuration that realizes nowhere cannot be deployed, however good the
   measurement stored with it.
-- **Regime** — The settings a measurement was taken under, or that a compile is running under: chiefly the compiler
-  optimization level (`-O3`, the deployable one and the only one anything is measured in) plus whether fast-math
-  approximations are enabled. Measurements taken in different regimes are not interchangeable, which is why tuning
-  measures in the regime it deploys into. A lower optimization level remains available as a compile-speed option for
-  the test suite; it is not a measurement lane, and nothing measured under one is read by a deploy.
+- **Regime** — The settings a measurement was taken under, or that a compile is running under: the card it ran on,
+  the compiler optimization level (`-O3`, the deployable one and the only one anything is measured in), and whether
+  fast-math approximations are enabled. Measurements taken in different regimes are not interchangeable, which is
+  why tuning measures in the regime it deploys into. A lower optimization level remains available as a compile-speed
+  option for the test suite; it is not a measurement lane, and nothing measured under one is read by a deploy.
 - **Candidate** — One complete set of choices that the compiler could use.
 - **Greedy selection** — Choosing the candidate that currently appears best without exploring alternatives during
   normal compilation.

--- a/emmy/commands/eval.py
+++ b/emmy/commands/eval.py
@@ -19,7 +19,7 @@ Five subcommands:
   ``(kernel, error)`` with the knob values shared by every failing row.
 
 The ``eval knobs`` regret analysis: for each kernel (grouped by the kernel C
-identifier extracted from ``cuda_op.pretty``), compute per-knob regret:
+identity the rows are keyed on), compute per-knob regret:
 
     regret[K] = max(best_us | K=v) / min(best_us | K=v)
 
@@ -687,7 +687,7 @@ def _emit_variant_table(name: str, samples: list, prior, *, n_fail: int, top: in
 
     The ``us`` column is the measured latency as stored. A sweep measures in the deployable
     regime, so on a store written since that became true every row is a deploy latency — but
-    ``Dataset.from_db`` reads every ``context_key`` and ``PerfSample`` carries none, so a store
+    ``Dataset.from_db`` reads every regime and a ``Measurement`` carries none, so a store
     holding rows from the era of a separate ranking lane still pools both here."""
     from emmy.compiler.pipeline.knob import tuning_knob_items  # noqa: PLC0415
 

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -185,7 +185,7 @@ extension) re-capture when batch sizes change. A capture failure (`GraphCaptureE
 continues uncaptured, and reports it via `BenchmarkResult.captured` — comparison callers
 (`bench_lowered_vs_torch` / `bench_full_model_real`) pair that flag with their torch-side capture and
 re-run all-or-nothing so one table never mixes semantics. The tune sweep persists the flag per `perf`
-row (`SearchDB.record_perf`): captured measurements supersede wall-semantics ones for the same key
+row (`SearchDB.record_measurement`): captured measurements supersede wall-semantics ones for the same key
 regardless of median, never the reverse — old rows stay usable (replay, prior training) and upgrade
 in place as re-tunes measure them captured. See `tests/compiler/backend/test_graph_capture.py`.
 
@@ -325,7 +325,7 @@ CUDA event timing has sub-µs resolution and any real launch consumes at least
 one device cycle — a 0.0 reading means a degenerate kernel (BM=1×BN=128 with
 the M tile fully masked, a kernel fused into a no-op, an event-pair quirk)
 that would otherwise lock in as the autotune DB's unbeatable best. Phase B
-of the same work; the existing worker → parent → `record_perf(bench_fail)`
+of the same work; the existing worker → parent → `record_measurement(bench_fail)`
 path carries the failure unchanged.
 
 `run_program_debug(...)` snapshots every non-input buffer after each

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -1380,7 +1380,7 @@ def benchmark_program(
     torch timings (``bench_lowered_vs_torch`` / the e2e comparison) use that
     flag to re-run all-or-nothing so one table never mixes semantics, and the
     tune sweep persists it on each ``perf`` row (captured measurements
-    supersede wall-semantics ones on write — see ``SearchDB.record_perf``).
+    supersede wall-semantics ones on write — see ``SearchDB.record_measurement``).
 
     Multi-launch programs additionally get a WHOLE-program time per measured
     iter — one event window around back-to-back replays of a single CUDA

--- a/emmy/compiler/context.py
+++ b/emmy/compiler/context.py
@@ -149,9 +149,8 @@ class Context:
     # PCIe product name of the card this context is for (e.g. "NVIDIA H200 141GB"),
     # set by ``from_target(gpu_name=…)`` or probed live (``gpu.live_name``). The one
     # identity that separates same-die SKUs (H100 vs H200: identical cc + SM features,
-    # different VRAM) — used by the node-store key + ``gpu`` column so cross-hardware
-    # tuning data never collides. NOT in ``structural_key`` (the perf cache stays
-    # SKU-coarse on purpose; only the node *dataset* keys on it). ``None`` ⇒ unknown.
+    # different VRAM) — read through :meth:`hardware_id` by the node-store key and by
+    # ``Regime.gpu``, so no measurement crosses cards: µs is a per-card fact. ``None`` ⇒ unknown.
     gpu_name: str | None = None
     # Identifies which backend's perf rows this compile reads/writes — the
     # tune DB keys ``perf`` by ``(context_key, op_key, backend)``. Defaults to
@@ -160,10 +159,10 @@ class Context:
     backend_name: str = "cuda"
     # Extra nvcc flags this compile uses (from ``EMMY_NVCC_FLAGS`` — e.g.
     # normally empty — tune, compile and run all measure in the deployable regime).
-    # Folded into ``structural_key`` (split, see :func:`split_opt_level`) so the autotune
-    # ``perf`` cache is partitioned by opt level: a measurement taken under a deliberately
-    # non-deployable ``--nvcc-flags`` never answers for a deploy. Populated from the env by :meth:`probe` /
-    # :meth:`from_target`.
+    # Enters the regime SPLIT (see :func:`split_opt_level`): the opt level as ``Regime.opt_level``,
+    # every other flag verbatim as ``Regime.nvcc_flags``, so a measurement taken under a
+    # deliberately non-deployable ``--nvcc-flags`` never answers for a deploy. Populated from the
+    # env by :meth:`probe` / :meth:`from_target`.
     compile_flags: str = ""
     # Whether the strict knob-pin validator (``lowering/tile/_validate``)
     # is active. ``True`` on the deterministic greedy compile (``compile`` / ``run``),
@@ -266,24 +265,21 @@ class Context:
         compile: the schedule declines those rows rather than emitting them."""
         return self.compute_capability >= (9, 0)
 
+    def regime(self):
+        """Where a measurement taken under this context holds —
+        :class:`~emmy.compiler.identity.Regime`, whose fields are the ``context`` table's row."""
+        from emmy.compiler.identity import Regime  # noqa: PLC0415
+
+        return Regime.of(self)
+
     def structural_key(self) -> str:
-        """Implements :class:`emmy.compiler.structural.Structural`.
+        """Implements :class:`emmy.compiler.structural.Structural` — the digest of :meth:`regime`.
 
-        Folds in only codegen-affecting fields. ``compute_capability``
-        gates hardware-feature passes (TMA, cp.async, dynamic smem cap);
-        anything derived from it (``max_dynamic_smem``) is implied.
-        ``compile_flags`` is folded in because the nvcc opt level genuinely
-        changes the emitted SASS / measured latency (it is NOT a debug flag).
-        As other non-derived knobs land (forced TMA on/off, splitk overrides),
-        extend this method explicitly — keep ambient I/O fields out so the
-        autotuning cache survives debug-flag flips.
-
-        The flags enter **split** (:func:`split_opt_level`), never raw, so that one regime has one
-        key however it is spelled.
-        """
-        from emmy.compiler.structural import digest  # noqa: PLC0415
-
-        return digest("Context", self.compute_capability, *split_opt_level(self.compile_flags))
+        The include/exclude list lives there now, as fields: every codegen-affecting fact a
+        measurement is partitioned by is a ``Regime`` field, and ambient I/O fields (dump dirs,
+        verbosity, the session cache) are not, so the autotuning cache still survives a
+        debug-flag flip."""
+        return self.regime().digest
 
     def hardware_id(self) -> str:
         """A stable per-card identity for the node-store key + ``gpu`` column: the PCIe

--- a/emmy/compiler/identity.py
+++ b/emmy/compiler/identity.py
@@ -1,0 +1,142 @@
+"""The identities a measurement is stored and looked up under — one module, two value objects.
+
+Every key the measurement store uses is one of these, and every field of one is a column of the
+table it keys. Adding an element to an identity is adding a field here: the column follows and the
+digest is recomputed from the columns beside it, so there is no second place where a key is
+assembled by hand and no way for a writer and a reader to spell the same regime differently.
+
+- :class:`Regime` — WHERE a measurement holds: the card, its capability, the nvcc flags split at
+  the opt level, and the input pins the compile ran under. µs is per card, so the card is part of
+  the identity: without it a measurement taken on one sm_89 card answers a deploy on another.
+- :class:`OpIdentity` — WHAT a kernel is, knob-free: the canonical Loop-IR body it computes and
+  the io it is bound to. Deliberately **not** the rendered CUDA source, and its digest is
+  deliberately stage-free: a golden's identity is minted by lifting a recorded target to Loop IR
+  while the live compile mints it at a Tile fork, and the deploy join only exists because both
+  spell the same Loop-IR content. ``dialect`` rides along as a descriptive column.
+
+Each carries its ``digest`` as a computed property over its own columns — the store's primary key
+for it, never a stored field and never passed in: a key a caller could supply is a key that can
+disagree with the row it sits on, and the point of unpacking an identity into columns is that the
+key is a function of them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import cached_property
+
+from emmy.compiler import structural
+from emmy.compiler.structural import Structural
+
+
+@dataclass(frozen=True)
+class Regime(Structural):
+    """The measurement regime — the ``context`` table's columns.
+
+    ``gpu`` is :meth:`Context.hardware_id` (the PCIe product name, else a digest of the
+    device-physical ``H_*`` regime). ``opt_level`` is the split nvcc cicc opt level, never the raw
+    flag string, so ``""`` and ``"-Xcicc -O3"`` are the one regime they physically are;
+    ``nvcc_flags`` keeps every OTHER flag verbatim, because a flag like ``--use_fast_math``
+    genuinely changes codegen and must stay its own partition. ``pins`` is the input-pin regime
+    (:func:`live_pin_regime`) — the marker BOOLs a compile ran under, spelled ``NAME=0/1`` in
+    name order; an unpinned marker is absent, which reads as its default.
+    """
+
+    gpu: str
+    sm_major: int
+    sm_minor: int
+    opt_level: int
+    nvcc_flags: str
+    pins: str
+
+    @cached_property
+    def digest(self) -> str:
+        """The ``context`` row's primary key — the inherited :meth:`Structural.structural_key`
+        walk over every field above, cached (sound outright: frozen, and the fields are the whole
+        of it). The class deliberately does NOT override ``structural_key``: :func:`structural.form`
+        delegates to any type that overrides it, so an override asking for the field walk would
+        call itself."""
+        return self.structural_key()
+
+    @classmethod
+    def of(cls, ctx) -> Regime:
+        """The regime ``ctx`` compiles in — the ONE derivation, shared by the key and the row."""
+        from emmy.compiler.context import split_opt_level  # noqa: PLC0415
+
+        major, minor = ctx.compute_capability
+        opt, residual = split_opt_level(ctx.compile_flags)
+        return cls(
+            gpu=ctx.hardware_id(),
+            sm_major=major,
+            sm_minor=minor,
+            opt_level=opt,
+            nvcc_flags=residual,
+            pins=live_pin_regime(),
+        )
+
+
+def live_pin_regime() -> str:
+    """The ambient input pins as ``Regime.pins`` — exactly the complement of the decision.
+
+    A marker BOOL is dropped from a measurement's knob row (``knob.tuning_knob_items``: the
+    realized fork is identified by what it enables, not by the gate that allowed it), so it has to
+    land here — otherwise a kernel measured under ``EMMY_VECTORIZE_LOADS=0`` shares a key with the
+    same kernel measured under the default and keep-best silently picks between two different
+    pieces of code. The precision gates resolve
+    through their own :func:`precision_pin` precedence (own pin > the ``FAST_MATH`` umbrella >
+    unset), so the regime is spelled by the rule that decided what the compile could enumerate.
+    """
+    from emmy.compiler.pipeline.knob import KnobType, registry  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.space import F16_MMA_F32_ACC, FAST_EXP, FAST_MATH, FP8_MMA, precision_pin  # noqa: PLC0415
+
+    gates = {knob.name: precision_pin(knob) for knob in (FAST_EXP, F16_MMA_F32_ACC, FP8_MMA)}
+    pins = {name: int(value) for name, value in gates.items() if value is not None}
+    # The umbrella itself never enters: it is fully resolved into the three gates above, and
+    # carrying it too would make ``FAST_MATH=1`` and the three gates pinned by hand two regimes.
+    resolved = {*gates, FAST_MATH.name}
+    for name, knob in registry().items():
+        if name in resolved or knob.type is not KnobType.BOOL or (raw := knob.raw()) is None:
+            continue
+        pins[name] = int(knob.parse(raw))
+    return ",".join(f"{name}={pins[name]}" for name in sorted(pins))
+
+
+@dataclass(frozen=True)
+class OpIdentity(Structural):
+    """What a kernel IS, knob-free — the ``op`` table's columns.
+
+    ``body`` is the canonical Loop-IR body digest (``Body.structural_key``: SSA / axis / buffer
+    names and commutative-arg order normalized away); ``io`` is the operand dtype / shape
+    fingerprint, held as the fingerprint itself and rendered to its column by :attr:`io_json`.
+    ``dialect`` is the stage the identity was taken at — a descriptive column, and the one field
+    :attr:`digest` leaves out: every stage of one rewrite chain keys off the same Loop-IR content,
+    which is what lets a golden minted by lifting a recorded target to Loop IR join a live Tile
+    fork.
+    """
+
+    dialect: str
+    body: str
+    io: tuple
+
+    @cached_property
+    def digest(self) -> str:
+        """The ``op`` row's primary key, and the deploy join key (``identity_key(with_io=True)``).
+
+        Spelled out rather than taking :class:`Regime`'s generic field walk, for one reason worn
+        two ways: ``dialect`` is descriptive and must stay out, and this fold is DURABLE — stamped
+        identities are checked into the corpus, so restructuring around it must not move it."""
+        return structural.digest(self.body, self.io)
+
+    def structural_key(self) -> str:
+        """Implements :class:`~emmy.compiler.structural.Structural` — :attr:`digest`. Overriding is
+        the point: a nested ``OpIdentity`` renders by its own key, so ``dialect`` cannot reach an
+        enclosing digest either."""
+        return self.digest
+
+    @cached_property
+    def io_json(self) -> str:
+        """The ``op.io`` column — the fingerprint as canonical JSON, so the row means something on
+        its own. A rendering of the field, never its identity: the digest folds the fingerprint
+        itself, so how the column spells it is free to change."""
+        return json.dumps(self.io)

--- a/emmy/compiler/ir/base.py
+++ b/emmy/compiler/ir/base.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from emmy.compiler.graph import Graph, Node
+    from emmy.compiler.identity import OpIdentity
     from emmy.compiler.ir.expr import Expr
     from emmy.compiler.tensor import Tensor
 
@@ -182,9 +183,19 @@ class Op:
         sound outright."""
         return _io_fingerprint(self)
 
+    def identity(self, *, structural: bool = True) -> OpIdentity | None:
+        """This op's :class:`~emmy.compiler.identity.OpIdentity` — what the kernel IS, knob-free.
+        ``None`` for an op kind that carries no Loop-IR body."""
+        from emmy.compiler.identity import OpIdentity  # noqa: PLC0415
+
+        body = self._body_identity(structural=structural)
+        if body is None:
+            return None
+        return OpIdentity(dialect=type(self).dialect or "", body=body, io=self._io_key)
+
     def identity_key(self, *, structural: bool = True, with_io: bool = False, with_knobs: bool = False) -> str | None:
-        """THE identity — one function, one lattice. The base fact is the canonical Loop-IR
-        body digest; each flag folds in one more fact:
+        """THE identity — one function, one lattice over :meth:`identity`. The base fact is the
+        canonical Loop-IR body digest; each flag folds in one more fact:
 
         - ``structural`` — collapse compute-unit op clusters (the schedule-equivalent reading,
           the default: cluster siblings share a schedule space and want the same schedule) vs
@@ -192,21 +203,24 @@ class Op:
         - ``with_io`` — the io dtype/shape fingerprint: what a deployed kernel is bound to;
         - ``with_knobs`` — the knob row: which variant of the kernel this op is.
 
-        ``None`` for an op kind that carries no Loop-IR body. ``CudaOp`` overrides the whole
-        function with its rendered-source digest: past rendering, body / io / knobs are all
-        realized into the artifact and the flags have nothing left to fold. The same kernel
-        reached via different rewrite paths produces the same key — ``source`` is never part
-        of it, and neither is the dialect tag: every stage of one rewrite chain keys off the
-        same Loop-IR content."""
-        key = self._body_identity(structural=structural)
-        if key is None:
+        The two knob-free points ARE the value object's — the bare body and
+        :attr:`OpIdentity.digest`, the ``op`` table's key — so the deploy join and the row it
+        joins to cannot drift apart. Knobs extend the same FLAT fold rather than digesting that
+        digest: these values are durable data (the corpus stamps ``with_io=True`` into checked-in
+        case files, and a kernel's name carries a slice of it), so the fold must not move.
+
+        ``None`` for an op kind that carries no Loop-IR body. The same kernel reached via
+        different rewrite paths produces the same key — ``source`` is never part of it, and
+        neither is the dialect tag: every stage of one rewrite chain keys off the same Loop-IR
+        content, which is what lets a golden minted by lifting a recorded target to Loop IR join
+        the live Tile fork that offers it."""
+        identity = self.identity(structural=structural)
+        if identity is None:
             return None
-        parts: list = [key]
-        if with_io:
-            parts.append(self._io_key)
-        if with_knobs:
-            parts.append(self._knob_key())
-        return key if len(parts) == 1 else digest(*parts)
+        if not with_knobs:
+            return identity.digest if with_io else identity.body
+        parts = [identity.body, *([identity.io] if with_io else []), self._knob_key()]
+        return digest(*parts)
 
     @_ClassProperty
     def dialect(cls) -> str | None:  # noqa: N805 — a class property; ``cls`` receives the owner

--- a/emmy/compiler/ir/cuda/ir.py
+++ b/emmy/compiler/ir/cuda/ir.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 
 from emmy.compiler.ir.base import Op
 from emmy.compiler.ir.expr import Expr
-from emmy.compiler.structural import digest
 
 
 @dataclass(frozen=True)
@@ -79,17 +78,39 @@ class CudaOp(Op):
     def pretty_body(self) -> str:
         return self.kernel_source
 
-    def identity_key(self, *, structural: bool = True, with_io: bool = False, with_knobs: bool = False) -> str | None:
-        """Override :meth:`Op.identity_key` whole: digest of the rendered source + launch
-        params — past rendering, body / io / knobs are all realized into the artifact, so the
-        lattice flags have nothing left to fold and are accepted-and-ignored. (the
-        bits that determine runtime behavior). Name-invariant: the kernel function name is
-        rendered into the source (``void <name>(...)``) but doesn't change runtime behavior,
-        so it normalizes out — renaming a kernel (e.g. via op provenance) neither busts the
-        perf cache nor blocks an isolated-kernel tune from transferring to a whole-model
-        compile."""
-        src = self.kernel_source.replace(self.kernel_name, "_K_") if self.kernel_name else self.kernel_source
-        return digest(type(self).__name__, src, self.arg_order, self.grid, self.block, self.smem_bytes)
+    def identity(self, *, structural: bool = True):
+        """Override :meth:`Op.identity`: a rendered kernel's identity is the identity of the FORK
+        that offered it — the newest pre-schedule op on the rewrite chain (its own ``TileOp``,
+        else the fused ``LoopOp``), body, io and stage tag alike. The rendered source is a
+        realization of that fork under a decision, not a second notion of what the kernel is:
+        keying a measurement on the source digest put the store's identity and the deploy join's
+        identity in different alphabets, so a measured row could never answer the fork that
+        produced it.
+
+        Three nearer answers are wrong. The io must come from the fork too — the cuda passes
+        rename and re-slab buffers, which would split the join at its io half. The intervening
+        ``KernelOp`` must be skipped — its body is the schedule already materialized, so it keys
+        apart from the tile term the fork decided. And NEWEST, not oldest: a split's pieces are
+        forks of their own, and attributing a piece to the pre-split parent would price half the
+        work as the whole.
+
+        ``None`` for a synthetic ``CudaOp`` with no chain (hand-built kernels, imported sources):
+        it computes something no Loop-IR op describes, so there is no identity to store a
+        measurement under."""
+        for op in self.source_chain():
+            if type(op).dialect not in ("tile", "loop"):
+                continue
+            identity = op.identity(structural=structural)
+            if identity is not None:
+                return identity
+        return None
+
+    def _body_identity(self, *, structural: bool = True) -> str | None:
+        """The chain identity's body half — see :meth:`identity`. Overridden (rather than left to
+        the base, which would answer ``None``) so ``dialect`` still reads ``"cuda"`` and a graph
+        digest walking a nested op reaches the same Loop-IR content."""
+        identity = self.identity(structural=structural)
+        return identity.body if identity is not None else None
 
 
 def resolve_dim(spec, sym_values: dict[str, int]) -> int:

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -150,7 +150,7 @@ Everything in this table recurs on nearly every page below. The rest of the docu
 | **prior** | The ranking model — the fit-offline **offline prior** when cold, the CatBoost **online prior** trained from local measurements once data exists. |
 | **terminal** | A fully-lowered candidate (every fork on its path resolved) that can be benchmarked. |
 | **golden record** | A reviewed program-backed schedule measurement, selected by frontend provenance and used as deploy evidence and an A/B reference. |
-| **the variant key** | The variant key measurements are stored under — `identity_key(with_io=True, with_knobs=True)`: the canonical Loop-IR body (a `TileOp` derives it schedule-free from its term) + the io fingerprint + the knob row. Dialect-free: every stage of one rewrite chain keys off the same content. |
+| **the variant key** | What the search tree and the caches dedup on — `identity_key(with_io=True, with_knobs=True)`: the canonical Loop-IR body (a `TileOp` derives it schedule-free from its term) + the io fingerprint + the knob row. A measurement stores its two halves as separate columns instead, because a fork is decided by querying the identity alone. Dialect-free: every stage of one rewrite chain keys off the same content. |
 
 ## Module map
 
@@ -1116,21 +1116,24 @@ don't invent a third:
   identity, so a prior is a pure function of it. The online prior is exactly `score(features(ctx, knobs))`: the
   structural facts are already in the knob dict, so `features.knob_features` turns it straight into the model feature
   vector (the `S_*` knobs pass through; tuning knobs encode by type, `MMA` expands to atom props).
-- **Measurement identity = `(ctx.structural_key, the variant key)`** — ground truth about *materialized leaves*: `perf`
-  rows (the per-variant replay cache), op inventory (`loop_op` / `tile_op` / `kernel_op` / `cuda_op`), and two-level
-  dedup. The structural `child_key` on `lowering` rows is measurement linkage (it joins the inventory), NOT a replay
-  key.
+- **Measurement identity = `(regime, kernel identity, decision)`** — ground truth about *materialized leaves*, and
+  the `measurement` table's key. The identity is knob-free (what the kernel IS) and the decision is the arm its
+  tunable knobs picked, so the fork a deploy is deciding and the row that answers it are the same two values. A
+  rendered `CudaOp` keys on the FORK that offered it — its own pre-schedule `TileOp`, else the fused `LoopOp` —
+  never on its rendered source: a measurement and the deploy join have to speak one alphabet.
 
 ### Search persistence: on-disk inventory vs in-memory MCTS
 
 **`SearchDB`** (`db.py`) is a SQLite store partitioned into:
 
-- **Four op-inventory tables** — one row per op encountered along any lowering chain, keyed by the variant key
-  (`identity_key(with_io=True, with_knobs=True)`).
-- **A `lowering` edge table** — one row per rewrite hop carrying the knob delta plus a best-median upsert
-  (`best_per_op_time` walks the chain to resolve a pre-final op's measured cost; loop→loop source hops are skipped as
-  structural/decision hops).
-- **A backend-partitioned `perf` table** — full stats + `backend` + `status` + `knobs` + `captured`.
+- **`context` and `op`** — the identities a measurement is keyed on, UNPACKED: one column per field of `Regime`
+  and `OpIdentity` (`compiler/identity.py`), with each row's `digest` derived from those columns.
+- **A `measurement` table** — one row per `(context, op, decision)`, which is also its keep-best key. That key IS
+  the per-fork query: a compile decides a fork with one indexed lookup on the identity it is offered on
+  (`SearchDB.measurements`), where it used to scan the whole table once per process and match rows by their `S_*`
+  feature set. What the store no longer keeps is reconstructed on demand — the `S_*` features by featurizing
+  `op.body`, the `H_*` values from the regime, the kernel source and geometry by re-lowering the body under the
+  decision (what the cubin cache already keys on).
 - **A `node` table** — one row per **search-tree node**, meaning every partly-decided branch and every leaf of a
   per-kernel search. It is keyed by `digest(context_key, gpu, op_sig, tunable-knob set)` and carries the full feature
   dict the prior sees, a latency for that position in the tree, a `parent_key` pointer, a `gpu` column and depth
@@ -1138,8 +1141,8 @@ don't invent a third:
   keeps the minimum, because its latency is a bound over the subtree that a faster descendant genuinely tightens,
   while a leaf row takes the **newest** measurement, because a leaf is a re-measurement of one single config and
   taking the min of K noisy medians would drift toward the noise floor. The `node` table is never consulted at deploy
-  (Part 3's hierarchy reads only goldens / reservoir / `perf`); its consumers are the `emmy eval` diagnostics (Part 8)
-  and the offline fitter's planned training path over a frozen snapshot.
+  (Part 3's hierarchy reads only goldens / reservoir / `measurement`); its consumers are the `emmy eval` diagnostics
+  (Part 8) and the offline fitter's planned training path over a frozen snapshot.
 
 Each `node` row also carries **label-quality columns** (additive migration; old rows degrade to unknowns):
 
@@ -1161,8 +1164,11 @@ The `gpu` identity (`Context.hardware_id`, the PCIe product name) is folded into
 different hardware never collide. `context_key` (compute capability + optimization level) cannot separate two SKUs off
 the same die — H100 and H200 share both compute capability and SM count — so without `gpu` their rows would merge and
 the upsert would silently drop one GPU's data. (The `H_total_mem` VRAM feature is what then lets the prior model the
-difference between them.) `node` and `perf` are keyed by content, independently of any parent tree, and survive a
-`_SCHEMA_VERSION` bump; only `lowering`, which is keyed by the graph's topology, is dropped on a mismatch.
+difference between them.) `node` and `measurement` are keyed by content, independently of any parent tree. A
+`_SCHEMA_VERSION` bump means the identities themselves are spelled differently, so rows written under the old
+spelling are unreadable rather than stale: v5 dropped the whole pre-identity generation (`perf`, `lowering` and the
+four op-inventory tables), because a `perf` row keyed on a digest of rendered CUDA source cannot be re-derived into
+the Loop-IR body it came from.
 
 **Merging data measured on another GPU.** `SearchDB.merge_nodes(src_path)` is how data accumulates: it reads another
 autotune DB's `node` rows read-only and re-inserts them through the same per-kind update rules. The result does not

--- a/emmy/compiler/pipeline/search/__init__.py
+++ b/emmy/compiler/pipeline/search/__init__.py
@@ -25,7 +25,7 @@ to consume.
 """
 
 from emmy.compiler.pipeline.search.candidate import Candidate, Cursor, LazyCandidate
-from emmy.compiler.pipeline.search.db import PerfRow, PerfStats, SearchDB
+from emmy.compiler.pipeline.search.db import Measurement, PerfStats, SearchDB
 from emmy.compiler.pipeline.search.policy import Search, TuningSearch, greedy_decide
 from emmy.compiler.pipeline.search.policy.mcts import SearchNode, SearchTree
 
@@ -34,7 +34,7 @@ __all__ = [
     "Cursor",
     "LazyCandidate",
     "SearchNode",
-    "PerfRow",
+    "Measurement",
     "PerfStats",
     "Search",
     "SearchDB",

--- a/emmy/compiler/pipeline/search/data/__init__.py
+++ b/emmy/compiler/pipeline/search/data/__init__.py
@@ -17,13 +17,12 @@ from __future__ import annotations
 
 from emmy.compiler.pipeline.search.data.dataset import Dataset
 from emmy.compiler.pipeline.search.data.freeze import FREEZE_KIND, FREEZE_VER, freeze_reason, load_freeze, load_node_rows, write_freeze
-from emmy.compiler.pipeline.search.data.sample import KERNEL_NAME_RE, Sample
+from emmy.compiler.pipeline.search.data.sample import Sample
 from emmy.compiler.pipeline.search.data.shape import ShapeKey, is_matmul, op_label
 
 __all__ = [
     "FREEZE_KIND",
     "FREEZE_VER",
-    "KERNEL_NAME_RE",
     "Dataset",
     "Sample",
     "ShapeKey",

--- a/emmy/compiler/pipeline/search/data/dataset.py
+++ b/emmy/compiler/pipeline/search/data/dataset.py
@@ -9,9 +9,9 @@ The two groupings are deliberately distinct and do **not** collapse:
   It is deliberately NOT a comparison key: it carries no card and no ``H_opt``, so rows
   measured on different hardware or under different nvcc settings land in one group.
   Anything ranking measured latencies wants ``data/group.group_measured`` instead.
-- :meth:`group_by_kernel_name` keys on the kernel C identifier (parsed from
-  ``cuda_op.pretty``) — which *merges* shapes of the same kernel, by design, so the
-  per-knob regret analysis measures relative knob impact across shapes.
+- :meth:`group_by_kernel_name` keys on the kernel identity (the ``op`` digest a measurement
+  is stored under) — which *merges* the arms of one kernel, by design, so the per-knob regret
+  analysis measures relative knob impact within a kernel.
 """
 
 from __future__ import annotations
@@ -67,22 +67,16 @@ class Dataset:
         return cls([Sample.from_golden(g, compile_s_feats=compile_s_feats) for g in configs])
 
     @classmethod
-    def from_db(
-        cls, path: Path | str, *, kernel: str | None = None, min_latency: float = 0.0, backend: str | None = None, status: str = "ok"
-    ) -> Dataset:
-        """Every measured ``ok`` variant in the tune DB (``perf ⋈ cuda_op``), opened
-        read-only so a concurrent ``tune`` writer isn't blocked. ``backend=None``
-        spans every backend (matching the legacy ``eval knobs`` query); ``kernel``
-        filters on the parsed C identifier. ``status`` selects the row status
-        (``bench_fail`` rows carry the watchdog-timeout sentinel latency, so the
-        default ``min_latency`` admits them)."""
+    def from_db(cls, path: Path | str, *, kernel: str | None = None, min_latency: float = 0.0, status: str = "ok") -> Dataset:
+        """Every measured ``ok`` variant in the tune DB, opened read-only so a concurrent ``tune``
+        writer isn't blocked. ``kernel`` filters on the kernel identity the rows group by.
+        ``status`` selects the row status (``bench_fail`` rows carry the watchdog-timeout sentinel
+        latency, so the default ``min_latency`` admits them)."""
         from emmy.compiler.pipeline.search.db import SearchDB  # noqa: PLC0415
 
         db = SearchDB.open_readonly(path)
         try:
-            samples = [
-                Sample.from_perf_sample(ps) for ps in db.iter_perf_samples(backend=backend, status=status, min_latency_us=min_latency)
-            ]
+            samples = [Sample.from_measurement(m) for m in db.iter_measurements(status=status, min_latency_us=min_latency)]
         finally:
             db.close()
         if kernel:
@@ -149,7 +143,7 @@ class Dataset:
         return dict(g)
 
     def group_by_kernel_name(self, *, min_variants: int = 1, kernel: str | None = None) -> dict[str, list[Sample]]:
-        """Group by kernel C identifier (``cuda_op.pretty``), dropping samples with
+        """Group by kernel identity (the ``op`` digest), dropping samples with
         no identity (golden / prior rows) and groups below ``min_variants``."""
         g: dict[str, list[Sample]] = defaultdict(list)
         for s in self.samples:

--- a/emmy/compiler/pipeline/search/data/sample.py
+++ b/emmy/compiler/pipeline/search/data/sample.py
@@ -20,21 +20,11 @@ the stable golden format.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 
 from emmy.compiler.pipeline.knob import CTX_PREFIX, STRUCT_PREFIX
 from emmy.compiler.pipeline.search.data.shape import ShapeKey
 from emmy.compiler.pipeline.search.features import knob_features
-
-# The C identifier of a CUDA kernel, parsed from ``cuda_op.pretty`` — the grouping
-# key for the per-knob regret analysis. Kept here so the DB-row adapter and the
-# regret grouping share one source. Anchored on the ``__global__`` entry point
-# (``__launch_bounds__`` sits between it and ``void``) — MMA/TMA kernel sources
-# open with ``__device__`` helper preludes (``emmy_ldmatrix_x4``, ``mbarrier_init``),
-# so a bare first-``void`` match would name the helper, collapsing distinct kernels
-# into one leaderboard bucket and hiding them from ``--kernel`` filters.
-KERNEL_NAME_RE = re.compile(r"__global__\s+(?:__launch_bounds__\([^)]*\)\s+)?void\s+(\w+)\s*\(")
 
 
 def _split_by_prefix(knobs: dict) -> tuple[dict, dict, dict]:
@@ -123,22 +113,15 @@ class Sample:
         )
 
     @classmethod
-    def from_perf_sample(cls, ps) -> Sample:
-        """A tune-DB ``perf ⋈ cuda_op`` row (:class:`db.PerfSample`) as a ``Sample``.
-        Splits the recorded knob dict by prefix; the kernel C identifier (for
-        per-knob regret grouping) is parsed from ``cuda_op.pretty``."""
-        tunable, ctx, s = _split_by_prefix(ps.knobs)
-        m = KERNEL_NAME_RE.search(ps.pretty or "")
-        return cls(
-            knobs=tunable,
-            latency_us=ps.latency_us,
-            name=m.group(1) if m else None,
-            context=ctx,
-            pretty=ps.pretty,
-            source="db",
-            s_full=s,
-            error=ps.error,
-        )
+    def from_measurement(cls, m) -> Sample:
+        """A tune-DB :class:`db.Measurement` row as a ``Sample``.
+
+        The grouping name is the kernel's IDENTITY, not the C identifier the store used to recover
+        from a saved kernel source: the identity is what the rows are keyed on, so rows that group
+        together are exactly the rows measuring one kernel — where the C identifier merged
+        distinct kernels a provenance pass happened to name alike."""
+        tunable, ctx, s = _split_by_prefix(m.knobs)
+        return cls(knobs=tunable, latency_us=m.us_median, name=m.op, context=ctx, source="db", s_full=s, error=m.error)
 
     @classmethod
     def from_prior_row(cls, knobs: dict, latency_us: float) -> Sample:

--- a/emmy/compiler/pipeline/search/db.py
+++ b/emmy/compiler/pipeline/search/db.py
@@ -1,26 +1,18 @@
-"""SQLite-backed inventory + measurement store for the search package.
+"""SQLite-backed measurement store for the search package.
 
 Pure persistence layer — no MCTS state, no propagation walks. Tables:
 
-- ``loop_op`` / ``tile_op`` / ``kernel_op`` / ``cuda_op`` — one row per
-  op encountered along a lowering chain. Keyed by ``identity_key(with_io=True, with_knobs=True)``.
-  Each row stores the JSON form (for programmatic inspection) and the
-  pretty-printed form (for human inspection).
-- ``lowering`` — best-known child for each parent op, one row per
-  rewrite hop along the lowering chain (Loop→Tile, every intra-Tile
-  autotune step, Tile→Kernel, Kernel→Cuda). Each row carries the knob
-  delta the rule stamped at that hop plus a best-median upsert — the
-  chain :meth:`SearchDB.best_per_op_time` walks to resolve a pre-final
-  op's measured cost (greedy fork picks come from the ``Prior``, never
-  DB replay). ``record_lowering`` upserts uniformly across
-  dialects: a strictly better measured median replaces the row; a
-  None measurement (bench_fail terminal) never overwrites a
-  known-good row. Deterministic rewrites (single option) trivially
-  win their own slot via the same path.
-- ``perf`` — backend-agnostic measurement store. ``op_key`` is whichever
-  terminal op the backend measured, or the finalized Loop cache key for a
-  directly measured whole-slice structural route. ``backend`` partitions the
-  table so the loop interpreter and the CUDA backend can coexist in the same DB.
+- ``context`` / ``op`` — the identities a measurement is keyed on, UNPACKED: one column per
+  field of :class:`~emmy.compiler.identity.Regime` and :class:`~emmy.compiler.identity.OpIdentity`,
+  with the row's ``digest`` derived from those columns. Adding an element to an identity is
+  adding a field to that module: the column follows and no key is assembled by hand anywhere.
+- ``measurement`` — one row per ``(regime, kernel, decision)``, which is also the keep-best key.
+  The kernel is its knob-free identity and the decision is the canonical row of tunable knobs, so
+  a compile decides a fork with ONE indexed query on the identity it is offered on
+  (:meth:`SearchDB.measurements`) instead of scanning the table and matching on a feature proxy.
+  What used to sit beside the measurement is reconstructed on demand: the ``S_*`` features
+  (featurize ``op.body``), the ``H_*`` values (from the regime), the kernel source and launch
+  geometry (re-lower the body under the decision — what the cubin cache already keys on).
 - ``node`` — one row per search-tree node (every partial branch + leaf of a
   per-kernel autotune search), keyed by ``digest(context_key, op_sig,
   tunable-knob set)``. Each row carries the full feature dict passed to the
@@ -28,7 +20,7 @@ Pure persistence layer — no MCTS state, no propagation walks. Tables:
   — the best latency reachable below the node; keep-min across sessions for
   branches, newest-measurement for leaves), and
   a ``parent_key`` pointer so ancestry between rows is recoverable. Content-keyed
-  (parent-tree-independent), so it survives schema-version drops like ``perf``.
+  (parent-tree-independent), so it survives schema-version drops.
   Written once per finished search by :meth:`SearchDB.record_nodes`, fed by the
   post-order tree walk ``TuningSearch._collect_node_records`` — alongside (not
   replacing) the online prior's reservoir feed. Label-quality columns (additive
@@ -60,26 +52,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from emmy.compiler.identity import OpIdentity, Regime
 from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
 
 logger = logging.getLogger(__name__)
-
-
-def _jsonable_geometry(geometry) -> list:
-    """Render a launch grid/block to a JSON-safe nested list for the inventory
-    tables. Int / str pass through; nested specs recurse; composite ``Expr``
-    factors (ceil-div block extents for hint-driven masked tiles) render to
-    their pretty string — inventory rows are for human inspection, not
-    re-execution."""
-
-    def conv(x):
-        if isinstance(x, (int, str)):
-            return x
-        if isinstance(x, (tuple, list)):
-            return [conv(e) for e in x]
-        return x.pretty()  # Expr
-
-    return [conv(spec) for spec in geometry]
 
 
 @dataclass(frozen=True)
@@ -95,55 +71,26 @@ class PerfStats:
 
 
 @dataclass(frozen=True)
-class PerfRow:
-    """One ``perf`` row.
+class Measurement:
+    """One ``measurement`` row: what a kernel's arm cost, where it was measured.
 
-    ``captured``: the measurement ran under CUDA graph capture (pure GPU time);
-    False = wall semantics including per-launch dispatch (all pre-capture rows).
-    Both kinds stay usable (replay, prior training); on write, a captured
-    measurement supersedes an uncaptured one for the same key — see
-    :meth:`SearchDB.record_perf`."""
+    ``op`` is the knob-free kernel identity (:attr:`OpIdentity.digest`) and ``knobs`` the arm it
+    decided — the canonical tunable row, which together with the regime is this row's key.
+    ``captured``: the measurement ran under CUDA graph capture (pure GPU time); False = wall
+    semantics including per-launch dispatch. Both kinds stay usable (replay, prior training); on
+    write, a captured measurement supersedes an uncaptured one for the same key — see
+    :meth:`SearchDB.record_measurement`."""
 
-    context_key: str
-    op_key: str
-    backend: str
+    op: str
+    knobs: dict
     status: str
-    stats: PerfStats
+    us_median: float
+    us_min: float
+    us_max: float
+    n_samples: int
     measured_at: str
-    knobs: dict
     captured: bool = False
-
-
-@dataclass(frozen=True)
-class PerfSample:
-    """One measured terminal kernel — a ``perf`` row joined to its ``cuda_op``.
-
-    The minimal row the dataset layer reads: the kernel's pretty source (for the C
-    identifier), the recorded knobs (which already carry the ``S_*`` / ``H_*``
-    features the variant was stamped with), and the median latency. Backs
-    :meth:`SearchDB.iter_perf_samples`."""
-
-    pretty: str
-    knobs: dict
-    latency_us: float
-    error: str | None = None  # bench_fail failure text (None on ok rows / pre-error-column DBs)
-
-
-@dataclass(frozen=True)
-class LoweringRow:
-    """One ``lowering`` row — best-known child for a parent op.
-
-    ``knobs`` is the delta added at this rewrite step (e.g.
-    ``005_blockify_launch`` adds ``{"BN": 64, "BM": 64}``). Greedy
-    replay picks the fork whose newly-stamped knobs agree with this
-    delta — no need to compare structural keys per fork."""
-
-    parent_key: str
-    parent_dialect: str
-    child_key: str
-    child_dialect: str
-    knobs: dict
-    best_median_us: float | None
+    error: str | None = None  # a failure's message — the one thing beside the µs that is not reconstructible
 
 
 @dataclass(frozen=True)
@@ -298,11 +245,8 @@ def impossible_kernel_reason(row: NodeRow) -> str | None:
     return None
 
 
-# The ``perf`` SELECT column list — order must match ``_row_to_perf``.
-_PERF_COLS = (
-    "context_key, op_key, backend, status, latency_us_median, latency_us_min, latency_us_max, "
-    "latency_us_mean, latency_us_variance, n_samples, measured_at, knobs, captured"
-)
+# The ``measurement`` SELECT column list — order must match :func:`_row_to_measurement`.
+_MEASUREMENT_COLS = "op, decision, status, us_median, us_min, us_max, n_samples, measured_at, captured, error"
 
 
 class SearchDB:
@@ -313,95 +257,74 @@ class SearchDB:
     ``~/.cache/emmy/autotune.db``).
     """
 
-    # Bumped whenever the fork-tree topology shifts in ways that change
-    # ``parent_key`` / ``child_key`` for the same physical decision —
-    # stale ``lowering`` rows from older versions won't match the new
-    # keys and would silently slow the next tune sweep. On version
-    # mismatch we drop the ``lowering`` table only; ``perf`` /
-    # ``loop_op`` / ``tile_op`` etc. survive (source-hash keyed,
-    # parent-tree-independent).
+    # The store keys on identities, not on tree topology: a row survives any change that does not
+    # change what a kernel IS. A bump means the identities themselves are spelled differently, and
+    # the rows written under the old spelling are unreadable — not stale, unreadable — so they are
+    # dropped on the next open.
     #
     # Version log:
-    #   1: M9.4 — planner-hoisted FM / FN / BN / BM forks. Parent-tree
-    #       topology shifted vs. the legacy downstream forks.
-    #   2: explicit-knob OFF sentinels — every variant now stamps every planner
-    #       knob (tier-foreign ones get an OFF value: WM/WN/MMA on scalar,
-    #       BM/BN/BR/FK on warp), so ``identity_key(with_io=True, with_knobs=True)`` (which folds the knob dict)
-    #       shifts for every TileOp/KernelOp. Stale ``lowering`` rows won't match.
-    #   3: the RASTER launch-order codec — every contraction row now spells a fifth
-    #       schedule family (``RASTER: ''``/``gm8``), so ``identity_key(with_io=True, with_knobs=True)`` shifts for every
-    #       matmul TileOp/KernelOp; cached pre-RASTER chains would silently replay
-    #       old-key kernels and starve the new rows of evidence.
-    #   4: the ``S_ext_serial_cell_work`` structural stamp — every op's knob row gains one
-    #       ``S_*`` feature, so ``identity_key(with_io=True, with_knobs=True)`` shifts for every
-    #       TileOp/KernelOp (the realization corpus's 211 restamped identities are the same
-    #       shift); stale ``lowering`` rows would silently never match.
-    _SCHEMA_VERSION = 4
+    #   1-4: the fork-tree generations of the ``lowering``/``perf`` schema (planner-hoisted forks,
+    #       explicit knob OFF sentinels, the RASTER codec, the ``S_ext_serial_cell_work`` stamp).
+    #   5: the unpacked measurement store. ``perf`` (one composite ``op_key`` folding body, io AND
+    #       knobs, inside a row found by its ``S_*`` feature set) becomes ``measurement`` keyed on
+    #       ``(context, op, decision)`` — the identity a fork is offered on, beside the arm it
+    #       decides. The op inventory (``loop_op`` / ``tile_op`` / ``kernel_op`` / ``cuda_op``) and
+    #       ``lowering`` collapse into ``op``: a chain's every stage keys off the same Loop-IR
+    #       content, so the parent-to-child links they existed to replay are the same row. No
+    #       migration is possible in either direction — a ``perf`` row's ``op_key`` is a digest of
+    #       a rendered CUDA source, and no amount of re-derivation recovers the Loop-IR body it
+    #       was rendered from — so pre-5 stores are dropped whole, with a count in the log.
+    _SCHEMA_VERSION = 5
+
+    _LEGACY_TABLES = ("perf", "lowering", "loop_op", "tile_op", "kernel_op", "cuda_op")
 
     _SCHEMA = [
+        # ``Regime``, unpacked. The digest is derived from the columns beside it, never stored
+        # independently of them: a reader that wants to know what a regime WAS reads the row.
         """
-        CREATE TABLE IF NOT EXISTS loop_op (
-            key       TEXT PRIMARY KEY,
-            body_json TEXT NOT NULL,
-            pretty    TEXT NOT NULL
+        CREATE TABLE IF NOT EXISTS context (
+            digest     TEXT PRIMARY KEY,
+            gpu        TEXT NOT NULL,
+            sm_major   INTEGER NOT NULL,
+            sm_minor   INTEGER NOT NULL,
+            opt_level  INTEGER NOT NULL,
+            nvcc_flags TEXT NOT NULL,
+            pins       TEXT NOT NULL
+        )
+        """,
+        # ``OpIdentity``, unpacked. ``dialect`` is the stage the identity was taken at — a
+        # descriptive column, deliberately NOT in the digest: every stage of one rewrite chain
+        # keys off the same Loop-IR content, which is what lets a golden minted by lifting a
+        # recorded target to Loop IR join the live Tile fork that offers it.
+        """
+        CREATE TABLE IF NOT EXISTS op (
+            digest     TEXT PRIMARY KEY,
+            dialect    TEXT NOT NULL,
+            body       TEXT NOT NULL,
+            io         TEXT NOT NULL
         )
         """,
         """
-        CREATE TABLE IF NOT EXISTS tile_op (
-            key       TEXT PRIMARY KEY,
-            body_json TEXT NOT NULL,
-            pretty    TEXT NOT NULL
+        CREATE TABLE IF NOT EXISTS measurement (
+            context     TEXT NOT NULL REFERENCES context (digest),
+            op          TEXT NOT NULL REFERENCES op (digest),
+            decision    TEXT NOT NULL,
+            status      TEXT NOT NULL,
+            us_median   REAL NOT NULL,
+            us_min      REAL NOT NULL,
+            us_max      REAL NOT NULL,
+            n_samples   INTEGER NOT NULL,
+            measured_at TEXT NOT NULL,
+            captured    INTEGER NOT NULL DEFAULT 0,
+            error       TEXT,
+            PRIMARY KEY (context, op, decision)
         )
         """,
-        """
-        CREATE TABLE IF NOT EXISTS kernel_op (
-            key       TEXT PRIMARY KEY,
-            body_json TEXT NOT NULL,
-            pretty    TEXT NOT NULL
-        )
-        """,
-        """
-        CREATE TABLE IF NOT EXISTS cuda_op (
-            key           TEXT PRIMARY KEY,
-            kernel_source TEXT NOT NULL,
-            arg_order     TEXT NOT NULL,
-            grid          TEXT NOT NULL,
-            block         TEXT NOT NULL,
-            smem_bytes    INTEGER NOT NULL,
-            pretty        TEXT NOT NULL
-        )
-        """,
-        """
-        CREATE TABLE IF NOT EXISTS lowering (
-            parent_key      TEXT PRIMARY KEY,
-            parent_dialect  TEXT NOT NULL,
-            child_key       TEXT NOT NULL,
-            child_dialect   TEXT NOT NULL,
-            knobs           TEXT NOT NULL DEFAULT '{}',
-            best_median_us  REAL
-        )
-        """,
-        """
-        CREATE TABLE IF NOT EXISTS perf (
-            context_key          TEXT NOT NULL,
-            op_key               TEXT NOT NULL,
-            backend              TEXT NOT NULL,
-            status               TEXT NOT NULL,
-            latency_us_median    REAL NOT NULL,
-            latency_us_min       REAL NOT NULL,
-            latency_us_max       REAL NOT NULL,
-            latency_us_mean      REAL NOT NULL,
-            latency_us_variance  REAL NOT NULL,
-            n_samples            INTEGER NOT NULL,
-            measured_at          TEXT NOT NULL,
-            knobs                TEXT NOT NULL DEFAULT '{}',
-            captured             INTEGER NOT NULL DEFAULT 0,
-            error                TEXT,
-            PRIMARY KEY (context_key, op_key, backend)
-        )
-        """,
+        # The per-fork query's index: one point lookup per fork, where the deploy used to scan
+        # the whole table once per process and memoize the result on the file's mtime.
+        "CREATE INDEX IF NOT EXISTS measurement_fork ON measurement (context, op)",
         # Content-keyed (``node_key`` folds context + op_sig + knob set), so —
-        # unlike ``lowering`` — it is parent-tree-independent and survives a
+        # unlike the retired ``lowering`` — it is parent-tree-independent and survives a
         # ``_SCHEMA_VERSION`` bump. ``CREATE … IF NOT EXISTS`` auto-creates it on
         # the next open of a pre-``node`` DB; no version bump / ALTER needed.
         """
@@ -446,7 +369,7 @@ class SearchDB:
         # hashes and remains valid across fork-tree changes.
         cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
         if cur_version != self._SCHEMA_VERSION:
-            self._conn.execute("DROP TABLE IF EXISTS lowering")
+            self._drop_legacy_tables(cur_version)
             self._conn.execute(f"PRAGMA user_version = {self._SCHEMA_VERSION}")
         # Additive ``node.gpu`` migration must run BEFORE the schema loop — the
         # ``node_gpu`` index in ``_SCHEMA`` references the column, so it has to exist
@@ -457,16 +380,10 @@ class SearchDB:
             self._conn.execute("ALTER TABLE node ADD COLUMN gpu TEXT NOT NULL DEFAULT ''")
         for stmt in self._SCHEMA:
             self._conn.execute(stmt)
-        # Additive migration: pre-existing DBs lack the ``error`` column
-        # (``CREATE TABLE IF NOT EXISTS`` never alters). Writer-side only —
-        # read-only consumers tolerate its absence instead. (``perf`` has no index on
-        # ``error``, so unlike ``node.gpu`` this can run after the schema loop.)
-        if not self._has_perf_error_column():
-            self._conn.execute("ALTER TABLE perf ADD COLUMN error TEXT")
         # Additive ``node`` label-quality columns (visits / is_leaf / variance /
         # n_samples / status / run_id / measured_at). Per-column ALTERs so a
         # crash-interrupted migration self-heals on the next open; no index
-        # references them, so like ``perf.error`` this runs after the schema loop.
+        # references them, so unlike ``node.gpu`` this runs after the schema loop.
         have = {r[1] for r in self._conn.execute("PRAGMA table_info(node)")}
         for col, ddl in self._NODE_ENRICH_COLUMNS:
             if col not in have:
@@ -493,8 +410,19 @@ class SearchDB:
         ("feat_ver", "INTEGER NOT NULL DEFAULT 1"),
     )
 
-    def _has_perf_error_column(self) -> bool:
-        return any(r[1] == "error" for r in self._conn.execute("PRAGMA table_info(perf)"))
+    def _drop_legacy_tables(self, cur_version: int) -> None:
+        """Drop the pre-5 measurement store. Its rows key on a digest of a rendered CUDA source
+        folded with a knob dict — an alphabet the identity module cannot re-derive from anything
+        the store kept — so they are unreadable rather than stale, and there is no migration to
+        write. The count goes in the log so the loss is visible where it happens; a machine that
+        wants its numbers back re-benches (``emmy run --golden-file FILE --bench --record``)."""
+        for table in self._LEGACY_TABLES:
+            if self._conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)).fetchone() is None:
+                continue
+            rows = self._conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]  # noqa: S608 — fixed literal names
+            if rows:
+                logger.warning("[db] dropping %d %s row(s) from schema v%d — pre-identity keys, unreadable here", rows, table, cur_version)
+            self._conn.execute(f"DROP TABLE {table}")  # noqa: S608 — fixed literal names
 
     def _has_node_gpu_column(self) -> bool:
         return any(r[1] == "gpu" for r in self._conn.execute("PRAGMA table_info(node)"))
@@ -512,10 +440,10 @@ class SearchDB:
     @classmethod
     def open_readonly(cls, path: Path | str) -> SearchDB:
         """Open an existing DB **read-only** — no schema creation, no version
-        check, no ``DROP TABLE lowering``, no WAL pragma — so a read-side consumer
+        check, no legacy-table drop, no WAL pragma — so a read-side consumer
         (``eval``, the dataset layer) never contends with a concurrent ``tune``
-        writer or mutates the file. The read methods (``iter_perf`` /
-        ``iter_perf_samples`` / ``lookup_*``) work; any write raises (the
+        writer or mutates the file. The read methods (``measurement`` /
+        ``measurements`` / ``iter_measurements``) work; any write raises (the
         connection is ``?mode=ro``). Raises ``sqlite3.OperationalError`` if the
         file is absent. A non-sqlite file fails HERE with a named reason (sqlite
         itself defers header validation to the first query, which would surface
@@ -539,158 +467,65 @@ class SearchDB:
         return self
 
     # ------------------------------------------------------------------
-    # Op-inventory writes (idempotent INSERT OR IGNORE)
+    # Measurements — write
     # ------------------------------------------------------------------
 
-    def record_loop_op(self, key: str, body_json: str, pretty: str) -> None:
-        self._conn.execute(
-            "INSERT OR IGNORE INTO loop_op (key, body_json, pretty) VALUES (?, ?, ?)",
-            (key, body_json, pretty),
-        )
-
-    def record_tile_op(self, key: str, body_json: str, pretty: str) -> None:
-        self._conn.execute(
-            "INSERT OR IGNORE INTO tile_op (key, body_json, pretty) VALUES (?, ?, ?)",
-            (key, body_json, pretty),
-        )
-
-    def record_kernel_op(self, key: str, body_json: str, pretty: str) -> None:
-        self._conn.execute(
-            "INSERT OR IGNORE INTO kernel_op (key, body_json, pretty) VALUES (?, ?, ?)",
-            (key, body_json, pretty),
-        )
-
-    def record_cuda_op(
+    def record_measurement(
         self,
-        key: str,
+        regime: Regime,
+        identity: OpIdentity,
+        knobs: dict | None,
         *,
-        kernel_source: str,
-        arg_order: list[str],
-        grid: list[int],
-        block: list[int],
-        smem_bytes: int,
-        pretty: str,
-    ) -> None:
-        self._conn.execute(
-            "INSERT OR IGNORE INTO cuda_op (key, kernel_source, arg_order, grid, block, smem_bytes, pretty) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                key,
-                kernel_source,
-                json.dumps(list(arg_order)),
-                json.dumps(_jsonable_geometry(grid)),
-                json.dumps(_jsonable_geometry(block)),
-                int(smem_bytes),
-                pretty,
-            ),
-        )
-
-    # ------------------------------------------------------------------
-    # Lowering edges
-    # ------------------------------------------------------------------
-
-    def record_lowering(
-        self,
-        parent_key: str,
-        parent_dialect: str,
-        child_key: str,
-        child_dialect: str,
-        *,
-        knobs: dict | None = None,
-        measured_median_us: float | None,
-    ) -> None:
-        """Upsert one ``parent_key`` → ``child_key`` lowering edge.
-
-        ``knobs`` is the delta this rewrite step stamps onto the child
-        (e.g. partition_loops adds ``{"BN": 64, "BM": 64, ...}``;
-        launch_geometry adds nothing). Greedy replay picks forks by
-        knob-subset match against this delta, so the row is enough to
-        reconstruct the chain without re-querying ``perf``.
-
-        Best-of upsert across every dialect — autotune fork rules live
-        at Tile→Tile (blockify, split_register_axes) and used to be excluded
-        here; recording every hop is how the chain stays replayable.
-        Rows where the rewrite is genuinely deterministic (a single
-        option) still trivially win their own slot, just via the same
-        upsert path.
-        """
-        knobs_json = json.dumps(knobs or {}, sort_keys=True, default=str)
-        existing = self._conn.execute(
-            "SELECT child_key, best_median_us FROM lowering WHERE parent_key = ?",
-            (parent_key,),
-        ).fetchone()
-        if existing is None:
-            self._conn.execute(
-                "INSERT INTO lowering (parent_key, parent_dialect, child_key, child_dialect, knobs, best_median_us) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (parent_key, parent_dialect, child_key, child_dialect, knobs_json, measured_median_us),
-            )
-            return
-        # Replace iff the new measurement is strictly better than the
-        # stored best (or the stored best is NULL). A None measurement
-        # never overwrites a known-good row.
-        cur_best = existing[1]
-        if measured_median_us is None:
-            return
-        if cur_best is None or measured_median_us < cur_best:
-            self._conn.execute(
-                "UPDATE lowering SET child_key = ?, child_dialect = ?, knobs = ?, best_median_us = ? WHERE parent_key = ?",
-                (child_key, child_dialect, knobs_json, measured_median_us, parent_key),
-            )
-
-    # ------------------------------------------------------------------
-    # Perf — write
-    # ------------------------------------------------------------------
-
-    def record_perf(
-        self,
-        context_key: str,
-        op_key: str,
-        *,
-        backend: str,
         status: str,
         stats: PerfStats,
-        knobs: dict | None = None,
         captured: bool = False,
         error: str | None = None,
     ) -> None:
-        """Upsert one ``perf`` row. Keep-best-``ok`` policy: a ``bench_fail``
-        never overwrites a prior ``ok`` row, and among same-semantics ``ok``
-        rows the lowest median wins. ``captured`` (CUDA-graph-captured, pure GPU
-        time) adds a precedence axis: a captured measurement supersedes an
-        uncaptured (wall-semantics) one regardless of median — the numbers
-        aren't comparable, and captured is the better truth — while an
-        uncaptured measurement never overwrites a captured one. ``error`` is the
-        failure text for a ``bench_fail`` row (whitespace-collapsed, truncated)
-        so failure forensics (``eval failures``) need no tune-log grepping."""
-        existing = self.lookup_perf(context_key, op_key, backend=backend)
+        """Upsert one ``measurement`` row, minting its ``context`` and ``op`` rows.
+
+        THE writer: everything measured enters the store here, so the identities are unpacked in
+        one place and a reader can always answer "what regime / what kernel is this" from the
+        columns. Keep-best-``ok`` policy on the ``(context, op, decision)`` key: a failure never
+        overwrites a prior ``ok`` row, and among same-semantics ``ok`` rows the lowest median
+        wins. ``captured`` (CUDA-graph-captured, pure GPU time) adds a precedence axis: a captured
+        measurement supersedes an uncaptured (wall-semantics) one regardless of median — the
+        numbers aren't comparable, and captured is the better truth — while an uncaptured
+        measurement never overwrites a captured one. ``error`` is the failure text for a failed
+        row (whitespace-collapsed, truncated) so failure forensics (``eval failures``) need no
+        tune-log grepping."""
+        context, op, decision = regime.digest, identity.digest, _decision(knobs)
+        existing = self._row(context, op, decision)
         if existing is not None and existing.status == "ok":
             if status != "ok":
                 return  # a failure never replaces a good measurement
             if existing.captured and not captured:
                 return  # wall semantics never overwrites a captured row
-            if not (captured and not existing.captured) and stats.median >= existing.stats.median:
+            if not (captured and not existing.captured) and stats.median >= existing.us_median:
                 return  # same semantics: keep the best median
-        knobs_json = json.dumps(knobs or {}, sort_keys=True, default=str)
+        self._conn.execute(
+            "INSERT OR IGNORE INTO context (digest, gpu, sm_major, sm_minor, opt_level, nvcc_flags, pins) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (context, regime.gpu, regime.sm_major, regime.sm_minor, regime.opt_level, regime.nvcc_flags, regime.pins),
+        )
+        self._conn.execute(
+            "INSERT OR IGNORE INTO op (digest, dialect, body, io) VALUES (?, ?, ?, ?)",
+            (op, identity.dialect, identity.body, identity.io_json),
+        )
         if error is not None:
             error = " ".join(str(error).split())[:300] or None
         self._conn.execute(
-            "INSERT OR REPLACE INTO perf "
-            "(context_key, op_key, backend, status, latency_us_median, latency_us_min, latency_us_max, "
-            " latency_us_mean, latency_us_variance, n_samples, measured_at, knobs, captured, error) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO measurement "
+            "(context, op, decision, status, us_median, us_min, us_max, n_samples, measured_at, captured, error) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
-                context_key,
-                op_key,
-                backend,
+                context,
+                op,
+                decision,
                 status,
                 stats.median,
                 stats.min,
                 stats.max,
-                stats.mean,
-                stats.variance,
                 stats.n_samples,
                 datetime.now(UTC).isoformat(),
-                knobs_json,
                 int(captured),
                 error,
             ),
@@ -790,12 +625,12 @@ class SearchDB:
         not an exact ledger); the value-paired columns (``is_leaf`` / ``variance`` /
         ``n_samples`` / ``status`` / ``run_id`` / ``measured_at``, stamped ``now``
         when the row carries none) travel WITH ``value_us`` — replaced together,
-        untouched otherwise. Status follows ``record_perf``'s keep-best-``ok``
+        untouched otherwise. Status follows ``record_measurement``'s keep-best-``ok``
         policy: an ``ok`` row is never downgraded by a later ``bench_fail``
         (whatever the fail's sentinel ``value_us``), while a fail row upgrades to
         ``ok`` unconditionally; fail-vs-fail follows the leaf rule (newest sentinel).
 
-        Manual lookup-guard + INSERT/UPDATE (the ``record_perf`` / ``record_lowering``
+        Manual lookup-guard + INSERT/UPDATE (the ``record_measurement``
         idiom) rather than ``INSERT OR REPLACE`` — the latter would reset
         ``n_updates`` and drop the old value. Row-at-a-time autocommit like the rest
         of the file; a finished search is a few-hundred-row batch at most.
@@ -898,7 +733,7 @@ class SearchDB:
         """Yield one :class:`NodeRow` per stored search-tree node (the value-of-position
         dataset backing ``eval prior --dataset nodes``). Self-contained — no join.
         A read-only open of a pre-``node`` DB has no such table, so this degrades to
-        yielding nothing instead of raising (mirrors ``iter_perf_samples``'
+        yielding nothing instead of raising (mirrors ``iter_measurements``'
         missing-column degrade). Optional ``context_key`` / ``op_sig`` scope to one
         regime / operation."""
         if not self._has_node_table():
@@ -998,126 +833,70 @@ class SearchDB:
         return len(rows)
 
     # ------------------------------------------------------------------
-    # Perf — read
+    # Measurements — read
     # ------------------------------------------------------------------
 
-    def lookup_lowering(self, parent_key: str) -> LoweringRow | None:
-        """Return the best-known child for ``parent_key``, or ``None``
-        when no row exists. Used by :meth:`best_per_op_time`'s chain
-        walk to resolve a pre-final op's measured cost."""
-        row = self._conn.execute(
-            "SELECT parent_key, parent_dialect, child_key, child_dialect, knobs, best_median_us FROM lowering WHERE parent_key = ?",
-            (parent_key,),
-        ).fetchone()
-        if row is None:
-            return None
-        return LoweringRow(
-            parent_key=row[0],
-            parent_dialect=row[1],
-            child_key=row[2],
-            child_dialect=row[3],
-            knobs=json.loads(row[4]) if row[4] else {},
-            best_median_us=row[5],
-        )
+    def measurement(self, regime: Regime, identity: OpIdentity, knobs: dict | None) -> Measurement | None:
+        """The one row for an exact arm, or ``None``."""
+        return self._row(regime.digest, identity.digest, _decision(knobs))
 
-    def lookup_perf(self, context_key: str, op_key: str, *, backend: str) -> PerfRow | None:
+    def _row(self, context: str, op: str, decision: str) -> Measurement | None:
         row = self._conn.execute(
-            f"SELECT {_PERF_COLS} FROM perf WHERE context_key = ? AND op_key = ? AND backend = ?",  # noqa: S608
-            (context_key, op_key, backend),
+            f"SELECT {_MEASUREMENT_COLS} FROM measurement WHERE context = ? AND op = ? AND decision = ?",  # noqa: S608
+            (context, op, decision),
         ).fetchone()
-        return _row_to_perf(row) if row else None
+        return _row_to_measurement(row) if row else None
 
-    def min_latency_for_context(self, context_key: str, *, backend: str | None = None) -> float | None:
-        if backend is None:
-            row = self._conn.execute(
-                "SELECT MIN(latency_us_median) FROM perf WHERE context_key = ? AND status = 'ok'",
-                (context_key,),
-            ).fetchone()
+    def measurements(self, regime: Regime, identity: OpIdentity | None = None) -> list[Measurement]:
+        """Every measured arm of ``identity`` in ``regime`` — THE per-fork query.
+
+        One indexed point lookup on the identity the fork is offered on, which is what replaces
+        the whole-table scan the deploy used to build once per process and match by feature
+        subset. ``identity=None`` spans the regime (the dataset / eval readers)."""
+        context = regime.digest
+        if identity is None:
+            cur = self._conn.execute(f"SELECT {_MEASUREMENT_COLS} FROM measurement WHERE context = ?", (context,))  # noqa: S608
         else:
-            row = self._conn.execute(
-                "SELECT MIN(latency_us_median) FROM perf WHERE context_key = ? AND backend = ? AND status = 'ok'",
-                (context_key, backend),
-            ).fetchone()
+            cur = self._conn.execute(
+                f"SELECT {_MEASUREMENT_COLS} FROM measurement WHERE context = ? AND op = ?",  # noqa: S608
+                (context, identity.digest),
+            )
+        return [_row_to_measurement(row) for row in cur]
+
+    def min_latency_for_context(self, context_key: str) -> float | None:
+        """Fastest ``ok`` median measured in a regime — the pricing floor probes read it."""
+        row = self._conn.execute(
+            "SELECT min(us_median) FROM measurement WHERE context = ? AND status = 'ok' AND us_median > 0",
+            (context_key,),
+        ).fetchone()
         return row[0] if row and row[0] is not None else None
 
-    def iter_perf(self, context_key: str, *, backend: str | None = None) -> Iterator[PerfRow]:
-        if backend is None:
-            cur = self._conn.execute(
-                f"SELECT {_PERF_COLS} FROM perf WHERE context_key = ?",  # noqa: S608
-                (context_key,),
-            )
-        else:
-            cur = self._conn.execute(
-                f"SELECT {_PERF_COLS} FROM perf WHERE context_key = ? AND backend = ?",  # noqa: S608
-                (context_key, backend),
-            )
-        for row in cur:
-            yield _row_to_perf(row)
-
-    def iter_perf_samples(self, *, backend: str | None = "cuda", status: str = "ok", min_latency_us: float = 0.0) -> Iterator[PerfSample]:
-        """Yield one :class:`PerfSample` per measured terminal kernel — ``perf``
-        joined to ``cuda_op`` on ``op_key = key``. The single place the two tables
-        are joined; backs ``Dataset.from_db``. ``backend=None`` spans every backend.
-        Filters to ``status`` (default ``ok``) and ``latency_us_median >
-        min_latency_us`` so callers don't re-filter stale / failed rows. The
-        ``error`` select degrades to ``NULL`` on a pre-error-column DB opened
-        read-only (the additive migration runs writer-side only)."""
-        error_col = "perf.error" if self._has_perf_error_column() else "NULL"
-        sql = (
-            f"SELECT cuda_op.pretty, perf.knobs, perf.latency_us_median, {error_col} "  # noqa: S608 — column name from a fixed two-way choice
-            "FROM perf JOIN cuda_op ON perf.op_key = cuda_op.key "
-            "WHERE perf.status = ? AND perf.latency_us_median > ?"
+    def iter_measurements(self, *, status: str = "ok", min_latency_us: float = 0.0) -> Iterator[Measurement]:
+        """Every measured row across every regime — the dataset layer's read (``Dataset.from_db``).
+        Filters to ``status`` (default ``ok``) and ``us_median > min_latency_us`` so callers don't
+        re-filter stale / failed rows."""
+        cur = self._conn.execute(
+            f"SELECT {_MEASUREMENT_COLS} FROM measurement WHERE status = ? AND us_median > ?",  # noqa: S608
+            (status, min_latency_us),
         )
-        params: list = [status, min_latency_us]
-        if backend is not None:
-            sql += " AND perf.backend = ?"
-            params.append(backend)
-        for pretty, knobs_json, us, error in self._conn.execute(sql, params):
-            try:
-                knobs = json.loads(knobs_json) if knobs_json else {}
-            except (TypeError, json.JSONDecodeError):
-                continue
-            yield PerfSample(pretty=pretty, knobs=knobs, latency_us=us, error=error)
+        for row in cur:
+            yield _row_to_measurement(row)
 
-    # ------------------------------------------------------------------
-    # Per-op best time (summed into the outer terminal reward)
-    # ------------------------------------------------------------------
+    def best_per_op_time(self, regime: Regime, identity: OpIdentity, knobs: dict | None) -> float | None:
+        """Best measured median (µs) for a kernel, or ``None`` when it has no clean ``ok`` row.
 
-    def best_per_op_time(self, context_key: str, op_key: str, *, backend: str = "cuda") -> float | None:
-        """Best measured median (us) for the kernel that ``op_key`` lowers
-        to in ``context_key``, or ``None`` when it has no clean ``ok``
-        measurement.
-
-        ``op_key`` is typically a finalized ``LoopOp`` key (the unit the
-        outer search hands to the inner per-op tuner). Two ways it carries a
-        time:
-
-        1. **Direct row** — the two-level inner search records the best
-           *whole-slice* total (``Σ`` over the slice's CudaOps, so split-K
-           main + combine are both counted) under the LoopOp key itself.
-           Preferred when present.
-        2. **Chain walk** — otherwise follow the ``lowering`` best-known child
-           links down to the ``cuda`` dialect and read that terminal's
-           context-keyed median. A ``CudaOp`` key resolves here directly (no
-           lowering row as parent).
-        """
-        direct = self.lookup_perf(context_key, op_key, backend=backend)
-        if direct is not None and direct.status == "ok":
-            return direct.stats.median
-        cur: str | None = op_key
-        seen: set[str] = set()
-        while cur is not None and cur not in seen:
-            seen.add(cur)
-            row = self.lookup_lowering(cur)
-            if row is None:
-                break
-            cur = row.child_key
-            if row.child_dialect == "cuda":
-                break
-        if cur is None or cur == op_key:
-            return None
-        perf = self.lookup_perf(context_key, cur, backend=backend)
-        return perf.stats.median if perf is not None and perf.status == "ok" else None
+        The exact arm answers when it was measured — the two-level inner search records the best
+        *whole-slice* total (``Σ`` over the slice's kernels, so a split-K main + combine both
+        count) under the slice's own arm, and that Σ is the honest price of the slice. Otherwise
+        the identity's best ``ok`` arm answers: every stage of a rewrite chain shares one
+        identity, so the terminal's own measurement is found here directly — the chain of
+        parent-to-child links this walk used to follow was a way of spelling that join when a
+        measurement keyed on a rendered kernel instead of on what the kernel is."""
+        exact = self.measurement(regime, identity, knobs)
+        if exact is not None and exact.status == "ok":
+            return exact.us_median
+        rows = [m.us_median for m in self.measurements(regime, identity) if m.status == "ok" and m.us_median > 0]
+        return min(rows) if rows else None
 
     # ------------------------------------------------------------------
     # House-keeping
@@ -1127,23 +906,27 @@ class SearchDB:
         self._conn.close()
 
 
-def _row_to_perf(row: tuple) -> PerfRow:
-    stats = PerfStats(
-        median=row[4],
-        min=row[5],
-        max=row[6],
-        mean=row[7],
-        variance=row[8],
-        n_samples=row[9],
-    )
-    knobs = json.loads(row[11]) if row[11] else {}
-    return PerfRow(
-        context_key=row[0],
-        op_key=row[1],
-        backend=row[2],
-        status=row[3],
-        stats=stats,
-        measured_at=row[10],
-        knobs=knobs,
-        captured=bool(row[12]),
+def _decision(knobs: dict | None) -> str:
+    """The ``measurement.decision`` column — the arm a knob dict decides, as canonical JSON.
+    ONE projection, shared by the writer and every lookup: the tunable row (``tuning_knob_items``
+    drops the ``S_*`` / ``CTX_*`` stamps and the marker BOOLs, which ride ``Regime.pins``), so a
+    caller hands over the op's raw knobs and cannot spell the key two ways."""
+    from emmy.compiler.pipeline.knob import tuning_knob_items  # noqa: PLC0415
+
+    return json.dumps(dict(tuning_knob_items(dict(knobs or {}))), sort_keys=True)
+
+
+def _row_to_measurement(row: tuple) -> Measurement:
+    """One ``measurement`` SELECT (:data:`_MEASUREMENT_COLS` order) as a :class:`Measurement`."""
+    return Measurement(
+        op=row[0],
+        knobs=json.loads(row[1]) if row[1] else {},
+        status=row[2],
+        us_median=row[3],
+        us_min=row[4],
+        us_max=row[5],
+        n_samples=row[6],
+        measured_at=row[7],
+        captured=bool(row[8]),
+        error=row[9],
     )

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -426,42 +426,6 @@ def _priced_pick(
     return min(priced, key=lambda op_us: op_us[1])[0]
 
 
-# Process-wide memo for the built DB index, keyed on (db path, mtime, context key).
-# The index depends only on the DB file and cc+nvcc-flags (NOT the
-# op shape — ``structural_key`` folds neither), so for a serve boot it is identical
-# across all ~96 program compiles; without this the 527 MB perf scan reran each time.
-# Bounded to the current key (cleared on miss), like ``_load_prior_cached``.
-_DB_INDEX_CACHE: dict = {}
-
-
-def _db_measured_index(db, ctx) -> _Measured:
-    """Caching wrapper over :func:`_db_measured_index_build` — memoizes the built
-    index per process on ``(db path, mtime, context keys)``, invalidated when the
-    DB file's mtime changes. An in-memory DB (no ``_path``) or an unstatable file
-    bypasses the cache and rebuilds. Best-effort throughout: a failed key
-    computation just rebuilds."""
-    path = getattr(db, "_path", None)
-    if path is None:
-        return _db_measured_index_build(db, ctx)
-    try:
-        # Stat the main file AND its ``-wal`` sidecar: in WAL mode a ``record_perf``
-        # commit can land in the WAL without bumping the main file's mtime, so a
-        # main-mtime-only key could serve a stale index to a same-process
-        # write-then-read (the tune lane). ``os.stat`` on a missing WAL → skip it.
-        wal = path.with_name(path.name + "-wal")
-        mtime = (path.stat().st_mtime_ns, wal.stat().st_mtime_ns if wal.exists() else 0)
-        key = (str(path), mtime, ctx.structural_key())
-    except Exception:  # noqa: BLE001 — any key-build failure → just rebuild uncached
-        return _db_measured_index_build(db, ctx)
-    hit = _DB_INDEX_CACHE.get(key)
-    if hit is not None:
-        return hit
-    index = _db_measured_index_build(db, ctx)
-    _DB_INDEX_CACHE.clear()  # keep only the current (path, mtime, keys)
-    _DB_INDEX_CACHE[key] = index
-    return index
-
-
 class _Measured(NamedTuple):
     """One DB scan's two answers, because the scan is expensive and both come from the same rows.
 
@@ -473,48 +437,26 @@ class _Measured(NamedTuple):
     failed: dict[frozenset, list[float]]
 
 
-def _db_measured_index_build(db, ctx) -> _Measured:
-    """The tune DB's measured CUDA perf rows for this compile's regime, split into what ranks and
-    what disqualifies.
+def _db_measured_index(db, ctx) -> _Measured:  # noqa: ARG001 — the arguments are the next step's
+    """The tune DB's measured rows for this compile's regime — **empty until the per-fork query
+    lands**.
 
-    Rows are indexed by their ``S_*`` structural signature (stringified values because perf knobs
-    round-trip JSON). One context key is sufficient: tune measures in the deployable regime, and
-    ``Context.structural_key`` gives that regime one key however its flags are spelled. Rows from a
-    deliberately non-deployable compile key elsewhere and are not consulted.
+    The index found rows by their ``S_*`` feature set: a scan of the whole table per process,
+    memoized on the DB file's mtime, matched by a subset rule that exists only because features
+    drift. The store now keys rows on the kernel's identity, which the fork point already holds,
+    so the replacement is one indexed lookup per fork (:meth:`SearchDB.measurements`) — and the
+    features are no longer stored beside the measurement, so nothing here is findable meanwhile.
+    Until that lands a greedy compile decides from the recorded goldens and the prior, which is a
+    REAL loss of evidence on a tuned machine, so it says so once."""
+    global _WARNED_MEASURED_TIER_OFF
+    if not _WARNED_MEASURED_TIER_OFF:
+        _WARNED_MEASURED_TIER_OFF = True
+        logger.warning("[greedy] measured-evidence tier is off: the store keys on kernel identity and the per-fork query is not wired yet")
+    return _Measured({}, {})
 
-    A non-``ok`` row is evidence too — the bench watchdog measured that variant not finishing — but
-    it is evidence a ranker cannot use, since its sentinel latency is a timeout constant rather
-    than a speed. It lands in ``failed`` instead, and only where NO variant of that signature was
-    measured ``ok``: one surviving row means the shape is realizable and merely has bad rows.
-    Failures are collected BEFORE the placement-route filter below, because a route's latency is
-    unattributable without a child-schedule receipt while a kernel that hung is attributable to
-    the kernel whatever route produced it.
 
-    Best-effort: any failure returns an empty index so deploy falls back to the prior.
-    """
-
-    index: dict[frozenset, list[tuple[dict, float]]] = {}
-    survived: set[frozenset] = set()
-    failures: dict[frozenset, list[float]] = {}
-    try:
-        for row in db.iter_perf(ctx.structural_key(), backend="cuda"):
-            sig = frozenset((k, str(v)) for k, v in row.knobs.items() if k.startswith("S_"))
-            if row.status != "ok":
-                failures.setdefault(sig, []).append(float(getattr(row.stats, "median", 0.0) or 0.0))
-                continue
-            survived.add(sig)
-            if row.stats.median <= 0:
-                continue
-            tun = {k: str(v) for k, v in row.knobs.items() if not k.startswith(("S_", "H_"))}
-            # A placement route's latency belongs to the exact ordered child schedule tree that
-            # ran. The perf schema carries no such receipt, so legacy route rows cannot be direct
-            # deploy evidence; independently selected children would be a different measurement.
-            if any(key.split("@", 1)[0] == "PLACE" for key in tun):
-                continue
-            index.setdefault(sig, []).append((tun, float(row.stats.median)))
-    except Exception:  # noqa: BLE001 — a DB consult failure must never break compile
-        return _Measured({}, {})
-    return _Measured(index, {sig: us for sig, us in failures.items() if sig not in survived})
+#: One warning per process for the tier above — a compile emits thousands of fork decisions.
+_WARNED_MEASURED_TIER_OFF = False
 
 
 def _sig_groups(index: dict[frozenset, list[tuple[dict, float]]], sig: frozenset) -> list[list[tuple[dict, float]]]:

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -590,7 +590,7 @@ class TuningSearch(Search):
                 out[row.node_key] = row
                 return
             # Within-batch duplicate (empty knob-delta chain): keep one row per key.
-            # An ``ok`` row always beats a ``bench_fail`` (record_perf's policy);
+            # An ``ok`` row always beats a ``bench_fail`` (record_measurement's policy);
             # among same-status rows prefer the directly-benched one (it carries the
             # bench stats) with the min value. Either way the survivor takes the
             # first-seen depth/parent and the max (not sum) of the visits, so

--- a/emmy/compiler/pipeline/search/policy/terminal_bench.py
+++ b/emmy/compiler/pipeline/search/policy/terminal_bench.py
@@ -7,7 +7,6 @@ persists, or reads a policy attribute.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import statistics
@@ -15,8 +14,6 @@ import statistics
 from emmy.compiler.backend.cuda.program import compile_budget_overrun
 from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.cuda.ir import CudaOp
-from emmy.compiler.ir.kernel.ir import KernelOp
-from emmy.compiler.ir.loop.ir import LoopOp
 from emmy.compiler.pipeline.search.db import PerfStats
 
 # The engine logger keeps the existing ``[tune]`` log channel and verbosity toggles.
@@ -36,7 +33,7 @@ class TerminalBench:
         self.backend = backend
         self.db = db
         self.graph = cand.graph
-        self.context_key = cand.ctx.structural_key()
+        self.regime = cand.ctx.regime()
         order = self.graph.topological_order()
         self.cuda_nodes = [self.graph.nodes[nid] for nid in order if isinstance(self.graph.nodes[nid].op, CudaOp)]
         # Kernel-bearing nodes a rewrite left un-lowered (a validation-filtered rewrite under
@@ -47,7 +44,6 @@ class TerminalBench:
         # issue-#327 "impossibly fast" split-K rows — a finalize kernel's cached µs standing in
         # for the whole matmul).
         self.unlowered = [nid for nid in order if not isinstance(self.graph.nodes[nid].op, (CudaOp, InputOp, ConstantOp))]
-        self.backend_name = getattr(backend, "name", "stub")
         #: Per-KERNEL measurements, ``[(knobs, median_us, status), ...]`` in launch order — what
         #: the search trains its prior on. A terminal is a Σ over its kernels; when a structural
         #: fork made it several, they hold DIFFERENT rows and there is no single row to attribute
@@ -102,81 +98,15 @@ class TerminalBench:
             )
         return cls._point_stats(lt.time_ms * 1000.0)
 
-    @staticmethod
-    def _body_json(op, dialect: str) -> str:
-
-        return json.dumps(
-            {
-                "dialect": dialect,
-                "name": getattr(op, "name", None) or getattr(op, "kernel_name", None) or "?",
-                "body_repr": repr(op.body),
-            },
-            default=str,
-        )
-
-    def _record_op_inventory(self, op) -> None:
-
-        key = op.identity_key(with_io=True, with_knobs=True)
-        if key is None:
-            return
-        if isinstance(op, CudaOp):
-            self.db.record_cuda_op(
-                key,
-                kernel_source=op.kernel_source,
-                arg_order=list(op.arg_order),
-                grid=list(op.grid),
-                block=list(op.block),
-                smem_bytes=op.smem_bytes,
-                pretty=op.kernel_source,
-            )
-        elif isinstance(op, KernelOp):
-            self.db.record_kernel_op(key, self._body_json(op, "kernel"), op.pretty_body())
-        elif isinstance(op, LoopOp):
-            self.db.record_loop_op(key, self._body_json(op, "loop"), op.pretty_body())
-
     def _persist(self, cuda_op, *, stats, status: str, captured: bool = False, error: str | None = None) -> None:
-        cuda_key = cuda_op.identity_key(with_io=True, with_knobs=True)
-        if cuda_key is None:
+        """One measured kernel as one ``measurement`` row: its knob-free identity, the arm its
+        knobs decided, and the µs. The rewrite chain needs no rows of its own — every stage of it
+        keys off the same Loop-IR content, so the row a chain's terminal writes IS the row its
+        LoopOp is priced by."""
+        identity = cuda_op.identity()
+        if identity is None:
             return
-        chain = [op for op in cuda_op.source_chain() if op.dialect is not None]
-        for op in chain:
-            self._record_op_inventory(op)
-        for parent_op, child_op in zip(chain[1:], chain[:-1], strict=False):
-            p_dialect = parent_op.dialect
-            c_dialect = child_op.dialect
-            if p_dialect is None or c_dialect is None:
-                continue
-            if p_dialect == c_dialect == "loop":
-                # loop→loop source hops are structural/decision hops, not
-                # lowering rewrites: the splice attribution stamped by the
-                # identity strategy (a decomposition's kernels → the
-                # pre-split op), the keep-vs-split rebind, name stamps.
-                # A ``lowering`` row holds ONE best child per parent, so
-                # recording a multi-kernel decomposition's hops would let
-                # ``best_per_op_time``'s chain walk resolve the pre-split
-                # op to a single fragment kernel's median — half the work
-                # masquerading as the whole op. The decomposition's cost
-                # is a Σ, owned by the two-level tuner, never this table.
-                continue
-            p_key = parent_op.identity_key(with_io=True, with_knobs=True)
-            c_key = child_op.identity_key(with_io=True, with_knobs=True)
-            if p_key is None or c_key is None:
-                continue
-            p_knobs = getattr(parent_op, "knobs", None) or {}
-            c_knobs = getattr(child_op, "knobs", None) or {}
-            knobs_delta = {k: v for k, v in c_knobs.items() if p_knobs.get(k) != v}
-            self.db.record_lowering(
-                p_key,
-                p_dialect,
-                c_key,
-                c_dialect,
-                knobs=knobs_delta,
-                measured_median_us=stats.median if status == "ok" else None,
-            )
-        knobs = getattr(cuda_op, "knobs", None) or {}
-        self.db.record_perf(
-            self.context_key, cuda_key, backend=self.backend_name, status=status, stats=stats, knobs=knobs, captured=captured, error=error
-        )
+        self.db.record_measurement(self.regime, identity, cuda_op.knobs, status=status, stats=stats, captured=captured, error=error)
         logger.info("[tune]   %s @ %.2f us  (%s)", getattr(cuda_op, "kernel_name", "?"), stats.median, status)
 
     def _accumulate(self, acc, s):
@@ -220,8 +150,11 @@ class TerminalBench:
         # useful here because ``backend.benchmark`` runs the whole graph.
         cached_rows = []
         for node in self.cuda_nodes:
-            key = node.op.identity_key(with_io=True, with_knobs=True)
-            row = self.db.lookup_perf(self.context_key, key, backend=self.backend_name) if key is not None else None
+            identity = node.op.identity()
+            if identity is None:
+                cached_rows = None
+                break
+            row = self.db.measurement(self.regime, identity, node.op.knobs)
             if row is None:
                 cached_rows = None
                 break
@@ -233,15 +166,16 @@ class TerminalBench:
             for node, row in zip(self.cuda_nodes, cached_rows, strict=True):
                 if row.status != "ok":
                     status = row.status
-                agg = self._accumulate(agg, row.stats)
-                self._note(node.op, row.stats, row.status)
-                logger.info("[tune]   %s @ %.2f us  (%s, cached)", row.op_key[:12], row.stats.median, row.status)
+                stats = self._point_stats(row.us_median)
+                agg = self._accumulate(agg, stats)
+                self._note(node.op, stats, row.status)
+                logger.info("[tune]   %s @ %.2f us  (%s, cached)", row.op[:12], row.us_median, row.status)
             return "done", (agg or self._point_stats(0.0), status)
 
         if self.backend is None:
             # No real measurement → do NOT persist. Writing the 1.0us stub
             # to a shared DB used to clobber tuned ``best_median_us`` values
-            # (record_lowering / record_perf keep the minimum), so any plain
+            # (``record_measurement`` keeps the minimum), so any plain
             # ``emmy run`` (which routes through ``Pipeline.run`` without
             # a backend) was overwriting real autotune rows with 1.0us stubs.
             # Tests that need lowering edges in stub mode should pass an

--- a/emmy/compiler/pipeline/search/strategy/two_level.py
+++ b/emmy/compiler/pipeline/search/strategy/two_level.py
@@ -352,8 +352,8 @@ class TwoLevelStrategy(SearchStrategy):
         it."""
         db, prior, progress = self.db, self.prior, self.progress
         identity = _identity()
-        ctx_key = ctx.structural_key()
-        backend_name = getattr(self.pool[0], "name", "cuda")
+        regime = ctx.regime()
+        ctx_key = regime.digest
         # Group structurally-identical kernel roots under one ``identity_key(with_io=True, with_knobs=True)`` — insertion order =
         # first occurrence (drives the progress tail name). Ops with no cache key are
         # unreachable through the bench path so they don't enter the dedup map at all.
@@ -432,7 +432,8 @@ class TwoLevelStrategy(SearchStrategy):
                 if best_total is not None:
                     # captured=True: the sweep benches under graph capture by default, so this
                     # Σ-best bookkeeping row derives from captured measurements.
-                    db.record_perf(ctx_key, work.key, backend=backend_name, status="ok", stats=_point_stats(best_total), captured=True)
+                    stats = _point_stats(best_total)
+                    db.record_measurement(regime, work.op.identity(), work.op.knobs, status="ok", stats=stats, captured=True)
                 if prior is not None:
                     # In-flight refit (single-threaded → no lock): stream this op's rows into
                     # the global reservoir; refit + checkpoint once enough new rows accumulate.
@@ -456,7 +457,7 @@ class TwoLevelStrategy(SearchStrategy):
                     else:
                         logger.info("[tune] enrolled minted kernel %s: no clean measurement", name)
                     return
-                best = db.best_per_op_time(ctx_key, work.key, backend=backend_name)
+                best = db.best_per_op_time(regime, work.op.identity(), work.op.knobs)
                 searched_knobs = searched_us = searched_cuda_ops = None
                 searched_structural = False
                 if searched is not None:

--- a/plans/measurement-store-identity-schema.md
+++ b/plans/measurement-store-identity-schema.md
@@ -113,18 +113,39 @@ featurizes on load and a freeze is a snapshot of `measurement` joined with `op`.
 Each step lands green on its own, keeps the realization corpus under strict evidence as its acceptance test, and
 should not grow the line count under `emmy/`.
 
-1. **Identity module.** Add `Regime`, `OpIdentity`, `Decision`. Route `Context.structural_key`, `Op.identity_key`
-   (drop the CUDA-source override), `canonical_row_key` and `golden.kernel_identity` through them. Fold the
-   input pins into `Regime`. Verify: kernel-source digest battery (`scripts/digest_kernels.py`) unchanged; the
-   corpus's `offered` / `realized` unchanged; the fork-time identity of a kernel equals the persisted identity
-   the golden replay keys its rows by (`_replay.signatures` today) — this is the join the design rests on.
-2. **Schema.** Create `context`, `op`, `measurement`; the perf writer (`persist_kernel_perf`, the one writer)
-   writes them. One-time migration of an existing DB: `perf` rows whose `op_key` can be re-derived from the
-   `cuda_op` inventory migrate, the rest are dropped with a count in the log. Verify: `emmy eval variants` and
-   `eval knobs` read the new tables and agree with the old on a migrated DB.
-3. **Per-fork query.** `greedy_decide` asks `db.measurements(regime, identity)` at each fork and runs the
-   existing arm logic over that short list: schedule rows through `Fork.admits` / `leaf_for`, route rows through
-   `pins.spelled_arm`, failed rows as disqualification. Delete `_Measured`, `_db_measured_index*`,
+1. **Identity module — LANDED.** `emmy/compiler/identity.py`, not under `search/`: `context.py` and
+   `ir/base.py` sit below `pipeline` and both produce identities. `Context.structural_key`, `Op.identity_key`
+   (CUDA-source override dropped) and `canonical_row_key` route through it; `golden.kernel_identity` follows,
+   since it already asked for the deploy identity. Three findings from the verification:
+   - `OpIdentity`'s digest must NOT fold the `dialect`, or the golden's lift-minted identity stops matching the
+     live Tile fork. It stays a descriptive column.
+   - a `CudaOp` keys on the newest PRE-SCHEDULE op of its chain (its own `TileOp`, else the fused `LoopOp`),
+     body and io alike — not the nearest predecessor, whose materialized `KernelOp` body keys apart from the
+     tile term the fork decided, and not the oldest, which would price a split's piece as the parent it was cut
+     from. Checked on five corpus cases including a split-K cut: the measured identity equals the fork's.
+   - `Regime.pins` carries every marker BOOL, not just the precision gates — it is the exact complement of
+     `Decision`, which drops them, so `EMMY_VECTORIZE_LOADS=0` rows cannot merge with default ones.
+
+   Identity VALUES are unchanged, deliberately: this is a restructuring, and the digest is durable data — the
+   corpus stamps `identity_key(with_io=True)` into 208 checked-in case files and a kernel's name carries a slice
+   of it. So `OpIdentity.io` holds the io fingerprint itself (the column renders it via `io_json`, the way
+   `Decision` renders its knob row) and the lattice fold stays FLAT — `digest(body, io, knobs)`, never a digest
+   of a digest. Verified against the corpus: live fork identity == the checked-in stamp, no regen.
+2. **Schema — LANDED, no migration.** After step 1 a `perf` row's `op_key` is a digest of a rendered CUDA source
+   and cannot be re-derived into the Loop-IR body it was rendered from, so the pre-5 store is dropped whole with
+   a count in the log. `lowering` went with it: every pre-schedule stage of a chain shares one `op` digest, so
+   `best_per_op_time` reads the terminal's row directly instead of walking parent-to-child links. Two departures
+   from the sketch above: `measurement` keeps a `captured` column (the captured-supersedes-wall precedence is
+   not reconstructible) and `context` keeps the residual `nvcc_flags` beside the split opt level (a
+   `--use_fast_math` compile must stay its own partition). `iter_perf_samples` now groups by the op digest
+   instead of the C identifier it parsed out of the stored kernel source. Still to verify on a real store:
+   `emmy eval variants` / `eval knobs`.
+3. **Per-fork query — NEXT, and the measured tier is OFF until it lands.** `_db_measured_index` returns empty
+   with a one-per-process warning: its rows were found by feature set, and the features are no longer stored
+   beside the measurement. `_DB_INDEX_CACHE` and the build are already gone. `greedy_decide` asks
+   `db.measurements(regime, identity)` at each fork and runs the existing arm logic over that short list:
+   schedule rows through `Fork.admits` / `leaf_for`, route rows through `pins.spelled_arm`, failed rows as
+   disqualification. Delete `_Measured`, `_db_measured_index*`,
    `_DB_INDEX_CACHE`, `_sig_groups`, the subset branch of `Prior.sig_groups`, `fork_signature` as a lookup key.
    Verify: the cold-pick tests, the two serving stitch tests, a serve boot's compile count and wall time.
 4. **Golden import is a DB write.** `golden.import_file(db, path)`: each entry with an identity is one

--- a/plans/measurement-store-identity-schema.md
+++ b/plans/measurement-store-identity-schema.md
@@ -1,0 +1,164 @@
+# Measurement store on unpacked identities: remove the in-memory evidence mirror
+
+Working note, 2026-09-03. Follows PR #704 (golden replay as the one measured-evidence pick). Not tracked.
+
+## Goal
+
+The tune DB becomes the only measured store. A compile decides each fork by one query on the identity of the
+kernel it is offered on. A golden reaches a deploy by being written into that DB as ordinary measurement rows
+before the compile starts. Nothing measured lives in memory beside the DB: no per-compile evidence index, no
+golden row import into that index, no reservoir tier.
+
+Every identity the store keys on is a value object in ONE module, its fields are the table's columns, and its
+digest is derived from those fields. Adding an element to an identity is adding a field: the column follows and a
+migration recomputes the digest from the columns beside it.
+
+## Why
+
+- The pick matches on a proxy. Rows are found by their `S_*` feature set, with a subset rule that exists only
+  because features drift. Different kernels never share a signature, so the signature is a stand-in for identity
+  and the identity is what should be stored and queried.
+- The DB holds three notions of kernel identity beside the one the deploy matches on: `perf.op_key` (the
+  identity lattice with io and knobs, and for a rendered kernel the CUDA-source digest), `node.op_sig` (the
+  identity pass's feature-signature digest) and the Loop-IR body identity goldens carry. Keys are assembled by
+  hand in about ten places (`Context.structural_key`, `Op.identity_key`, `identity.op_sig`, `fork_signature`,
+  `canonical_row_key`, `golden.kernel_identity`, `golden._set_key`, `scope_token`, two `node_key`s).
+- The evidence index is a full scan of the perf table per process, memoized on mtime and golden scope, because the
+  lookup key sits inside a JSON blob. With an indexed identity column the per-fork query is a point lookup.
+- `perf` has no card column: a measurement on one sm_89 card answers a deploy on another.
+- Goldens are imported into the live regime through `regime_live` and scoped through `records_override` /
+  `EMMY_GOLDEN_FILE` / `sole_evidence`, a second isolation mechanism beside "which DB file".
+
+## The identity module
+
+One module (working name `emmy/compiler/pipeline/search/identity.py`; the DB module imports it, nothing in it
+imports the DB) defines frozen dataclasses. `Structural.structural_key()` already digests a frozen dataclass's
+fields, so the identity, the row and the digest are one object; no hand-assembled key survives.
+
+```python
+@dataclass(frozen=True)
+class Regime(Structural):  # where a measurement holds
+    gpu: str  # the card; µs is per card, capability alone is not enough
+    sm_major: int
+    sm_minor: int
+    opt_level: int  # split nvcc opt level, never the raw flag string
+    pins: Pins  # the input-pin regime (FAST_MATH and the precision gates); absent = OFF
+
+
+@dataclass(frozen=True)
+class OpIdentity(Structural):  # what a kernel IS, knob-free
+    dialect: str  # the stage the identity is taken at (loop | tile)
+    body: str  # canonical Loop-IR program, wire form
+    io: str  # operand dtypes / shapes / strides, canonical JSON
+
+
+@dataclass(frozen=True)
+class Decision:  # the arm: canonical row of tunable knobs, open key set
+    knobs: Mapping[str, str]  # canonical JSON in the table; '{}' for a forkless kernel
+```
+
+Every producer and consumer of a key imports these: the perf writer, the pick, the golden importer, the identity
+pass, the corpus helpers, `eval`. `Op.identity_key` returns `OpIdentity(...).structural_key()` and its CUDA-source
+override goes: a measurement keys on the Loop-IR body identity or the golden's identity and the DB's never meet.
+
+## Schema
+
+```sql
+CREATE TABLE context (            -- Regime, unpacked; digest derived from the columns
+    digest     TEXT PRIMARY KEY,
+    gpu        TEXT NOT NULL,
+    sm_major   INTEGER NOT NULL,
+    sm_minor   INTEGER NOT NULL,
+    opt_level  INTEGER NOT NULL,
+    pins       TEXT NOT NULL
+);
+
+CREATE TABLE op (                 -- OpIdentity, unpacked; digest derived from the columns
+    digest     TEXT PRIMARY KEY,
+    dialect    TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    io         TEXT NOT NULL
+);
+
+CREATE TABLE measurement (        -- one row per (regime, kernel, decision); the PK is the keep-best key
+    context     TEXT NOT NULL REFERENCES context (digest),
+    op          TEXT NOT NULL REFERENCES op (digest),
+    decision    TEXT NOT NULL,    -- canonical JSON
+    status      TEXT NOT NULL,    -- ok | failed | timeout
+    us_median   REAL NOT NULL,
+    us_min      REAL,
+    us_max      REAL,
+    n_samples   INTEGER NOT NULL,
+    source      TEXT NOT NULL,    -- tune | bench | golden:<file digest>
+    measured_at TEXT NOT NULL,
+    error       TEXT,             -- a failure's message is the one thing not reconstructible
+    PRIMARY KEY (context, op, decision)
+);
+CREATE INDEX measurement_fork ON measurement (context, op);
+```
+
+Not stored, reconstructed on demand: `S_*` features (featurize `op.body`), `H_*` values (from the regime), kernel
+source / grid / block / smem / pretty text (re-lower the body under the decision in the regime; the cubin cache
+already keys on that), parent-to-piece relations (replay the parent's op under its route decision; pieces are
+identities of their own). Dropped tables: `loop_op`, `tile_op`, `kernel_op`, `cuda_op` (collapse into `op`),
+`lowering`, `perf` (becomes `measurement`).
+
+Open question, decide before step 5: the `node` table (search-tree samples with a features blob; the offline
+fitter, `eval prior --dataset nodes` and the freeze read it). A leaf sample is a measurement row; a partial node's
+value is an aggregate over the leaves beneath it. Dropping `node` from the durable store means the fitter
+featurizes on load and a freeze is a snapshot of `measurement` joined with `op`.
+
+## Steps
+
+Each step lands green on its own, keeps the realization corpus under strict evidence as its acceptance test, and
+should not grow the line count under `emmy/`.
+
+1. **Identity module.** Add `Regime`, `OpIdentity`, `Decision`. Route `Context.structural_key`, `Op.identity_key`
+   (drop the CUDA-source override), `canonical_row_key` and `golden.kernel_identity` through them. Fold the
+   input pins into `Regime`. Verify: kernel-source digest battery (`scripts/digest_kernels.py`) unchanged; the
+   corpus's `offered` / `realized` unchanged; the fork-time identity of a kernel equals the persisted identity
+   the golden replay keys its rows by (`_replay.signatures` today) — this is the join the design rests on.
+2. **Schema.** Create `context`, `op`, `measurement`; the perf writer (`persist_kernel_perf`, the one writer)
+   writes them. One-time migration of an existing DB: `perf` rows whose `op_key` can be re-derived from the
+   `cuda_op` inventory migrate, the rest are dropped with a count in the log. Verify: `emmy eval variants` and
+   `eval knobs` read the new tables and agree with the old on a migrated DB.
+3. **Per-fork query.** `greedy_decide` asks `db.measurements(regime, identity)` at each fork and runs the
+   existing arm logic over that short list: schedule rows through `Fork.admits` / `leaf_for`, route rows through
+   `pins.spelled_arm`, failed rows as disqualification. Delete `_Measured`, `_db_measured_index*`,
+   `_DB_INDEX_CACHE`, `_sig_groups`, the subset branch of `Prior.sig_groups`, `fork_signature` as a lookup key.
+   Verify: the cold-pick tests, the two serving stitch tests, a serve boot's compile count and wall time.
+4. **Golden import is a DB write.** `golden.import_file(db, path)`: each entry with an identity is one
+   `measurement` row (its knobs are the decision, its µs the measurement, `source = golden:<digest>`); an
+   identity-less single-kernel entry derives its identity from its program once; re-import deletes by source
+   first, and an `imports (source, compiler_fingerprint)` row makes it idempotent. `compile`, `run`, `tune` and
+   the `serve` parent import the repository's per-card files, or the one `--golden PATH` names, before
+   compiling. Decision for the user: import the YAML µs as-is (keeps today's whole-target pricing against
+   per-kernel rows) or bench on import (`run --golden --bench` IS the import; a cold machine benches once before
+   it serves). Recommendation: bench on import. Delete `evidence_rows`, `regime_live`, the replay's persisted
+   "replays" section, `records_override`, `RECORDS_OVERRIDE`, `scope_token`, `scope_explicit`, `sole_evidence`,
+   `EMMY_GOLDEN_FILE` / `config.golden_scope` / `golden_file_override`. The replay (`golden._replay`) stays only
+   where identities are minted at record time (`helpers.complete`, the strict decode).
+5. **Isolation is a DB file.** The realization corpus, the release gate (`eval golden --serving-config`) and
+   `--golden PATH` compile against a scratch DB named through `EMMY_TUNE_DB`, import into it, and turn strict
+   evidence on. `make test` sets `EMMY_TUNE_DB` to an empty scratch path instead of `EMMY_GOLDEN_FILE=`.
+6. **Retire the reservoir as an evidence tier.** The tuner already writes every measurement as rows, so the
+   reservoir is a subset of the DB. Keep it as the online prior's training sample only; delete `evidence_pick`
+   and the reservoir-first branch of the hierarchy. Optional for the first five steps; it is the last in-memory
+   mirror.
+
+## What stays
+
+`pins.spelled_arm`, `Fork.admits` / `leaf_for`, strict evidence and `EvidenceError`, the splice events carrying arm
+knobs, the corpus's one-entry-per-kernel format, `run --bench` writing rows through the one writer.
+
+## Risks
+
+- **Identity at fork time vs persisted identity.** Step 1's verification. If they differ for cut pieces, the
+  importer needs the replay after all and the design degrades to today's, keyed by identity instead of features.
+- **Whole-target µs.** A golden's µs covers every kernel of its target. Written per kernel it over-prices the
+  golden's arm against a per-kernel DB row of the same identity. Bench-on-import removes this; as-is import keeps
+  it, exactly as today.
+- **Concurrent writers.** Imports run in the command process before the compile; xdist workers and the corpus
+  use their own scratch DB. SQLite WAL covers the occasional overlap on one machine.
+- **Freeze and fitter.** Dropping `node` changes what a reported prior number is evaluated against. Decide before
+  step 5; the first four steps do not touch `node`.


### PR DESCRIPTION
Measurements are now stored and looked up by what a kernel IS, rather than found by scanning a
table and matching on the feature set the kernel happened to be stamped with. The identities the
store keys on became two small value objects whose fields are the table's columns, and the four
op-inventory tables, the lowering edge table and the perf table collapsed into three: context, op
and measurement. Identity values themselves did not move, so nothing checked in had to be
restamped. This is steps 1 and 2 of `plans/measurement-store-identity-schema.md`; the pick itself
is not rewired yet, so the tune DB's evidence tier is switched off in the meantime and says so.

## Why

The deploy found a measured row by its `S_*` feature set: a full scan of `perf` per process,
memoized on the DB file's mtime, matched by a subset rule that exists only because features drift.
Different kernels never share a signature, so the signature was a stand-in for identity — and
identity is what should be stored and queried. Meanwhile the DB held three notions of what a
kernel is beside the one a deploy matches on, and keys were assembled by hand in about ten places.

## The identity module

`emmy/compiler/identity.py` — two frozen value objects, each carrying its own `digest` as a
computed property over its own columns:

- **`Regime`** — where a measurement holds: `gpu`, `sm_major`, `sm_minor`, `opt_level`,
  `nvcc_flags`, `pins`. The card is new to the key: µs is a per-card fact, and `perf` had no card
  column, so a measurement on one sm_89 card answered a deploy on another.
- **`OpIdentity`** — what a kernel is, knob-free: `dialect`, `body`, `io`.

`Context.structural_key` and `Op.identity_key` route through them. It lives at `emmy/compiler/`
rather than under `search/` because `context.py` and `ir/base.py` sit below `pipeline` and both
produce identities.

The digest is computed, never stored beside the fields and never passed in — a key a caller could
supply is a key that can disagree with the row it sits on. (SQL cannot help: SQLite has no
sha256, a generated column cannot be a `PRIMARY KEY`, and the fold's input is a Python-side
canonical rendering.)

**Identity values are unchanged.** `OpIdentity.io` holds the io fingerprint itself (the column
renders it via `io_json`) and the lattice fold stays flat — `digest(body, io, knobs)`, never a
digest of a digest. Verified against the corpus: the live fork identity equals the checked-in
stamp, so none of the 208 case files needed regenerating.

## Schema

```sql
context (digest PK, gpu, sm_major, sm_minor, opt_level, nvcc_flags, pins)
op      (digest PK, dialect, body, io)
measurement (context, op, decision, status, us_median, us_min, us_max,
             n_samples, measured_at, captured, error,
             PRIMARY KEY (context, op, decision))
CREATE INDEX measurement_fork ON measurement (context, op);
```

`measurement`'s key is also its keep-best key, and it IS the per-fork query: one indexed lookup on
the identity a fork is offered on. What the store no longer keeps is reconstructed on demand — the
`S_*` features by featurizing `op.body`, the `H_*` values from the regime, the kernel source and
geometry by re-lowering the body under the decision, which is what the cubin cache already keys on.

`lowering` goes because every pre-schedule stage of a chain shares one `op` digest, so
`best_per_op_time` reads the terminal's row directly instead of walking parent-to-child links.

**No migration, by necessity.** A `perf` row's `op_key` is a digest of rendered CUDA source, and
nothing re-derives the Loop-IR body it came from. Schema v5 drops the pre-identity generation
whole, with a row count in the log. A tuned machine re-tunes.

## Three findings from verifying the join

The join this design rests on is "the identity a kernel is measured under equals the identity of
the fork that offered it". Checking it on corpus cases moved the design three times:

1. **`OpIdentity`'s digest must not fold `dialect`.** A golden's identity is minted by lifting a
   recorded target to Loop IR; the live compile mints it at a Tile fork. Fold the stage tag in and
   that join dies. It stays a descriptive column.
2. **A `CudaOp` keys on the newest *pre-schedule* op of its chain** — its own `TileOp`, else the
   fused `LoopOp` — body and io alike. Not the nearest predecessor: the intervening `KernelOp`
   body is the schedule already materialized, so it keys apart from the tile term the fork
   decided. Not the oldest: that prices a split's piece as the parent it was cut from. And not
   body-from-chain with io-from-here: the cuda passes rename and re-slab buffers, which splits the
   join at its io half.
3. **`Regime.pins` carries every marker BOOL**, not just the precision gates — it is the exact
   complement of the decision's knob row, which drops them. Otherwise a kernel measured under
   `EMMY_VECTORIZE_LOADS=0` shares a key with the same kernel measured under the default, and
   keep-best silently picks between two different pieces of code.

## What this deliberately breaks

The measured-evidence tier is **off** until the per-fork query lands (step 3):
`_db_measured_index` returns empty with a one-per-process warning. Its rows were findable only by
feature set, and the features are no longer stored beside the measurement. A greedy compile
decides from the recorded goldens and the prior meanwhile — a real loss of evidence on a tuned
machine, which is why it announces itself rather than failing silently into the `except Exception`
that used to wrap the scan.

## Verification

- Realization corpus (`offered` / `realized` / staleness): **409 passed, 25 skipped, 9 xfailed**,
  no case file touched.
- `tests/compiler/pipeline/search` + `test_knob`: **221 passed, 8 failed, 1 collection error** —
  every one of them a test calling a removed API (`lookup_perf`, `_db_measured_index_build`) or
  building a bare `CudaOp` with no rewrite chain, which now correctly has no identity to store a
  measurement under. Those fixtures are the next commit's work.
- Store round-trip: digest equals the digest of its own columns, `S_*` stamps drop out of the arm,
  keep-best holds, `measurements()` and `best_per_op_time` return the arms.
- `make lint` clean. Full `make test` was still running when this was opened; the number above is
  the targeted subset.

## Line balance

`git diff --stat main -- emmy/`: **16 files, +386 / −713** — net −327 under `emmy/`, so the new
capability arrives smaller than what it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
