### PR TITLE
Gate the goldens on strict decode, and record the softmax-V tier as a regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,31 +252,37 @@ You MUST complete ALL of the following checks before every commit. These are not
    replace them with the correct established term or a plain-word explanation (see Documentation Conventions).
 10. **Run tests**: `make test` — fix any failures before proceeding
 11. **Run linter**: `make lint` — if it fails, run `make format` and re-check
+12. **Decode the goldens** whenever the change touches the compiler (anything under `emmy/compiler/`, and always
+    for a schedule-codec, enumeration or knob-spelling change): `make test-goldens`. Off the default lane and needs no
+    GPU. `make test` guards the realization corpus against exactly this class of change and nothing guarded the
+    checked-in model goldens, so a rebuild of the schedule space can invalidate every recorded row in silence. If rows
+    go red, name the change that did it in the PR body — do **not** re-record them to make it green, which enshrines
+    the regression as the new reference.
 
 ### Before submitting (MANDATORY — do NOT skip these)
 
 You MUST audit the complete diff after the before-committing checks and before requesting review:
 
-12. **Remove unnecessary functionality**: Which new functionality can be removed?
-13. **Reuse existing mechanisms**: Which existing CLI, library, recipe, or skill can be reused instead?
-14. **Rethink touched functionality**: Can existing functionality be rearchitected around the PR's needs so one
+13. **Remove unnecessary functionality**: Which new functionality can be removed?
+14. **Reuse existing mechanisms**: Which existing CLI, library, recipe, or skill can be reused instead?
+15. **Rethink touched functionality**: Can existing functionality be rearchitected around the PR's needs so one
     simpler shared design replaces parallel or specialized paths?
-15. **Remove obsolete code**: Delete existing code that the PR makes unnecessary. Apply the boy-scout rule within the
+16. **Remove obsolete code**: Delete existing code that the PR makes unnecessary. Apply the boy-scout rule within the
     PR's scope and leave touched code cleaner, without expanding into an unrelated refactor.
-16. **Keep reasoning and reports out of code**: Which logic should become concise agent instructions? Code may
+17. **Keep reasoning and reports out of code**: Which logic should become concise agent instructions? Code may
     transform structural data, but scripts must not interpret results or assemble human-readable reports.
-17. **Minimize the diff**: Can the same outcome be achieved with fewer changed lines, files, flags, and abstractions?
-18. **Check the core line balance**: run `git diff --stat main -- emmy/`. A PR that introduces no new functionality
+18. **Minimize the diff**: Can the same outcome be achieved with fewer changed lines, files, flags, and abstractions?
+19. **Check the core line balance**: run `git diff --stat main -- emmy/`. A PR that introduces no new functionality
     (a refactor, a cleanup, a fix) must NOT increase the line count under `emmy/` — net growth there without new
     capability is the typical sign of architectural creep: another special case, helper, or early return layered onto
     a design that no longer fits. If the balance is positive, do not shave lines cosmetically to pass the check —
     restructure so the layering disappears, or say explicitly in the PR body why the growth is justified.
-19. **Apply the audit findings**: perform the removals and consolidation before requesting review. Tests must protect
+20. **Apply the audit findings**: perform the removals and consolidation before requesting review. Tests must protect
     the smaller contract, not preserve unnecessary machinery.
 
 ### Submitting
 
-20. Push and open a PR
+21. Push and open a PR
 
 # Behavioral Guidelines:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ one compile regime everywhere in the repo.
 
 Checked-in model goldens are not exercised by the per-commit test suite. The nightly `onboard-model` workflow owns
 their repository validation, strict decode, and exact-GPU replay so model qualification stays with its GPU evidence.
+The decode half alone is also reachable off the default lane, on any machine: `make test-goldens` strictly decodes
+every checked-in golden file (one case per file) against the current compiler, which is how you see a card's rows go
+green again after a tuning round re-records them.
 
 Or for a specific test file:
 
@@ -167,11 +170,13 @@ Quick test models / scripts (for local iteration):
 ## Key Make Targets
 
 - `make setup` — create venv and install dependencies (includes ruff)
