### PR TITLE
Promote only a kernel's shared output sweep, not a sibling nest's axis (#699 regression)

### DIFF
--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -101,11 +101,18 @@ the placement fork; a Loop IR fusion or emission workaround sees one kernel at a
 construction. Copies that differ in captured axis names cannot share an object and stay with value clustering; copies
 that differ in exposed result names stay distinct because unifying them would rename their consumers.
 
-An output sweep used by any nested contraction operand is promoted into the Tile's free-axis placement. Promotion
-expands the enclosing-axis context, so construction normalizes the Fold tree once more under that final scope; one
-construction and a reconstruction therefore expose the same closed operand edges and placement seams.
-The invariant also applies when a schedule row constructs or reloads an already-mapped Tile: promotion extends the
-grid in lockstep with the free axes, so per-cell replication never mistakes the swept coordinate for an SSA name.
+The kernel's SHARED output sweep — an axis on every store's sweep path — is promoted into the Tile's free-axis
+placement when any nested contraction operand reads it: the coordinate is that contraction's output coordinate, and
+promoting an axis every store rides replicates nothing but the statistics evaluated ahead of the sweep. A sibling
+output nest's axis is never promoted, however many contractions read it: the other nests do not ride it, so promoting
+it would evaluate them once per cell — DeepSeek-V4 post4096's residual root holds four sibling nests, and promoting
+all seven of their axes made its grid their product, 2^56 cells, which no launch can cover. A contraction under a
+sibling nest stays under its sweep loop, where `Fold.lower` places it like any term reading the axis, and the
+placement fork cuts it out at its own free coordinates. Promotion expands the enclosing-axis context, so construction
+normalizes the Fold tree once more under that final scope; one construction and a reconstruction therefore expose the
+same closed operand edges and placement seams. The invariant also applies when a schedule row constructs or reloads
+an already-mapped Tile: promotion extends the grid in lockstep with the free axes, so per-cell replication never
+mistakes the swept coordinate for an SSA name.
 
 **Storage-decode factors hoist to the epilogue.** A product argument whose cone is a STORAGE DECODE
 (`ElementwiseImpl.decodes` — the trait, never an op-name list) times factors constant along the fold
@@ -134,8 +141,9 @@ as a supported slow path.
 
 A node's own canonical forms are formation's (`Fold.__post_init__` orients a bilinear term A-first, `Lambda` orders
 its body); `TileOp.__post_init__` applies the tree-wide ones and the legacy output-sweep-to-free-axis adjustment
-whenever a contraction operand reads the sweep axis. The contraction may be the root compute node or a later site in
-the Fold tree; in either case the coordinate belongs in kernel placement rather than a post-compute output loop.
+whenever a contraction operand reads the kernel's shared output sweep. The contraction may be the root compute node or
+a later site in the Fold tree; in either case the coordinate belongs in kernel placement rather than a post-compute
+output loop.
 A specification's `sweep` is the output loop NEST the store rode in the source, as an outermost-first axis path — the
 one fact extraction destroys, since a write's index names its coordinates but not the order its loops nested in.
 Consecutive output specifications over one path reconstitute one loop nest, sibling sweeps sibling loops, and a
@@ -156,8 +164,9 @@ reuses an enclosing or sibling sweep's name (the fused quantize kernel's byte sw
 alpha-renamed at the lift, binder and references together, since a term tree names one coordinate per name. The
 kernel binder's serial arm hands the stores to the term the same way, so the emitted kernel places them exactly as
 the identity's `loop_body` does; only a projection stream spelled without the term (the peeled root's tail, a cut
-piece) still wraps the trailing run reading the axis into one loop. A contraction is exempt because post-init
-promotes a sweep its operands read into a real free axis right after normalization.
+piece) still wraps the trailing run reading the axis into one loop. A contraction reading the kernel's shared output
+sweep never meets this rule, because post-init promotes that sweep into a real free axis right after normalization;
+one reading a sibling nest's axis is placed by it like any other fold.
 
 A fold FED by the body — one whose subtree captures a name a plain body member defines — is likewise never hoisted,
 no matter what kind: a projection evaluates its operands before its scalar body, so the capture would read a value

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -357,13 +357,12 @@ class TileOp(Op):
             raise ValueError("cannot canonicalize a TileOp after a schedule has been attached")
         object.__setattr__(self, "op", normalized)
 
