### PR TITLE
Sibling reduce loops: merge two alpha-equal copies of one cone

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -517,21 +517,21 @@ canonicalized before validation:
   so the same rule keeps it outside the axes it partitions without a naming convention.
 
 - `eliminate_copy_aliases` — drop `y = copy(x)` Assigns.
-- `unify_sibling_reduce_axes` — rename sibling reduce Loops whose
-  reduce-axis Load positions overlap on any `(source, dim)` pair so
-  they share one canonical axis name (softmax's max + sum sweeps; the
-  two matmul reductions in `silu(x@Wg) * (x@Wu)` that both index `x`
-  at the same K slot). Union-find groups all transitively-overlapping
-  Loops at one scope.
-- `merge_sibling_reduce_loops` — concatenate sibling reduce Loops that
-  share `axis.name` / `extent` into one Loop body. Gated on disjoint
-  SSA defs across the two halves, the second body not reading any name
-  the first body defines (blocks softmax-style sequential reduces
-  where sum-exp reads `acc_max`), and no between-stmt def consumed by
-  the second loop. Eliminates the duplicate K traversal in patterns
-  like `silu(x@Wg) * (x@Wu)`; subsequent normalization collapses the
-  duplicate `x` loads, and the lowering passes stage both weight tensors
-  symmetrically.
+- `unify_sibling_reduce_axes` — rename sibling reduce Loops whose reduce-axis Load positions overlap so they share one
+  canonical axis name (softmax's max + sum sweeps; the two matmul reductions in `silu(x@Wg) * (x@Wu)` that both index
+  `x` at the same K slot). A position is `(source, dim, anchor, coefficient)`, read through `affine_form`: a blocked
+  reduce indexes its stream at `o·B + i` and still walks that dimension, while the anchor keeps `o·B + i` apart from
+  `o·B + 32 + j`, which walk different halves. Union-find groups all transitively-overlapping Loops at one scope.
+- `merge_sibling_reduce_loops` — concatenate sibling reduce Loops that share `axis.name` / `extent` into one Loop body.
+  Every gate is phrased over what the second Loop reads from its ENCLOSING scope (`free_names` — what it uses and does
+  not bind itself): it must read no name the first body defines (blocking softmax-style sequential reduces where
+  sum-exp reads `acc_max`), and no between-stmt def. Names both bodies merely happen to bind are a COLLISION, not a
+  dependence — two alpha-equal copies of one cone always share every spelling — so the incoming body's copies rename
+  apart. Only a name the incoming Loop still binds after it closes (its immediate carriers, which `Loop.render`
+  declares ahead of the loop) refuses, because the rename cannot reach that name's readers outside. Eliminates the
+  duplicate K traversal in patterns like `silu(x@Wg) * (x@Wu)`, and the duplicate score pass between the channels of a
+  blocked twisted carrier; subsequent normalization collapses the duplicate loads, and the lowering passes stage both
+  weight tensors symmetrically.
 - `split_invariant_divides` — rewrite `divide(x, y)` into
   `reciprocal(y) + multiply(x, recip)` when `y` is loop-invariant
   w.r.t. some axis `x` depends on, so the rcp can hoist out of the