-- `make test` — run `pytest` using the venv (skips `perf`-marked tests; see the `tests/perf` architecture). Compiles
+- `make test` — run `pytest` using the venv (skips the off-lane `perf` / `goldens` tests). Compiles
   kernels at `-Xcicc -O1` (correctness lane, ~12% faster than `-O3` on a cold cache; perf tests use `-O3` via
   `make bench-kernels`)
 - `make test-corpus-regen` — restamp the realization corpus's derived half after a kernel-identity or schedule-codec
   change (`make test` detects the staleness on any machine; this applies the fix)
+- `make test-goldens` — strict-decode every checked-in golden against the current compiler (off the default lane,
+  no GPU needed; a stale row is detectable anywhere, re-recording it is what needs the card)
 - `make test-durations` — re-measure `tests/durations.json`, the checked-in per-test timings the suite balances its
   xdist workers on; commit the result when the balance has drifted
 - `make lint` — run `ruff check` and `ruff format --check`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-agent clean bench bench-force bench-kernels bench-kernels-tune test-compose test-durations test-corpus-regen lint format git-sha-guard pypi-dist \
+.PHONY: help setup setup-agent clean bench bench-force bench-kernels bench-kernels-tune test-compose test-durations test-corpus-regen test-goldens lint format git-sha-guard pypi-dist \
 	serve-models serve-config serve-config-guard serve-goldens serve-warm serve-image serve-verify serve-push
 
 help:
@@ -23,6 +23,7 @@ help:
 	@echo "  serve-models    - List the models with a pinned release config"
 	@echo "  test-durations - Re-measure tests/durations.json (the CI test-balancing baseline)"
 	@echo "  test-corpus-regen - Restamp the realization corpus after an identity / codec change (COMPLETE=1 adds entries)"
+	@echo "  test-goldens   - Strict-decode every checked-in golden (off the default lane, no GPU needed)"
 	@echo "  clean          - Remove virtual environment and generated files"
 	@echo "  test-compose   - Test docker-compose generation with sample config"
 
@@ -85,6 +86,14 @@ test: setup
 # is a realization regression to review, not a mechanical restamp.
 test-corpus-regen: setup
 	./venv/bin/python -m tests.compiler.realization.regen $(if $(COMPLETE),--complete,)
+
+# Strict-decode every checked-in golden. Off the default lane: a full pass re-derives every
+# recorded row's enumeration, minutes per file. Run it after a tuning round has re-recorded a
+# card's rows, to see which files the compiler can replay again. Needs no GPU — decoding targets
+# each record's DECLARED capability, so a stale row is detectable anywhere; re-recording it is
+# what needs the card.
+test-goldens: setup
+	./venv/bin/pytest tests/compiler/pipeline/search/test_golden.py -m goldens -n auto --dist=loadgroup -v -p no:randomly --no-header
 
 # Regenerate tests/durations.json — the checked-in per-test timings the conftest
 # LPT-buckets on, so CI's first (cache-less) run is balanced. Runs through one xdist

--- a/README.md
+++ b/README.md
@@ -325,7 +325,9 @@ three proposed deployment matrix entries. Disabled recipes are not deployable or
 Canonical model goldens live beside their recipe at `recipes/<model>/golden/<gpu-slug>_<compute-cap>.yaml`, with one
 file per exact GPU. A model with complete compiler evidence but no serving recipe receives an `onboarding`/`untested`
 recipe shell before its golden is committed. Model-agnostic hardware goldens remain under
-`emmy/compiler/pipeline/search/goldens/`.
+`emmy/compiler/pipeline/search/goldens/`. `make test-goldens` strictly decodes every one of those files against the
+current compiler — off the default test lane and needing no GPU, it is how you see which cards a tuning round has
+brought back in line.
 
 Generic workload (run any tool on the VM, pull back result files):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ emmy_serving = "emmy.serving:register"
 asyncio_mode = "auto"
 markers = [
     "perf: GPU performance comparison vs PyTorch (deselected by default; run with `pytest -m perf`)",
+    "goldens: strict decode of the checked-in golden corpus (deselected by default; run with `pytest -m goldens`)",
 ]
 
 [tool.ruff]

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -118,7 +118,10 @@ the shared module already provides.
   **declared** capability rather than the live card — `Context.from_target(compute_cap)` — so the enumeration and
   lowering stages are machine-independent and an sm_70 lockout is exercised on a box that has no sm_70. Only the
   build and accuracy stages consult the live card, and they gate on `device_compute_capability() == compute_cap`,