+        # Only the kernel's SHARED output sweep — an axis every store rides — promotes: hoisting it replicates
+        # nothing but the statistics ahead of the sweep, while a sibling nest's axis would replicate every
+        # other nest per cell (DeepSeek-V4 post4096's root: four nests, a 2^56-cell grid).
         contractions = tuple(site.node for site in sites(normalized) if site.node.as_contraction() is not None)
-        promoted = {
-            axis.name
-            for store in self.output_specs
-            for axis in store.sweep
-            if any(any(axis.name in edge.free_axes for edge in con.operands) for con in contractions)
-        }
+        shared = set.intersection(*({axis.name for axis in store.sweep} for store in self.output_specs)) if self.output_specs else set()
+        promoted = {name for name in shared if any(any(name in edge.free_axes for edge in con.operands) for con in contractions)}
         if not promoted:
             self._own_axes()
             self._validate_schedule()

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -210,8 +210,10 @@ gaps stand between here and a boot that serves, both follow-ups to #692:
    proxy should not be the decider. **(b)** the materialized shape is right: a route whose contribution
    consumer is a pure staged mma with no serial hidden-dim walk, the walk living once in a producer piece, and
    the statistics computed once per row. **(c)** two blockers characterized on post-#699 main, each its own
-   item: the residual root's output sweeps are all promoted into its placement (the emitted kernel decodes a
-   2^56-thread linear grid — un-launchable), and the contribution producer still recomputes the carrier chain
+   item: the residual root's output sweeps were all promoted into its placement (the emitted kernel decoded a
+   2^56-thread linear grid — un-launchable) — FIXED by this PR (`fix/residual-output-sweep-promotion`: only the
+   kernel's shared output sweep promotes; a sibling output nest's axis stays a sweep, and the residual launches at
+   its 4096-row grid again), and the contribution producer still recomputes the carrier chain
    per (row, a28) cell (the next seam, `PLACE@…inner` on the `a32` contraction, is on its ballot). Pricing
    floors beyond #702's are OUT by review decision: a golden must carry every kernel of the route, and strict
    evidence then keeps the prior from deciding at all. The path to serving: make `emmy tune` able to measure

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -211,9 +211,9 @@ gaps stand between here and a boot that serves, both follow-ups to #692:
    consumer is a pure staged mma with no serial hidden-dim walk, the walk living once in a producer piece, and
    the statistics computed once per row. **(c)** two blockers characterized on post-#699 main, each its own
    item: the residual root's output sweeps were all promoted into its placement (the emitted kernel decoded a
-   2^56-thread linear grid — un-launchable) — FIXED by this PR (`fix/residual-output-sweep-promotion`: only the
-   kernel's shared output sweep promotes; a sibling output nest's axis stays a sweep, and the residual launches at
-   its 4096-row grid again), and the contribution producer still recomputes the carrier chain
+   2^56-thread linear grid — un-launchable) — FIXED by #723 (only the kernel's shared output sweep promotes; a
+   sibling output nest's axis stays a sweep, and the residual launches at its 4096-row grid, 16 blocks × 256
+   threads, again), and the contribution producer still recomputes the carrier chain
    per (row, a28) cell (the next seam, `PLACE@…inner` on the `a32` contraction, is on its ballot). Pricing
    floors beyond #702's are OUT by review decision: a golden must carry every kernel of the route, and strict
    evidence then keeps the prior from deciding at all. The path to serving: make `emmy tune` able to measure

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -157,6 +157,31 @@ def test_nested_contraction_promotes_a_shared_store_sweep() -> None:
     assert tile.output_specs[0].sweep == ()
 
 
