### PR TITLE
Split the contribution flow so development goes fast and checks run once per PR

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -18,6 +18,14 @@ skills and CloudRift inference endpoint.
 There is no generic experiment workflow or GitHub dispatch input for `emmy bench`. Requested experiment runs start
 from a developer checkout through the tracked `.agents/skills/run-experiment` skill.
 
+## Pull-request body
+
+`PULL_REQUEST_TEMPLATE.md` fixes the shape of every PR: a title that describes the change functionally, an
+abstract of one plain-English paragraph and at most five bullets, an optional single artifact backing that
+abstract — a small table, a diagram, a few lines of output — a horizontal rule, and then the rest under
+headings chosen to fit the change. `Abstract` is the only fixed heading. The split exists so a reader can
+decide from the abstract alone whether the PR concerns them, which is why code references stay below the rule.
+
 ## Pull-request checks
 
 **Tests** runs three parallel jobs and installs the CI dependency set on Python 3.13. A newer commit cancels the

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -21,10 +21,12 @@ from a developer checkout through the tracked `.agents/skills/run-experiment` sk
 ## Pull-request body
 
 `PULL_REQUEST_TEMPLATE.md` fixes the shape of every PR: a title that describes the change functionally, an
-abstract of one plain-English paragraph and at most five bullets, an optional single artifact backing that
-abstract — a small table, a diagram, a few lines of output — a horizontal rule, and then the rest under
-headings chosen to fit the change. `Abstract` is the only fixed heading. The split exists so a reader can
-decide from the abstract alone whether the PR concerns them, which is why code references stay below the rule.
+abstract of one short plain-English paragraph, an optional single artifact backing that abstract — a small
+table, a diagram, a few lines of output — a horizontal rule, and then the rest under headings chosen to fit
+the change. `Abstract` is the only fixed heading. The split exists so a reader can decide from the abstract
+alone whether the PR concerns them, which is why code references stay below the rule. The template also asks
+for two revision passes before posting, because the failure it guards against is a first draft that lists
+everything done instead of saying what the change is.
 
 ## Pull-request checks
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,35 @@
 <!--
 Title: a functional description, readable with no context. "Fix X", "Optimize Y", "Do X because Y".
 Not a component name, not a branch name, not a ticket id.
+
+Write this body, then revise it at least twice before posting. Each pass: read it as a reviewer who has no context,
+check it against the rules below and against the design philosophy in AGENTS.md, and cut. A first draft is always too
+long. Stop when nothing else can come out without losing the point.
 -->
 
 ## Abstract
 
 <!--
-One paragraph, plain technical English: what was done and why. No file paths, no symbol names, no code.
-Then at most five bullets, and only if they carry something the paragraph cannot. Skip the bullets if it reads fine
-without them. A long list here means the abstract failed.
+One short paragraph, plain technical English: what was done and why. Four or five sentences is already long. No file
+paths, no symbol names, no code.
+
+No bullets. A list here is almost always a first draft that was never revised — if the points belong together, they
+belong in the paragraph, and if they do not, they belong below the rule. In the rare case a list is genuinely the
+clearest form, five bullets is the hard cap.
 
 "Abstract" is the one fixed heading. Everything below is named for whatever the change is about.
 -->
 
 <!--
 OPTIONAL: one small artifact that carries the abstract's claim — a short table of before/after numbers, a diagram, a
-few lines of output. One only, and only if it says something the paragraph cannot or is more illustractive than text.
-Name the heading for what it shows ("Latency", "New pass order"). Delete this block if there is nothing worth showing.
+few lines of output. One only, and only if it says something the paragraph cannot. Name the heading for what it shows
+("Latency", "New pass order"). Delete this block if there is nothing worth showing.
 -->
 
 ---
 
 <!--
 Everything else, under headings that fit the story: design decisions, alternatives rejected, measurements, what broke,