-  beside `requires_sm90` in spirit but keyed on equality rather than a floor.
+  beside `requires_sm90` in spirit but keyed on equality rather than a floor. The one golden lane inside pytest sits
+  off the default one: `make test-goldens` (the `goldens` marker) strictly decodes every checked-in file, one case
+  per file. It is deselected for COST, not for card-dependence — decoding replays each record at its declared
+  capability, so a stale row is detectable on any machine; re-recording one is what needs the card.
 - **Keep one subprocess smoke per report path.** Filtering, join, and presentation variants use small synthetic
   records at the owning unit layer instead of launching the CLI repeatedly over the full repository corpus.
 - **Async tests** — tests for async functions are plain `async def` (no decorator needed; `asyncio_mode = "auto"` handles it). Mock async callables with `AsyncMock`.
@@ -163,10 +166,11 @@ the shared module already provides.
 ## Running
 
 ```bash
-pytest tests/ -v                       # all tests (skips `perf`-marked tests)
+pytest tests/ -v                       # all tests (skips off-lane `perf` / `goldens` tests)
 pytest tests/deploy/test_recipe.py -v  # single file
 pytest tests/planner/ -v               # single directory
 pytest tests/perf/ -m perf -v          # GPU perf suite (see tests/perf/ARCHITECTURE.md)
+pytest tests/compiler/pipeline/search/ -m goldens -v   # strict-decode the checked-in goldens (make test-goldens)
 ```
 
 Under `make test` (`-n auto --dist=loadgroup`) the root `conftest.py` routes every CUDA-touching test onto two
@@ -219,9 +223,18 @@ large fraction of the card FREE at startup, plus checkpoint downloads and minute
 mark on anything else silently drops it from `make test` even on GPU machines (this hid the serving runner's GPU
 correctness pins for a while). GPU correctness tests guard themselves with `requires_cuda` / `importorskip` instead.
 
-Repository golden validation is intentionally outside pytest. Model goldens are GPU-specific qualification evidence,
-so the nightly `onboard-model` workflow validates the selected recipe-local file, strictly decodes every row, and
-replays it on the named GPU. This keeps expensive model/card qualification out of the per-commit suite.
+`goldens` is the second off-lane marker, gated by the same hook. `tests/compiler/pipeline/search/test_golden.py`
+strictly decodes every checked-in golden file — one case per file, so a card's rows go green as a whole when a tuning
+round re-records them — and `make test-goldens` runs it. A full pass re-derives every recorded row's enumeration,
+minutes per file, which is why it is off the default lane; the derivation memo
+(`~/.cache/emmy/golden_identity.json`, keyed by compiler fingerprint and record content) makes a re-run cost only the
+rows that actually changed.
+
+Repository golden *qualification* is intentionally outside pytest. Model goldens are GPU-specific qualification
+evidence, so the nightly `onboard-model` workflow validates the selected recipe-local file, strictly decodes every
+row, and replays it on the named GPU. This keeps expensive model/card qualification out of the per-commit suite. Only
+the decode half is also reachable without the card, off the default lane (`make test-goldens` above) — it targets each
+record's declared capability; the measured replay is what the nightly's GPU is for.
 
 Optional adapter tests use `pytest.importorskip` for their own dependency extras. The network-free tiny Diffusers DiT
 trace runs when the `image` extra is installed; the real checkpoint/CUDA comparison is additionally `perf`-marked and

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -1,7 +1,10 @@
 """Configuration checks for the 2026 compiler-submission experiments."""
 
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 from emmy.benchmark.command_workload import build_substitution_map, render_command
 from emmy.benchmark.tasks import enumerate_tasks
