### PR TITLE
Revert the serial-work clamp: the kernel-set Σ prices rows as estimated, never bounded

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -403,18 +403,11 @@ is reached only by pointing `EMMY_OFFLINE_FILE` (or `--offline-file`) at it. Eac
 `provenance.scope`; read that before drawing conclusions from one, because a scoped artifact has no reason to beat
 the shipped weights outside the slice it was fit on.
 
-The proxy stays uncalibrated, and the one consumer that needs absolute µs enforces a physical bound instead: in
-the kernel-set Σ (`policy/greedy._resolved_price`), a summand whose serial-work lower bound
-(`features.serial_floor_us` — the row's per-thread serial trips, i.e. the nest-aware `S_ext_serial_cell_work`
-stamp after its reduce-partition coverage, at a per-trip constant conservative for any GPU clock) exceeds the
-enforcement guard (`_SERIAL_FLOOR_ENFORCE_US`, 1 ms) is clamped to that bound. No fitted weight can guarantee the bound at magnitudes no measurement
-can reach: DeepSeek-V4 `post4096`'s fused 2^30-trip recomputation nest priced 4.29e-37 µs and beat every
-recomputation-free composed-cut arm until the bound priced it honestly. The guard is jurisdiction, not tuning —
-the bound ignores launch overhead and memory traffic, so at ordinary magnitudes the model's ranking stands
-untouched, while a bound past the guard is un-servable whatever those effects are. A measured µs is never below
-the bound, so the clamp only ever lifts model garbage; the prior's own scoring surfaces are untouched, because
-any µs bound there collapses live-range sibling deltas — the plateau failure `latency_proxy`'s history warns
-about. (`D_serial_cell_work`, the same quantity log-scaled, rides the featurization as an ordinary fit signal.)
+The proxy stays uncalibrated, and nothing in the deploy path corrects it by hand: the kernel-set Σ
+(`policy/greedy._resolved_price`) sums each row's own price as stamped or estimated. Where the prior ends up deciding
+a production election, the defect is the missing evidence — no recorded golden or measured row for that kernel —
+and the fix is to record it, not to bound the estimate. (`D_serial_cell_work`, the stamped per-thread serial work
+log-scaled, rides the featurization as an ordinary fit signal.)
 
 What a newcomer needs to know about the fit:
 

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -430,8 +430,7 @@ def knob_features(knobs: dict) -> dict[str, float]:
     feats.setdefault("MMA_tier", 0.0)  # scalar tier / no schedule node = no warp atom
     work = _serial_cell_trips(knobs)
     if work:
-        # The one feature monotone in per-thread serial work — what the pricing policy's
-        # calibration bound (:func:`serial_floor_us`) rests on, and a fit signal for the priors.
+        # The one feature monotone in per-thread serial work — a fit signal for the priors.
         feats["D_serial_cell_work"] = math.log2(1.0 + work)
     return feats
 
@@ -447,27 +446,6 @@ def _serial_cell_trips(knobs: dict) -> float:
         return 0.0
     decomp = _reduce_decomp(knobs)
     return work / max(decomp.cta * decomp.coop, 1)
-
-
-#: Serial-work calibration bound, µs per per-thread serial trip. This is an ISSUE-RATE bound,
-#: not a dependency-latency one: even fully independent, perfectly pipelined trips each issue at
-#: least one instruction, and no current GPU issues a thread's instruction faster than ~0.1 ns —
-#: dependence chains, multi-statement bodies, or an ``Mma`` in the trip body only raise the true
-#: cost, never lower it. The one slack this leaves — a trip whose real cost is far above 0.1 ns —
-#: is absorbed by the enforcement guard at the consumer: the bound only ever decides where it is
-#: orders of magnitude past every legitimate kernel, so under-estimating a trip never flips an
-#: honest election.
-SERIAL_TRIP_FLOOR_US = 1e-4
-
-
-def serial_floor_us(knobs: dict) -> float:
-    """A physical lower bound, in µs, on one launch of the kernel the row ``knobs`` describes:
-    its per-thread serial trips at the per-trip bound. True regardless of any model, so a
-    kernel-set comparison may clamp an estimated summand to it — and a measured µs is never below
-    it, so clamping measurements is a no-op. It is a BOUND, not an estimate: it ignores launch
-    overhead and memory traffic, so its jurisdiction is where it is decisively large (the
-    enforcement guard lives with the clamp, ``policy/greedy._resolved_price``)."""
-    return _serial_cell_trips(knobs) * SERIAL_TRIP_FLOOR_US
 
 
 def _free_slots(knobs: dict) -> tuple[int, int, int, int] | None:

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -56,17 +56,6 @@ preference — the alternative is that an all-failed kernel has no ``ok`` row,
 therefore no evidence at all, and falls through to the prior as though nothing
 were known about it. That is how DeepSeek-V4's post block kept a fused arm whose
 every benched variant hung.