-what got slower, what was removed. Code references are fine here. Length is fine here.
+what got slower, what was removed. Code references are fine here. Length is fine here, but the same revision rule
+applies — a section a reviewer would skip should not exist.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Title: a functional description, readable with no context. "Fix X", "Optimize Y", "Do X because Y".
+Not a component name, not a branch name, not a ticket id.
+-->
+
+## Abstract
+
+<!--
+One paragraph, plain technical English: what was done and why. No file paths, no symbol names, no code.
+Then at most five bullets, and only if they carry something the paragraph cannot. Skip the bullets if it reads fine
+without them. A long list here means the abstract failed.
+
+"Abstract" is the one fixed heading. Everything below is named for whatever the change is about.
+-->
+
+<!--
+OPTIONAL: one small artifact that carries the abstract's claim — a short table of before/after numbers, a diagram, a
+few lines of output. One only, and only if it says something the paragraph cannot or is more illustractive than text.
+Name the heading for what it shows ("Latency", "New pass order"). Delete this block if there is nothing worth showing.
+-->
+
+---
+
+<!--
+Everything else, under headings that fit the story: design decisions, alternatives rejected, measurements, what broke,
+what got slower, what was removed. Code references are fine here. Length is fine here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@ Not a component name, not a branch name, not a ticket id.
 Write this body, then revise it at least twice before posting. Each pass: read it as a reviewer who has no context,
 check it against the rules below and against the design philosophy in AGENTS.md, and cut. A first draft is always too
 long. Stop when nothing else can come out without losing the point.
+
+Do not hard-wrap the text you write here. GitHub wraps it for the reader, and manual line breaks only make the
+body hard to edit. The ~120-character rule applies to files in the repository, not to a pull-request body.
 -->
 
 ## Abstract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,12 +318,16 @@ Then run the gates, in this order, after every edit above is in:
     go red, name the change that did it in the PR body — do **not** re-record them to make it green, which enshrines
     the regression as the new reference.
 25. **Write the PR body** to `.github/PULL_REQUEST_TEMPLATE.md`. The title is a functional description readable
-    with no context. The abstract is one plain-English paragraph plus at most five bullets, no code references.
-    One optional artifact may follow it — a small table, a diagram, a few lines of output — when it carries the
+    with no context. The abstract is one short plain-English paragraph — no bullets, no code references. One
+    optional artifact may follow it — a small table, a diagram, a few lines of output — when it carries the
     claim better than the paragraph. Then a horizontal rule, then everything else — decisions, measurements,
     what broke, what got slower, what was removed — under headings that fit the story. `Abstract` is the only
     fixed heading.
-26. **Mark the PR ready for review.** This is the last step. A draft PR that has not been through finalization
+26. **Revise the PR body at least twice before posting.** Write it, then reread it as a reviewer with no
+    context, check it against the template and against the design philosophy below, cut, and repeat. A first
+    draft is always too long: it lists what was done instead of saying what the change is, and it keeps
+    sentences that no reviewer would miss. Stop when nothing else can come out without losing the point.
+27. **Mark the PR ready for review.** This is the last step. A draft PR that has not been through finalization
     is not ready, whatever else is green.
 
 # Behavioral Guidelines:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,14 @@ get the same precedence. `config.py` is the source of truth for the full var lis
 
 ## Running Tests
 
+`make test` runs the whole suite. It takes many minutes, so **do not run it while developing** — run only the tests
+that cover the change, under a two-minute budget, and leave the full suite for the finalization stage (see
+Contribution Instructions).
+
 ```bash
-make test
+./venv/bin/pytest tests/test_storage.py -v                        # one file
+./venv/bin/pytest tests/compiler/passes/test_fusion_rules.py -k pointwise   # a few tests
+make test                                                        # the whole suite — finalization only
 ```
 
 `make test` compiles CUDA kernels at **`-Xcicc -O1`** — the **correctness lane**: `-O1` changes runtime perf, not
@@ -84,17 +90,11 @@ removed the cicc unroll blowup it rested on. The cold/warm gap also puts kernel 
 suite's wall time, so it is not the dominant cost either. Keeping `-O1` here buys ~12% cold; dropping it would leave
 one compile regime everywhere in the repo.
 