@@ -408,6 +411,7 @@ def test_neptune_emmy_pytorch_a100_share_one_experiment(project_root) -> None:
     assert '"captured_whole_forward"' in pytorch_runner
 
 
+@pytest.mark.skipif(shutil.which("timeout") is None, reason="run_emmy.sh needs GNU coreutils `timeout`")
 def test_neptune_emmy_runner_fails_when_one_setup_is_incomplete(project_root, tmp_path) -> None:
     directory = Path(project_root) / EXP / "compiler_neptune_emmy_pytorch_a100"
     golden_dir = tmp_path / "golden"

--- a/tests/compiler/pipeline/search/test_golden.py
+++ b/tests/compiler/pipeline/search/test_golden.py
@@ -1,0 +1,55 @@
+"""Strict decode of the checked-in golden corpus.
+
+Off the default lane behind the ``goldens`` marker: a full pass re-derives every recorded row's
+enumeration, which costs minutes per file. Run it with ``make test-goldens`` after a tuning round
+has re-recorded a card's rows, to see which files the compiler can still replay.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from emmy.compiler.pipeline.search.golden import (
+    _records_of,
+    _repository_golden_paths,
+    decode_record,
+    flush_identity_store,
+    siblings_of,
+)
+
+
+def _paths() -> list[Path]:
+    with _repository_golden_paths() as paths:
+        return list(paths)
+
+
+def _label(path: Path) -> str:
+    """The card's file for a hardware golden, ``<model>/<card>.yaml`` for a recipe-local one."""
+    return f"{path.parent.parent.name}/{path.name}" if path.parent.name == "golden" else path.name
+
+
+@pytest.mark.goldens
+@pytest.mark.parametrize("path", _paths(), ids=_label)
+def test_every_recorded_row_still_decodes(path: Path) -> None:
+    """Every row a golden file records must still equal an enumerated leaf of its own target.
+
+    A row that does not is no evidence a deploy can use: the compile that reads it either picks a
+    schedule the enumeration no longer offers, or falls through to the prior. Decoding replays the
+    persisted program at the record's DECLARED capability, so this holds on any machine — a card is
+    needed to re-record a stale row, not to detect one.
+    """
+    records = _records_of(path)
+    failures = []
+    for record in records:
+        try:
+            reason = decode_record(record, siblings_of(record, records))
+        except Exception as exc:  # noqa: BLE001 — the reason IS the product here
+            reason = f"{type(exc).__name__}: {exc}"
+        if reason is not None:
+            failures.append(f"  {record.name}: {' '.join(reason.split())[:120]}")
+    # Persist what this pass derived: the memo is keyed by compiler fingerprint and record content,
+    # so re-running after a tuning round only re-derives the rows that were actually re-recorded.
+    flush_identity_store()
+    listed = "\n".join(failures[:20])
+    more = f"\n  ... and {len(failures) - 20} more" if len(failures) > 20 else ""
+    assert not failures, f"{len(failures)}/{len(records)} recorded rows equal no enumerated leaf:\n{listed}{more}"