--- a/emmy/compiler/ir/stmt/normalize.py
+++ b/emmy/compiler/ir/stmt/normalize.py
@@ -1,26 +1,33 @@
 """Body-level normalization passes.
 
 Pure ``body → body`` transforms applied via :func:`normalize_body` from
-``LoopOp.__post_init__`` and ``TileOp.__post_init__`` so every constructed
-Op lands in canonical form. The passes operate on the shared Stmt
-vocabulary (``Loop``, ``Load``, ``Assign``, ``Accum``, ``Select``,
-``Write``) and recurse through every block-structured Stmt
-(``Loop`` / ``StridedLoop`` / ``Tile`` / ``Cond``) so they apply uniformly
-to Loop IR and Tile IR bodies.
+``LoopOp.__post_init__`` and from :meth:`Body.structural_key`, so a
+constructed Loop-IR Op and every identity digest land in canonical form. The
+passes operate on the shared Stmt vocabulary (``Loop``, ``Load``, ``Assign``,
+``Accum``, ``Select``, ``Write``) and recurse through every block-structured
+Stmt (``Loop`` / ``StridedLoop`` / ``Tile`` / ``Cond``).
+
+A ``TileOp`` does NOT run these: it normalizes its TERM
+(``normalize_fold_tree``), and the kernel it materializes is built straight
+from ``Fold.lower``. So a body these passes could improve reaches the emitter
+unchanged whenever it comes down the term path — the sibling-loop merge below
+is reachable from Loop IR and from the digest, not from a materialized
+``KernelOp``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import replace
+from itertools import count
 
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import Expr, Literal, SimplifyCtx, Var, affine_form
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.stmt.blocks import Cond, Loop, StridedLoop
-from emmy.compiler.ir.stmt.body import Body
-from emmy.compiler.ir.stmt.leaves import Accum, Assign, Init, Load, Pack, Select, Unpack, Write
+from emmy.compiler.ir.stmt.body import Body, free_names
+from emmy.compiler.ir.stmt.leaves import Accum, Assign, Init, Load, Mma, Pack, Select, Unpack, Write
 
 # ---------------------------------------------------------------------------
 # Visitor helpers shared by every pass below
@@ -317,7 +324,7 @@ def _unify_siblings(body: Body) -> Body:
     # extents matches both static and symbolic siblings: two ``Dim('seq_len')``
     # siblings unify (both back to ``Var('seq_len')``); two distinct symbolic
     # names don't. ``Expr`` is frozen + hashable so it slots into the tuple key.
-    entries: list[tuple[int, str, object, frozenset[tuple[str, int]]]] = []
+    entries: list[tuple[int, str, object, frozenset[tuple[str, int, object, int]]]] = []
     for i, s in enumerate(stmts):
         if isinstance(s, Loop) and s.is_reduce:
             positions = _reduce_axis_source_positions(s.body, s.axis.name)
@@ -360,17 +367,33 @@ def _unify_siblings(body: Body) -> Body:
     return Body(stmts)
 
 
-def _reduce_axis_source_positions(body: Body, reduce_axis_name: str) -> set[tuple[str, int]]:
-    """Collect ``(source, dim)`` positions where ``Var(reduce_axis_name)``
-    appears bare in a Load index within ``body`` (recursing into nested
-    blocks)."""
-    return {
-        (s.input, dim)
-        for s in body.iter()
-        if isinstance(s, Load)
-        for dim, e in enumerate(s.index)
-        if isinstance(e, Var) and e.name == reduce_axis_name
-    }
+def _reduce_axis_source_positions(body: Body, reduce_axis_name: str) -> set[tuple[str, int, object, int]]:
+    """Collect ``(source, dim, anchor, coefficient)`` positions where a Load index within ``body``
+    is AFFINE in ``Var(reduce_axis_name)`` (recursing into nested blocks).
+
+    A bare ``Var`` is the ``(source, dim, 0, 1)`` case, so this generalizes the original bare-Var
+    reading rather than replacing it. Affine matters because a BLOCKED reduce reads its stream at
+    ``outer·B + inner``: the axis still walks that dimension, and refusing to see it left sibling
+    loops over one block unmergeable for no semantic reason.
+
+    The anchor and coefficient ride the key because that is what makes the reading sound. Two
+    siblings indexing ``x[…, o·B + i]`` and ``x[…, o·B + j]`` walk the SAME dimension and unify;
+    ``o·B + i`` against ``o·B + 32 + j`` walk different halves and must not. ``(source, dim)`` alone
+    cannot tell those apart — seeing through the offset would be a miscompile, not a generalization.
+    """
+    out: set[tuple[str, int, object, int]] = set()
+    for s in body.iter():
+        if not isinstance(s, Load):
+            continue
+        for dim, e in enumerate(s.index):
+            form = affine_form(e, {reduce_axis_name})
+            if form is None:
+                continue
+            anchor, coeffs = form
+            coeff = coeffs.get(reduce_axis_name, 0)
+            if coeff:
+                out.add((s.input, dim, anchor, coeff))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -395,20 +418,22 @@ def merge_sibling_reduce_loops(stmts: Body) -> Body:
     """Merge sibling reduce ``Loop``s with matching ``axis.name`` and
     ``axis.extent`` into one Loop whose body is the concatenation.
 
