### PR TITLE
Speed up the tile stage: index the schedule restriction, skip per-step revalidation (46%)

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -131,6 +131,12 @@ owning type's interface: declare it as a `functools.cached_property` on the clas
 `__post_init__`. This works on a frozen dataclass too — `cached_property` writes through `__dict__` directly, and a
 `__getstate__` that pickles only declared fields strips it.
 
+A derived read that is a FAMILY keyed by an argument — one value per site, per operand, per family name — takes
+`utils.cached_method`, which is `cached_property`'s storage under a private slot while the attribute stays a call. It
+is a declared descriptor on the owning class, so the family is as visible as any other member, and it keeps the
+per-key laziness a whole-family `cached_property` would give up. Do not reach for a `functools.cache` keyed on `self`:
+it hashes the whole term per call and pins every term ever built for the life of the process.
+
 Never stash a derived value in a memo table keyed off some other object — `obj.__dict__.get(...)`,
 `object.__setattr__(obj, "_my_cache", ...)`, or a named memo-slot helper. An undeclared attribute is invisible to
 readers of the class, dodges pickling rules, grows a second spelling of the same fact, and smears one type's

--- a/STYLE.md
+++ b/STYLE.md
@@ -124,6 +124,27 @@ dict it replaces — note the 3.15 builtin is NOT a `dict` subclass, which the e
 Don't hand-roll immutable dict subclasses, and don't use `types.MappingProxyType` — it can't be pickled or
 deep-copied and is not a `dict`.
 
+### Value types are `frozen=True`; simple ones are `slots=True` too
+
+Default to `@dataclass(frozen=True)` for anything that models a value — an IR term, a schedule choice, a domain, a
+composition prefix. Frozen is what lets one object be shared by many wrappers with no defensive copy, lets a derived
+read cache on the term at all, and makes `dataclasses.replace` the only way a "change" happens.
+
+A SIMPLE value type — a small object that is its fields plus the behavior reading them, with no derived state of its
+own — takes `slots=True` as well. It drops the per-instance `__dict__`, which cuts memory and speeds attribute
+access, and that is worth having on the leaf choice objects an enumeration builds in the millions (`Tile`, `Work`,
+`Reduce`, `Stage`, `Raster`).
+
+A BIGGER type — one that owns derived reads the rest of the compiler depends on (`Fold`, `TileOp`, `ClassicDomains`,
+`ClassicScheduleContext`) — stays unslotted and declares those reads with `cached_property` or `cached_method`, per
+the next section. The two are mutually exclusive: both cache through the very `__dict__` that `slots=True` removes,
+so a slotted class raises `TypeError: No '__dict__' attribute on 'X' instance to cache 'y' property` on the first
+read. Never add `__dict__` back to `__slots__` to have both — a type wanting caches is telling you which side it is
+on.
+
+One cost worth knowing either way: `@dataclass(slots=True)` builds a NEW class object and regenerates every method,
+so it makes import-time class construction more expensive, not less.
+
 ### Derived values are first-class members, not `__dict__` stashes
 
 A derived value another module reads (a lowered body, an identity digest, a canonical rendering) is part of the

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -53,12 +53,16 @@ arriving as ordinary statements.
 
 **Derived reads memoize on the immutable term; pickling carries only the stored params.** A term's
 expensive derived reads — the structural key, `Fold.deps`, `Lambda.free_names`, the synthesized
-`loop`, the normalize fixpoint stamp, the codec's spelling tables — ride the instance
-(`cached_property` entries and `structural.instance_memo` tables), which is sound because the term
-never changes, and is what keeps a walk over a large fused tree linear instead of re-deriving every
-subtree per ancestor. `__getstate__` strips them: every memo recomputes after transport, and an
-id-keyed cache carried across processes could collide with a fresh object's id. A memo holds only
-values derivable from the term — never decisions, never mutable policy.
+`loop`, the normalize fixpoint stamp, the codec's spelling tables — ride the instance, which is what
+keeps a walk over a large fused tree linear instead of re-deriving every subtree per ancestor. They
+are declared members: a `cached_property` on the type that owns the value, or a field computed in
+`__post_init__`, per STYLE.md. `__getstate__` strips them: every memo recomputes after transport,
+and an id-keyed cache carried across processes could collide with a fresh object's id. A memo holds
+only values derivable from the term — never decisions, never mutable policy.
+
+The `structural.instance_memo` tables are a holdout predating that rule, not a second sanctioned
+form. STYLE.md forbids the undeclared memo slot they stash into; new derived reads take a declared
+member, and the existing tables are to be converted to one.
 
 **Tile IR stores terms, not statements.** `TileOp` holds the `Fold` term; the typed classic
 schedule, materialization, output specifications, and knobs belong to `TileOp`, not the term. So `Fold` lives in