+def test_sibling_output_sweeps_stay_sweeps() -> None:
+    """Two sibling output nests, each holding the contraction whose output coordinate it sweeps. Neither
+    axis is the kernel's shared output sweep — every store rides its own — so neither is promoted:
+    promoting one would evaluate the other nest per cell. DeepSeek-V4 post4096's residual root holds
+    four such nests, and promoting all seven of their axes made its grid their 2^56-cell product."""
+    p = Axis("p", 4)
+    second = _reduce_loop(
+        Load(name="left2", input="x", index=(Var("m"), Var("k"))),
+        Load(name="right2", input="u", index=(Var("p"), Var("k"))),
+        Assign(name="product2", op="multiply", args=("left2", "right2")),
+        Accum(name="acc2", value="product2", op="add", axes=("k",)),
+    )
+    body = (Assign(name="a", op="relu", args=("acc",)), Assign(name="b", op="relu", args=("acc2",)))
+    root = projection((_matmul(), second), body, ("a", "b"))
+    stores = (
+        OutputSpec(write=Write(output="out", index=(Var("m"), Var("n")), value="a"), sweep=(N16,)),
+        OutputSpec(write=Write(output="out2", index=(Var("m"), Var("p")), value="b"), sweep=(p,)),
+    )
+
+    tile = _tile(root, N16, p, K32, free=(M8,), output_specs=stores)
+
+    assert tuple(axis.name for axis in tile.place.free) == ("m",)
+    assert tuple(tuple(axis.name for axis in store.sweep) for store in tile.output_specs) == (("n",), ("p",))
+
+
 def test_nested_contraction_promotes_a_swept_column_beside_an_implicit_unit_row() -> None:
     """A nested linear site turns the swept column into grid placement before scheduling."""
     r = Axis("r", 4)

--- a/tests/compiler/passes/test_total_lift.py
+++ b/tests/compiler/passes/test_total_lift.py
@@ -241,12 +241,13 @@ def test_sibling_q_and_kv_regions_total_lift_with_separate_outputs() -> None:
 
     # The root projection has nothing of its own: its operands are the q contraction and the k/v
     # pair normalization merged over their shared row; the writes are boundary specs. Each output
-    # loop's axis is a contraction output, so post-init promotes it onto the grid like any
-    # contraction sweep, and the kernel-scope program is flat.
+    # loop's axis is a contraction output, but neither is the kernel's SHARED output sweep — the q
+    # store does not ride kv, nor the k/v stores q — so post-init leaves both as sweeps: promoting
+    # one would evaluate the other region once per cell of it. The row alone is on the grid.
     assert tile.op.axis is None and not tile.op.lift.body
     assert [(edge.as_contraction() is not None, len(edge.exposes)) for edge in tile.op.operands] == [(True, 1), (True, 2)]
-    assert [axis.extent for axis in tile.place.free] == [Dim(3), Dim(4), Dim(2)]
-    assert all(spec.sweep == () for spec in tile.output_specs) and len(tile.output_specs) == 3
+    assert [axis.extent for axis in tile.place.free] == [Dim(3)]
+    assert [tuple(axis.extent for axis in spec.sweep) for spec in tile.output_specs] == [(Dim(4),), (Dim(2),), (Dim(2),)]
     # The closed program opens the two sweeps as SIBLING loops under the row: no term is evaluated
     # over both, so neither nests in the other.
     (m_loop,) = tile.loop_body

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -367,6 +367,7 @@
  "tests/compiler/passes/test_placement_routing.py::test_rms_norm_fused_pin_lowers_one_kernel": 0.07,
  "tests/compiler/passes/test_placement_routing.py::test_scoped_cut_preserves_every_multi_output_parent_port": 2.54,
  "tests/compiler/passes/test_schedule_space_separation.py::test_an_axis_renamed_twin_preserves_the_node_id_vocabulary": 4.58,
+ "tests/compiler/passes/test_schedule_space_separation.py::test_an_off_precision_gate_stamps_the_same_space": 5.0,
  "tests/compiler/passes/test_schedule_space_separation.py::test_split_dim_store_does_not_share_an_identity": 15.13,
  "tests/compiler/passes/test_schedule_space_separation.py::test_transposed_free_extents_stamp_different_spaces": 20.92,
  "tests/compiler/passes/test_schedule_walk.py::test_computed_fold_sites_are_keyed_schedule_sites[flash_pair-2-3]": 35.36,