-    Gates a merge on three conditions:
+    Gates a merge on three conditions, all phrased over what the second Loop
+    reads from its enclosing scope (:func:`free_names` — what it uses and does
+    not bind itself):
 
-    1. The two bodies have disjoint SSA defs — no name collision and
-       no inner-scope shadowing once they share one Loop.
-    2. The second Loop's body does not read any SSA name the first
-       Loop's body defines (including ``Accum`` exports). When it
-       does, the two reductions are sequentially dependent — e.g.
-       softmax's sum-exp loop reads ``acc_max`` from the preceding
-       max loop. Merging would replace that read of the *finalized*
-       max with a read of the in-flight per-iter value, changing
-       semantics.
-    3. No statement that sits between the two Loops defines an SSA
-       name the second Loop's body reads — otherwise the merge would
-       move that read above its def.
+    1. It reads no SSA name the first Loop's body defines. When it does, the
+       two reductions are sequentially dependent — e.g. softmax's sum-exp loop
+       reads ``acc_max`` from the preceding max loop. Merging would replace
+       that read of the *finalized* max with a read of the in-flight per-iter
+       value, changing semantics.
+    2. No statement between the two Loops defines a name it reads — otherwise
+       the merge would move that read above its def.
+    3. The names both bodies happen to bind are a COLLISION, not a dependence,
+       and the incoming body's copies rename apart — which is what makes two
+       alpha-equal copies of one cone mergeable at all. Only a name the incoming
+       Loop still binds after it closes (:func:`_carried_out`) refuses: the
+       rename cannot reach the readers that name has outside the loop.
 
     Statements that sit between the two original Loops stay in their
     original positions in the parent Body. References to the first
@@ -432,6 +457,32 @@ def merge_sibling_reduce_loops(stmts: Body) -> Body:
         return _merge_sibling_reduce_loops(Body(recursed))
 
     return walk(stmts)
+
+
+def _carried_out(body: Body) -> frozenset[str]:
+    """The names a ``Loop`` over ``body`` still binds after it CLOSES.
+
+    :meth:`Loop.render` declares the carriers of the immediate body ahead of the loop, so those —
+    and, under a nested loop that does not seed its own, that loop's carriers too — are the names a
+    later statement can still read. Every other definition lives inside the block the loop closes,
+    which is what makes it renamable when two loops merge.
+    """
+    out = {name for stmt in body if isinstance(stmt, (Accum, Mma)) for name in stmt.carried_names()}
+    for stmt in body:
+        if isinstance(stmt, Loop) and not stmt.seed:
+            out |= _carried_out(stmt.body)
+    return frozenset(out)
+
+
+def _rename_apart(body: Body, clashing: frozenset[str], taken: frozenset[str]) -> Body:
+    """``body`` with each name in ``clashing`` renamed to one neither side spells."""
+    used = set(body.ssa_defs) | set(body.ssa_uses) | set(taken)
+    mapping: dict[str, str] = {}
+    for name in sorted(clashing):
+        fresh = next(candidate for n in count(1) if (candidate := f"{name}__m{n}") not in used)
+        mapping[name] = fresh
+        used.add(fresh)
+    return Body(tuple(s.rename(mapping) for s in body))
 
 
 def _merge_sibling_reduce_loops(body: Body) -> Body:
@@ -458,24 +509,37 @@ def _merge_sibling_reduce_loops(body: Body) -> Body:
                 and t.axis.name == merged.axis.name
                 and t.axis.extent == merged.axis.extent
                 and t.unroll == merged.unroll
+                and t.seed == merged.seed
             ):
                 continue
+            # ONE reading of what the incoming loop needs from around it: the names it reads and
+            # does not bind itself. A name it both defines and uses is its own local — which is
+            # what two alpha-equal copies of a single cone always share — and counting those as
+            # reads reports a dependence that is not there.
+            reads = free_names(t)
             merged_defs = Body.coerce(merged.body).ssa_defs
-            if merged_defs & Body.coerce(t.body).ssa_defs:
+            if merged_defs & reads:
                 continue