-Checked-in model goldens are not exercised by the per-commit test suite. The nightly `onboard-model` workflow owns
+Checked-in model goldens are not exercised by the default test suite. The nightly `onboard-model` workflow owns
 their repository validation, strict decode, and exact-GPU replay so model qualification stays with its GPU evidence.
 The decode half alone is also reachable off the default lane, on any machine: `make test-goldens` strictly decodes
 every checked-in golden file (one case per file) against the current compiler, which is how you see a card's rows go
 green again after a tuning round re-records them.
-
-Or for a specific test file:
-
-```bash
-./venv/bin/pytest tests/test_recipe.py -v
-```
 
 When running a large subset (e.g. `tests/compiler/`), pass the same `-n auto --dist=loadgroup` flags `make test` uses to
 parallelize (add `-p no:randomly` for a stable order):
@@ -232,7 +232,9 @@ acceptable reason to go wider. Python code stays under 140 chars (Ruff-enforced)
 
 ## Contribution Instructions
 
-IMPORTANT: You MUST follow ALL of these steps for EVERY code change. Do NOT skip any step.
+Two speeds. Development is fast: small test subsets, quick commits, no sweeps. Finalization is strict and runs
+once, at the end of the PR. Every step below is required for every code change, but each belongs to its own
+stage — do not pull finalization work into the edit loop, and do not skip it at the end.
 
 ### Writing code
 
@@ -253,53 +255,76 @@ code. It is fine to write code that processes structural data by selecting field
 or producing a CSV, TSV, or JSON table. Do not write scripts that interpret results or assemble human-readable
 reports; agents perform that reasoning and write the report.
 
-### Before committing (MANDATORY — do NOT skip these)
+### While developing — go fast
 
-You MUST complete ALL of the following checks before every commit. These are not optional:
+4. **Run only the tests that cover what you changed.** Name the test files or test ids. A directory sweep is not a
+   subset. The full suite takes many minutes; it belongs to finalization, not to the edit loop.
+5. **Hold a two-minute budget** for every test run or exploratory script you start yourself. If it does not finish in
+   two minutes, cut the scope: fewer tests, a smaller model, a smaller shape. A longer run needs a reason and the
+   user's agreement.
+6. **Commit as soon as the chosen subset is green.** Do not run the full suite, the linter, or the documentation pass
+   before a commit. Say in the commit message what you did not verify.
+7. **Open a draft PR with the first push.** Use `.github/PULL_REQUEST_TEMPLATE.md`; a title and a rough abstract
+   are enough at this point. Everything after that lands as more commits on the same PR.
 