--- a/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma.yaml
@@ -1,0 +1,283 @@
+# evidence: the softmax-V half of a head-dim-128 SDPA must keep offering its warp tier. The row below is a
+# recorded RTX 5090 golden (11.84 us, fast-math); today the kernel enumerates two rows, neither carrying an mma
+# TILE, and greedy falls to a scalar schedule measured at 1459.8 us. `offered` passes at 5719f823 and fails from
+# b93a86c2 (#691), which restamped the realization corpus for the new schedule codec but not the model goldens.
+compute_cap:
+- 12
+- 0
+programs:
+- inputs: [x0, x1, x2]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: x0
+    op: input
+    outputs: [[x0, f16, [1, 8, 512, 128]]]
+  - id: x1
+    op: input
+    outputs: [[x1, f16, [1, 8, 512, 128]]]
+  - id: x2
+    op: input
+    outputs: [[x2, f16, [1, 8, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs: {is_causal: false, sliding_window: null, scale: null}
+    inputs: [x0, x1, x2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 512, 128]]]
+configs:
+- program: 0
+  target:
+    loop: 0
+  realizations:
+  - name: k_sdpa_6679cd.a781328aa577
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f16/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    identity: 444efd06c17763ea28ed4301e3440153b01b722db5352992ea83aeb3fed44c46
+loops:
+- inputs: [x0, x1, x2]
+  outputs: [scaled_dot_product_attention]
+  nodes:
+  - id: scaled_dot_product_attention_scale
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_scale
+      value: 0.08838834764831843
+      context_value: null
+      load_ops: {__tuple__: []}
+      source_path: null
+      source_parts: {__tuple__: []}
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
+  - id: x0
+    op: input
+    outputs: [[x0, f16, [1, 8, 512, 128]]]
+  - id: x1
+    op: input
+    outputs: [[x1, f16, [1, 8, 512, 128]]]
+  - id: x2
+    op: input
+    outputs: [[x2, f16, [1, 8, 512, 128]]]
+  - id: scaled_dot_product_attention
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names: {tuple: [in0]}
+            input: scaled_dot_product_attention_scale
+            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
+            dtype: null
+        - class: Loop
+          fields:
+            axis: {class: Axis, fields: {name: a0, extent: {dim: 8}, window: null}}
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a3, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in1]}
+                                    input: x0
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in2]}
+                                    input: x1
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a3}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3_s1]}, base: null}
+                              unroll: false
+                              seed: true
+                          - class: Assign
+                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
+                          - class: Accum
+                            fields:
+                              name: acc1
+                              value: v1
+                              op: {elementwise: maximum}
+                              dtype: null
+                              axes: {tuple: [a2_s2]}
+                              base: null
+                        unroll: false
+                        seed: true
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a4, extent: {dim: 128}, window: null}}
+                              body:
+                                body:
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in3]}
+                                    input: x0
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a1}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in4]}
+                                    input: x1
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a2}}
+                                      - {expr: {var: a4}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v2, op: {elementwise: multiply}, args: {tuple: [in3, in4]}, dtype: null}
+                                - class: Accum
+                                  fields: {name: acc2, value: v2, op: {elementwise: add}, dtype: null, axes: {tuple: [a4_s1]}, base: null}
+                              unroll: false
+                              seed: true
+                          - class: Assign
+                            fields: {name: v3, op: {elementwise: multiply}, args: {tuple: [acc2, in0]}, dtype: null}
+                          - class: Assign
+                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc1]}, dtype: null}
+                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
+                          - class: Accum
+                            fields: {name: acc3, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2_s1]}, base: null}
+                        unroll: false
+                        seed: true
+                    - class: Assign
+                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc3]}, dtype: null}
+                    - class: Loop
+                      fields:
+                        axis: {class: Axis, fields: {name: a5, extent: {dim: 128}, window: null}}
+                        body:
+                          body:
+                          - class: Loop
+                            fields:
+                              axis: {class: Axis, fields: {name: a6, extent: {dim: 512}, window: null}}
+                              body:
+                                body:
+                                - class: Loop
+                                  fields:
+                                    axis: {class: Axis, fields: {name: a7, extent: {dim: 128}, window: null}}
+                                    body:
+                                      body:
+                                      - class: Load
+                                        fields:
+                                          names: {tuple: [in5]}
+                                          input: x0
+                                          index:
+                                            tuple:
+                                            - {expr: {literal: {value: 0, dtype: int}}}
+                                            - {expr: {var: a0}}
+                                            - {expr: {var: a1}}
+                                            - {expr: {var: a7}}
+                                          dtype: null
+                                      - class: Load
+                                        fields:
+                                          names: {tuple: [in6]}
+                                          input: x1
+                                          index:
+                                            tuple:
+                                            - {expr: {literal: {value: 0, dtype: int}}}
+                                            - {expr: {var: a0}}
+                                            - {expr: {var: a6}}
+                                            - {expr: {var: a7}}
+                                          dtype: null
+                                      - class: Assign
+                                        fields: {name: v7, op: {elementwise: multiply}, args: {tuple: [in5, in6]}, dtype: null}
+                                      - class: Accum
+                                        fields: {name: acc4, value: v7, op: {elementwise: add}, dtype: null, axes: {tuple: [a7_s1]}, base: null}
+                                    unroll: false
+                                    seed: true
+                                - class: Assign
+                                  fields: {name: v8, op: {elementwise: multiply}, args: {tuple: [acc4, in0]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc1]}, dtype: null}
+                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
+                                - class: Load
+                                  fields:
+                                    names: {tuple: [in7]}
+                                    input: x2
+                                    index:
+                                      tuple:
+                                      - {expr: {literal: {value: 0, dtype: int}}}
+                                      - {expr: {var: a0}}
+                                      - {expr: {var: a6}}
+                                      - {expr: {var: a5}}
+                                    dtype: null
+                                - class: Assign
+                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
+                                - class: Assign
+                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in7, v11]}, dtype: null}
+                                - class: Accum
+                                  fields:
+                                    name: acc5
+                                    value: v12
+                                    op: {elementwise: add}
+                                    dtype: null
+                                    axes: {tuple: [a6_s1]}
+                                    base: null
+                              unroll: false
+                              seed: true
+                          - class: Write
+                            fields:
+                              output: scaled_dot_product_attention
+                              index:
+                                tuple:
+                                - {expr: {literal: {value: 0, dtype: int}}}
+                                - {expr: {var: a0}}
+                                - {expr: {var: a1}}
+                                - {expr: {var: a5}}
+                              values: {tuple: [acc5]}
+                              value_dtype: null
+                              atomic: false
+                              swizzle: NONE
+                        unroll: false
+                        seed: true
+                  unroll: false
+                  seed: true
+            unroll: false
+            seed: true
+      name: k_sdpa_6679cd
+    inputs: [scaled_dot_product_attention_scale, x0, x1, x2]
+    outputs: [[scaled_dot_product_attention, f16, [1, 8, 512, 128]]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,7 +197,7 @@ _GATE_SECONDS = 5.0
 #: so they are exempt from the staleness gate and from the written baseline — otherwise every
 #: `make bench-kernels` would fail demanding entries that `make test`, which skips it,
 #: can never record.
-_OFF_LANE_MARKERS = ("perf",)
+_OFF_LANE_MARKERS = ("perf", "goldens")
 #: Node ids seen carrying an off-lane marker this session (filled during collection).
 _OFF_LANE_ITEMS: set[str] = set()
 
@@ -385,17 +385,19 @@ _CUDA_CLI_GROUP = "cuda-cli"
 def pytest_collection_modifyitems(config, items):
     import heapq
 
-    # Deselect ``perf`` unless explicitly requested. Lives here — not in
+    # Deselect every off-lane marker unless explicitly requested. Lives here — not in
     # ``tests/perf/conftest.py`` — so the gate holds for ANY ``tests/``
     # collection (e.g. ``pytest tests/serving/``), not only runs that happen
     # to collect ``tests/perf/`` and load its conftest.
     selected = config.getoption("-m") or ""
     _OFF_LANE_ITEMS.update(i.nodeid for i in items if any(m in i.keywords for m in _OFF_LANE_MARKERS))
-    if "perf" not in selected:
-        skip_perf = pytest.mark.skip(reason="perf marker not selected; run with `pytest -m perf`")
+    for marker in _OFF_LANE_MARKERS:
+        if marker in selected:
+            continue
+        skip = pytest.mark.skip(reason=f"{marker} marker not selected; run with `pytest -m {marker}`")
         for item in items:
-            if "perf" in item.keywords:
-                item.add_marker(skip_perf)
+            if marker in item.keywords:
+                item.add_marker(skip)
 
     # Step 1: pin every CUDA-touching item to an xdist_group so each
     # chain lands on one worker and runs sequentially — ``cuda`` for


### PR DESCRIPTION
## Why

`decode_record` already answers *"does this recorded row still realize?"*, but nothing ran it over the shipped
corpus. So a schedule-codec change can invalidate every model golden in silence. That is not hypothetical — it
has already happened.

Bisected, on the same 25-record RTX 5090 sample:

| commit | | decode failures |
| --- | --- | ---: |
| `d6a852ec` — *"Re-record RTX 5090 gemma-4-12b-it goldens"* (Aug 24) | | 0 / 25 |
| `5719f823` | parent | 3 / 25 |
| **`b93a86c2`** | **"Rebuild classic scheduling around generic composition" (#691)** | **18 / 25** |
| `ec02ce80` | current main | 74% of all 630 |

No golden file has been edited since Aug 24. The corpus did not rot; the compiler stopped enumerating what it
describes. #691 correctly restamped the realization corpus for the new codec — `make test` would have gone red
otherwise — and the model goldens, which nothing checks per-commit, were left behind.

## What this adds

**1. The missing tripwire** (`d751aad3`). A `goldens` off-lane pytest marker plus `make test-goldens`, strict-
decoding every checked-in golden. Off the default lane because a full pass re-derives every recorded row's
enumeration, minutes per file. `goldens` joins `perf` in the conftest's off-lane set, which stops being a
one-marker special case and becomes a loop. **Needs no GPU** — decoding targets each record's declared
capability, so a stale row is detectable anywhere; re-recording it is what needs the card.

**2. A realization case for one #691 regression** (`dd499f89`). The softmax-V half of a head-dim-128 SDPA no
longer offers its warp tier. The authored row is a recorded 5090 golden (11.84 us, fast-math); today the kernel
enumerates two rows, neither carrying an mma TILE:

```
WORK=w2x4 realized t256; TILE=mma_m16n8k16_f16_f16/f1x4/k8 realized (off); STAGE=d1/smem realized (off)
```

Greedy's scalar fallback measures **1459.8 us** on a 5090 against the recorded 11.84 us — 124x. The compiler
already asks for this investigation itself on every such compile: *"the tune measured a schedule tier this
compile did not offer; investigate the enumeration (offer gates) for this kernel."*

**3. The instruction that makes the gate matter** (`c307fbb5`). A gate nobody runs is not a gate. Added to the
before-committing checklist as step 12, conditioned on the change touching `emmy/compiler/` — it is minutes per file,
so it does not belong on every commit. It carries the lesson too: when rows go red, name the change that did it, do
**not** re-record them. Re-recording on a compiler that has lost a schedule captures the fallback as the new
reference and the regression becomes invisible again.

**4. An unrelated macOS fix** (`f2015dc2`). `run_emmy.sh` calls GNU `timeout`, which macOS does not ship, so the
neptune runner test fails on any Mac checkout. Skip on the tool, not the platform. Happy to drop this commit if
you would rather it went separately.

## This PR is RED, deliberately

`offered` and `realized` fail for the new case. Per the corpus's own rule — *"never add an `_xfail_` suffix to
make a red test green; that converts a regression into a recorded gap and the ratchet stops meaning anything"* —
it carries no suffix. I verified it is a regression rather than a never-implemented gap: this exact case's
`offered` stage **passes at `5719f823`** and fails from `b93a86c2` onward.

If you want the gate to land independently, `dd499f89` is a clean cherry-pick out.

## Relationship to open work

- **#706** fixes a different #691 regression (nested write-only output sweeps). Same root commit, different
  symptom; this case is not covered by it.
- **#711** addresses #704 regime-pin spelling. Adjacent to the decode failures but distinct.
- **#714** re-qualifies golden-bench by regenerating goldens from current `main`. That is the complementary fix
  for stale *data* — but note that re-recording on today's compiler would capture the 1459.8 us scalar schedule
  as the new golden for this kernel, silently enshrining the regression. The case here is what stops that.

## Not established

The 74% figure is measured on the 630 RTX 5090 records. `make test-goldens` fails on all 11 files across all
five cards, but I have not broken the other cards down by cause. How much of the 74% is respellable versus
genuinely lost capability is still being measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrQFki2ECdpo7S2YLHC9yg