-            if merged_defs & Body.coerce(t.body).ssa_uses:
+            incoming = Body.coerce(t.body)
+            # What is left of the shared spellings is a COLLISION, not a dependence: two bodies
+            # binding one name for unrelated values. Renaming the incoming body's copy apart is
+            # sound for every name the loop closes over; a name it still binds afterwards has
+            # readers the rename cannot reach, so that one refuses.
+            clashing = merged_defs & incoming.ssa_defs
+            if clashing & _carried_out(incoming):
                 continue
             between_defs: set[str] = set()
             for k in range(i + 1, j):
                 if k in consumed:
                     continue
                 between_defs |= Body.coerce(Body((items[k],))).ssa_defs
-            if between_defs & Body.coerce(t.body).ssa_uses:
+            if between_defs & reads:
                 continue
             merged = Loop(
                 axis=merged.axis,
-                body=Body(tuple(merged.body) + tuple(t.body)),
+                body=Body(tuple(merged.body) + tuple(_rename_apart(incoming, clashing, merged_defs))),
                 unroll=merged.unroll,
+                seed=merged.seed,
             )
             consumed.add(j)
         out.append(merged)

--- a/tests/compiler/ir/stmt/test_merge_sibling_reduce_loops.py
+++ b/tests/compiler/ir/stmt/test_merge_sibling_reduce_loops.py
@@ -12,7 +12,7 @@ then merge must concatenate the bodies into one K-loop.
 from __future__ import annotations
 
 from emmy.compiler.ir.axis import Axis
-from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.stmt.blocks import Loop
 from emmy.compiler.ir.stmt.body import Body
 from emmy.compiler.ir.stmt.leaves import Accum, Assign, Load, Write
@@ -187,9 +187,10 @@ def test_merge_skips_when_second_loop_reads_first_loops_accum() -> None:
     assert len(loops) == 2, "softmax-style sequential reduces must stay distinct"
 
 