-4. **Update `STYLE.md`** if any style changes were introduced — READ the current `STYLE.md` and compare
-5. **Update `README.md`** if project setup, structure, or usage patterns changed — READ the current `README.md` and compare
-6. **Update `AGENTS.md`** if general instructions are no longer accurate — READ this file and compare
-7. **Update `ARCHITECTURE.md`** files in every directory that was modified — READ each relevant `ARCHITECTURE.md` and compare
-8. **Prune `plans/`**: if the change executed/landed a plan, **delete that plan file**. Then enforce the cap — if
-   `plans/` holds more than 10 files, remove the executed/obsolete ones; if all remaining plans are still incomplete,
-   remove the oldest. Never add a `plans/*.md` reference to durable docs or code (see Documentation Conventions).
-9. **Check terminology**: review every text this change adds or edits — code comments, docstrings, docs, report
-   text, the commit message and PR body — against [`GLOSSARY.md`](GLOSSARY.md). Remove any invented terms and
-   replace them with the correct established term or a plain-word explanation (see Documentation Conventions).
-10. **Run tests**: `make test` — fix any failures before proceeding
-11. **Run linter**: `make lint` — if it fails, run `make format` and re-check
-12. **Decode the goldens** whenever the change touches the compiler (anything under `emmy/compiler/`, and always
+### Finalization — once per PR (MANDATORY — do NOT skip these)
+
+Run this stage once, at the end, over the complete diff. It is the only place the full suite, the linter, and the
+documentation sweep belong. Do not spread these steps across the development commits.
+
+Audit the diff:
+
+8. **Remove unnecessary functionality**: Which new functionality can be removed?
+9. **Reuse existing mechanisms**: Which existing CLI, library, recipe, or skill can be reused instead?
+10. **Rethink touched functionality**: Can existing functionality be rearchitected around the PR's needs so one
+    simpler shared design replaces parallel or specialized paths?
+11. **Remove obsolete code**: Delete existing code that the PR makes unnecessary. Apply the boy-scout rule within the
+    PR's scope and leave touched code cleaner, without expanding into an unrelated refactor.
+12. **Keep reasoning and reports out of code**: Which logic should become concise agent instructions? Code may
+    transform structural data, but scripts must not interpret results or assemble human-readable reports.
+13. **Minimize the diff**: Can the same outcome be achieved with fewer changed lines, files, flags, and abstractions?
+14. **Check the core line balance**: run `git diff --stat main -- emmy/`. A PR that introduces no new functionality
+    (a refactor, a cleanup, a fix) must NOT increase the line count under `emmy/` — net growth there without new
+    capability is the typical sign of architectural creep: another special case, helper, or early return layered onto
+    a design that no longer fits. If the balance is positive, do not shave lines cosmetically to pass the check —
+    restructure so the layering disappears, or say explicitly in the PR body why the growth is justified.
+15. **Apply the audit findings**: perform the removals and consolidation now, not after review. Tests must protect the
+    smaller contract, not preserve unnecessary machinery.
+
+Then update the documentation:
+
+16. **Update `STYLE.md`** if any style changes were introduced — READ the current `STYLE.md` and compare
+17. **Update `README.md`** if project setup, structure, or usage patterns changed — READ the current `README.md`
+    and compare
+18. **Update `AGENTS.md`** if general instructions are no longer accurate — READ this file and compare
+19. **Update `ARCHITECTURE.md`** files in every directory that was modified — READ each relevant
+    `ARCHITECTURE.md` and compare
+20. **Prune `plans/`**: if the change executed/landed a plan, **delete that plan file**. Then enforce the cap — if
+    `plans/` holds more than 10 files, remove the executed/obsolete ones; if all remaining plans are still incomplete,
+    remove the oldest. Never add a `plans/*.md` reference to durable docs or code (see Documentation Conventions).
+21. **Check terminology**: review every text this change adds or edits — code comments, docstrings, docs, report
+    text, the commit message and PR body — against [`GLOSSARY.md`](GLOSSARY.md). Remove any invented terms and
+    replace them with the correct established term or a plain-word explanation (see Documentation Conventions).
+
+Then run the gates, in this order, after every edit above is in:
+
+22. **Run the full suite**: `make test` — fix any failures. If a realization case comes back stale, `make
+    test-corpus-regen` applies the fix.
+23. **Run the linter**: `make lint` — if it fails, run `make format` and re-check
+24. **Decode the goldens** whenever the change touches the compiler (anything under `emmy/compiler/`, and always
     for a schedule-codec, enumeration or knob-spelling change): `make test-goldens`. Off the default lane and needs no
     GPU. `make test` guards the realization corpus against exactly this class of change and nothing guarded the
     checked-in model goldens, so a rebuild of the schedule space can invalidate every recorded row in silence. If rows
     go red, name the change that did it in the PR body — do **not** re-record them to make it green, which enshrines
     the regression as the new reference.
-
-### Before submitting (MANDATORY — do NOT skip these)
-
-You MUST audit the complete diff after the before-committing checks and before requesting review:
-
-13. **Remove unnecessary functionality**: Which new functionality can be removed?
-14. **Reuse existing mechanisms**: Which existing CLI, library, recipe, or skill can be reused instead?
-15. **Rethink touched functionality**: Can existing functionality be rearchitected around the PR's needs so one
-    simpler shared design replaces parallel or specialized paths?
-16. **Remove obsolete code**: Delete existing code that the PR makes unnecessary. Apply the boy-scout rule within the
-    PR's scope and leave touched code cleaner, without expanding into an unrelated refactor.
-17. **Keep reasoning and reports out of code**: Which logic should become concise agent instructions? Code may
-    transform structural data, but scripts must not interpret results or assemble human-readable reports.
-18. **Minimize the diff**: Can the same outcome be achieved with fewer changed lines, files, flags, and abstractions?
-19. **Check the core line balance**: run `git diff --stat main -- emmy/`. A PR that introduces no new functionality
-    (a refactor, a cleanup, a fix) must NOT increase the line count under `emmy/` — net growth there without new
-    capability is the typical sign of architectural creep: another special case, helper, or early return layered onto
-    a design that no longer fits. If the balance is positive, do not shave lines cosmetically to pass the check —
-    restructure so the layering disappears, or say explicitly in the PR body why the growth is justified.
-20. **Apply the audit findings**: perform the removals and consolidation before requesting review. Tests must protect
-    the smaller contract, not preserve unnecessary machinery.
-
-### Submitting
-
-21. Push and open a PR
+25. **Write the PR body** to `.github/PULL_REQUEST_TEMPLATE.md`. The title is a functional description readable
+    with no context. The abstract is one plain-English paragraph plus at most five bullets, no code references.
+    One optional artifact may follow it — a small table, a diagram, a few lines of output — when it carries the
+    claim better than the paragraph. Then a horizontal rule, then everything else — decisions, measurements,
+    what broke, what got slower, what was removed — under headings that fit the story. `Abstract` is the only
+    fixed heading.
+26. **Mark the PR ready for review.** This is the last step. A draft PR that has not been through finalization
+    is not ready, whatever else is green.
 
 # Behavioral Guidelines:
 
@@ -344,7 +369,35 @@ When your changes create orphans:
 
 The test: Every changed line should trace directly to the user's request.
 
-## 4. Goal-Driven Execution
+**Exception — a major win.** If the change exposes a restructure that would make the design clearly simpler, say so.
+Do not do it silently and do not bury it: describe the win, say what it costs, and let the user decide. Staying
+surgical is the default, not a reason to keep quiet about a better shape.
+
+## 4. Design Quality Over Compatibility
+
+**A simpler design beats a compatible one.** Every artifact in Emmy can be regenerated — goldens, corpus cases, tune
+databases, priors, dumps. None of them is a reason to keep a worse design alive. Breaking a format, a name, or a
+stored file is cheap; carrying a second path forever is not.
+
+The measure of quality is the design itself: how few concepts it takes to explain, and how few lines the core under
+`emmy/` needs to carry it. Growth in the core without new capability is the warning sign — see the line-balance step
+in the Contribution Instructions.
+
+Dropping a feature is allowed too, when the feature is what forces the complexity. That call belongs to the user, not
+to you. Your job is to offer it: name the feature, name the simplification it buys, and wait.
+
+## 5. No Noise
+
+**Surface what matters, when it matters.** Which concerns are worth raising depends on the stage.
+
+- While prototyping or refactoring: broken paths, slower kernels, and a smaller feature set are fine. Keep working.
+  Do not stop to report them.
+- At finalization: every one of them has to be surfaced and written into the PR body — what broke, what got slower,
+  what was removed, and why.
+
+The same fact is noise in the middle of the work and required at the end. Judge by the stage.
+
+## 6. Goal-Driven Execution
 
 **Define success criteria. Loop until verified.**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,9 @@ markdown habit, and it is wrong for this repo. Aim for lines in the 90–120 ran
 Table rows, ASCII diagrams, and long URLs may overflow past 120 if wrapping would hurt readability — that's the only
 acceptable reason to go wider. Python code stays under 140 chars (Ruff-enforced).
 
+A pull-request or issue body is not a file in the repo: write it in unwrapped paragraphs and let GitHub wrap them.
+Manual line breaks there only make it harder to edit.
+
 ## Contribution Instructions
 
 Two speeds. Development is fast: small test subsets, quick commits, no sweeps. Finalization is strict and runs

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ emmy vm delete cloudrift --instance-id <id>
 ## Development
 
 ```bash
-make test      # run pytest
+make test      # run the whole pytest suite — takes many minutes, run it once when finishing a PR
 make lint      # ruff check + format check
 make format    # auto-fix
 make wheel     # build the wheel into dist/
@@ -469,8 +469,9 @@ require CloudRift organization access.
 1. Fork and branch from `main` (e.g. `feature/my-change`)
 2. Follow [STYLE.md](STYLE.md) and per-directory `ARCHITECTURE.md` files
 3. Add tests in `tests/` (see [tests/ARCHITECTURE.md](tests/ARCHITECTURE.md))
-4. `make test && make lint` (use `make format` to auto-fix)
-5. Open a PR against trunk
+4. While developing, run only the tests that cover your change, and open a **draft** PR early
+5. Finish the PR once, at the end: audit the diff, update the docs, then `make test && make lint` (use `make format`
+   to auto-fix), fill in `.github/PULL_REQUEST_TEMPLATE.md`, and mark the PR ready for review
 
 ## License
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -668,7 +668,7 @@ offers, or a schedule row no kernel of the replay enumerates, is stale and is no
 realizes is the question the nightly `onboard-model` workflow asks with the strict decode (`golden.decode_record`),
 over the same replay: the persisted program must select exactly one kernel (a receipt selects its child by stored
 identity), a routing record's every cut key must name a seam the cut pass offers, and a schedule row must equal one
-enumerated leaf under the record's own pins. The per-commit tests do not load checked-in goldens because proving a
+enumerated leaf under the record's own pins. The default test suite does not load checked-in goldens because proving a
 row enumerates its whole fork costs record count times fork size.
 
 **Whether goldens are training data differs between the two halves of the prior.** The **online** prior never trains

--- a/recipes/ARCHITECTURE.md
+++ b/recipes/ARCHITECTURE.md
@@ -33,8 +33,8 @@ hardware/kernel goldens have no recipe owner and remain under `emmy/compiler/pip
 
 If complete compiler qualification produces a model golden before serving qualification produces a runnable recipe,
 create the normal `onboarding`/`untested` shell first and store the golden beneath it. The nightly `onboard-model`
-workflow owns repository validation, strict decode, and exact-GPU replay for recipe-local goldens; per-commit tests do
-not load checked-in golden YAML.
+workflow owns repository validation, strict decode, and exact-GPU replay for recipe-local goldens; the default
+test suite does not load checked-in golden YAML.
 
 ## Lifecycle
 

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -110,7 +110,7 @@ the shared module already provides.
   serving-twin matrix for a named checkpoint and GPU. The serving-image release workflow owns exact
   model/revision/card qualification. Retain a small model fixture only when it proves reusable behavior that a
   synthetic input cannot.
-- **Do not load checked-in golden YAML in the per-commit suite — except the realization corpus.** Unit tests use
+- **Do not load checked-in golden YAML in the default suite — except the realization corpus.** Unit tests use
   synthetic records and working files, and the nightly `onboard-model` workflow owns repository schema validation,
   strict decode, and exact-GPU replay for `recipes/*/golden/*.yaml`. `tests/compiler/realization/cases/` differs on
   both counts that motivated the rule: its files are hand-minimized reproducers rather than model qualification
@@ -165,10 +165,13 @@ the shared module already provides.
 
 ## Running
 
+While developing, run only the tests that cover the change, under a two-minute budget. The whole suite takes many
+minutes and belongs to the finalization stage of a PR — see the Contribution Instructions in `AGENTS.md`.
+
 ```bash
-pytest tests/ -v                       # all tests (skips off-lane `perf` / `goldens` tests)
-pytest tests/deploy/test_recipe.py -v  # single file
-pytest tests/planner/ -v               # single directory
+pytest tests/deploy/test_recipe.py -v   # single file — the development lane
+pytest tests/deploy/ -k recipe -v      # a few tests — the development lane
+pytest tests/ -v                       # all tests, finalization only (skips off-lane `perf` / `goldens` tests)
 pytest tests/perf/ -m perf -v          # GPU perf suite (see tests/perf/ARCHITECTURE.md)
 pytest tests/compiler/pipeline/search/ -m goldens -v   # strict-decode the checked-in goldens (make test-goldens)
 ```
@@ -232,7 +235,7 @@ rows that actually changed.
 
 Repository golden *qualification* is intentionally outside pytest. Model goldens are GPU-specific qualification
 evidence, so the nightly `onboard-model` workflow validates the selected recipe-local file, strictly decodes every
-row, and replays it on the named GPU. This keeps expensive model/card qualification out of the per-commit suite. Only
+row, and replays it on the named GPU. This keeps expensive model/card qualification out of the default suite. Only
 the decode half is also reachable without the card, off the default lane (`make test-goldens` above) — it targets each
 record's declared capability; the measured replay is what the nightly's GPU is for.
 


### PR DESCRIPTION
## Abstract

Every commit used to be expected to carry the full test suite, the linter and a documentation sweep, which made the edit loop slow and the checklist easy to ignore. This change splits the flow by stage: while developing you run only the tests that cover what you changed, under a two-minute budget, and commit as soon as they pass; everything else runs once, at the end of the pull request, in a finalization stage that closes by marking the draft ready for review. It also writes down the guidance those stages lean on — how to communicate, when design quality outranks compatibility, and what a pull-request body should look like.

### Where the work happens

| Step | Before | After |
| --- | --- | --- |
| Full test suite | before every commit | once, at finalization |
| Linter, documentation sweep, plan pruning | before every commit | once, at finalization |
| Diff audit | before opening the PR | at finalization, before the gates |
| Draft PR | not mentioned | opened with the first push |
| Test runs while developing | unbounded | named tests, two-minute budget |

---

## Why two speeds

The old instructions were one mandatory checklist attached to the word "commit". Followed literally, a five-line fix paid for a full suite run, a lint pass and a documentation review; followed loosely, the checklist meant nothing. Splitting it by stage keeps both halves honest. Order inside finalization is now fixed — audit the diff, update the documentation, then run the gates — so the suite runs after every edit is in rather than being invalidated by the next one.

## New guidance

**Communication.** Write as you would speak: short sentences, only what matters, no code references unless asked, established vocabulary only. Disagreement is expected when there is a reason, but raising a concern needs a real stake.

**Design quality over compatibility.** Goldens, corpus cases, tuning databases and priors can all be regenerated, so breaking a format is cheap while carrying a second path is not. Quality is measured by how few concepts the design needs and how few lines the core carries. Reducing the feature set is a legitimate option when the feature is what forces the complexity; offering it is the agent's job, deciding is the developer's.

**No noise.** Mid-refactor breakage and slower kernels stay unreported. At finalization they go into the pull request.

**Major wins.** Staying surgical is still the default, but a restructure that would clearly simplify the design must be surfaced rather than silently skipped or silently performed.

## Pull-request template

New: a functional title, a short abstract with no bullets and no code references, one optional supporting artifact, and everything else below a horizontal rule under headings that fit the change. It asks for two revision passes before posting, because the failure mode it guards against is a first draft that lists everything done instead of saying what the change is.

## Consistency pass

Three architecture files called the suite "per-commit"; it is now the default suite. The test architecture, the project overview and the GitHub Actions architecture pick up the development lane, the finalization stage and the template.

## Verification

Documentation only; no code changed. The linter passes. No test reads these files, so the suite has nothing to say about this change and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGg8uKwBRBdckMXLx897oS
