### PR TITLE
A param names itself: Lambda.cone stops resolving a read through the body's write-back

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -482,6 +482,12 @@ the shared substrate behind the rules that slice cones (the demoted-operand prod
 `lowering/tile/030_cut`) — eligibility judgments stay in the rules, per
 `pipeline/passes/ARCHITECTURE.md`.
 
+`backward_cone` resolves reads by NAME over a body it assumes is SSA, so it is only sound where one name has one
+def. `Lambda.cone` is the caller that cannot assume it: a stored combine takes its states in as params and writes
+them back on the way out to spell its results (`Recipe.program`), so a read of the INCOMING state would resolve
+forward to the write-back. A param names itself, and `cone` keeps it that way by hiding the re-bindings from the
+walk. Any other caller that cones a non-SSA body owes itself the same reading.
+
 `rewrite` has two distinct rename channels that must stay disjoint:
 `rename_ssa` carries **SSA-name** renames, `sigma` carries **axis**
 substitutions. `Load`/`Write` index exprs apply *both*

--- a/emmy/compiler/ir/pure/lam.py
+++ b/emmy/compiler/ir/pure/lam.py
@@ -186,8 +186,22 @@ class Lambda:
         """The closed cone of one definition — the statements of the body ``name`` depends on, as a
         lambda over what they read (a param names itself: an empty body returning it). What a
         reader asks of one result without the rest of the body: the score a fold's lift computes,
-        the value one component of a projection denotes. Params in :meth:`closing`'s order."""
-        members = () if name in self.params else tuple(self.body.backward_cone((name,)).members)
+        the value one component of a projection denotes. Params in :meth:`closing`'s order.
+
+        A PARAM NAMES ITSELF, and that has to hold for the reads inside the cone too. A stored
+        combine is not SSA in its states: it takes ``acc`` in as a param and writes ``acc`` back on
+        the way out to spell its result. :meth:`Body.backward_cone` resolves by name over a body it
+        documents as SSA, so a read of the INCOMING ``acc`` resolves forward to that trailing write
+        and drags it into the cone — which is how a weight cone came to carry the pivot's own state
+        advance, and the kernel to read an uninitialized accumulator. Hiding the re-bindings makes
+        the walk see the binder's scoping instead: under a param's spelling the body reads the
+        value that came in, so the read lands in ``external_reads`` and closes back as that param.
+        """
+        if name in self.params:
+            return Lambda.closing((), Body(()), (name,))
+        params = set(self.params)
+        visible = Body(tuple(s for s in self.body if not (_exposed_defines(s) & params) or name in _exposed_defines(s)))
+        members = tuple(visible.backward_cone((name,)).members)
         return Lambda.closing((), Body(members), (name,))
 
     def rename(self, names) -> Lambda:

--- a/tests/compiler/ir/pure/test_lambda.py
+++ b/tests/compiler/ir/pure/test_lambda.py
@@ -99,6 +99,20 @@ def test_cone_is_one_definition_closed_over_what_it_reads() -> None:
     assert set(fn.cone("w").params) == {"a", "b", "k"} and len(fn.cone("w").body) == 3
 
 
+def test_cone_reads_a_param_as_what_came_in_not_as_the_bodys_write_back() -> None:
+    """A stored combine is not SSA in its states: it takes ``m`` in and writes ``m`` back on the way
+    out to spell its result. The cone of the incoming side's factor must read the ORIGINAL ``m`` —
+    resolving that read forward to the write-back drags the pivot's own advance into the weight and
+    leaves the kernel reading an uninitialized accumulator."""
+    combine = SOFTMAX.program(("m", "l"))
+    beta = combine.cone("m__o__beta")
+    assert beta.params == ("m", "m__o")
+    assert [stmt.name for stmt in beta.body] == ["m__o__gn", "m__o__dg_o", "m__o__beta"]
+    assert all(stmt.op.name != "copy" for stmt in beta.body)
+    # The channel's rescale reads its OWN state the same way — as the param, never as its result.
+    assert "l" in combine.cone("m__o__l_sa").params
+
+
 def test_rename_maps_params_body_and_results_in_lockstep() -> None:
     fn = Lambda(params=("m", "m__o"), body=Body((Assign("t", "maximum", ("m", "m__o")), Assign("m", "copy", ("t",)))), results=("m",))
     renamed = fn.rename({"m": "acc", "m__o": "acc__o", "t": "acc__t"})


### PR DESCRIPTION
## The defect

`Body.backward_cone` resolves reads by name over a body it documents as *closed under SSA
dependence*. A stored combine is not SSA in its states: `Recipe.program` takes each state in as a
param and writes it back on the way out to spell its result —

```
acc1__o__gn    = maximum(acc1, acc1__o)     # <- reads the INCOMING acc1
...
acc1           = copy(acc1__o__gn)          # <- re-binds the param to spell the result
```

So the backward walk from any factor reached `acc1`, found the *trailing* write, and pulled it in.
Two things went wrong at once:

- the cone carried a statement that does not feed its root — the pivot's own state advance rode
  inside the weight, `eliminate_copy_aliases` folded the pivot read into a self-read, and the
  kernel emitted `float acc1__o__gn = fmaxf(acc1__o__gn, v1);` over an uninitialized register;
- the cone *lost* `acc1` from its params, so it claimed to bind the state it was meant to read.
  That hides the pivot dependence from every uses-vs-defs reading downstream.

On the softmax combine, `cone("m__o__beta")`:

| | params | body |
|---|---|---|
| before | `('m__o',)` | `gn`, `dg_o`, `beta`, **`m = copy(gn)`** |
| after | `('m', 'm__o')` | `gn`, `dg_o`, `beta` |

## The fix

`Lambda.cone` hides the param re-bindings from the walk, which is what its documented contract —
*a param names itself* — already promised. Under a param's spelling the body reads the value that
came in, so the read lands in `external_reads` and closes back as that param.

## Why now

`#720` landed the sibling-reduce merge, whose gates are phrased over what a loop reads from its
enclosing scope (`free_names`). The second half of this defect defeats exactly that reading: with
the pivot's read disguised as a write, the channel loop does not *read* `acc1`, so the dependence
gate does not fire and the merge is free to fuse the pivot loop with a channel loop. `#720` is
correct on its own terms and this is the missing half, not a fix to it.

## Evidence

- New case in `tests/compiler/ir/pure/test_lambda.py`, red on `main`, green here.
- **Blast radius, instrumented.** `Lambda.cone` was wrapped to report every call where the new
  filter actually hides a statement, then run over `tests/compiler/ir/` and the twist/decompose
  passes: it fires **only** on a twisted combine. Every other caller cones a *lift*, which is SSA
  with no param re-binding, so the walk there is byte-identical.
- 343 tests green across `ir/pure`, `ir/tile`, `ir/stmt` and `passes/test_twisted_rewrite.py`;
  `ruff` clean.
- **Not run:** the rest of `tests/compiler/`, the realization corpus, `make test-goldens`.

## Core line balance

`git diff --stat main -- emmy/` is +22/-2, of which 6 lines are `ARCHITECTURE.md` and 10 are the
docstring recording the invariant. The code itself is +5/-2 — a two-line expression becomes a
guard, a visibility filter and the walk. The growth is the fix, not layering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cxTAnHwqm2D82k6Wiygm4