--- a/emmy/compiler/ir/schedule/classic.py
+++ b/emmy/compiler/ir/schedule/classic.py
@@ -502,6 +502,13 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
     _restricted_kernel_set: frozenset[KernelSchedule] | None = field(default=None, repr=False, compare=False)
     _restricted_nodes: Mapping[NodeId, tuple[NodeSchedule, ...]] | None = field(default=None, repr=False, compare=False)
     _restricted_edges: Mapping[EdgeSite, tuple[EdgeSchedule, ...]] | None = field(default=None, repr=False, compare=False)
+    #: Membership indexes over the two tuples above. The tuples keep enumeration ORDER, which
+    #: decides every tie; these answer ``in``, which a composition step asks once per site and
+    #: once per incident edge. Scanning the tuples instead spent 29% of one SDPA_L schedule walk
+    #: inside the choices' generated ``__eq__``. ``_restricted_kernel_set`` indexes the kernels
+    #: the same way.
+    _restricted_node_sets: Mapping[NodeId, frozenset[NodeSchedule]] | None = field(default=None, repr=False, compare=False)
+    _restricted_edge_sets: Mapping[EdgeSite, frozenset[EdgeSchedule]] | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if not isinstance(getattr(self.tile_op, "op", None), Fold):
@@ -552,6 +559,8 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
                 object.__setattr__(self, "_restricted_kernel_set", frozenset(kernels))
                 object.__setattr__(self, "_restricted_nodes", nodes)
                 object.__setattr__(self, "_restricted_edges", edges)
+                object.__setattr__(self, "_restricted_node_sets", frozendict({site: frozenset(c) for site, c in nodes.items()}))
+                object.__setattr__(self, "_restricted_edge_sets", frozendict({edge: frozenset(c) for edge, c in edges.items()}))
             if self._allowed_works is None:
                 assert self._restricted_kernels is not None
                 object.__setattr__(
@@ -673,6 +682,8 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             _restricted_kernel_set=None,
             _restricted_nodes=None,
             _restricted_edges=None,
+            _restricted_node_sets=None,
+            _restricted_edge_sets=None,
         )
 
     @property
@@ -846,8 +857,8 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             self._pins is not None
             and self._restricted_nodes is not None
             and (
-                node not in self._restricted_nodes[site]
-                or any(choice not in self._restricted_edges[edge] for edge, choice in pick.edges.items())
+                node not in self._restricted_node_sets[site]
+                or any(choice not in self._restricted_edge_sets[edge] for edge, choice in pick.edges.items())
             )
         ):
             self._refuse(self._node_restriction_refusal(site, node) or "pick is outside the schedule restriction", site)
@@ -865,16 +876,35 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
         nodes = {**self.assignment.nodes, site: support.node}
         axes = {**self._axes, **{claim.name: (claim.tile, claim.units) for claim in support.axes}}
         fragments = {**self._fragments, **{(claim.role, claim.edge): claim.value for claim in support.fragments}}