-
-**One physical bound, and it is not a preference.** The kernel-set Σ
-(:func:`_resolved_price`) clamps a summand to its serial-work lower bound where
-that bound is decisively large (:data:`_SERIAL_FLOOR_ENFORCE_US`). This is the
-one exception to "no hand-written tier", and it is an exception in the same
-sense the disqualification is: not a ranking opinion but a fact no measurement
-can overrule — no thread retires 2^30 dependent-nest trips in microseconds, and
-no measurement can even EXIST at such magnitudes (the bench watchdog fires
-first), so "fix it by measuring" is unavailable exactly where the bound binds.
-A measured µs is never below the bound, so evidence always wins where evidence
-can exist.
 """
 
 from __future__ import annotations
@@ -80,7 +69,6 @@ from typing import TYPE_CHECKING, NamedTuple
 from emmy.compiler.graph import Graph
 from emmy.compiler.pipeline.fork import Fork, flatten_leaves, fork_signature, iter_leaves, leaf_for, leaf_knobs
 from emmy.compiler.pipeline.knob import schedule_pin_fingerprint
-from emmy.compiler.pipeline.search.features import serial_floor_us
 
 logger = logging.getLogger(__name__)
 
@@ -231,18 +219,6 @@ def _decision_key(fp: ForkPoint, blocked: dict | None) -> tuple | None:
     )
 
 
-#: Enforcement guard for the serial-work bound (µs): the clamp in :func:`_resolved_price` applies
-#: only to a kernel whose bound exceeds this — 1 ms, three orders above launch overhead and three
-#: below the bench watchdog. Below it the bound sits inside the range launch overhead and memory
-#: traffic legitimately dominate, and the model's ranking (however uncalibrated) must stand;
-#: above it per-thread serial work alone makes the kernel un-servable and nothing may price it
-#: lower. The lower edge is pinned by measurement: the largest legitimate ``serial_floor_us``
-#: across the qwen3emb realization corpus family is **6.55 µs** (``sdpa-s512``'s fused kernel,
-#: 2^16 serial trips — a shape whose fused election is correct and pinned by its ``realized``
-#: replay), so 1 ms stands ~150x above the biggest bound the guard must ignore.
-_SERIAL_FLOOR_ENFORCE_US = 1e3
-
-
 def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: dict | None = None) -> float | None:
     """Σ over a resolved slice's kernels of each one's estimated µs — the ONE cost rule.
 
@@ -270,24 +246,7 @@ def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: d
     measured µs, one the model decided contributes the model's ranking score. Mixing them in a Σ is
     the known cost of comparing kernel SETS with a per-kernel ranker — the exposure the module
     docstring names, and the prior's to fix by being calibrated, not this function's to paper