### PR DESCRIPTION
## The regression

Since #699 the DeepSeek-V4-Flash `post4096` serving twin's residual root cannot launch: every output sweep of the
root is promoted into its placement, and the grid becomes the product of all of them. Replays of the golden
realization `post4096.k_linear_softmax_matmul_mean_reduce_9716a1.f86b6dbe35b7.m4096` (sm_70, the tune-DB copy as
the only evidence, no online prior):

- **before #699** (`d64622a5`): the residual `k_linear_softmax_matmul_mean_reduce_9716a1` launches as
  `int _gid = …; int a0 = _gid;` — 16 blocks × 256 threads, every output sweep (`a10`, `a14`, `a17`, `a20`, `a27`,
  `a35`, …) a serial loop inside the kernel.
- **on `origin/main` (`30480ae5`)**: the same residual decodes a 2^56-thread linear grid —
  `long long _gid …; int a0 = _gid / 17592186044416; int a10 = (_gid / 4398046511104) % 4; … int a34 = (_gid) % 4096;`
  — a launch of **281,474,976,710,656 CTAs × 256 threads** (`a0×a10×a16×a19×a19_1×a26×a26_1×a34 =
  4096·4·4·4096·4·4096·4·4096 ≈ 7.2e16` cells). `gridDim.x` tops out at 2^31−1: the kernel cannot launch.

## Root cause