-def test_merge_skips_on_ssa_name_collision() -> None:
-    """If both bodies define the same SSA name, merging would create
-    inner-scope shadowing — skip rather than guess a rename."""
+def test_merge_renames_a_colliding_local_rather_than_refusing() -> None:
+    """Two bodies binding one name for UNRELATED values is a collision, not a dependence — and it
+    is what alpha-equal copies of a single cone always look like. The incoming body's local is
+    renamed apart and the merge proceeds."""
     a = Axis("k", 16)
     body = Body(
         (
@@ -201,7 +202,91 @@ def test_merge_skips_on_ssa_name_collision() -> None:
     out = merge_sibling_reduce_loops(body)
 
     loops = [s for s in out if isinstance(s, Loop)]
-    assert len(loops) == 2, "name collision on 'v' must block the merge"
+    assert len(loops) == 1
+    loads = {s.input: s.names[0] for s in loops[0].body if isinstance(s, Load)}
+    assert loads["A"] != loads["B"], "each half keeps its own binding"
+    accums = {s.name: s.value for s in loops[0].body if isinstance(s, Accum)}
+    assert accums["acc0"] == loads["A"] and accums["acc1"] == loads["B"]
+
+
+def test_merge_refuses_a_collision_on_a_name_the_loop_still_binds() -> None:
+    """A carrier of the incoming Loop's own scope is declared ahead of that loop and read after
+    it, so a rename could not reach its readers. That one collision refuses."""
+    a = Axis("k", 16)
+    body = Body(
+        (
+            Loop(axis=a, body=(Load(name="p", input="A", index=(Var("k"),)), Accum(name="acc", value="p"))),
+            Loop(axis=a, body=(Load(name="q", input="B", index=(Var("k"),)), Accum(name="acc", value="q"))),
+            Write(output="out", index=(Var("n"),), value="acc"),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    assert len([s for s in out if isinstance(s, Loop)]) == 2
+
+
+def test_merge_renames_an_accum_that_stays_inside() -> None:
+    """The counterpart, and the case a blocked reduce hits: an ``Accum`` bound in a NESTED loop
+    crosses that loop's boundary but is consumed within this body. Nothing outside reads it, so it
+    renames apart like any other local."""
+    outer, inner = Axis("k", 16), Axis("d", 8)
+
+    def half(tag: str) -> Loop:
+        return Loop(
+            axis=outer,
+            body=(
+                Loop(axis=inner, body=(Load(name="v", input=tag, index=(Var("k"), Var("d"))), Accum(name="acc0", value="v"))),
+                Accum(name=f"out_{tag}", value="acc0"),
+            ),
+        )
+
+    out = merge_sibling_reduce_loops(Body((half("A"), half("B"))))
+
+    assert len([s for s in out if isinstance(s, Loop)]) == 1
+
+
+def test_unify_groups_loops_indexed_affinely_in_the_reduce_axis() -> None:
+    """A BLOCKED reduce reads its stream at ``outer·B + inner``. The axis still walks that
+    dimension, so siblings over one block must unify — refusing anything but a bare ``Var`` left
+    them unmergeable for no semantic reason."""
+    o = Var("o")
+    blocked = [
+        Loop(
+            axis=Axis(name, 64),
+            body=(
+                Load(name=f"v_{name}", input="x", index=(BinaryExpr("+", BinaryExpr("*", o, Literal(64, "int")), Var(name)),)),
+                Accum(name=f"acc_{name}", value=f"v_{name}"),
+            ),
+        )
+        for name in ("i", "j")
+    ]
+
+    out = unify_sibling_reduce_axes(Body(tuple(blocked)))
+
+    names = {s.axis.name for s in out if isinstance(s, Loop)}
+    assert len(names) == 1, "affine siblings over one block index the same dimension"
+
+
+def test_unify_keeps_apart_blocks_at_different_offsets() -> None:
+    """``o·B + i`` and ``o·B + 32 + j`` walk different halves of the same dimension. Seeing through
+    the offset would unify them and miscompile; the anchor is on the key so they stay distinct."""
+    o = Var("o")
+
+    def at(name: str, extra: int) -> Loop:
+        base = BinaryExpr("*", o, Literal(64, "int"))
+        shifted = base if not extra else BinaryExpr("+", base, Literal(extra, "int"))
+        return Loop(
+            axis=Axis(name, 32),
+            body=(
+                Load(name=f"v_{name}", input="x", index=(BinaryExpr("+", shifted, Var(name)),)),
+                Accum(name=f"acc_{name}", value=f"v_{name}"),
+            ),
+        )
+
+    out = unify_sibling_reduce_axes(Body((at("i", 0), at("j", 32))))
+
+    assert len({s.axis.name for s in out if isinstance(s, Loop)}) == 2
 
 
 def test_merge_skips_when_between_stmt_def_used_by_second_loop() -> None:
@@ -306,3 +391,109 @@ def test_unify_then_merge_collapses_gated_mlp_pattern() -> None:
     assert accs_inside == ["acc0", "acc1"]
     x_loads = [s for s in loops[0].body if isinstance(s, Load) and s.input == "x"]
     assert len(x_loads) == 2, "dedup happens in a later pass — merge alone leaves both x loads"
+
+
+def test_merge_collapses_three_alpha_equal_siblings() -> None:
+    """Merging is pairwise, so a third copy has to fold into the pair already merged: each binds
+    ``acc0`` for its own value, and all three end up in one loop."""
+    outer, inner = Axis("k", 16), Axis("d", 8)
+
+    def half(tag: str) -> Loop:
+        return Loop(
+            axis=outer,
+            body=(
+                Loop(axis=inner, body=(Load(name="v", input=tag, index=(Var("k"), Var("d"))), Accum(name="acc0", value="v"))),
+                Accum(name=f"out_{tag}", value="acc0"),
+            ),
+        )
+
+    out = merge_sibling_reduce_loops(Body((half("A"), half("B"), half("C"))))
+
+    assert len([s for s in out if isinstance(s, Loop)]) == 1
+
+
+def _blocked_channel(block: Axis, inner: Axis, tag: str, tail: tuple) -> Loop:
+    """One inner fold of a blocked twisted carrier: re-derive the score over the block, weigh it
+    against the block pivot, then accumulate this channel's own contribution.
+
+    Every channel is an alpha-equal copy of the same cone down to the spellings — the weight's
+    temps come out of ONE stored combine — and each recomputes the score, which is the recompute
+    the merge exists to remove.
+    """
+    score = BinaryExpr("+", BinaryExpr("*", Var("a2_o"), Literal(64, "int")), Var(block.name))
+    return Loop(
+        axis=block,
+        body=(
+            Loop(
+                axis=inner,
+                body=(
+                    Load(name="in1", input="x0", index=(Var(inner.name),)),
+                    Load(name="in2", input="x1", index=(score, Var(inner.name))),
+                    Assign(name="v0", op="multiply", args=("in1", "in2")),
+                    Accum(name="acc0", value="v0"),
+                ),
+            ),
+            Assign(name="v1", op="multiply", args=("acc0", "scale")),
+            Assign(name="acc1__o__gn", op="maximum", args=("acc1__blk", "v1")),
+            Assign(name="acc1__o__dg_o", op="subtract", args=("v1", "acc1__o__gn")),
+            Assign(name="acc1__o__beta", op="exp", args=("acc1__o__dg_o",)),
+            *tail,
+            Accum(name=f"{tag}__blk", value=f"{tag}__blk__e"),
+        ),
+    )
+
+
+def test_merge_collapses_the_channel_loops_of_a_blocked_twisted_carrier() -> None:
+    """The shape blocking attention's carrier produces: a block pivot, then one inner loop per
+    channel, all over the same block. The pivot must stay apart — the weight reads its finished
+    accumulator — and the channels must collapse, which is what takes ``Q·K`` from three passes
+    over the block to two.
+
+    The enclosing scope re-binds the very temps the channels use (``acc1__o__gn`` and friends are
+    the stored combine's, instantiated in both places), so a merge gate that asks whether a name
+    is read anywhere around the pair — instead of what the loop itself still binds — refuses here.
+    """
+    block, inner = Axis("a2_p", 64), Axis("a3", 32)
+    score = BinaryExpr("+", BinaryExpr("*", Var("a2_o"), Literal(64, "int")), Var("a2_p"))
+    pivot = Loop(
+        axis=block,
+        body=(
+            Loop(
+                axis=inner,
+                body=(
+                    Load(name="in1", input="x0", index=(Var("a3"),)),
+                    Load(name="in2", input="x1", index=(score, Var("a3"))),
+                    Assign(name="v0", op="multiply", args=("in1", "in2")),
+                    Accum(name="acc0", value="v0"),
+                ),
+            ),
+            Assign(name="acc1__blk__e", op="multiply", args=("acc0", "scale")),
+            Accum(name="acc1__blk", value="acc1__blk__e"),
+        ),
+    )
+    expectation = _blocked_channel(
+        Axis("a2_c1", 64),
+        inner,
+        "acc5__sum",
+        (
+            Load(name="in7", input="x2", index=(score, Var("a5"))),
+            Assign(name="acc5__sum__blk__e", op="multiply", args=("acc1__o__beta", "in7")),
+        ),
+    )
+    denominator = _blocked_channel(Axis("a2_c2", 64), inner, "acc3", (Assign(name="acc3__blk__e", op="copy", args=("acc1__o__beta",)),))
+    combine = (
+        Assign(name="acc1__o__gn", op="maximum", args=("acc1", "acc1__blk")),
+        Assign(name="acc1__o__dg_o", op="subtract", args=("acc1__blk", "acc1__o__gn")),
+        Assign(name="acc1__o__beta", op="exp", args=("acc1__o__dg_o",)),
+        Accum(name="acc5__sum", value="acc5__sum__blk"),
+        Accum(name="acc3", value="acc3__blk"),
+        Accum(name="acc1", value="acc1__o__gn"),
+    )
+
+    out = merge_sibling_reduce_loops(unify_sibling_reduce_axes(Body((pivot, expectation, denominator, *combine))))
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 2, "the pivot stays apart; the two channels merge"
+    assert [s.name for s in loops[0].body if isinstance(s, Accum)] == ["acc1__blk"]
+    assert [s.name for s in loops[1].body if isinstance(s, Accum)] == ["acc5__sum__blk", "acc3__blk"]
+    assert len([s for s in loops[1].body if isinstance(s, Loop)]) == 2, "both score passes are inside now"


### PR DESCRIPTION
## What was wrong

`merge_sibling_reduce_loops` refused every merge it exists for whenever the two halves were **copies of one cone**
rather than structurally distinct reductions. Two copies always share every local spelling, and both gates read those
shared names as conflicts:

- the dependence gate asked `merged_defs & t.ssa_uses`, so a name the incoming loop binds **itself** counted as a read
  of the first loop;
- any def collision refused outright.

`unify_sibling_reduce_axes` also has to give the two loops one axis name first, and it read a Load position as a bare
`Var` only — which a blocked reduce never is, since it indexes its stream at `o·B + i`.

## What changed

**One reading of what the incoming loop needs from around it** — `free_names(t)`, the existing helper: what it uses
and does not bind. It gates the dependence check and the between-statements check, replacing two different spellings
of the same question.

**A collision is not a dependence.** What is left of the shared spellings is two bodies binding one name for unrelated
values, so the incoming body's copies rename apart. Only a name the loop still binds *after it closes* refuses:
`Loop.render` declares its immediate carriers (and a nested `seed=False` loop's) ahead of the loop, so those have
readers outside that a rename cannot reach, while every other definition lives in the block the loop closes. That is
`_carried_out`.

**`Loop.seed` was silently dropped** when the merged loop was rebuilt. It is now carried and gated on.

**Affine reduce-axis positions.** A position is `(source, dim, anchor, coefficient)` through `affine_form`, so the axis
is recognized as walking that dimension at `o·B + i`. The anchor rides the key deliberately: `o·B + i` and
`o·B + 32 + j` walk different halves and must stay apart — seeing through the offset would be a miscompile, not a
generalization.

## The motivating shape

A blocked twisted carrier — a block pivot plus one inner fold per channel, all over the same block, each re-deriving
the score. The pivot must stay apart (the weight reads its finished accumulator) and the channels must collapse, which
takes `Q·K` from three passes over the block to two. `test_merge_collapses_the_channel_loops_of_a_blocked_twisted_carrier`
carries that scope, including the enclosing statements that re-bind the very temps the channels use — the case that
defeats any gate asking "is this name read anywhere around the pair" instead of "what does the loop itself still bind".

## Testing

Green: `tests/compiler/ir/stmt/`, `tests/compiler/ir/pure/`, `tests/compiler/ir/loop/` (167),
`tests/compiler/passes/test_twisted_rewrite.py`, `test_decompose_rules.py`, `tests/compiler/ir/tile/test_normalize.py`,
`tests/compiler/ir/test_shape_inference.py` (127). `make lint` clean.

**Not run — reviewers should weigh this:** the full suite, the realization corpus, `make test-goldens`, and
`scripts/digest_kernels.py`. The pass runs in every `LoopOp.__post_init__` and in `Body.structural_key`, so kernel
source changes wherever sibling reduce loops now fuse; the digest A/B is owed before merge.

## Two things deliberately left out

1. **A `Lambda.cone` fix.** Investigating this exposed a separate defect: a stored combine is not SSA in its states
   (it reads `acc` and writes `acc` back on the way out), and `backward_cone` resolves by name, so a coefficient's
   cone swallows that trailing write. Downstream copy-alias elimination then folds a read into a self-read. It is a
   real miscompile but it belongs to the pure-IR layer, not to loop normalization, and only a term path that cones a
   *combine* reaches it — every caller on `main` cones a lift. Separate PR.
2. **The merge is not on the path that emits a term-lowered kernel.** `normalize_body` runs from
   `LoopOp.__post_init__` and `Body.structural_key`; `TileOp.__post_init__` normalizes the *term*, and
   `010_materialize` builds the `KernelOp` straight from `Fold.lower`. So this fix is correct and reachable from Loop
   IR and from the digest, but a kernel materialized from a term still carries its sibling loops. The stale module
   docstring claiming `TileOp.__post_init__` ran these passes is corrected here; closing the gap itself is a
   follow-up with its own design choice (normalize the materialized body, teach `Fold.lower` to share a loop between
   sibling terms, or restructure the term so the siblings never appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cxTAnHwqm2D82k6Wiygm4