-        return replace(
-            self,
+        return self._advance(
             position=self.position + 1,
             _assignment=Schedule(None, nodes, {**self.assignment.edges, **support.edges}),
             _work=work,
-            _axes=axes,
-            _fragments=fragments,
+            _axes=frozendict(axes),
+            _fragments=frozendict(fragments),
             _raster_eligible=self._raster_eligible or support.raster_eligible,
             _producer_eligible=self._producer_eligible and support.producer_eligible,
         )
+
+    def _advance(self, **changed) -> ClassicScheduleContext:
+        """This context with the fields ONE composition step changes, skipping ``__post_init__``.
+
+        Everything that ``__post_init__`` derives or proves belongs to ``tile_op``, ``domains`` or
+        ``_pins`` — the node order covering every site exactly once, the domains covering it, the
+        restriction tables and the works they allow — and a step touches none of the three, so a
+        step re-derives only conclusions it already carries. Its own remaining checks do not reach a
+        step either: the position bound holds because ``_extend_local`` advances only off a
+        ``next_site``, and the stage restriction is validated at position 0. The caller passes
+        ``_axes`` / ``_fragments`` already frozen, which is the one normalization lost with the
+        skipped ``__post_init__``. ``replace`` re-ran all of it once per composition step —
+        43.5k times for one SDPA_L schedule walk.
+
+        The public ``extend`` keeps the validating path: a pick decoded from a golden row or handed
+        in by a caller has proved none of this."""
+        advanced = object.__new__(type(self))
+        advanced.__dict__.update(self.__dict__)
+        advanced.__dict__.update(changed)
+        return advanced
 
     def _local_support(
         self,

--- a/emmy/compiler/ir/schedule/classic.py
+++ b/emmy/compiler/ir/schedule/classic.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
+from functools import cached_property
 
 from frozendict import frozendict
 
 from emmy.compiler.ir.pure.fold import Fold
 from emmy.compiler.structural import instance_memo
+from emmy.utils import cached_method
 
 from .base import Schedule, ScheduleContext, ScheduleRefused
 from .choices import (
@@ -395,29 +397,20 @@ class ClassicDomains:
             size *= len(choices)
         return size
 
-    @property
+    @cached_property
     def kernel_set(self) -> frozenset[KernelSchedule]:
         """Indexed kernel membership for compatibility checks."""
-        memo = instance_memo(self, "_memo_membership")
-        if "kernel" not in memo:
-            memo["kernel"] = frozenset(self.kernel)
-        return memo["kernel"]
+        return frozenset(self.kernel)
 
+    @cached_method
     def node_set(self, site: NodeId) -> frozenset[NodeSchedule]:
         """Indexed node-domain membership for one site."""
-        memo = instance_memo(self, "_memo_membership")
-        nodes = memo.setdefault("nodes", {})
-        if site not in nodes:
-            nodes[site] = frozenset(self.nodes[site])
-        return nodes[site]
+        return frozenset(self.nodes[site])
 
+    @cached_method
     def edge_set(self, edge: EdgeSite) -> frozenset[EdgeSchedule]:
         """Indexed edge-domain membership for one site."""
-        memo = instance_memo(self, "_memo_membership")
-        edges = memo.setdefault("edges", {})
-        if edge not in edges:
-            edges[edge] = frozenset(self.edges[edge])
-        return edges[edge]
+        return frozenset(self.edges[edge])
 
 
 @dataclass(frozen=True)

--- a/emmy/compiler/ir/schedule/classic.py
+++ b/emmy/compiler/ir/schedule/classic.py
@@ -201,6 +201,11 @@ def _target_memo(tile_op, target, slot: str) -> dict:
     Every candidate schedule over one tile shares these tables, and the composition context is
     replaced at each step, so the tile owns them. The target is retained beside its table so the
     id keying it cannot be recycled while the table lives.
+
+    That retention is the tell: this keys a table by ``id(target)`` and stores it on ``tile_op``,
+    caching a fact about a PAIR on one member of it. STYLE.md forbids the shape, and it is the
+    hardest of the ``instance_memo`` callers to retire — a ``cached_property`` cannot express it,
+    so it wants a different owner or a cache threaded through the context.
     """
     table = instance_memo(tile_op, slot)
     if id(target) not in table:

--- a/emmy/compiler/structural.py
+++ b/emmy/compiler/structural.py
@@ -68,14 +68,21 @@ class Structural(Protocol):
 
 
 def instance_memo(obj, slot: str) -> dict:
-    """The named per-instance memo table riding an IMMUTABLE object — the structural-key
-    pattern, as one mechanism: a derived read caches on the term it derives from (the table is
-    created on first use via ``object.__setattr__``, so frozen dataclasses take it), and the
-    owner's ``__getstate__`` strips it so no cache — an id-keyed one especially — crosses a
-    process boundary. The retired bottom-up term hasher originated the pattern with its
-    single-slot form; the normalize fixpoint stamp (``ir/tile/normalize.py``) and the codec's
-    spelling tables (``ir/tile/path.py``) go through this table form. A memo holds ONLY values
-    derivable from the object; never decisions, never mutable policy."""
+    """The named per-instance memo table riding an IMMUTABLE object: a derived read caches on the
+    term it derives from (the table is created on first use via ``object.__setattr__``, so frozen
+    dataclasses take it), and the owner's ``__getstate__`` strips it so no cache — an id-keyed one
+    especially — crosses a process boundary. A memo holds ONLY values derivable from the object;
+    never decisions, never mutable policy.
+
+    DEPRECATED, and closed to new callers. The undeclared attribute this stashes into is what
+    STYLE.md's "Derived values are first-class members" rule forbids: it is invisible to readers of
+    the class, dodges the pickling rules, and smears one type's functionality across whichever
+    module caches for it. A derived read belongs on the type that owns it — a ``cached_property``
+    returning the whole keyed family, or a field computed in ``__post_init__``. The remaining
+    callers (the classic domains' membership indexes, the per-target support tables, the codec
+    spelling tables, the normalize fixpoint stamp) are to be converted; ``_target_memo`` is the
+    hard one, since it keys a table by ``id(target)`` and stores it on ``tile_op`` — a fact about a
+    PAIR, stashed on one member of it."""
     table = obj.__dict__.get(slot)
     if table is None:
         table = {}


### PR DESCRIPTION
## What

`emmy compile --ir tile` is the first stage that must CHOOSE a schedule, and on a fused attention
term it dominated the command. On `SDPA_L` (1x4x128x64 fp16 SDPA — the listing kernel from the
FlashAttention part-2 article) the tile phase was 3.0s of a 4.7s compile, all of it in the classic
composition walk: ~43.5k `_extend_local` steps across 7 descent samples over a 433k-row pool.

Two changes to `ClassicScheduleContext`, then two doc/cleanup commits that follow from them.

**Index the restriction.** A py-spy sampling profile put **29% of the walk inside the choice types'
generated `__eq__`**, reached from two lines — `node not in self._restricted_nodes[site]` and its
edge counterpart scan TUPLES, so each membership test is a linear walk comparing dataclasses.
`_restricted_kernel_set` already indexes the kernels one line away; nodes and edges never got the
same treatment. The tuples stay (they carry enumeration order, which decides every tie) and the
frozensets answer `in` only, so this is a second view of one domain, not a second definition of
membership.

**Skip per-step revalidation.** `_extend_local` ended in `dataclasses.replace`, re-running
`__post_init__` on every step: the node order covering every site, the domains covering it, the
restriction tables and their allowed works. None of that depends on the step — all three are
properties of `tile_op` / `domains` / `_pins` — and the remaining checks cannot fire on one (the
position bound holds off `next_site`, the stage restriction validates at position 0). `_advance`
copies the context and overwrites the six fields a step changes. The public `extend` keeps every
check: a pick decoded from a golden row has proved none of this.

## Numbers

SDPA_L, in-process tile phase, min of 5:

| | tile phase | end to end |
| --- | --- | --- |
| baseline | 3.035s | 4.72s |
| `+ _advance` | 2.786s (-8%) | 4.58s |
| `+ frozensets` | **1.647s (-46%)** | **3.35s (-29%)** |

The end-to-end gain is smaller because ~1.6s is fixed Python + torch startup. Emitted tile IR is
byte-identical to baseline at every step. `<string>:__eq__` went from 27.8% self time to under 2%;
the remaining profile is flat, with no single dominant cost.

## The instance_memo commits

Reviewing the memo tables this walk leans on surfaced a contradiction between two durable docs.
STYLE.md's "Derived values are first-class members, not `__dict__` stashes" forbids the pattern by
name — including "or a named memo-slot helper" — while `emmy/compiler/ir/ARCHITECTURE.md` presented
`structural.instance_memo` beside `cached_property` as sanctioned and explained why it was sound.
`instance_memo`'s own docstring read as the pattern's charter.

STYLE.md wins here. The invariants that hold either way stay (derived reads ride the immutable term,
`__getstate__` strips them, a memo holds only derivable values and never decisions); what goes is the
endorsement. `ClassicDomains`' membership indexes are converted to declared members —
`cached_property` for the kernel set, `utils.cached_method` for the per-site families, which keeps
their laziness. `__getstate__` needed no change; it already filters to `__dataclass_fields__`.

STYLE.md gains a sentence naming `cached_method`, since the rule covered a single derived value and
not a family keyed by an argument — which is why this code reached for `instance_memo` in the first
place.

Three `instance_memo` callers remain and are deliberately out of scope: the codec spelling tables,
the normalize fixpoint stamp (its owner `Fold` is in `ir/pure/` while the normalizer is in
`ir/tile/`, and `ir/pure/` has zero upward imports — that layering call wants its own change), and
`_target_memo`, the one a declared member cannot express. `_target_memo` also carries a real hazard
for whoever takes it: its tables are shared per-tile today, across separate `project_classic` calls
and the nested pricing resolves, and narrowing that scope could give back much of what this PR wins.

## Line balance

`git diff --stat main -- emmy/` is +64/-29 in Python, but the executable delta is roughly **+3
lines**. The rest is the comment justifying why skipping `__post_init__` is sound and the
deprecation docstrings — both load-bearing for a change whose safety is not obvious from the code.

## Testing

- Emitted tile IR byte-identical to baseline on SDPA_L, verified after each commit.
- `tests/compiler/ir/schedule/` (40) and `tests/compiler/pipeline/search/policy/` (26) pass.
- `make lint` clean.
- **Not run, at the author's request:** the full compiler suite, the realization corpus, and
  `make test-goldens`. The last is required by AGENTS.md for anything under `emmy/compiler/` and
  matters here specifically — a schedule-composition change is exactly the class that can invalidate
  recorded golden rows silently. Please run these before merging.

## Next lever, for reference

Profiling after these changes points at `ClassicScheduleCodec.delta` — 18.5% of the run — called
from `fork.py:step`, which builds an incrementally-encoded knob row for every branch. Leaves encode
their own complete row independently, and a sampled descent never reads an intermediate branch's
`knobs`, so those rows are largely built and discarded. Making `_ScheduleFork.row` lazy should
recover most of it. Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)