`TileOp.__post_init__` promotes an output sweep into `place.free` when any nested contraction operand reads it
(#648, widened to nested sites in #675). What that rule could SEE was bounded by extraction: before #699,
`extract_output_specs` set `OutputSpec.sweep` only for the "legacy single output sweep" — the one non-reduce loop at
the tail of the stream holding every store (rms/softmax's normalize sweep), and only when no flat tail store stood
beside it. Every other output loop — a sibling nest, a nested nest — became a `ProjectionRegion` whose specs carried
`sweep=None`. The promotion rule therefore only ever met the kernel's one shared output sweep.

#699 retired `ProjectionRegion`: every output loop lifts to a zero-axis term evaluated over its sweep coordinate and
its stores reach the boundary as sweep specs; #706 then spelled `OutputSpec.sweep` as the store's whole loop-nest
path and the promotion block began iterating every axis of every store's path. On the post4096 root that domain is
four sibling output nests — `(a10,a16)`, `(a19)`, `(a19_1)`, `(a19_1,a26)`, `(a19_1,a26_1,a34)` — and each axis is
the genuine output coordinate of the contraction hoisted out of that nest (`linear_4_wt[a27, a26]` reads `a26`, the
`acc49` slab reads `a26_1` and `a34`, the score matmul reads `a10` and `a16`). Nothing is captured-but-unread: the
operand edges' `free_axes` are exact. The rule itself over-applies — promoting a sibling nest's axis evaluates every
OTHER nest once per cell of it, so promoting all seven made the placement their product. The cut consumer inherits
`place=tile.place` verbatim, so after every contraction was cut out into producer pieces (which size their own grids
from what the seam reads — `_cut.py` already anticipated "an output sweep the grid carries for a sibling's sake"),
the residual — a pointwise store kernel — kept the 2^56-cell grid.

## The fix, and why it is the semantic one

Promotion is sound exactly when the axis is on EVERY store's sweep path — the kernel's one shared output sweep, the
only thing the pre-#699 `sweep` field could name: hoisting it replicates nothing but the statistics evaluated ahead
of the sweep (the per-cell replication the invariant describes). A sibling nest's axis is not such an axis, whatever
reads it. `TileOp.__post_init__` now takes the promotion candidates as the intersection of the stores' sweep paths
and promotes a shared axis exactly as before when a contraction operand reads it. A contraction under a sibling nest
stays under its sweep loop, where `Fold.lower` already places any term reading the axis, and the placement fork cuts
it out at its own free coordinates. No cap on grid size, no pricing change; `emmy/` Python is net −1 line.

`tests/compiler/passes/test_total_lift.py::test_sibling_q_and_kv_regions_total_lift_with_separate_outputs`, written
by #699, pinned the over-promotion for the fused q/k/v shape (`free == [m, q, kv]`, both sweeps stripped): that is
the same pathology at `4·2` instead of `4096·4·4·4096·…` — the q contraction evaluated once per `kv` cell and the
k/v pair once per `q` cell. Its placement expectations now read `free == [m]` with both sweeps kept; the one-kernel
claim, the sibling-loop `loop_body` and the `{m,q}` / `{m,kv}` seams it asserts all still hold.

## Replay after the fix (same golden, same evidence, deterministic)

| piece | launch | launchable |
| --- | --- | --- |
| `…__place_10cf5b720b` (`acc49` contribution; was `843da639e9`) | 67,108,864 × 128 | yes (unchanged) |
| `…__place_f5f8bc94ac` (was `05983f700d`) | 67,108,864 × 128 | yes (unchanged) |
| `…__place_895f05e860` (was `bed580ec13`) | 4 × 256 | yes |
| `…__place_947deab1a4` (was `ee3ad8be8b`) | 16,384 × 128 | yes |
| `…__place_1962fa992f` (was `ab50fc9ead`) | 1,024 × 128 | yes |
| `…__place_a97bb1167e__place_8a807213cf__place_ee37df43ab` | 16,384 × 128 | yes |
| `…__place_921364b0af` (was `b2c9ead08b`) | 65,536 × 256 | yes |
| `…__place_a97bb1167e__place_8a807213cf` (was `ab7fe4b606`) | 512 × 256 | yes |
| `…__place_a97bb1167e` (new: the `mul_16` gate cone, cut at `a26 × a0 × a19_1`) | 40,960 × 256 | yes |
| **residual `k_linear_softmax_matmul_mean_reduce_9716a1`** | **16 × 256**, `int a0 = _gid;` | **yes** |

The residual is back to the pre-#699 shape (grid `a0` alone, every sibling nest a serial loop, no contraction inside).
No piece of the route is un-launchable; the two 67,108,864-CTA contribution pieces are identical before and after and
belong to the other known blocker (the producer recomputing the carrier chain per cell), out of scope here.

## Not a corpus case

`tests/compiler/realization/ARCHITECTURE.md` reserves a case for a schedule that should be realizable and is not.
This residual `offered` and `realized` — the row decodes and lowers — and fails only at launch on the exact card, a
stage the corpus cannot observe GPU-free; the placement invariant is pinned by the synthetic Tile IR test beside the
existing promotion tests instead.

## Checks

- `make test` recipe (`EMMY_NVCC_FLAGS="-Xcicc -O1" EMMY_GOLDEN_FILE= pytest tests/ -n auto --dist=loadgroup`):
  **4150 passed, 1035 skipped, 21 xfailed** (no CUDA on this machine); corpus staleness clean, no regen needed.
- `make lint` recipe: `ruff check` and `ruff format --check` clean.
- `make test-goldens` recipe: **11 failed** — every checked-in golden file. The identical gate on `origin/main`'s own
  `ir.py` (`30480ae5`) fails the same 11 files with byte-identical failing-row sets, per-file counts
  (`8/8, 9/9, 10/10, 10/13, 24/44, 48/73, 186/194, 38/63, 153/240, 226/352, 267/279`) and reasons — rows such as
  `pointwise.n4096`, `rms_norm.k2048`, `reduce.k2048` and `matmul.square.512` (no output sweep, no contraction) are
  among them, which this change cannot reach. Pre-existing on `main`, not re-recorded here.
- `git diff --stat origin/main -- emmy/`: `ir.py` +5/−6 (net −1), `ir/tile/ARCHITECTURE.md` +18/−9 (the promotion
  paragraph restated).
- `plans/deepseek-v4-emmy-serving-v100.md`: the Stage 0 round-three blocker clause now records the fix; `plans/`
  holds 10 files, none executed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