-    over. What this Σ DOES enforce is the physical bound no calibration could relax: a summand
-    whose serial-work lower bound (:func:`~..features.serial_floor_us` — the kernel's per-thread
-    serial trips at a per-trip time conservative for any GPU clock) exceeds
-    :data:`_SERIAL_FLOOR_ENFORCE_US` is clamped to that bound. A measured µs is never below the
-    bound, so the clamp only ever lifts model garbage: the cold proxy priced DeepSeek-V4
-    ``post4096``'s fused 2^30-trip recomputation nest at 4.29e-37 µs, under every one of its
-    recomputation-free composed-cut arms, and no fitted weight can guarantee the bound at
-    magnitudes no measurement can reach. The guard is jurisdiction, not tuning: the bound ignores
-    launch overhead and memory traffic, so at ordinary magnitudes it must not adjudicate a
-    fused-vs-cut µs delta (an ungated draft flipped three qwen3emb sdpa corpus replays to a cut
-    election by comparing trip counts alone) — while a bound past the guard is un-servable
-    whatever those effects are. The guard's honest escape: a nest under ~2^23 per-thread trips
-    (bound < 1 ms; several ms real) is still adjudicated by the uncalibrated proxy, so a
-    2^23-class recomputation defect stays electable — smaller than the 2^30 class this bound
-    exists for, but not free. Sibling ranking within one kernel is decided upstream and never
-    reads this Σ, which is what makes the clamp safe here and NOT on the prior's scoring
-    surfaces (there any µs bound collapses live-range deltas — the plateau failure
-    ``latency_proxy``'s history warns about)."""
+    over."""
     scored: dict[str, float | None] = {d.node_id: d.score for d in trace}
     total = 0.0
     for nid, node in terminal.nodes.items():
@@ -312,8 +271,7 @@ def _resolved_price(terminal: Graph, trace: list, ctx: Context, prior, failed: d
             us = prior.mean_scores(rows)[0] if prior is not None else None
         if us is None:
             return None
-        floor = serial_floor_us(knobs)
-        total += max(us, floor) if floor > _SERIAL_FLOOR_ENFORCE_US else us
+        total += us
     return total
 
 

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -180,7 +180,8 @@ gaps stand between here and a boot that serves, both follow-ups to #692:
    cold-start answer. NOTE: the host's tune DB now carries those 9 rows, so any unpinned compile there elects the
    partitioned route — intended, now that #700 makes it build.
 3. **Price the recomputation so the statistics piece gets elected — LANDED (#702), then the clamp REVERTED by
-   review decision; the statistics piece elected under it measured 8.6 ms on the host.** Even the elected 2³⁰ route ran past the 60 s bench watchdog
+   review decision; the statistics piece elected under it measured 8.6 ms on the host.** Even the elected 2³⁰ route
+   ran past the 60 s bench watchdog
    per launch: the dominant cost was re-evaluating the mHC statistics subtree 16,384× (4096 carrier positions × 4
    streams) inside the consumer piece's sum-of-squares reduce. Characterized GPU-free: the materializing seam
    (`PLACE@a8`, the gate's fn-projection) was OFFERED and priced away — the offline cold-start proxy gave the

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -179,20 +179,21 @@ gaps stand between here and a boot that serves, both follow-ups to #692:
    disqualifications, and no online prior was written. The monotone serial-work prior feature remains the
    cold-start answer. NOTE: the host's tune DB now carries those 9 rows, so any unpinned compile there elects the
    partitioned route — intended, now that #700 makes it build.
-3. **Price the recomputation so the statistics piece gets elected — LANDED (#702), and the elected statistics
-   piece measures 8.6 ms on the host.** Even the elected 2³⁰ route ran past the 60 s bench watchdog
+3. **Price the recomputation so the statistics piece gets elected — LANDED (#702), then the clamp REVERTED by
+   review decision; the statistics piece elected under it measured 8.6 ms on the host.** Even the elected 2³⁰ route ran past the 60 s bench watchdog
    per launch: the dominant cost was re-evaluating the mHC statistics subtree 16,384× (4096 carrier positions × 4
    streams) inside the consumer piece's sum-of-squares reduce. Characterized GPU-free: the materializing seam
    (`PLACE@a8`, the gate's fn-projection) was OFFERED and priced away — the offline cold-start proxy gave the
    fused 2³⁰-trip nest 4.29e-37 µs against the cut arm's 1.02e-17, with zero weights on any structural feature.
-   The landed fix is pricing: the nest-aware `S_ext_serial_cell_work` stamp, the coverage-adjusted
-   `D_serial_cell_work` feature, and a guarded clamp at the kernel-set Σ (`policy/greedy._resolved_price`) — a
-   kernel whose serial-work lower bound exceeds 1 ms prices at least that bound; below the guard elections stand
-   untouched, so a future recomputation nest under ~2²³ per-thread trips is still adjudicated by the uncalibrated
-   proxy. (Plus: disqualification signatures survive featurizer vocabulary growth — the stamp alone had silenced
-   the host DB's 9 `bench_fail` rows — and `SearchDB` schema v4 drops stale `lowering` chains keyed pre-stamp.)
-   Replayed on the pinned twins + host-DB copy, the greedy elects the same 12-piece plan plus exactly the
-   `PLACE@a8` statistics piece — 13 kernels, the consumer drops 2³⁰ → 2¹⁶ and the route's worst piece is 2¹⁹
+   #702 answered with pricing: the nest-aware `S_ext_serial_cell_work` stamp, the `D_serial_cell_work` fit signal,
+   and a guarded clamp at the kernel-set Σ that priced a kernel at least its serial-work lower bound past 1 ms.
+   The clamp was reverted on review: a lower bound on the prior's estimate is not how the deploy path elects —
+   the prior must not decide a production election at all, and where it does, the missing golden or measured row
+   is the defect. The stamp and fit signal stay (the prior can learn serial work), as do the two fixes that rode
+   the same PR: disqualification signatures survive featurizer vocabulary growth (the stamp alone had silenced
+   the host DB's 9 `bench_fail` rows) and `SearchDB` schema v4 dropping stale `lowering` chains keyed pre-stamp.
+   Under the clamp, replayed on the pinned twins + host-DB copy, the greedy elected the same 12-piece plan plus
+   exactly the `PLACE@a8` statistics piece — 13 kernels, the consumer drops 2³⁰ → 2¹⁶ and the route's worst piece is 2¹⁹
    per-thread trips (the unaided fused monster was 2³⁸).
 4. **Make the elected pieces fast — OPEN; the path is now recorded goldens, not pricing.** Measured on the host
    2026-09-02: the elected route benched completely for the first time (every earlier attempt died on the 60 s

--- a/tests/compiler/pipeline/search/policy/test_greedy.py
+++ b/tests/compiler/pipeline/search/policy/test_greedy.py
@@ -140,52 +140,6 @@ def test_an_empty_recorded_signature_condemns_nothing() -> None:
     assert greedy._resolved_price(terminal, trace, ctx, None, failed={frozenset(): [2_000_000.0]}) == 5.0
 
 
-def _priced(kernels: dict[str, tuple[dict, float]]) -> float:
-    """``_resolved_price`` over SimpleNamespace kernels: ``{node_id: (knobs, traced score)}``."""
-    terminal = SimpleNamespace(
-        nodes={nid: SimpleNamespace(op=SimpleNamespace(knobs=knobs, identity_key=lambda **_kw: "k")) for nid, (knobs, _) in kernels.items()}
-    )
-    trace = [SimpleNamespace(node_id=nid, score=score) for nid, (_, score) in kernels.items()]
-    return greedy._resolved_price(terminal, trace, SimpleNamespace(features=lambda: {}), None)
-
-
-def test_the_kernel_set_price_enforces_the_serial_work_bound():
-    """A summand whose serial-work lower bound is past the enforcement guard prices at least that
-    bound. Measured live on DeepSeek-V4 ``post4096``: the cold proxy priced the fused 2^30-trip
-    recomputation nest at 4.29e-37 µs, UNDER its recomputation-free composed-cut arms (best
-    1.02e-17 µs Σ), so the greedy kept the nest; bounded, the fused arm prices its honest ~1e5 µs
-    and loses."""
-    garbage = 4.29e-37
-    fused_monster = _priced({"n": ({"S_ext_serial_cell_work": float(2**30)}, garbage)})
-    assert fused_monster == pytest.approx(float(2**30) * 1e-4, rel=1e-6)
-    cut_arm = _priced(
-        {
-            "p": ({"S_ext_serial_cell_work": float(2**16)}, garbage),
-            "c": ({"S_ext_serial_cell_work": float(2**16)}, garbage),
-        }
-    )
-    assert cut_arm < fused_monster  # the recomputation nest loses on its serial-work bound
-
-
-def test_the_serial_bound_has_no_jurisdiction_at_ordinary_magnitudes():
-    """The bound ignores launch overhead and memory traffic, so below the enforcement guard the
-    model's ranking stands exactly as before — an ungated draft flipped three qwen3emb sdpa
-    corpus replays to a cut election by comparing trip counts alone. The 2^16 row IS the largest
-    of those shapes (``sdpa-s512``'s fused kernel, ``serial_floor_us`` 6.55 µs — the biggest
-    legitimate floor measured across the qwen3emb corpus family), so lowering the guard under it
-    breaks this test before it breaks the corpus. And a measured µs is never below the bound, so
-    the clamp is a no-op on it even past the guard."""
-    from emmy.compiler.pipeline.search.features import serial_floor_us
-
-    sdpa_s512 = {"S_ext_serial_cell_work": float(2**16)}
-    assert serial_floor_us(sdpa_s512) < greedy._SERIAL_FLOOR_ENFORCE_US
-    garbage = 4.29e-37
-    fused_small = _priced({"n": (sdpa_s512, garbage)})
-    assert fused_small == pytest.approx(garbage)  # bound 6.55 µs — inside the guard, not enforced
-    measured = _priced({"n": ({"S_ext_serial_cell_work": float(2**30)}, 2_000_000.0)})
-    assert measured == 2_000_000.0  # a measured µs already satisfies the bound
-
-
 def test_schedule_pick_descends_directly_to_complete_measured_row() -> None:
     materialized = []
     rows = [{"TILE": str(tile), "STAGE": str(stage)} for tile in range(100) for stage in range(100)]

--- a/tests/compiler/pipeline/test_knob.py
+++ b/tests/compiler/pipeline/test_knob.py
@@ -346,18 +346,6 @@ def test_knob_features_serial_cell_work_divides_by_reduce_coverage():
     assert "D_serial_cell_work" not in knob_features({"S_n_load": 3.0})
 
 
-def test_serial_floor_is_the_covered_trips_at_the_per_trip_bound():
-    """``serial_floor_us``: a physical lower bound on one kernel-launch — the row's per-thread
-    serial trips (stamp ÷ reduce-partition coverage) at the per-trip bound; zero with no stamp."""
-    from emmy.compiler.pipeline.search.features import SERIAL_TRIP_FLOOR_US, serial_floor_us
-
-    work = float(2**20)
-    assert serial_floor_us({"S_ext_serial_cell_work": work}) == pytest.approx(work * SERIAL_TRIP_FLOOR_US)
-    coop = serial_floor_us({"S_ext_serial_cell_work": work, "WORK": "t128", "REDUCE": "coop"})
-    assert coop == pytest.approx(work / 128 * SERIAL_TRIP_FLOOR_US)
-    assert serial_floor_us({}) == 0.0
-
-
 def test_knob_features_stage_codec():
     """The ``STAGE`` codec (``d<depth>/copy|reg|cp|tma[/p<reg_depth>]``) featurizes to the
     ``D_stage_*`` family; an absent / gmem-direct stage contributes nothing."""


### PR DESCRIPTION
Follows the review decision on #706 / #708 ("remove the lower bound hack — if the prior kicks in, the golden is not replayed or not present for the kernel"): this removes the one that was already merged, #702's clamp.

**Removed.** `features.serial_floor_us` and its per-trip constant, the enforcement guard `_SERIAL_FLOOR_ENFORCE_US`, and the clamp in `policy/greedy._resolved_price` — the kernel-set Σ now sums each row's price as stamped or estimated, with no hand-written bound. Their tests (three) and the doc paragraphs describing the bound go with them; the pipeline ARCHITECTURE now states the rule the other way round: where the prior ends up deciding a production election, the defect is the missing recorded golden or measured row for that kernel, and the fix is to record it.

**Kept from #702**, deliberately: the `S_ext_serial_cell_work` stamp and the `D_serial_cell_work` fit signal (the prior can *learn* serial work — that is the "fix the prior" direction, and dropping the stamp would force another corpus restamp and schema bump for no behavioral change); the disqualification-signature match that survives featurizer vocabulary growth (without it a tune DB's `bench_fail` rows stop binding); and SearchDB schema v4. Say if the stamp should go too.

Core line balance: `emmy/` −71 lines. `make lint` clean. `make test`: 4141 passed; the 2 failures are `attention/sdpa-hd128-softmax-v-mma.yaml` at `offered`/`realized`, which fail identically on `main` since #715 (being handled separately).

The DeepSeek serving plan's round-three item 3 records the revert; item 4 already describes the recorded-golden path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)