### PR TITLE
Record the softmax-V warp tier as an open realization gap, not a closed red case

### DIFF
--- a/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
@@ -1,7 +1,15 @@
-# evidence: the softmax-V half of a head-dim-128 SDPA must keep offering its warp tier. The row below is a
-# recorded RTX 5090 golden (11.84 us, fast-math); today the kernel enumerates two rows, neither carrying an mma
-# TILE, and greedy falls to a scalar schedule measured at 1459.8 us. `offered` passes at 5719f823 and fails from
-# b93a86c2 (#691), which restamped the realization corpus for the new schedule codec but not the model goldens.
+# evidence: the schedule pins the value channel on tensor cores (the P·V half beside the score's mma) with its
+# softmax weights compute-filled into shared memory — the tier `sdpa-computed-value-cut-mma_xfail_offered` and
+# `qwen3emb/sdpa-s*_xfail_offered` record: the twist carries P·V inside its carrier on this tree and offers no
+# child contraction site (#699), so the score contraction is the kernel's only TILE/STAGE site and `STAGE d1/smem`
+# resolves nowhere. #715 measured greedy's scalar fallback at 1459.8 us on an RTX 5090 against 11.84 us for this
+# row (fast-math), 124x.
+#
+# #715 added this case closed, as a #691 regression; that bisect does not reproduce. The row as spelled — one site
+# carrying WORK w2x4, TILE mma_m16n8k16_f16_f16/f1x4/k8 and STAGE d1/smem — is offered at neither #691's parent
+# (5719f823: the fill lived on the P·V site `@pj`, the f1x4/k8 atom on the score site `@a3`, and no `w2x4` at
+# all) nor #699's parent (4a4e6521: the same shape on integer sites), so it records the gap #699 opened, not a
+# passing case that stopped passing.
 compute_cap:
 - 12
 - 0

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -600,6 +600,7 @@
  "tests/compiler/realization/test_realization.py::test_realization[attention/rmsnorm-qk-sdpa-workspace-chain.yaml-realized]": 6.95,
  "tests/compiler/realization/test_realization.py::test_realization[attention/sdpa-computed-value-cut-mma_xfail_offered.yaml-offered]": 5.83,
  "tests/compiler/realization/test_realization.py::test_realization[attention/sdpa-computed-value-cut-mma_xfail_offered.yaml-realized]": 10.38,
+ "tests/compiler/realization/test_realization.py::test_realization[attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml-offered]": 6.1,
  "tests/compiler/realization/test_realization.py::test_realization[fused/gate-up-distinct-a_xfail_realized.yaml-offered]": 11.24,
  "tests/compiler/realization/test_realization.py::test_realization[fused/gate-up-distinct-a_xfail_realized.yaml-realized]": 100.93,
  "tests/compiler/realization/test_realization.py::test_realization[fused/gate-up-shared-a.yaml-built]": 11.17,


### PR DESCRIPTION
## Why

`make test` on main is red: `attention/sdpa-hd128-softmax-v-mma.yaml` (#715) fails `offered` and `realized`, and its
`offered` node (6 s) is missing from `tests/durations.json`, which the session-end gate reports as a failure too.

#715 committed the case red on purpose, as a closed case, on the claim that it is a #691 regression: "`offered`
passes at 5719f823 and fails from b93a86c2". I ran the case, as checked in, in trees at three commits. It fails
`offered` at all of them:

| tree | outcome under the case's pin |
| --- | --- |
| `5719f823` (#691's parent) | `PinRefused: STAGE pin 'd1/smem' at STAGE@a3 names no stage this contraction can realize` |
| `4a4e6521` (#699's parent) | `STAGE pin 'd1/smem' does not resolve for this contraction` |
| `main` | `STAGE pin 'd1/smem' does not resolve for this contraction` |

The row as spelled — one site carrying `WORK w2x4`, `TILE mma_m16n8k16_f16_f16/f1x4/k8` and `STAGE d1/smem` — was
never enumerable for this program. Before #699 the kernel had two contraction sites: the `d1/smem` compute fill
lived on the P·V site (`@pj`, later `@n4`), the `f1x4/k8` f16-accumulate atom on the score site (`@a3` / `@n3`),
and `w2x4` was not in the WORK domain at all. #699 ("Enforce term closedness") retired the P·V child site: the
twist now carries P·V inside its carrier, the score contraction is the kernel's only TILE/STAGE site, and no edge
offers a fill stage. #699 recorded exactly that loss on the two cases that pinned the tier —
`sdpa-computed-value-cut-mma` and `qwen3emb/sdpa-s*` went from closed to `_xfail_offered` with the evidence
"offers no child contraction site yet".

So this is not a closed case that stopped passing; it is a third record of the gap #699 opened, filed without the
suffix the corpus uses for one. The row is also in no checked-in golden, at HEAD or at `d6a852ec` (the Aug 24
re-record #715 cites), so the "recorded RTX 5090 golden" is the PR author's own measurement; the evidence line now
attributes it as such.

## What this does

- `git mv` the case to `sdpa-hd128-softmax-v-mma_xfail_offered.yaml` — the corpus's spelling for a known gap — and
  rewrite its leading comment so the `# evidence:` line names why the tier should realize (the same
  P·V-on-tensor-cores evidence the two sibling open cases carry) and the provenance paragraph states what was
  verified instead of the bisect that does not reproduce.
- Add the `offered` node's duration to `tests/durations.json`, hand-inserted in sorted position: `make
  test-durations` on a GPU-less box would replace the whole baseline with this machine's timings.

On the rule "never add an `_xfail_` suffix to make a red test green": it guards a case that was green. This one was
authored red, its stated green point does not exist, and the corpus's own "Adding a case" flow is to add a known
gap *with* the suffix and prove it fails without it and passes with it — both shown here. The ratchet is intact:
the gap stays recorded on three cases, and closing it is a `git mv` on each.

## Verification

- `PYTHONPATH=$PWD make test` on a GPU-less Mac: 4144 passed, 1035 skipped, 21 xfailed, exit 0. The case reports
  `offered` XFAIL (strict) and `realized` / `built` / `correct` skipped; no durations-gate error.
- `make lint` clean. Nothing under `emmy/` changes, so `make test-goldens` does not apply.

## Follow-up, not this PR

Restoring a schedulable P·V contraction site on a twisted fold — the tier #699 retired — would close all three open
cases at once and is the compiler fix the 124x scalar fallback calls for. That is a feature, not a fix for a red
main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
