### PR TITLE
Make Tile IR blockification explicit for every fold

### DIFF
--- a/emmy/compiler/ir/schedule/choices.py
+++ b/emmy/compiler/ir/schedule/choices.py
@@ -51,8 +51,8 @@ from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 
 from emmy.compiler.ir.atom import SCALAR_ATOM, Atom, AtomKind, atom_for
-from emmy.compiler.ir.axis import Axis
-from emmy.compiler.ir.expr import Expr, Literal
+from emmy.compiler.ir.axis import Axis, Window
+from emmy.compiler.ir.expr import BinaryExpr, Expr, Literal, Var
 
 # ===========================================================================================
 # The one rule every codec below shares. Each value type parses and spells its own grammar by
@@ -505,10 +505,13 @@ class PlacedTile:
     def mn(self) -> tuple[Side, Side]:
         """The ``(m, n)`` output :class:`Side` pair — each placed axis with its derived geometry.
         Requires :meth:`at` to have bound the placement; :attr:`m` / :attr:`n` index it."""
-        dims = ((self.tile_m, self.units_m, self.reg_m), (self.tile_n, self.units_n, self.reg_n))
+        dims = (
+            (self.tile_m, self.units_m, self.reg_m, self.atom.atom_m),
+            (self.tile_n, self.units_n, self.reg_n, self.atom.atom_n),
+        )
         return tuple(
-            Side(axis=ax, tile=tile, units=units, reg=reg, block=ax.name + "_b", unit=ax.name + "_u")
-            for ax, (tile, units, reg) in zip(self.axes, dims, strict=True)
+            Side(axis=ax, tile=tile, units=units, reg=reg, atom=atom, block=ax.name + "_b", unit=ax.name + "_u")
+            for ax, (tile, units, reg, atom) in zip(self.axes, dims, strict=True)
         )
 
     @property
@@ -954,38 +957,17 @@ class Raster:
 _RASTER_RE = re.compile(r"g([mn])(\d+)")
 
 
-def _ext_expr(axis: Axis) -> Expr:
-    """The axis extent as an ``Expr`` — a literal int (static) or the symbolic ``Dim`` expr."""
-    return Literal(axis.extent.as_static(), "int") if axis.extent.is_static else axis.extent.expr
-
-
-def _overhangs(axis: Axis, tile: int) -> bool:
-    """True iff a ``tile``-wide CTA block overhangs ``axis`` (symbolic or non-divisible extent) —
-    so its tail must be masked."""
-    if tile <= 1:
-        return False
-    return not (axis.extent.is_static and axis.extent.as_static() % tile == 0)
-
-
 @dataclass(frozen=True)
 class Side:
-    """One tiled output axis of a contraction — the outer ``m`` or inner ``n`` — paired with its
-    derived per-CTA tile geometry. The two ride as a ``(m, n)`` pair (:attr:`Fold.mn`)
-    mirroring :class:`Tile`'s own ``units`` / ``regs`` tuples, so the factorizer
-    threads one object per axis instead of a dozen loose ``*_m`` / ``*_n`` args. The tile width,
-    unit / register counts, and bound block/unit var names are derived from an axis + a
-    :class:`Tile`; the ``mask`` / ``ext`` follow from the axis + width.
+    """One output axis after its symbolic GRID, UNIT, REGISTER and ATOM levels are bound."""
 
-    Lives here, beside ``Tile``, because it is SCHEDULE geometry, not algebra: ``ir/tile/ir.py``
-    already imports this module, so a tile-side home would make the schedule slice unable to derive
-    its own ``(m, n)`` reading."""
-
-    axis: Axis  # the output axis (a param)
-    tile: int  # the per-CTA width = units · reg · atom_dim
-    units: int  # parallel units on this axis (warps for mma / threads for scalar)
-    reg: int  # register sub-cells per unit on this axis
-    block: str  # the bound grid-block var (the axis name + ``_b``)
-    unit: str  # the bound unit var (the axis name + ``_u``)
+    axis: Axis
+    tile: int
+    units: int
+    reg: int
+    atom: int
+    block: str
+    unit: str
 
     @property
     def name(self) -> str:
@@ -993,13 +975,25 @@ class Side:
 
     @property
     def mask(self) -> bool:
-        """True iff a ``tile``-wide CTA block overhangs the axis (its tail must be masked)."""
-        return _overhangs(self.axis, self.tile)
+        return self.tile > 1 and not (self.axis.extent.is_static and self.axis.extent.as_static() % self.tile == 0)
 
     @property
     def ext(self) -> Expr:
-        """The axis extent as an ``Expr`` — a static literal or the symbolic ``Dim`` expr."""
-        return _ext_expr(self.axis)
+        return self.axis.extent_expr()
+
+    @property
+    def axes(self) -> tuple[Axis, Axis]:
+        parent = self.axis.source_axis or self.axis
+        return Axis(self.block, self.axis.extent.ceil_div(self.tile), window=Window(parent=parent)), Axis(self.unit, self.units)
+
+    def base(self, register: int) -> Expr:
+        block = BinaryExpr("*", Var(self.block), Literal(self.tile, "int"))
+        unit = BinaryExpr("*", Var(self.unit), Literal(self.reg * self.atom, "int"))
+        return BinaryExpr("+", BinaryExpr("+", block, unit), Literal(register * self.atom, "int"))
+
+    @property
+    def cta_base(self) -> Expr:
+        return BinaryExpr("*", Var(self.block), Literal(self.tile, "int"))
 
 
 __all__ = [

--- a/emmy/compiler/ir/schedule/classic.py
+++ b/emmy/compiler/ir/schedule/classic.py
@@ -17,6 +17,7 @@ from frozendict import frozendict
 from emmy.compiler.ir.pure.fold import Fold
 from emmy.compiler.structural import instance_memo
 from emmy.utils import cached_method
+from emmy.compiler.ir.tile.block import BlockClaim
 
 from .base import Schedule, ScheduleContext, ScheduleRefused
 from .choices import (
@@ -181,6 +182,7 @@ class _LocalSupport:
     edges: Mapping[EdgeSite, EdgeSchedule]
     work: Work | None = None
     axes: tuple[_AxisAgreement, ...] = ()
+    blocks: tuple[BlockClaim, ...] = ()
     fragments: tuple[_FragmentAgreement, ...] = ()
     raster_eligible: bool = False
     producer_eligible: bool = True
@@ -465,6 +467,15 @@ class ClassicMaterialization:
         for edge, resolved in self.stages.items():
             if edge not in schedule.edges or resolved.choice != schedule.edges[edge].stage:
                 raise ValueError(f"materialized stage at {edge_site_spelling(edge)} does not derive from its classic choice")
+        expected_blocks = {}
+        for site, choice in schedule.nodes.items():
+            geometry = self.tiles.get(site)
+            stages = {stage for edge, stage in self.stages.items() if edge[0] == site}
+            if len(stages) > 1:
+                raise ValueError(f"{node_id_spelling(site)} has more than one resolved block width")
+            for claim in source.blocks[site].claims(choice, geometry, next(iter(stages), None)):
+                if not claim.accepted or expected_blocks.setdefault(claim.parameter, claim.width) != claim.width:
+                    raise ValueError(f"schedule binds block parameter {claim.parameter!r} inconsistently")
         producer = workers.producer_warps if workers is not None else 0
         if schedule.kernel.work.producer != producer:
             raise ValueError(f"classic producer band {schedule.kernel.work.producer} disagrees with WarpSpec producer band {producer}")
@@ -487,6 +498,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
     _assignment: ClassicAssignment = field(default_factory=lambda: Schedule(None, {}, {}), repr=False)
     _work: Work | None = field(default=None, repr=False)
     _axes: Mapping[str, tuple[int, int]] = field(default_factory=frozendict, repr=False)
+    _blocks: Mapping[str, int] = field(default_factory=frozendict, repr=False)
     _fragments: Mapping[tuple[str, str], tuple] = field(default_factory=frozendict, repr=False)
     _raster_eligible: bool = field(default=False, repr=False)
     _producer_eligible: bool = field(default=True, repr=False)
@@ -525,6 +537,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
         if not isinstance(self._assignment, Schedule):
             raise TypeError("classic context assignment must be a Schedule")
         object.__setattr__(self, "_axes", frozendict(self._axes))
+        object.__setattr__(self, "_blocks", frozendict(self._blocks))
         object.__setattr__(self, "_fragments", frozendict(self._fragments))
         if self._pins is not None:
             object.__setattr__(self, "_pins", frozendict({family: tuple(values) for family, values in self._pins.items()}))
@@ -825,6 +838,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             _assignment=Schedule(None, {}, {}),
             _work=None,
             _axes=frozendict(),
+            _blocks=frozendict(),
             _fragments=frozendict(),
             _raster_eligible=False,
             _producer_eligible=True,
@@ -873,12 +887,14 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
         work = support.work or self._work
         nodes = {**self.assignment.nodes, site: support.node}
         axes = {**self._axes, **{claim.name: (claim.tile, claim.units) for claim in support.axes}}
+        blocks = {**self._blocks, **{claim.parameter: claim.width for claim in support.blocks}}
         fragments = {**self._fragments, **{(claim.role, claim.edge): claim.value for claim in support.fragments}}
         return self._advance(
             position=self.position + 1,
             _assignment=Schedule(None, nodes, {**self.assignment.edges, **support.edges}),
             _work=work,
             _axes=frozendict(axes),
+            _blocks=frozendict(blocks),
             _fragments=frozendict(fragments),
             _raster_eligible=self._raster_eligible or support.raster_eligible,
             _producer_eligible=self._producer_eligible and support.producer_eligible,
@@ -979,6 +995,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
                 if node.tile.is_tiled and isinstance(geometry, PlacedTile)
                 else ()
             ),
+            blocks=self.tile_op.blocks[site].claims(node, geometry, resolved_stage),
             fragments=(
                 _fragment_agreements(
                     site,
@@ -1031,6 +1048,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             node,
             edges,
             work=work,
+            blocks=self.tile_op.blocks[site].claims(node),
             raster_eligible=node.tile.is_tiled and view.as_contraction() is not None,
         )
 
@@ -1041,6 +1059,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             work=self._work,
             previous_nodes=tuple(self.assignment.nodes.values()) if self._work is None else (),
             axes=tuple(self._axes.items()),
+            blocks=tuple(self._blocks.items()),
             fragments=tuple(self._fragments.items()),
             allowed_works=self._allowed_works,
         )
@@ -1057,6 +1076,7 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
         work: Work | None,
         previous_nodes: tuple[NodeSchedule, ...],
         axes: tuple[tuple[str, tuple[int, int]], ...],
+        blocks: tuple[tuple[str, int], ...],
         fragments: tuple[tuple[tuple[str, str], tuple], ...],
         allowed_works: frozenset[tuple[str, tuple[int, ...]]] | None,
     ) -> str | None:
@@ -1076,6 +1096,12 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             value = (claim.tile, claim.units)
             if axis_values.get(claim.name, value) != value:
                 return "pick disagrees on physical-axis geometry"
+        block_values = dict(blocks)
+        for claim in support.blocks:
+            if not claim.accepted:
+                return "pick does not consume the declared stream block"
+            if block_values.get(claim.parameter, claim.width) != claim.width:
+                return "pick disagrees on a symbolic block parameter"
         fragment_values = dict(fragments)
         for claim in support.fragments:
             key = (claim.role, claim.edge)

--- a/emmy/compiler/ir/schedule/classic_projection.py
+++ b/emmy/compiler/ir/schedule/classic_projection.py
@@ -324,60 +324,11 @@ def _options(state: _ProjectionState, node) -> tuple:
         ):
             continue
         valid_choices.append((choice, geometry))
-    # A site INSIDE a block exists to be bilinear. The block was cut so a channel could reach the
-    # tensor cores, and it costs a second pass over the stream to do it — a scalar row there pays
-    # that and buys nothing. So the scalar tier is offered only where no warp tile fits the block
-    # at all, and a warp tile that does not consume the block EXACTLY is not offered: the block is
-    # one step of the stream, and a row that half-covers it emits a different blocking from the
-    # one the term spells. This is blocking's own reading, applied to the sites it created.
-    if any(_block_of(state.tile, node, geometry) is not None for _, geometry in valid_choices):
-        fitting = [
-            choice
-            for choice, geometry in valid_choices
-            if choice.tile.is_warp and not _block_refusal(state.tile, node, choice.tile, geometry)
-        ]
-        valid_choices = fitting or [choice for choice, _ in valid_choices]
-    else:
-        valid_choices = [choice for choice, _ in valid_choices]
+    fitting = [choice for choice, geometry in valid_choices if all(claim.accepted for claim in state.tile.blocks_of(node).claims(choice, geometry))]
+    valid_choices = fitting or [choice for choice, _ in valid_choices]
     if not valid_choices:
         raise ClassicProjectionError(f"classic site {node_id_spelling(site)} has no locally supported choice")
     return tuple(valid_choices)
-
-
-def _block_extent(tile: TileOp, name: str | None) -> int | None:
-    """The block ``name`` walks, when it is a block's INNER axis — the one blocking cut the stream
-    into. The outer axis strides and is not one."""
-    if name is None:
-        return None
-    axis = tile.axis_of(name)
-    window = axis.window
-    return axis.extent.as_static() if window is not None and window.block and axis.step is None else None
-
-
-def _block_of(tile: TileOp, node, geometry) -> int | None:
-    """The block one site's tile has to consume, or ``None`` when the site is not inside a block.
-
-    Two sites sit inside one: the CHANNEL, whose K IS the block; and the SCORE the weight reads,
-    whose output covers the block.
-    """
-    block = _block_extent(tile, node.axis)
-    if block is not None:
-        return block
-    return _block_extent(tile, geometry.axes[1].name if isinstance(geometry, PlacedTile) else None)
-
-
-def _block_refusal(tile: TileOp, node, plan: Tile, geometry) -> bool:
-    """Whether one warp tile inside a block fails to consume exactly that block — the channel's
-    K-step in ONE trip, the score's fragment grid in one cover.
-
-    Both equations are the emitter's own (a fragment grid that does not cover the chunk it stores
-    has no seam), and reading them here is what keeps the enumeration from offering rows the kernel
-    binder must then refuse.
-    """
-    if _block_extent(tile, node.axis) is not None:
-        return plan.atom.atom_k * plan.bk != _block_extent(tile, node.axis)
-    block = _block_of(tile, node, geometry)
-    return block is not None and plan.regs[1] * plan.atom.atom_n != block
 
 
 def _edge_domain(state: _ProjectionState, site: int, choices: tuple) -> tuple[EdgeSchedule, ...]:
@@ -499,6 +450,7 @@ def materialize_classic(
         output_specs=tile.output_specs,
         schedule=assignment,
         axes=tile.axes,
+        blocks=tile.blocks,
         materialization=ClassicMaterialization(placed, resolved),
         workers=WarpSpec(assignment.kernel.work.producer) if assignment.kernel.work.producer else None,
     )

--- a/emmy/compiler/ir/tile/__init__.py
+++ b/emmy/compiler/ir/tile/__init__.py
@@ -9,6 +9,17 @@ separate from the term; dispatch reads the node's derived classification, not a 
 
 from emmy.compiler.ir.pure.fold import Fold
 from emmy.compiler.ir.schedule import FoldMove, Level, Placement, Reduce, ReduceStage
+from emmy.compiler.ir.tile.block import (
+    BlockAxis,
+    BlockClaim,
+    BoundBlockAxis,
+    BoundBlockLoop,
+    BoundSiteBlocks,
+    BoundTransposedLoop,
+    SiteBlocks,
+    bind_site,
+    blockify,
+)
 from emmy.compiler.ir.tile.ir import (
     OutputSpec,
     TileOp,
@@ -19,15 +30,24 @@ from emmy.compiler.ir.tile.ir import (
 from emmy.compiler.ir.tile.normalize import normalize_fold_tree
 
 __all__ = [
+    "BlockAxis",
+    "BlockClaim",
+    "BoundBlockAxis",
+    "BoundBlockLoop",
+    "BoundSiteBlocks",
+    "BoundTransposedLoop",
     "Fold",
     "FoldMove",
     "Level",
     "Placement",
     "Reduce",
     "ReduceStage",
+    "SiteBlocks",
     "OutputSpec",
     "TileOp",
     "apply_output_specs",
+    "bind_site",
+    "blockify",
     "observed_result_names",
     "normalize_fold_tree",
     "extract_output_specs",

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -219,6 +219,29 @@ def _pretty_place(tile) -> list[str]:
     return out
 
 
+def _pretty_blocks(tile) -> list[str]:
+    """The stored symbolic axis decomposition and its schedule binding, when decided."""
+    if not tile.blocks:
+        return []
+    widths = {}
+    if tile.schedule is not None:
+        schedule = sched_of(tile)
+        for site, choice in tile.schedule.nodes.items():
+            geometry = tile.materialization.tiles.get(site) if tile.materialization is not None else None
+            stage = schedule.get("STAGE", tile.sites[site].node)
+            widths.update((claim.parameter, claim.width) for claim in tile.blocks[site].claims(choice, geometry, stage))
+    rows = []
+    for blocks in tile.blocks:
+        entries = list(blocks.output)
+        if blocks.reduce is not None:
+            entries.append(blocks.reduce)
+        for block in entries:
+            bound = f" = {widths[block.parameter]}" if block.parameter in widths else ""
+            levels = " × ".join(block.levels)
+            rows.append(f"{block.parameter}{bound}: {block.axis.name} → {levels}")
+    return _pretty_region("blocks", rows)
+
+
 def tile_body(tile) -> str:
     """Render the kernel structurally (the dump view) — no lowering and nothing derived: the
     caller facts that live beside the term (``place`` / ``workers`` / ``classic.kernel.work``), then the stored
@@ -229,6 +252,7 @@ def tile_body(tile) -> str:
     if tile.op is None:
         return ""
     lines = [f"    {line}" for line in _pretty_place(tile)]
+    lines += _pretty_blocks(tile)
     lines += pretty(tile.op, "    ", tile=tile)
     outputs = [
         f"{f'sweep({".".join(axis.name for axis in spec.sweep)}) ' if spec.sweep else ''}{line.strip()}"

--- a/emmy/compiler/ir/tile/block.py
+++ b/emmy/compiler/ir/tile/block.py
@@ -1,0 +1,402 @@
+"""Symbolic loop blocking for Tile IR.
+
+A :class:`BlockAxis` says which schedule parameters decompose one logical axis. It carries no
+chosen width. ``025_block`` installs one :class:`SiteBlocks` value per Fold site before any
+schedule is selected; the classic schedule only binds those parameters.
+
+The table is also the one owner of placement. A contraction's output axes are discovered here,
+once, instead of being rediscovered while each schedule candidate is lowered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from emmy.compiler.dim import Dim
+from emmy.compiler.ir.axis import Axis, Window
+from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
+from emmy.compiler.ir.sigma import Sigma
+
+
+@dataclass(frozen=True)
+class BlockAxis:
+    """One logical axis and the symbolic schedule parameters that block it.
+
+    ``parameter`` identifies one width shared by every use of the same block. Most axes have a
+    site-local parameter. Axes introduced while reassociating a twisted carrier share the
+    parameter of their common source axis, which lets the existing TILE choices bind one width
+    consistently across the score and value contractions without a BLOCK codec family.
+    """
+
+    axis: Axis
+    parameter: str
+    levels: tuple[str, ...]
+    limit: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.parameter or not self.levels:
+            raise ValueError("a symbolic block axis requires a parameter and at least one level")
+
+    def partition(self, parts: int, *, outer: str, inner: str | None = None) -> tuple[Axis, Axis, Sigma]:
+        """Bind the GRID level to ``parts`` contiguous slices."""
+        if type(parts) is not int or parts < 1:
+            raise ValueError(f"block partition count must be a positive integer, got {parts!r}")
+        extent = self.axis.extent.as_static()
+        if extent % parts:
+            raise ValueError(f"block partition count {parts} does not divide {self.axis.name} extent {extent}")
+        width = extent // parts
+        outer_axis = Axis(outer, Dim(parts))
+        inner_axis = replace(
+            self.axis,
+            name=inner or self.axis.name,
+            extent=Dim(width),
+            window=Window(parent=self.axis.source_axis or self.axis, partition=True),
+        )
+        index = BinaryExpr("+", BinaryExpr("*", Var(outer_axis.name), Literal(width, "int")), Var(inner_axis.name))
+        return outer_axis, inner_axis, Sigma({self.axis.name: index})
+
+
+@dataclass(frozen=True)
+class SiteBlocks:
+    """The symbolic output and reduction blocks owned by one Fold schedule site."""
+
+    output: tuple[BlockAxis, BlockAxis] | tuple[()] = ()
+    reduce: BlockAxis | None = None
+
+    def __post_init__(self) -> None:
+        if self.output and len(self.output) != 2:
+            raise ValueError("a contraction block requires exactly two output axes")
+
+    def claims(self, choice, geometry=None, stage=None) -> tuple[BlockClaim, ...]:
+        """Bind this site's parameters from one existing schedule choice.
+
+        No value is selected here. TILE and REDUCE already selected the unit, register, atom and
+        grid widths, while STAGE already resolved a scalar copy chunk. This method only projects
+        those values onto the symbolic block parameters declared by the pass.
+        """
+        out = []
+        tile = choice.tile
+        if self.output:
+            for index, part in enumerate(self.output):
+                if geometry is None:
+                    if part.limit is not None:
+                        out.append(BlockClaim(part.parameter, 1, part.limit))
+                    continue
+                side = geometry.mn[index]
+                width = side.reg * side.atom if part.limit is not None else side.tile
+                out.append(BlockClaim(part.parameter, width, part.limit))
+        if self.reduce is not None:
+            reduction = getattr(choice, "reduce", None)
+            axis = self.reduce.axis
+            structural = axis.window is not None and axis.window.block
+            if structural and axis.step is not None:
+                if not isinstance(axis.step, Literal):
+                    raise ValueError("a structural block step must be static before scheduling")
+                width = axis.step.value
+            elif structural and not self.output:
+                width = axis.extent.as_static()
+            elif tile.is_warp:
+                width = tile.atom.atom_k * tile.bk
+            elif stage is not None and stage.bk_elems:
+                width = stage.bk_elems
+            elif reduction is not None:
+                width = reduction.parallel
+            else:
+                width = 1
+            out.append(BlockClaim(self.reduce.parameter, width, self.reduce.limit))
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class BlockClaim:
+    """One concrete width supplied to a symbolic block parameter by a schedule choice."""
+
+    parameter: str
+    width: int
+    limit: int | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.width) is not int or self.width < 1:
+            raise ValueError(f"block width must be a positive integer, got {self.width!r}")
+
+    @property
+    def accepted(self) -> bool:
+        """Whether the chosen width respects the form's fixed compatibility bound."""
+        return self.limit is None or self.width == self.limit
+
+
+@dataclass(frozen=True)
+class BoundBlockAxis:
+    """One symbolic axis after the schedule has supplied its block width."""
+
+    symbolic: BlockAxis
+    width: int
+    name: str = "_ks"
+    factors: tuple[tuple[str, int], ...] = ()
+    transposed: bool = False
+
+    def __post_init__(self) -> None:
+        if type(self.width) is not int or self.width < 1:
+            raise ValueError(f"block width must be a positive integer, got {self.width!r}")
+        if self.symbolic.limit is not None and self.width != self.symbolic.limit:
+            raise ValueError(f"block {self.symbolic.parameter!r} requires width {self.symbolic.limit}, got {self.width}")
+        if any(level not in self.symbolic.levels or type(width) is not int or width < 1 for level, width in self.factors):
+            raise ValueError("bound block factors must be positive widths of declared levels")
+        if len({level for level, _ in self.factors}) != len(self.factors):
+            raise ValueError("a bound block level may be supplied only once")
+        product = 1
+        for _, factor in self.factors:
+            product *= factor
+        if self.factors and product != self.width:
+            raise ValueError(f"bound block factors cover {product} elements, expected {self.width}")
+
+    @property
+    def axis(self) -> Axis:
+        """The outer axis walking the logical source one block at a time."""
+        source = self.symbolic.axis
+        return Axis(
+            self.name,
+            source.extent,
+            window=Window(parent=source.source_axis or source, block=True),
+            step=Literal(self.width, "int"),
+        )
+
+    @property
+    def inner(self) -> Axis:
+        """The local coordinate within one block."""
+        source = self.symbolic.axis
+        return Axis(f"{self.name}_i", self.width, window=Window(parent=source.source_axis or source, block=True))
+
+    @property
+    def extent(self) -> int | Dim:
+        """The source extent in the form consumed by kernel lowering."""
+        extent = self.symbolic.axis.extent
+        return extent.as_static() if extent.is_static else extent
+
+    @property
+    def chunks(self) -> int | Dim:
+        """The number of blocks covering the source axis."""
+        extent = self.symbolic.axis.extent
+        return -(-extent.as_static() // self.width) if extent.is_static else extent.ceil_div(self.width)
+
+    def factor(self, level: str) -> int:
+        """The bound width at one declared level, or one when the level is inactive."""
+        if level not in self.symbolic.levels:
+            raise ValueError(f"block {self.symbolic.parameter!r} has no {level!r} level")
+        return dict(self.factors).get(level, 1)
+
+    def on(self, symbolic: BlockAxis) -> BoundBlockAxis:
+        """Use this shared parameter binding on another declaration of the same block."""
+        if symbolic.parameter != self.symbolic.parameter:
+            raise ValueError(
+                f"cannot move block parameter {self.symbolic.parameter!r} onto {symbolic.parameter!r}"
+            )
+        return replace(self, symbolic=replace(self.symbolic, axis=symbolic.axis, limit=symbolic.limit))
+
+    @property
+    def lane(self) -> Axis | None:
+        """The cooperative BLOCK axis of a scalar reduction, when active."""
+        width = self.factor("block")
+        return Axis(f"{self.symbolic.axis.name}_co", width) if width > 1 else None
+
+    def loop(self, axis: Axis, lane: Axis | None = None) -> BoundBlockLoop:
+        """Bind a serial reduce loop to its BLOCK and REGISTER decomposition."""
+        coop = self.factor("block")
+        return self._loop(axis, coop, lane)
+
+    def _loop(self, axis: Axis, coop: int, lane: Axis | None) -> BoundBlockLoop:
+        registers = self.factor("register")
+        if (lane is None) != (coop == 1) or (lane is not None and lane.extent != coop):
+            raise ValueError("reduce loop lane does not match its bound BLOCK level")
+        source_step = axis.step.value if isinstance(axis.step, Literal) else 1
+        parallel = coop * registers
+        trips = axis.trips
+        masked = registers > 1 and not (trips is not None and trips % parallel == 0)
+        start = (
+            Literal(0, "int")
+            if lane is None
+            else BinaryExpr("*", Var(lane.name), Literal(source_step, "int"))
+            if source_step > 1
+            else Var(lane.name)
+        )
+        return BoundBlockLoop(
+            axis=axis,
+            lane=lane,
+            registers=registers,
+            register_span=coop * source_step,
+            stride=parallel * source_step,
+            masked=masked,
+            start=start,
+        )
+
+    def transposed_loop(self, axis: Axis, output: Axis, *, warp_size: int = 32) -> BoundTransposedLoop:
+        """Bind the transposed cooperative reduction's K and output lane axes."""
+        if not self.transposed:
+            raise ValueError("a non-transposed block has no transposed loop")
+        coop = self.factor("block")
+        if coop % warp_size:
+            raise ValueError(f"transposed BLOCK width {coop} must be a multiple of warp size {warp_size}")
+        k_ways = coop // warp_size
+        output_lane = Axis(f"{output.name}_ln", warp_size)
+        k_lane = Axis(f"{axis.name}_co", k_ways) if k_ways > 1 else None
+        output_block = Axis(f"{output.name}_blk", output.extent.ceil_div(warp_size), window=Window(parent=output))
+        cell = BinaryExpr(
+            "+",
+            BinaryExpr("*", Var(output_block.name), Literal(warp_size, "int")),
+            Var(output_lane.name),
+        )
+        overhang = not (output.extent.is_static and output.extent.as_static() % warp_size == 0)
+        return BoundTransposedLoop(
+            loop=self._loop(axis, k_ways, k_lane),
+            output_block=output_block,
+            output_lane=output_lane,
+            cell=cell,
+            overhang=overhang,
+            threads=coop,
+        )
+
+
+@dataclass(frozen=True)
+class BoundBlockLoop:
+    """The concrete serial loop left after a bound reduction block is distributed."""
+
+    axis: Axis
+    lane: Axis | None
+    registers: int
+    register_span: int
+    stride: int
+    masked: bool
+    start: object
+
+
+@dataclass(frozen=True)
+class BoundTransposedLoop:
+    """A transposed BLOCK decomposition across K groups and output lanes."""
+
+    loop: BoundBlockLoop
+    output_block: Axis
+    output_lane: Axis
+    cell: object
+    overhang: bool
+    threads: int
+
+
+@dataclass(frozen=True)
+class BoundSiteBlocks:
+    """One site's block axes after materialization."""
+
+    output: tuple = ()
+    reduce: BoundBlockAxis | None = None
+
+
+def bind_site(blocks: SiteBlocks, choice, geometry=None, stage=None, *, name: str = "_ks") -> BoundSiteBlocks:
+    """Bind a site's declared block parameters from its existing schedule choice."""
+    widths = {claim.parameter: claim.width for claim in blocks.claims(choice, geometry, stage)}
+    reduce = None
+    if blocks.reduce is not None:
+        try:
+            width = widths[blocks.reduce.parameter]
+        except KeyError:
+            raise ValueError(f"schedule did not bind block parameter {blocks.reduce.parameter!r}") from None
+        tile = choice.tile
+        reduction = getattr(choice, "reduce", None)
+        if tile.is_warp:
+            factors = (("tile", tile.bk), ("atom", tile.atom.atom_k))
+            transposed = False
+        elif stage is not None and stage.bk_elems:
+            factors = (("tile", stage.bk_elems), ("atom", 1))
+            transposed = False
+        elif reduction is not None:
+            factors = (("grid", reduction.cta), ("block", reduction.coop), ("register", reduction.reg))
+            transposed = reduction.coop_transposed
+        else:
+            factors = ()
+            transposed = False
+        reduce = BoundBlockAxis(blocks.reduce, width, name, factors, transposed)
+    output = geometry.mn if blocks.output and geometry is not None else ()
+    return BoundSiteBlocks(output, reduce)
+
+
+def _parameter(axis: Axis, site: int, role: str) -> tuple[str, int | None]:
+    window = axis.window
+    if window is not None and window.block and window.parent is not None:
+        width = axis.step.value if isinstance(axis.step, Literal) else axis.extent.as_static()
+        return f"{window.parent.name}.block", width
+    return f"b{site}.{role}", None
+
+
+def _output_axes(tile, node) -> tuple[Axis, Axis] | None:
+    """Derive the contraction's ``(m, n)`` axes once, during blockification."""
+    place = tile.place.on_grid()
+    free = tuple(place.free)
+    site = tile.sites[tile.node_id(node)]
+    ancestors = tuple(candidate for candidate in tile.sites if site.under(candidate))
+
+    def orient(mn):
+        view = node.as_contraction()
+        if mn is None or view is None:
+            return mn
+        order = {axis.name: (position, axis) for position, axis in enumerate((*place.free, *place.grid))}
+        left = max((order[name] for name in view.left_axes if name in order), default=None)
+        right = max((order[name] for name in view.right_axes if name in order), default=None)
+        if left is not None and right is not None:
+            return left[1], right[1]
+        first, second = mn
+        return (second, first) if second.name == view.left and first.name != view.left else mn
+
+    if all(candidate.node.axis is None for candidate in ancestors):
+        return orient(place.root_mn)
+    if len(free) < 2:
+        return None
+    parent = next(
+        (
+            found
+            for depth in range(len(site.hops) - 1, -1, -1)
+            if (found := next((candidate for candidate in tile.sites if candidate.hops == site.hops[:depth]), None)) is not None
+            and found.node.axis is not None
+        ),
+        None,
+    )
+    axis = tile.axis_of(parent.node.axis) if parent is not None else None
+    if axis is None:
+        return None
+    return orient((free[-2], axis.window.parent if axis.window is not None and not axis.window.block else axis))
+
+
+def blockify(tile) -> tuple[SiteBlocks, ...]:
+    """Declare every Fold site's symbolic axis decomposition."""
+    out = []
+    for site, record in enumerate(tile.sites):
+        node = record.node
+        output = ()
+        if node.as_contraction() is not None and (mn := _output_axes(tile, node)) is not None:
+            blocks = []
+            for role, axis in zip(("m", "n"), mn, strict=True):
+                parameter, limit = _parameter(axis, site, role)
+                blocks.append(BlockAxis(axis, parameter, ("grid", "unit", "register", "atom"), limit))
+            output = tuple(blocks)
+        reduce = None
+        if node.axis is not None:
+            axis = tile.axis_of(node.axis)
+            parameter, limit = _parameter(axis, site, "k")
+            levels = (
+                ("grid", "block", "register", "tile", "atom", "serial")
+                if node.as_contraction() is not None
+                else ("grid", "block", "register", "serial")
+            )
+            reduce = BlockAxis(axis, parameter, levels, limit)
+        out.append(SiteBlocks(output=output, reduce=reduce))
+    return tuple(out)
+
+
+__all__ = [
+    "BlockAxis",
+    "BlockClaim",
+    "BoundBlockAxis",
+    "BoundBlockLoop",
+    "BoundSiteBlocks",
+    "BoundTransposedLoop",
+    "SiteBlocks",
+    "bind_site",
+    "blockify",
+]

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -51,6 +51,7 @@ from emmy.compiler.ir.schedule.views import (
 )
 from emmy.compiler.ir.stmt import Body, Load, Loop, OutputSpec, Stmt, Write
 from emmy.compiler.ir.stmt.body import free_names
+from emmy.compiler.ir.tile.block import BlockAxis, SiteBlocks
 from emmy.compiler.ir.tile.normalize import normalize_fold_tree
 from emmy.compiler.ir.tile.path import Site, sites
 
@@ -321,6 +322,9 @@ class TileOp(Op):
     # free axes, each reduce axis, a split's slice and partition, a sweep. The term itself carries
     # names only; this is the domain it is evaluated on, and ``Fold.lower`` takes it whole.
     axes: tuple[Axis, ...] = ()
+    # The explicit symbolic block domain, one entry per Fold site. It is installed before
+    # scheduling and contains no chosen widths; the existing schedule families bind it.
+    blocks: tuple[SiteBlocks, ...] = ()
     workers: WarpSpec | None = None
     # The accepted semantic assignment and its derived lowering facts. Unscheduled Tile IR carries
     # neither; scheduling installs both together.
@@ -356,6 +360,8 @@ class TileOp(Op):
         if self.schedule is not None and normalized != self.op:
             raise ValueError("cannot canonicalize a TileOp after a schedule has been attached")
         object.__setattr__(self, "op", normalized)
+        if self.blocks and (len(self.blocks) != len(self.sites) or any(not isinstance(block, SiteBlocks) for block in self.blocks)):
+            raise ValueError("TileOp blocks must contain one SiteBlocks value per Fold site")
 
         # Only the kernel's SHARED output sweep — an axis every store rides — promotes: hoisting it replicates
         # nothing but the statistics ahead of the sweep, while a sibling nest's axis would replicate every
@@ -587,6 +593,12 @@ class TileOp(Op):
             return next(axis for axis in self.axes if axis.name == name)
         except StopIteration:
             raise KeyError(f"axis {name!r} is not in this kernel's axis table {[axis.name for axis in self.axes]}") from None
+
+    def blocks_of(self, node) -> SiteBlocks:
+        """The symbolic block domain declared for ``node``."""
+        if not self.blocks:
+            raise ValueError("TileOp has not been blockified")
+        return self.blocks[self.node_id(node)]
 
     def _body_identity(self, *, structural: bool = True) -> str | None:
         """Override :meth:`Op._body_identity` with the DERIVED body: :attr:`loop_body`'s

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -33,6 +33,7 @@ from emmy.compiler.ir.stmt import Accum, Assign, Body, Init, Load, Loop, Select,
 from emmy.compiler.ir.stmt.base import Stmt, dtype_promote
 from emmy.compiler.ir.tile.ir import TileOp, apply_output_specs
 from emmy.compiler.ir.tile.path import UnknownSiteError, sites
+from emmy.compiler.ir.tile.block import bind_site
 
 
 def cone_stat_dtypes(pro: tuple, stats: tuple[str, ...], inputs) -> dict[str, object]:
@@ -191,7 +192,6 @@ class Sched:
         self.place = place
         self._sites = None
         self._site_by_id = None
-        self._mn_by_id = {}
 
     def _all_sites(self):
         if self._sites is None:
@@ -267,6 +267,21 @@ class Sched:
             return None
         return self.materialization.tiles.get(self.tile.node_id(node))
 
+    def block_of(self, node):
+        """The node's block domain with widths supplied by its existing schedule choices."""
+        if self.schedule is None or self.materialization is None:
+            return None
+        site = self.tile.node_id(node)
+        stages = {stage for edge, stage in self.materialization.stages.items() if edge[0] == site}
+        if len(stages) > 1:
+            raise ValueError("current kernel lowering requires one resolved transport across a node's operand edges")
+        return bind_site(
+            self.tile.blocks_of(node),
+            self.schedule.nodes[site],
+            self.materialization.tiles.get(site),
+            next(iter(stages), None),
+        )
+
     def placed(self, node, plan):
         """``plan`` bound to the ``(m, n)`` output axes a ``TILE`` slice at ``node``'s site tiles —
         the same one rule :meth:`tile_of` reads through, offered to a caller holding a CANDIDATE
@@ -274,76 +289,8 @@ class Sched:
         placed geometry). Already-placed and unplaceable plans pass through."""
         if plan is None or self.place is None or isinstance(plan, PlacedTile):
             return plan
-        mn = self._mn_for(node)
-        return plan.at(*mn) if mn is not None else plan
-
-    def _mn_for(self, node):
-        """The cached ``(m, n)`` output axes for ``node``. Placement is a site fact: candidate
-        plans change tile sizes, never which output axes they tile."""
-        key = id(node)
-        if key not in self._mn_by_id:
-            self._mn_by_id[key] = self._derive_mn(node)
-        return self._mn_by_id[key]
-
-    def _derive_mn(self, node):
-        """The ``(m, n)`` output axes a ``TILE`` slice at ``node``'s site tiles, or ``None`` when
-        the placement cannot supply them (an unmapped / rank-<2 grid — the caller's untiled path).
-
-        THREE site shapes, one rule each — the geometry the retired ``Contraction`` node used to
-        carry as stamped fields, now read off the tree instead:
-
-        - a ROOT contraction, including one directly under a zero-axis projection that groups
-          several kernel outputs, tiles the kernel grid's trailing pair (``Placement.root_mn``,
-          the same reading the scheduler binds through at option assembly);
-        - a derived unit-axis contraction inherits its parent Fold's reduction domain, so its
-          result tiles the placement's trailing free pair;
-        - any other nested contraction takes the free m axis and its nearest ENCLOSING fold's axis as n —
-          read through a slice partial's window PARENT, so the view carries the pre-slice geometry
-          the fragment clamps were built against. A BLOCK window is the exception, and the reason
-          blocking exists: the enclosing fold walks one block at a time, so the block's OWN extent
-          is the n the fragment is sized against, not the stream it was carved from.
-        """
-        free = tuple(self.place.free)
-        site = self.site_of(node)
-        ancestors = tuple(candidate for candidate in self._all_sites() if site.under(candidate))
-
-        def orient(mn):
-            # The pair is each side's own free axis, the first operand's leading — the placement
-            # binds both, and a sibling output's sweep promoted beside them (the fused q/k/v
-            # projections, N 64 beside N 32) never stands in for either. With several own axes a
-            # side the trailing one is the role and the rest ride the grid; a side without one
-            # (the unit-row matvec) leaves the trailing pair to the placement.
-            view = node.as_contraction()
-            if mn is None or view is None:
-                return mn
-            order = {axis.name: (position, axis) for position, axis in enumerate((*self.place.free, *self.place.grid))}
-            left = max((order[name] for name in view.left_axes if name in order), default=None)
-            right = max((order[name] for name in view.right_axes if name in order), default=None)
-            if left is not None and right is not None:
-                return (left[1], right[1])
-            first, second = mn
-            return (second, first) if second.name == view.left and first.name != view.left else mn
-
-        if all(getattr(candidate.node, "axis", None) is None for candidate in ancestors):
-            return orient(self.place.root_mn)
-        if len(free) < 2:
-            return None
-        # The nearest ENCLOSING fold, through any zero-axis projection between them — a projection
-        # binds no coordinate, so it cannot be the one the result is evaluated over. A blocked
-        # carrier's weight cone reaches its score through exactly one such level.
-        parent = next(
-            (
-                found
-                for depth in range(len(site.hops) - 1, -1, -1)
-                if (found := next((s for s in self._all_sites() if s.hops == site.hops[:depth]), None)) is not None
-                and getattr(found.node, "axis", None) is not None
-            ),
-            None,
-        )
-        ax = self.axis_of(parent.node.axis) if parent is not None else None
-        if ax is None:
-            return None
-        return orient((free[-2], ax.window.parent if ax.window is not None and not ax.window.block else ax))
+        block = self.tile.blocks_of(node)
+        return plan.at(*(part.axis for part in block.output)) if block.output else plan
 
 
 def sched_of(tile) -> Sched:
@@ -367,6 +314,7 @@ def scheduled(
     materialization=None,
     workers=None,
     axes: tuple = (),
+    blocks: tuple = (),
 ):
     """Build a scheduled ``TileOp`` from one accepted semantic assignment.
 
@@ -389,6 +337,7 @@ def scheduled(
         knobs=knobs,
         output_specs=tuple(output_specs),
         axes=axes,
+        blocks=blocks,
         schedule=schedule,
         materialization=materialization,
     )

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -59,6 +59,7 @@ from emmy.compiler.ir.schedule.packing import block_scaled_atom, packed_readings
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
 from emmy.compiler.ir.stmt.passes import rename_free, rewrite
+from emmy.compiler.ir.tile.block import BoundBlockAxis
 from emmy.compiler.ir.tile.ops import cone_stat, cone_stat_dtypes, make_cone
 from emmy.compiler.pipeline.passes.lowering.kernel._eval import Value, evaluate
 from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
@@ -75,7 +76,6 @@ from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
     staged_kloop,
     sync_stat_fill,
 )
-from emmy.compiler.pipeline.passes.lowering.kernel._tiling import AxisOffset
 from emmy.compiler.pipeline.search.space import UNROLL
 
 #: The contraction semiring — multiply ⊗ then accumulate ⊕ (add). The same multiply-add ``mma.sync``
@@ -108,7 +108,8 @@ def scheduled_fold_contraction(fold: Fold, sched):
         # drains, and the chunk must be the block the term spells — the enumeration offers exactly
         # these (``_block_refusal``), and reading them here keeps a row it did not offer from
         # reaching the binder.
-        block = sched.axis_of(child.axis)
+        block = sched.block_of(child).reduce
+        assert block is not None
         producer = next((edge for edge in child.operands[0].operands if edge.as_contraction() is not None), None)
         plan = sched.tile_of(producer) if producer is not None else None
         if plan is None or not plan.is_warp:
@@ -119,7 +120,7 @@ def scheduled_fold_contraction(fold: Fold, sched):
         # to the ordinary tiers; letting it through asserts inside the atom.
         if producer.operands[0].as_slab() is None:
             continue
-        if stage.bk_elems != block.extent.as_static() or plan.n.reg * plan.atom.atom_n != stage.bk_elems:
+        if plan.n.reg * plan.atom.atom_n != block.width:
             continue
         return child, tile, stage
     return None
@@ -310,7 +311,7 @@ def _staged_inner_atom_loop(
     slabs: tuple[str, ...],
     mn: tuple[Side, Side],
     atom,
-    bk_elems,
+    block: BoundBlockAxis,
     ki,
     reg_depth: int = 1,
     offs=None,
@@ -371,8 +372,12 @@ def _staged_inner_atom_loop(
     byte_slabs = byte_slabs if byte_slabs is not None else (False,) * len(slabs)
     pads = pads if pads is not None else (0,) * len(slabs)
     scales = scales if scales is not None else (None,) * len(slabs)
-    atom_m, atom_n, atom_k = atom.shape
-    n_steps = bk_elems // atom_k
+    atom_m, atom_n, expected_atom_k = atom.shape
+    bk_elems = block.width
+    atom_k = block.factor("atom")
+    if atom_k != expected_atom_k:
+        raise ValueError(f"the bound ATOM K width is {atom_k}, expected {expected_atom_k} for {atom.name}")
+    n_steps = block.factor("tile")
     # Per-operand drain spec: (frag base fn, slab, ldm, tile-is-slab-row, reg count, warp-unit var,
     # atom dim, slot row off, swizzle, byte flag). A stacks the tile axis on the slab row (K the
     # col); B swaps (K the row, tile the col) — unless its slab is transposed (N-major: tile the
@@ -523,7 +528,7 @@ def clamp_last(idx: Expr, ext: Expr) -> Expr:
 def _side_base(side: Side) -> Expr:
     """The CTA's tile-base coordinate on ``side`` — ``block·tile`` (always in-bounds: the block
     count is ``ceil(extent / tile)``, so ``block·tile < extent``)."""
-    return BinaryExpr("*", Var(side.block), Literal(side.tile, "int"))
+    return side.cta_base
 
 
 def _sibling_sigma(sibling: Side | None) -> dict[str, Expr]:
@@ -794,12 +799,14 @@ def _child_contraction_block(
     *,
     child: Fold,
     tile: Tile,
+    mn: tuple[Side, Side],
     k0: Expr,
     lead: tuple,
     ns: str,
     epilogue=None,
     slabs: tuple = (None, None),
     child_k: Axis,
+    block: BoundBlockAxis,
     axes: tuple = (),
 ):
     """One scheduled contraction block producing fragments for an enclosing Fold.
@@ -816,17 +823,27 @@ def _child_contraction_block(
     The rows are the enclosing tile's own, warp-partitioned and absolute; the columns are the
     enclosing block. Returns ``(ops, cells, offset, mn, stmts, frags)`` with ``frags[i]`` the
     register row ``i``'s column fragments in column order."""
-    m, n = tile.mn
-    ops = _atom_ops(child, tile, epilogue=epilogue, lead=lead, frag_ns=ns, slabs=slabs, k_axis=child_k, axes=axes)
+    m, n = mn
+    ops = _atom_ops(
+        child,
+        tile,
+        epilogue=epilogue,
+        lead=lead,
+        frag_ns=ns,
+        slabs=slabs,
+        k_axis=child_k,
+        block=block,
+        axes=axes,
+    )
     offset = (
-        AxisOffset(atom_dim=tile.atom.atom_m, reg=m.reg, block_var=m.block, unit_var=m.unit, unit_count=m.units),
+        m,
         _BlockCols(atom_dim=tile.atom.atom_n, k0=k0),
     )
     cells = [(i, j) for i in range(m.reg) for j in range(n.reg)]
     decls = list(ops.state(cells))
-    _, region = ops.reduce(cells, offset, tile.mn)
+    _, region = ops.reduce(cells, offset, mn)
     frags = tuple(tuple(ops.frag(f"_c{i}_{j}") for j in range(n.reg)) for i in range(m.reg))
-    return ops, cells, offset, tile.mn, [*decls, *region], frags
+    return ops, cells, offset, mn, [*decls, *region], frags
 
 
 def _a_slab_operand(
@@ -1248,12 +1265,12 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
     the store guard."""
     c, stage, tile = ops.c, ops.stage, ops.tile
     k_axis = ops.k_axis
-    # The chunk stream. A static K unrolls a literal chunk count; a SYMBOLIC one hands the skeleton
-    # its ``Dim`` and the runtime ``ceil(K / bk)`` — the fill masks the last chunk's tail to the
-    # fold identity (:func:`_k_masked`), so the drain still reads whole chunks.
-    bk, static_k = stage.bk_elems, k_axis.extent.is_static
-    K = k_axis.extent.as_static() if static_k else k_axis.extent
-    n_chunks = K // bk if static_k else Dim(BinaryExpr("/", BinaryExpr("+", K.expr, Literal(bk - 1, "int")), Literal(bk, "int")))
+    block = ops.block
+    if block is None:
+        raise ValueError("a staged contraction requires its Tile IR K block")
+    bk = block.width
+    if bk != stage.bk_elems:
+        raise ValueError(f"the bound K block is {bk} elements but STAGE resolved {stage.bk_elems}")
     elem = ops.slab_elem()
     cta = _cta(mn, tile.atom.lanes, tile.launch_threads)
     finalize: list[Stmt] = []
@@ -1267,7 +1284,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
         operands, copies, fills = _block_scaled_operands(
             c,
             bs_pair,
-            stage.bk_elems,
+            bk,
             mn,
             ops.inputs[bs_pair.b[0].bits.input].dtype,
             ops.inputs[bs_pair.a.scale.input].dtype,
@@ -1325,7 +1342,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
         operands, sync_ops, async_ops, packed_pro = _packed_operands(
             c,
             packed,
-            stage.bk_elems,
+            bk,
             mn,
             ops.slab_swizzles(mn, elem.nbytes)[0],
             ops.inputs[packed.bits.input].dtype,
@@ -1350,9 +1367,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
             return pipelined_kloop(
                 operands=((copies, stage.depth), (fill, 1)),
                 build_segments=lambda slots: [(ops.staged_drain(operands, slots[0], cells, offset, mn), slabs)],
-                bk_elems=stage.bk_elems,
-                n_chunks=K // stage.bk_elems,
-                k_extent=K,
+                block=block,
             )
         # cp.async: one ``sync`` producer whose copied peers are the two copied slabs — the
         # same shape the fused norm→linear edge takes.
@@ -1363,7 +1378,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
         # that work — with ``cp.async``, or with the blocking vector copy on an atom whose target
         # has none. A term with no inline edge at all lands here too: then it is only the copy.
         operands, sync_ops, copy_ops, stat_pro = _sync_operands(
-            c, stage.bk_elems, mn, cta, ops.slab_swizzles(mn, elem.nbytes), ops.channels, ops.cone, ops.inputs, k_axis=k_axis, axes=ops.axes
+            c, bk, mn, cta, ops.slab_swizzles(mn, elem.nbytes), ops.channels, ops.cone, ops.inputs, k_axis=k_axis, axes=ops.axes
         )
         transport = SyncTransport(
             operands=sync_ops,
@@ -1386,7 +1401,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
             bufs=(c.operands[0].as_slab().load.input, c.operands[1].as_slab().load.input),
             mn=mn,
             k_axis=k_axis,
-            bk_elems=stage.bk_elems,
+            bk_elems=bk,
             base=_tile_base(mn),
             swizzles=ops.slab_swizzles(mn, elem.nbytes),
             elems=elems,
@@ -1408,9 +1423,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
         transport=transport,
         drain=drain,
         depth=stage.depth,
-        bk_elems=bk,
-        n_chunks=n_chunks,
-        k_extent=K,
+        block=block,
         workers=ops.workers,
         block_threads=tile.launch_threads,
     )
@@ -1629,11 +1642,21 @@ class _AtomOps:
     # The contraction's K with its extent and the kernel's axis table: the term names its axes,
     # the kernel holds them, and every open-body lowering of an operand here takes the table.
     k_axis: Axis | None = None
+    # The explicit K block declared by Tile IR and bound by the schedule. Staging and the atom
+    # drain consume this object; neither reconstructs a chunk width from TILE or STAGE.
+    block: BoundBlockAxis | None = None
     axes: tuple = ()
 
     def frag(self, name: str) -> str:
         """``name`` in this emission's fragment namespace (:attr:`frag_ns`)."""
         return f"{self.frag_ns}{name}"
+
+    @property
+    def block_width(self) -> int:
+        """The explicit Tile IR K-block width consumed by this emission."""
+        if self.block is None:
+            raise ValueError("a tiled contraction requires its Tile IR K block")
+        return self.block.width
 
     @property
     def channels(self) -> tuple:
@@ -1710,7 +1733,7 @@ class _MmaOps(_AtomOps):
             offs=tuple(op.slot_row(slot) for op in operands),
             mn=mn,
             atom=self.tile.atom,
-            bk_elems=self.stage.bk_elems,
+            block=self.block,
             ki="_ki",
             reg_depth=self.stage.reg_depth,
             swizzles=tuple(getattr(op, "swizzle", "NONE") for op in operands),
@@ -1728,7 +1751,7 @@ class _MmaOps(_AtomOps):
         """The drain's ``(scale slab, its row stride, the k block)`` for a PACKED-PAIR operand, or
         ``None``. The stride is the chunk's block count — the scale slab is ``tile × bk/block``."""
         scale = getattr(op, "scale", None)
-        return None if scale is None else (scale[0], self.stage.bk_elems // scale[1], scale[1])
+        return None if scale is None else (scale[0], self.block_width // scale[1], scale[1])
 
     def slab_swizzles(self, mn, elem_bytes: int) -> tuple[str, str]:  # noqa: ARG002 — per-operand widths come from slab_elems
         """The smem swizzle mode per operand slab, from each slab's inner (contiguous) row
@@ -1748,7 +1771,7 @@ class _MmaOps(_AtomOps):
         b16-indexed); the cp.async byte slab's bank spread is the row pad instead."""
         if self.tile.atom.fragment_layout == "m8n8k4":
             return ("NONE", "NONE")
-        b_inner = self.stage.bk_elems if self.c.as_contraction().b_trans else mn[1].tile
+        b_inner = self.block_width if self.c.as_contraction().b_trans else mn[1].tile
         # A TMA slab keeps the hardware spelling (the copy engine fixes its permutation, and the
         # descriptor splits its box down to the atom); every other transport writes the slab in
         # software, so its XOR reads the row index at the slab's OWN stride.
@@ -1759,7 +1782,7 @@ class _MmaOps(_AtomOps):
                 return "NONE"
             return pick_swizzle_atom(inner, nbytes)[1] if hardware else software_swizzle(inner, nbytes)
 
-        return tuple(mode(inner, e.nbytes) for e, inner in zip(self.slab_elems(), (self.stage.bk_elems, b_inner), strict=True))
+        return tuple(mode(inner, e.nbytes) for e, inner in zip(self.slab_elems(), (self.block_width, b_inner), strict=True))
 
     def state(self, cells):
         """The mma operand/accumulator register fragments — one ``_a``/``_b`` per register row/col and
@@ -1834,6 +1857,11 @@ class _MmaOps(_AtomOps):
         c = self.c
         atom, (m, n) = self.tile.atom, mn
         k_axis = self.k_axis
+        if self.block is None:
+            raise ValueError("gmem-direct MMA requires its Tile IR K block")
+        atom_k = self.block.factor("atom")
+        if atom_k != atom.atom_k:
+            raise ValueError(f"the bound ATOM K width is {atom_k}, expected {atom.atom_k} for {atom.name}")
         assert c.operands[0].as_slab() is not None, (
             "mma matmul arm: a register-resident (computed) A operand has no gmem-direct fragment loader here"
         )
@@ -1848,7 +1876,7 @@ class _MmaOps(_AtomOps):
         # (unknown at compile time) or a static K with a remainder. Both mask the same way: the
         # loaders zero-fill the fragment halves past ``k_zero``'s bound, so the summed reduction
         # keeps its identity. An exactly tiled static K carries no bound (byte-identical output).
-        k_exact = k_axis.extent.is_static and k_axis.extent.as_static() % atom.atom_k == 0
+        k_exact = k_axis.extent.is_static and k_axis.extent.as_static() % atom_k == 0
         k_zero = None if k_exact else (Var(k_axis.name), k_axis.extent_expr())
 
         def read_row(i):
@@ -1931,15 +1959,15 @@ class _MmaOps(_AtomOps):
             ]
 
         def wrap(body):
-            step = Literal(atom.atom_k, "int")
+            step = Literal(atom_k, "int")
             stmts, tail = list(body), []
             if _f16acc(atom):
                 # Promote every _F16ACC_STEPS atom-K steps (a compile-time-foldable modulo when
                 # the loop unrolls), plus the unconditional final fold after the loop — it also
                 # covers a symbolic / non-multiple K's partial last chunk.
                 promotes = _f16acc_promotes(m.reg, n.reg, 1, self.frag_ns)
-                period = atom.atom_k * _F16ACC_STEPS
-                fire = BinaryExpr("==", BinaryExpr("%", Var(k_axis.name), Literal(period, "int")), Literal(period - atom.atom_k, "int"))
+                period = atom_k * _F16ACC_STEPS
+                fire = BinaryExpr("==", BinaryExpr("%", Var(k_axis.name), Literal(period, "int")), Literal(period - atom_k, "int"))
                 stmts.append(Cond(cond=fire, body=tuple(promotes)))
                 tail = promotes
             return [
@@ -2011,7 +2039,7 @@ class _ScalarOps(_AtomOps):
         row by the slot, exactly as the mma drain does)."""
         a_op, b_op = operands
         offs = tuple(op.slot_row(slot) for op in operands)
-        return [_scalar_drain(self.c, cells, offset, (a_op.slab, b_op.slab), "_ki", self.stage.bk_elems, _tile_base(mn), offs)]
+        return [_scalar_drain(self.c, cells, offset, (a_op.slab, b_op.slab), "_ki", self.block_width, _tile_base(mn), offs)]
 
     def state(self, cells):
         """The scalar accumulator seeds. Gmem-direct (unstaged): none — the accumulators are seeded
@@ -2112,6 +2140,7 @@ def _atom_ops(
     frag_ns: str = "",
     slabs: tuple = (None, None),
     k_axis: Axis | None = None,
+    block: BoundBlockAxis | None = None,
     axes: tuple = (),
 ) -> _AtomOps:
     """The **one** atom dispatch — select the codegen strategy off the atom kind. ``c`` is the
@@ -2138,7 +2167,21 @@ def _atom_ops(
         # no semiring to re-thread and no former to go through.
         c = replace(c, operands=(make_cone([a_load], k_axis.name), *c.operands[1:]))
     cls = _MmaOps if isinstance(tile.atom, AtomKind) else _ScalarOps
-    return cls(c, tile, stage, inputs, workers, lead, Body(()) if epilogue is None else epilogue, seam, frag_ns, slabs, k_axis, axes)
+    return cls(
+        c=c,
+        tile=tile,
+        stage=stage,
+        inputs=inputs,
+        workers=workers,
+        lead=lead,
+        epilogue=Body(()) if epilogue is None else epilogue,
+        seam=seam,
+        frag_ns=frag_ns,
+        slabs=slabs,
+        k_axis=k_axis,
+        block=block,
+        axes=axes,
+    )
 
 
 def _row_value(value: Value, op: ElementwiseImpl, names: tuple[tuple[str, str], ...], group: int) -> tuple[list[Stmt], Value]:
@@ -2275,6 +2318,8 @@ def _fold_staged(
     producer_tile = sched.tile_of(source[producer_index]) if producer_index is not None else None
     producer_stage = sched.get("STAGE", source[producer_index]) if producer_index is not None else None
     producer_k = sched.axis_of(source[producer_index].axis) if producer_index is not None else None
+    producer_block = sched.block_of(source[producer_index]).reduce if producer_index is not None else None
+    producer_mn = sched.block_of(source[producer_index]).output if producer_index is not None else ()
 
     binder = {edge.axis: fold_k.name for edge in fold.operands if edge.axis is not None}
     zero = Sigma({fold.axis: Literal(0, "int")})
@@ -2289,7 +2334,12 @@ def _fold_staged(
         producer_tile = replace(producer_tile, axes=(producer_tile.axes[0], replace(producer_tile.axes[1], name=fold_k.name)))
     active_tile = producer_tile or tile
     lay = frag_layout(active_tile.atom.atom_m, active_tile.atom.atom_n)
-    bk = stage.bk_elems
+    block_axis = ops.block
+    if block_axis is None:
+        raise ValueError("a blocked carrier requires its Tile IR block")
+    bk = block_axis.width
+    if bk != stage.bk_elems:
+        raise ValueError(f"the bound carrier block is {bk} elements but STAGE resolved {stage.bk_elems}")
     cta = _cta(mn, tile.atom.lanes, tile.launch_threads)
     elem = ops.slab_elem()
     swizzles = ops.slab_swizzles(mn, elem.nbytes)
@@ -2341,6 +2391,7 @@ def _fold_staged(
     if m.mask:
         bounds += ((m.axis.name, m.ext, None),)
     if producer is not None:
+        assert producer_block is not None
         producer_slabs = (
             (invariant_op.slab, invariant_op.shape[1], invariant_op.swizzle) if invariant_op is not None else None,
             (stream_op.slab, stream_op.shape[1], stream_op.swizzle) if stream_op is not None else None,
@@ -2348,11 +2399,13 @@ def _fold_staged(
         _producer_ops, _producer_cells, producer_offset, _producer_mn, producer_body, producer_frags = _child_contraction_block(
             child=producer,
             tile=producer_tile,
+            mn=producer_mn,
             k0=k0,
             lead=ops.lead,
             ns=f"{ops.frag_ns}_fold",
             slabs=producer_slabs,
             child_k=producer_k,
+            block=producer_block,
             axes=sched.tile.axes,
         )
         producer_value = Value.frag(producer_frags)
@@ -2501,19 +2554,11 @@ def _fold_staged(
         merged, _, _ = evaluate(fold.combine, bindings, targets=carried)
         return [*block_ops.state(cells), *block_ops.staged_drain(operands, slot, cells, offset, mn), *merged]
 
-    extent = fold_k.extent.as_static() if fold_k.extent.is_static else fold_k.extent
-    n_chunks = (
-        extent // bk
-        if isinstance(extent, int)
-        else Dim(BinaryExpr("/", BinaryExpr("+", extent.expr, Literal(bk - 1, "int")), Literal(bk, "int")))
-    )
     pre, region = staged_kloop(
         transport=transport,
         drain=drain,
         depth=stage.depth,
-        bk_elems=bk,
-        n_chunks=n_chunks,
-        k_extent=extent,
+        block=block_axis,
         workers=ops.workers,
         block_threads=tile.launch_threads,
         lead=lead_segment,
@@ -2539,6 +2584,7 @@ def reduce_codegen(
     projection: tuple = (),
     carried: dict[str, Value] | None = None,
     k_axis: Axis | None = None,
+    block: BoundBlockAxis | None = None,
     axes: tuple = (),
 ):
     """The reusable, **sink-agnostic** ``(state_decls, reduce_region)`` from the atom strategy — the
@@ -2547,7 +2593,7 @@ def reduce_codegen(
     ``stage`` / ``inputs`` bind operand staging (both atoms stage the same smem slab off it, differing
     only in the drain leaf — ``ldmatrix`` vs plain ``Load``); ``workers`` splits the staged phases
     across producer / compute warp bands (the resolved :class:`WarpSpec`; ``None`` = uniform)."""
-    ops = _atom_ops(c, tile, stage, inputs, workers, seam=seam, lead=lead, frag_ns=frag_ns, k_axis=k_axis, axes=axes)
+    ops = _atom_ops(c, tile, stage, inputs, workers, seam=seam, lead=lead, frag_ns=frag_ns, k_axis=k_axis, block=block, axes=axes)
     if fold is None:
         return ops.state, ops.reduce
     if value_child is None or sched is None:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -58,7 +58,7 @@ from emmy.compiler.ir.schedule import Raster
 from emmy.compiler.ir.schedule.views import cone_seam
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
-from emmy.compiler.ir.tile import FoldMove, Level, Reduce, ReduceStage
+from emmy.compiler.ir.tile import BoundBlockAxis, FoldMove, Level, ReduceStage
 from emmy.compiler.ir.tile.ir import apply_output_specs, observed_result_names
 from emmy.compiler.ir.tile.ops import UnbindableProjection, chain_form, chain_members, projection_regions, projection_root, sched_of
 from emmy.compiler.pipeline.passes.lowering.kernel._atom import (
@@ -71,7 +71,7 @@ from emmy.compiler.pipeline.passes.lowering.kernel._atom import (
     store_sink,
 )
 from emmy.compiler.pipeline.passes.lowering.kernel._stage import sync_row_fill
-from emmy.compiler.pipeline.passes.lowering.kernel._tiling import atomize, grid_tile, register_tile, unit_tile
+from emmy.compiler.pipeline.passes.lowering.kernel._tiling import grid_tile
 
 # ---- the ambient cell environment and the wire a node produces ---------------------------------- #
 
@@ -267,8 +267,8 @@ def _refuse_partitioned_sweep(root, ctx: Ctx, axis: str) -> None:
     node = root
     while isinstance(node, Fold) and node.axis is None and node.operands:
         node = node.operands[0]
-    plan = ctx.sched.get("REDUCE", node) if isinstance(node, Fold) and node.axis is not None else None
-    if (plan is not None and (plan.coop > 1 or plan.reg > 1)) or (
+    block = ctx.sched.block_of(node).reduce if isinstance(node, Fold) and node.axis is not None else None
+    if (block is not None and (block.factor("block") > 1 or block.factor("register") > 1)) or (
         node.as_contraction() is not None and ctx.sched.tile_of(node) is not None
     ):
         raise UnbindableProjection(
@@ -387,6 +387,9 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
         tile = ctx.sched.tile_of(op) if isinstance(op, Fold) and op.as_contraction() is not None else None
         stage = ctx.sched.get("STAGE", op) if tile is not None else None
     if tile is not None and tile.axes is not None and len(grid) >= 2:
+        site_blocks = ctx.sched.block_of(value_child or op)
+        mn = site_blocks.output
+        assert len(mn) == 2
         epi = list(tail)
         if not has_write(epi):
             epi = with_store(epi, ctx.output, grid, c.exposes[0])
@@ -406,6 +409,13 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
         # dropped the other — leaving an axis no block, unit or lead var defines.
         lead = tuple(axis for axis in grid if axis.name not in {bound.name for bound in tile.axes})
         carried = {}
+        if value_child is not None:
+            child_block = site_blocks.reduce
+            declared = ctx.sched.tile.blocks_of(op).reduce
+            assert child_block is not None and declared is not None
+            block = child_block.on(declared)
+        else:
+            block = site_blocks.reduce
         state_decls, reduce_region = reduce_codegen(
             c,
             tile,
@@ -418,6 +428,7 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
             fold=op if value_child is not None else None,
             value_child=value_child,
             k_axis=k_axis,
+            block=block,
             axes=ctx.sched.tile.axes,
             sched=ctx.sched,
             projection=projection,
@@ -429,28 +440,37 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
             sink = fold_store_sink(tile, tuple(epi), carried, frag_ns)
         else:
             sink = store_sink(c, tile, Body(tuple(epi)), lead, frag_ns, k_axis=k_axis, axes=ctx.sched.tile.axes)
-        t = unit_tile(register_tile(atomize(tile.atom.shape[:2]), tile.mn), tile.mn)
-        mn, bt, lanes = tile.mn, tile.launch_threads, tile.atom.lanes
+        bt, lanes = tile.launch_threads, tile.atom.lanes
     else:
         # The reduce partition rides the :class:`Fold` node; ``None`` for a pure pointwise /
         # scalar per-cell zero-axis ``Fold`` (no partition). Every partitioned reduction is a
         # ``Fold`` node (a projecting zero-axis
         # ``Fold`` was already peeled off by :func:`_factorize`).
-        plan = (ctx.sched.get("REDUCE", op) or Reduce()) if isinstance(op, Fold) else None
-        t, mn, lead, lanes = atomize((1, 1)), (None, None), grid, 1
+        block = ctx.sched.block_of(op).reduce if isinstance(op, Fold) else None
+        mn, lead, lanes, inner_axes = (None, None), grid, 1, ()
         # A CHAIN root's members carry their own partitions; every partitioned member and the root
         # stride around ONE lane axis, in body order (:func:`_tile_chain_members`).
         members = chain_members(op) if isinstance(op, Fold) and op.axis is not None else ()
-        parts = tuple(
-            (member, p)
-            for member in (*members, op)
-            if (p := ctx.sched.get("REDUCE", member)) is not None and (p.coop > 1 or p.reg > 1) and not p.coop_transposed
-        )
+        parts = []
+        for member in (*members, op):
+            if not isinstance(member, Fold) or member.axis is None:
+                continue
+            member_block = ctx.sched.block_of(member).reduce
+            if (
+                member_block is None
+                or (member_block.factor("block") <= 1 and member_block.factor("register") <= 1)
+                or member_block.transposed
+            ):
+                continue
+            parts.append((member, member_block))
+        parts = tuple(parts)
         if any(member is not op for member, _ in parts):
             state, fold, close, lane = _tile_chain_members(op, parts, ctx, tail, out_val)
-            t = replace(t, axes=(lane,)) if lane is not None else t
+            inner_axes = (lane,) if lane is not None else ()
             bt = lane.extent.as_static() if lane is not None else None
-        elif plan is None or (plan.coop <= 1 and plan.reg <= 1) or (plan.coop_transposed and chain_form(op)):
+        elif block is None or (
+            block.factor("block") <= 1 and block.factor("register") <= 1
+        ) or (block.transposed and chain_form(op)):
             # The TERM places its own stores (``Fold.lower``): a sweep store's loop opens around
             # exactly the terms evaluated over that sweep, so sibling sweeps stay siblings, and a
             # streamed store rides its observed fold's reduce loop — the one placement rule the
@@ -459,22 +479,20 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
             placed = op.lower(frozenset(axis.name for axis in ctx.grid), output_specs, axes) if output_specs else op.lower(axes=axes)
             body = list(dict.fromkeys([*placed, *tail]))
             state, fold, close, bt = [], with_store(body, ctx.output, grid, out_val), [], None
-        elif plan.coop_transposed:
+        elif block.transposed:
             # The ``coop-t`` k-major matvec partition: the innermost output axis splits into a
             # shrunk ``<out>_blk`` grid axis (×32) + the 32-wide ``n_lane`` thread axis (with
             # ``k_co`` between them), so B loads coalesce across lanes. The emitted body's
             # output-var references were σ-substituted to ``blk·32 + n_lane`` inside (clamped,
             # and the store guarded, when 32 does not tile the swept extent).
-            state, fold, close, lanes_axes = _tile_reduce_axis_transposed(op, plan, ctx, tail, out_val)
-            out_ax = next(a for a in reversed(grid) if not (a.extent.is_static and a.extent.as_static() == 1))
-            blk = Axis(name=f"{out_ax.name}_blk", extent=out_ax.extent.ceil_div(32), window=Window(parent=out_ax))
-            lead = tuple(blk if a.name == out_ax.name else a for a in grid)
-            t = replace(t, axes=lanes_axes)
-            bt = plan.coop
+            state, fold, close, lanes_axes, output_block = _tile_reduce_axis_transposed(op, block, ctx, tail, out_val)
+            lead = tuple(output_block if a.name == output_block.window.parent.name else a for a in grid)
+            inner_axes = lanes_axes
+            bt = block.factor("block")
         else:
-            state, fold, close, lane = _tile_reduce_axis(op, plan, ctx, tail, out_val)
-            t = replace(t, axes=(lane,)) if lane is not None else t
-            bt = plan.coop if lane is not None else None
+            state, fold, close, lane = _tile_reduce_axis(op, block, ctx, tail, out_val)
+            inner_axes = (lane,) if lane is not None else ()
+            bt = block.factor("block") if lane is not None else None
 
         def state_decls(_cells):
             return state
@@ -486,9 +504,9 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
             return close
 
     return grid_tile(
-        t,
         mn=mn,
         lead_axes=lead,
+        inner_axes=() if tile is not None and tile.axes is not None and len(grid) >= 2 else inner_axes,
         block_threads=bt,
         lanes=lanes,
         state_decls=state_decls,
@@ -690,7 +708,7 @@ def emit_combine(
     return out
 
 
-def combine_tail(fold: Fold, *, reg: int, coop: int, lane) -> list[Stmt]:
+def combine_tail(fold: Fold, block: BoundBlockAxis, lane) -> list[Stmt]:
     """The algebra-driven **partial merge** that follows a partitioned reduce loop — the one place the
     two partial-fold geometries are assembled: the REG-tree fold of the ``reg`` ILP register copies
     into copy 0 (:func:`merge_stmts`), then — when threads cooperate (``lane`` is a lane :class:`Axis`,
@@ -701,6 +719,8 @@ def combine_tail(fold: Fold, *, reg: int, coop: int, lane) -> list[Stmt]:
     contraction's degenerate additive fold identically, so a cooperative reduce and a (future)
     cooperative-K contraction share this tail. ``merge_stmts`` keys a twisted combine's temps on
     the copy name, so each fold's internals are already unique."""
+    reg = block.factor("register")
+    coop = block.factor("block")
     merge: list[Stmt] = [st for r in range(1, reg) for st in merge_stmts(fold, tuple(f"{n}__r{r}" for n in fold.combine.results))]
     if lane is not None:
         merge += emit_combine(fold, t=lane.name, n_threads=coop)
@@ -708,8 +728,8 @@ def combine_tail(fold: Fold, *, reg: int, coop: int, lane) -> list[Stmt]:
 
 
 def _tile_reduce_axis_transposed(
-    op: Fold, plan, ctx: Ctx, tail: tuple, out_val: str
-) -> tuple[list[Stmt], list[Stmt], list[Stmt], tuple[Axis, ...]]:
+    op: Fold, block: BoundBlockAxis, ctx: Ctx, tail: tuple, out_val: str
+) -> tuple[list[Stmt], list[Stmt], list[Stmt], tuple[Axis, ...], Axis]:
     """The ``coop-t`` (transposed) cooperative reduce — the k-major-B matvec partition: 32
     ``n_lane`` threads (innermost) sweep the OUTPUT axis so B loads coalesce across lanes at
     every k step, and ``coop/32`` ``k_co`` slices ride the upper thread bits. The emitted body
@@ -721,31 +741,24 @@ def _tile_reduce_axis_transposed(
     own cell. Unsupported here (the enumeration must not offer ``t`` on them): shared-row
     ``smem`` shared-row staging, distributed full-row projections (a ``Loop`` in the tail)."""
     grid = ctx.grid
-    coop, reg = plan.coop, plan.reg
-    lanes_n = 32
-    k_ways = coop // lanes_n
-    assert coop % lanes_n == 0 and k_ways >= 1, f"b{coop}t needs a multiple of {lanes_n}"
     stage = ctx.sched.get("STAGE", op)
     assert not (stage is not None and stage.smem), "transposed coop cannot ride shared-row staging"
     out_ax = next(a for a in reversed(grid) if not (a.extent.is_static and a.extent.as_static() == 1))
 
     *hoisted, rloop = op.lower(axes=ctx.sched.tile.axes)
     view = op.as_reduction()
-    axis = rloop.axis
-    stride = k_ways * reg
-    masked = reg > 1 and not (axis.extent.is_static and axis.extent.as_static() % stride == 0)
-
-    n_lane = Axis(name=f"{out_ax.name}_ln", extent=lanes_n)
-    k_co = Axis(name=f"{axis.name}_co", extent=k_ways) if k_ways > 1 else None
-    start = Var(k_co.name) if k_co is not None else Literal(0, "int")
-    blk_name = f"{out_ax.name}_blk"
+    bound = block.transposed_loop(rloop.axis, out_ax)
+    loop = bound.loop
+    axis, n_lane, k_co = loop.axis, bound.output_lane, loop.lane
+    reg = loop.registers
+    blk_name = bound.output_block.name
     # The swept cell this lane owns. The grid is ``ceil(E / 32)`` blocks, so a swept axis 32 does
     # not tile leaves the last block's upper lanes OVERHANGING: they clamp-read the last valid
     # column (a duplicate sweep, in-bounds) and their store is discarded by the guard below — the
     # same masked-overhang contract the tiled contraction's ``clamp_last`` / ``Cond`` pair states.
-    cell = BinaryExpr("+", BinaryExpr("*", Var(blk_name), Literal(lanes_n, "int")), Var(n_lane.name))
+    cell = bound.cell
     out_ext = out_ax.extent_expr()
-    overhang = not (out_ax.extent.is_static and out_ax.extent.as_static() % lanes_n == 0)
+    overhang = bound.overhang
     subst = Sigma({out_ax.name: clamp_last(cell, out_ext) if overhang else cell})  # the sweep's reads
     store_subst = Sigma({out_ax.name: cell})  # the guarded projection: in range by the guard, so no clamp
 
@@ -763,13 +776,13 @@ def _tile_reduce_axis_transposed(
     stream_identity = (str(view.terms[0]), ElementwiseImpl("maximum").identity) if view.twisted else None
     copies: list[Stmt] = []
     for r in range(reg):
-        copies.extend(_replicate(rloop.body, r, k_ways, axis, masked, protected, stream_identity))
-    strided = StridedLoop(axis=axis, start=start, step=Literal(stride, "int"), body=Body(tuple(copies)), unroll=rloop.unroll)
+        copies.extend(_replicate(rloop.body, r, loop.register_span, axis, loop.masked, protected, stream_identity))
+    strided = StridedLoop(axis=axis, start=loop.start, step=Literal(loop.stride, "int"), body=Body(tuple(copies)), unroll=rloop.unroll)
     strided = strided.substitute(subst)
 
     merge: list[Stmt] = [st for r in range(1, reg) for st in merge_stmts(op, tuple(f"{n}__r{r}" for n in view.states))]
     if k_co is not None:
-        merge += emit_combine(op, t=k_co.name, n_threads=k_ways, inner=(n_lane.name, lanes_n))
+        merge += emit_combine(op, t=k_co.name, n_threads=k_co.extent.as_static(), inner=(n_lane.name, n_lane.extent.as_static()))
 
     tail_stmts = with_store(list(tail), ctx.output, grid, out_val)
     tail_stmts = [s.substitute(store_subst) for s in tail_stmts]
@@ -779,24 +792,18 @@ def _tile_reduce_axis_transposed(
         tail_stmts = [Cond(cond=BinaryExpr("==", Var(k_co.name), Literal(0, "int")), body=tuple(tail_stmts))]
 
     lanes_axes = ((k_co,) if k_co is not None else ()) + (n_lane,)
-    return [], [*(s.substitute(subst) for s in hoisted), strided, *merge], tail_stmts, lanes_axes
+    return [], [*(s.substitute(subst) for s in hoisted), strided, *merge], tail_stmts, lanes_axes, bound.output_block
 
 
-def _strided_fold(op: Fold, rloop, plan, ctx: Ctx, lane: Axis | None) -> list[Stmt]:
+def _strided_fold(op: Fold, rloop, block: BoundBlockAxis, ctx: Ctx, lane: Axis | None) -> list[Stmt]:
     """The partitioned reduce loop for ONE fold — ``reg`` ILP chains striding ``coop·reg`` from the
     lane's start, then the REG-tree merge and (when threads cooperate) the cross-thread combine.
     ``rloop`` is the fold's already-emitted serial reduce ``Loop``; the caller owns any prologue
     ``lower`` hoisted ahead of it and any smem row-staging rewrite."""
-    coop, reg = plan.coop, plan.reg
+    bound = block.loop(rloop.axis, lane)
+    reg = bound.registers
     view = op.as_reduction()
-    axis = rloop.axis
-    # A STRIDED axis walks its extent one BLOCK at a time, so the partition is over its trips, not
-    # over its coordinates: every span below is an iteration count times the axis's own step.
-    step = axis.step.value if isinstance(axis.step, Literal) else 1
-    trips = axis.trips
-    stride = coop * reg * step
-    masked = reg > 1 and not (trips is not None and trips % (coop * reg) == 0)
-    start = Literal(0, "int") if lane is None else BinaryExpr("*", Var(lane.name), Literal(step, "int")) if step > 1 else Var(lane.name)
+    axis = bound.axis
 
     # The reduce loop: ``reg`` interleaved accumulator chains (ILP), striding the axis by
     # ``coop·reg`` from the lane's start. The dissolved fold ``Accum``\\ s seed each copy's
@@ -831,14 +838,14 @@ def _strided_fold(op: Fold, rloop, plan, ctx: Ctx, lane: Axis | None) -> list[St
     stream_identity = (str(view.terms[0]), ElementwiseImpl("maximum").identity) if view.twisted else None
     copies: list[Stmt] = []
     for r in range(reg):
-        copies.extend(_replicate(rloop.body, r, coop * step, axis, masked, protected, stream_identity))
-    strided = StridedLoop(axis=axis, start=start, step=Literal(stride, "int"), body=Body(tuple(copies)), unroll=rloop.unroll)
+        copies.extend(_replicate(rloop.body, r, bound.register_span, axis, bound.masked, protected, stream_identity))
+    strided = StridedLoop(axis=axis, start=bound.start, step=Literal(bound.stride, "int"), body=Body(tuple(copies)), unroll=rloop.unroll)
 
     # The carrier-driven partial merge: the REG-tree fold of the ``reg`` ILP copies into the survivor
     # (copy 0's names) + (when threads cooperate) the cross-thread combine, reassigning the carried
     # state in place. The one shared tail a cooperative reduce and a future cooperative-K contraction
     # both emit (``combine_tail``).
-    return [strided, *combine_tail(op, reg=reg, coop=coop, lane=lane)]
+    return [strided, *combine_tail(op, block, lane)]
 
 
 def _tile_chain_members(
@@ -853,11 +860,13 @@ def _tile_chain_members(
     axis on every lane from zero. All cooperating members share ONE lane axis — the walk's
     one-inventory rule already forced their ``coop`` to agree — and the trailing projection
     closes lane-distributed."""
-    plans = {id(member): plan for member, plan in parts}
-    coop = max(plan.coop for _, plan in parts)
-    assert len({plan.coop for _, plan in parts if plan.coop > 1}) <= 1, "cooperating chain members must share one coop width"
-    head = next(member for member, plan in parts if plan.coop == coop)
-    lane = Axis(name=f"{head.axis}_co", extent=coop) if coop > 1 else None
+    blocks = {id(member): block for member, block in parts}
+    coop = max(block.factor("block") for _, block in parts)
+    assert len({block.factor("block") for _, block in parts if block.factor("block") > 1}) <= 1, (
+        "cooperating chain members must share one coop width"
+    )
+    head_block = next(block for _, block in parts if block.factor("block") == coop)
+    lane = head_block.lane
     fold: list[Stmt] = []
     for stmt in op.lower(axes=ctx.sched.tile.axes):
         member = None
@@ -867,8 +876,8 @@ def _tile_chain_members(
         if member is None:
             fold.append(stmt)
             continue
-        plan = plans[id(member)]
-        fold.extend(_strided_fold(member, stmt, plan, ctx, lane if plan.coop > 1 else None))
+        block = blocks[id(member)]
+        fold.extend(_strided_fold(member, stmt, block, ctx, lane if block.factor("block") > 1 else None))
     return [], fold, _lane_close(list(tail), lane, coop, ctx, out_val), lane
 
 
@@ -897,7 +906,9 @@ def _lane_close(tail: list[Stmt], lane: Axis | None, coop: int, ctx: Ctx, out_va
     return body_tail
 
 
-def _tile_reduce_axis(op: Fold, plan, ctx: Ctx, tail: tuple, out_val: str) -> tuple[list[Stmt], list[Stmt], list[Stmt], Axis | None]:
+def _tile_reduce_axis(
+    op: Fold, block: BoundBlockAxis, ctx: Ctx, tail: tuple, out_val: str
+) -> tuple[list[Stmt], list[Stmt], list[Stmt], Axis | None]:
     """Tile the REDUCE axis per the node's cooperating :class:`Reduce` — the reduce counterpart
     of the output ``unit_tile`` / ``register_tile`` levels: ``coop`` lanes across threads (the
     ``_co`` lane axis, the axis's UNIT level) and ``reg`` ILP chains across per-thread accumulators
@@ -908,7 +919,7 @@ def _tile_reduce_axis(op: Fold, plan, ctx: Ctx, tail: tuple, out_val: str) -> tu
     cross-thread combine), the distributed projection close, and the lane :class:`Axis` (``None``
     for standalone ILP — one thread per cell, lane fixed at 0)."""
     grid = ctx.grid
-    coop = plan.coop
+    coop = block.factor("block")
 
     # The per-cell reduce loop is the node's own lowering (``Fold.lower``) off the :class:`Fold`
     # **node** — the walk reaches any nested contraction as a node. The algebra
@@ -922,7 +933,7 @@ def _tile_reduce_axis(op: Fold, plan, ctx: Ctx, tail: tuple, out_val: str) -> tu
 
     # The cooperative lane axis (Tile-decoded, innermost) — present only when threads
     # cooperate; standalone ILP (coop == 1) runs one thread per cell, lane fixed at 0.
-    lane = Axis(name=f"{axis.name}_co", extent=coop) if coop > 1 else None
+    lane = block.lane
     start = Var(lane.name) if lane is not None else Literal(0, "int")
 
     # Shared-row staging (the fused norm→linear prologue): an input row folded by the cooperative
@@ -951,5 +962,5 @@ def _tile_reduce_axis(op: Fold, plan, ctx: Ctx, tail: tuple, out_val: str) -> tu
         rloop = replace(rloop, body=Body(tuple(_restage_loads(list(rloop.body), staged, smem_name, n_grid, grid_vars))))
         tail_src = _restage_loads(tail_src, staged, smem_name, n_grid, grid_vars)
 
-    fold = _strided_fold(op, rloop, plan, ctx, lane)
+    fold = _strided_fold(op, rloop, block, ctx, lane)
     return fill_stmts, [*hoisted, *fold], _lane_close(tail_src, lane, coop, ctx, out_val), lane

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -66,6 +66,7 @@ from emmy.compiler.ir.kernel.ir import (
     swizzle_base,
 )
 from emmy.compiler.ir.stmt import Body, Cond, Load, Loop, Stmt, StridedLoop, Write
+from emmy.compiler.ir.tile.block import BoundBlockAxis
 
 
 def _mul(a: Expr, b: Expr) -> Expr:
@@ -935,9 +936,7 @@ def _producer_band_kloop(
     transport: TmaTransport,
     drain: Callable[[Expr], list[Stmt]],
     ring: int,
-    bk_elems: int,
-    n_chunks: int,
-    k_extent: int,
+    block: BoundBlockAxis,
     aux_threads: int,
     block_threads: int,
     k_end: Expr | None = None,
@@ -974,9 +973,11 @@ def _producer_band_kloop(
     inits += tuple(MbarrierInit(mbar=_EMPTY_MBAR, count=1, slot=_lit(s)) for s in range(ring))
     pre: list[Stmt] = [Cond(cond=BinaryExpr("==", tid, _lit(0)), body=inits), Sync()]
 
-    k0, K = "_ks", k_extent
+    bk_elems, n_chunks, K = block.width, block.chunks, block.extent
+    assert isinstance(n_chunks, int) and isinstance(K, int)
+    k0 = block.axis.name
     i_expr = BinaryExpr("/", Var(k0), _lit(bk_elems))
-    kaxis = Axis(name=k0, extent=K)
+    kaxis = block.axis
     setmaxnreg = _CONSUMER_REGS * block_threads + _PRODUCER_REGS * aux_threads <= _SM_REGFILE
 
     # Producer: prefetch chunk ``c = i + ring - 1`` into slot ``c % ring`` (k0 clamped to the last
@@ -1056,10 +1057,7 @@ def pipelined_kloop(
     *,
     operands: tuple[tuple[object, int], ...],
     build_segments: Callable[[tuple[Expr, ...]], list[tuple[list[Stmt], frozenset[str]]]],
-    bk_elems: int,
-    n_chunks: int | Dim,
-    k_extent: int | Dim,
-    k0: str = "_ks",
+    block: BoundBlockAxis,
     k_end: Expr | None = None,
     k_first: Expr | None = None,
 ) -> tuple[list[Stmt], list[Stmt]]:
@@ -1101,6 +1099,8 @@ def pipelined_kloop(
     could otherwise prime past a static extent). A symbolic ``k_extent`` (a ``Dim``) allocates the
     full ``depth`` ring and clamps every fill — ring prefetch and kill-point refill alike — against
     the runtime chunk count. Returns ``(slab_decls, [prologue…, outer_loop])``."""
+    bk_elems, n_chunks, k_extent = block.width, block.chunks, block.extent
+    k0 = block.axis.name
     symbolic = isinstance(k_extent, Dim)
     k_pos: Expr = BinaryExpr("-", Var(k0), k_first) if k_first is not None else Var(k0)
     i_expr = BinaryExpr("/", k_pos, _lit(bk_elems))  # chunk index of the current step (stream-relative)
@@ -1213,7 +1213,7 @@ def pipelined_kloop(
                     body += g.transport.commit()
 
     outer = StridedLoop(
-        axis=Axis(name=k0, extent=k_extent),
+        axis=block.axis,
         start=k_first if k_first is not None else _lit(0),
         step=_lit(bk_elems),
         body=Body(tuple(body)),
@@ -1228,12 +1228,9 @@ def staged_kloop(
     transport,
     drain: Callable[[Expr], list[Stmt]],
     depth: int,
-    bk_elems: int,
-    n_chunks: int | Dim,
-    k_extent: int | Dim,
+    block: BoundBlockAxis,
     workers=None,
     block_threads: int | None = None,
-    k0: str = "_ks",
     k_end: Expr | None = None,
     k_first: Expr | None = None,
     lead: LeadSegment | None = None,
@@ -1255,9 +1252,6 @@ def staged_kloop(
     across producer / compute warp bands instead (:func:`_producer_band_kloop`) — TMA transport only (the
     scheduler's legality gate), ``block_threads`` naming the compute band.
 
-    ``k0`` names the chunk loop variable (default ``"_ks"``) — a drain whose body references the
-    chunk base by name passes its own axis name.
-
     ``k_end`` (an ``Expr`` over in-scope grid vars, CTA-uniform, ``≤ k_extent``) stops the chunk
     loop early. Chunks past it fold the carrier
     identity exactly, so skipping them is bit-identical; the prefetch clamp re-pins onto the last
@@ -1273,6 +1267,7 @@ def staged_kloop(
     # the transport absorb any over-primed tail chunk (TMA zero-fills its box; cp.async clamp-reads
     # the last valid key rows) — the drain masks those keys to the fold identity, so it stays
     # bit-identical to gmem-direct. Static callers pass plain ``int``s.
+    bk_elems, n_chunks, k_extent = block.width, block.chunks, block.extent
     if workers is not None:
         symbolic = isinstance(k_extent, Dim)
         assert lead is None, "the producer band drives one operand group — a nested producer has no band placement"
@@ -1286,9 +1281,7 @@ def staged_kloop(
             transport=transport,
             drain=drain,
             ring=min(depth, n_chunks) if n_chunks >= 2 else 1,
-            bk_elems=bk_elems,
-            n_chunks=n_chunks,
-            k_extent=k_extent,
+            block=block,
             aux_threads=32 * workers.producer_warps,
             block_threads=block_threads,
             k_end=k_end,
@@ -1306,10 +1299,7 @@ def staged_kloop(
     return pipelined_kloop(
         operands=groups,
         build_segments=segments,
-        bk_elems=bk_elems,
-        n_chunks=n_chunks,
-        k_extent=k_extent,
-        k0=k0,
+        block=block,
         k_end=k_end,
         k_first=k_first,
     )

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_tiling.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_tiling.py
@@ -1,115 +1,26 @@
-"""The generic tiling layer — where a schedule's PLAN becomes actual :class:`Axis` objects.
+"""Seal already-blockified axes around a kernel body.
 
-The schedule decides (a ``Tile`` / ``Reduce`` / ``Stage``, and which axis plays m, n or
-k); nothing it produces is an axis a kernel loops over. This module is the other half: the four
-levels a contraction's output cell is tiled through — GRID block / UNIT / REGISTER / ATOM —
-realized as the bound ``Tile`` axes plus the per-cell coordinate arithmetic that indexes them.
-
-    atomize → register_tile → unit_tile → grid_tile
-
-Each level zips the per-axis :class:`AxisOffset` pair (``Tiling.offset``) with the ``(m, n)``
-:class:`Side` pair, so the two axes never split into ``*_m`` / ``*_n`` locals, and each accumulates
-one term of :meth:`AxisOffset.base` — the register cell's real coordinate, ``block·(units·reg·atom)
-+ unit·(reg·atom) + r·atom``. The UNIT is the atom's parallel thread footprint: a warp for mma, a
-single thread for scalar, so the tensor-core warp tile and the scalar parallel thread-tile are the
-SAME level, differing only in the atom's ``lanes``. :func:`grid_tile` is the finalizer and the ONE
-seal every kernel binds through, whatever tier built it.
-
-This layer is **algebra-free**: it knows a `Side` pair, integer counts and three callables, and
-nothing about node kinds, contractions, reduce plans, operands or the ambient ``Ctx``. What varies
-per tier arrives as those callables (``state_decls`` / ``reduce_region`` / ``store`` — from
-``_atom.reduce_codegen`` + a sink for a contraction, from the reduce tier's own fold otherwise);
-the splice is shared. Keeping it apart from ``_factor`` (which walks nodes and dispatches tiers)
-is what makes that separation checkable rather than merely intended.
-
-Leading ``_`` so the pass loader skips this module.
+Symbolic blockification chooses the logical axes and schedule materialization binds their widths.
+This module does not split axes or compute coordinates. It only places the bound GRID and UNIT
+axes around the state, reduction, and store regions supplied by the lowering tier.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, replace
 
-from emmy.compiler.ir.axis import Axis, Window
-from emmy.compiler.ir.expr import BinaryExpr, Builtin, Expr, Literal, Var
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import BinaryExpr, Builtin, Literal
 from emmy.compiler.ir.kernel import Tile
 from emmy.compiler.ir.schedule import Side
 from emmy.compiler.ir.stmt import Body, Cond, Stmt
 
 
-def shrink_axis(axis: Axis, reg: int) -> Axis:
-    """The grid (cell) axis for a register-tiled free axis: ``ceil(E / reg)`` cells, each a
-    per-thread ``reg``-wide register sub-tile. ``Dim.ceil_div`` keeps a symbolic extent
-    symbolic (``(seq_len+reg-1)//reg``) so the launch grid sizes from the runtime extent."""
-    if reg <= 1:
-        return axis
-    return Axis(name=axis.name, extent=axis.extent.ceil_div(reg), window=Window(parent=axis.source_axis or axis))
-
-
-@dataclass(frozen=True)
-class AxisOffset:
-    """One output axis's per-register-cell coordinate, accumulated across the tiling levels (atom →
-    register → unit → grid). :meth:`base` reproduces ``block·(units·reg·atom) + unit·(reg·atom) +
-    r·atom`` once the UNIT level is present (the mma warp tile AND the scalar thread tile both go
-    through :func:`unit_tile`), else the bare ``Var(block)·reg + r``."""
-
-    atom_dim: int  # the atom step along this axis
-    reg: int = 1  # register sub-cells per unit
-    block_var: str | None = None  # the grid-block axis var (set at grid_tile)
-    unit_var: str | None = None  # the UNIT-level var — a warp for mma, a thread for scalar
-    unit_count: int = 1
-
-    def base(self, r: int) -> Expr:
-        """The offset of register cell index ``r`` along this axis."""
-        reg_term = Literal(r * self.atom_dim, "int")
-        if self.unit_var is not None:  # block·(units·reg·atom) + unit·(reg·atom) + r·atom
-            tile = self.unit_count * self.reg * self.atom_dim
-            e = BinaryExpr("*", Var(self.block_var), Literal(tile, "int"))
-            e = BinaryExpr("+", e, BinaryExpr("*", Var(self.unit_var), Literal(self.reg * self.atom_dim, "int")))
-            return BinaryExpr("+", e, reg_term)
-        return BinaryExpr("+", BinaryExpr("*", Var(self.block_var), Literal(self.reg, "int")), reg_term)  # no unit level
-
-
-@dataclass(frozen=True)
-class Tiling:
-    """The accumulating tiling state threaded through ``atomize → register_tile → unit_tile →
-    grid_tile`` — the per-axis ``(m, n)`` :class:`AxisOffset` tuple ``offset`` + the bound ``Tile``
-    axes (unit → grid) + ``block_threads``. Each level ``zip``\\ s ``offset`` with the ``(m, n)``
-    :class:`Side` pair, so the two axes never split into ``*_m`` / ``*_n`` locals."""
-
-    offset: tuple[AxisOffset, AxisOffset]
-    axes: tuple[Axis, ...] = ()
-    block_threads: int | None = None
-
-
-def atomize(atoms: tuple[int, int]) -> Tiling:
-    """The leaf: a single ``(atom_m, atom_n)`` atom (1×1 for a scalar cell). Seeds the per-axis
-    offset with the atom step; the atom-lane offset stays OUT of σ (added at render)."""
-    return Tiling(offset=tuple(AxisOffset(atom_dim=a) for a in atoms))
-
-
-def register_tile(t: Tiling, mn: tuple[Side, Side]) -> Tiling:
-    """The REGISTER level: ``m.reg × n.reg`` atoms per thread/warp. Records the cell counts; the
-    per-cell ``r·atom_dim`` term is applied at :meth:`AxisOffset.base`."""
-    return replace(t, offset=tuple(replace(o, reg=s.reg) for o, s in zip(t.offset, mn, strict=True)))
-
-
-def unit_tile(t: Tiling, mn: tuple[Side, Side]) -> Tiling:
-    """The UNIT level: ``m.units × n.units`` parallel units per CTA, where a *unit* is the atom's
-    thread footprint — a warp (32 lanes) for an mma atom, a single thread for a scalar atom (so the
-    tensor-core warp tile and the scalar parallel thread-tile are the same level, differing only in
-    the atom's ``lanes``). Adds the unit term ``unit·(reg·atom)`` to each axis offset + the per-axis
-    unit axes."""
-    offset = tuple(replace(o, unit_var=s.unit, unit_count=s.units) for o, s in zip(t.offset, mn, strict=True))
-    axes = (*t.axes, *(Axis(name=s.unit, extent=s.units) for s in mn))
-    return replace(t, offset=offset, axes=axes)
-
-
 def grid_tile(
-    t: Tiling,
     *,
-    mn: tuple[Side | None, Side | None],
-    lead_axes: tuple[Axis, ...] = (),
+    mn: tuple[Side, Side] | tuple[None, None],
+    lead_axes: tuple = (),
+    inner_axes: tuple = (),
     block_threads: int | None,
     lanes: int = 1,
     state_decls: Callable[[list[tuple[int, int]]], list[Stmt]],
@@ -118,46 +29,32 @@ def grid_tile(
     workers: object = None,
     raster: object = None,
 ) -> Tile:
-    """The GRID level + finalize — the ONE seal every kernel binds through: bind the block axes (the
-    shrunk grid), set the per-axis grid term ``block·tile``, append any leading (untiled) grid axes
-    verbatim and — when the atom is warp-cooperative (``lanes > 1``) — the atom ``_lane`` axis, then
-    splice the codegen callables' state + reduce-region + per-cell stores into the ``Tile``. The
-    three callables (atom-specific for a contraction, from :func:`~...kernel._atom.reduce_codegen` +
-    the ``store`` sink; the reduce tier's fill / partitioned fold / projection close) are the only
-    variation; the splice is shared. They take the per-cell ``offset`` (the ``(m, n)``
-    :class:`AxisOffset` tuple) + the ``mn`` :class:`Side` pair.
+    """Place one resolved block domain around the three lowering regions."""
+    tiled = mn[0] is not None and mn[1] is not None
+    if tiled:
+        sides = mn
+        block_axes = tuple(side.axes[0] for side in sides)
+        unit_axes = tuple(side.axes[1] for side in sides)
+        cells = [(i, j) for i in range(sides[0].reg) for j in range(sides[1].reg)]
+        offset = sides
+    else:
+        block_axes = unit_axes = ()
+        cells = [(0, 0)]
+        offset = (None, None)
+    lane_axes = (Axis("_lane", lanes),) if lanes > 1 else ()
+    axes = (*lead_axes, *block_axes, *unit_axes, *inner_axes, *lane_axes)
 
-    ``mn[0] is None`` is a 1-D output grid (only ``n`` tiled) — no ``m`` block axis is bound.
-    ``mn == (None, None)`` is the fully-untiled output (the reduce tier / degenerate fold): one cell
-    per thread, no block axis at all — the whole grid rides ``lead_axes``, and a tiled REDUCE axis
-    contributes its lane through ``t.axes``. ``lanes == 1`` (scalar) emits no ``_lane`` axis.
-
-    ``workers`` (a resolved :class:`WarpSpec`) appends its producer band as ``Tile.aux_threads`` and
-    guards the stores to the compute band — an aux thread's wrapped decode aliases a compute cell,
-    so an unguarded ``store`` would double-write it."""
-    offset = tuple(replace(o, block_var=s.block) if s is not None else o for o, s in zip(t.offset, mn, strict=True))
-    block_axes = tuple(
-        shrink_axis(Axis(name=s.block, extent=s.axis.extent, window=Window(parent=s.axis)), s.tile) for s in mn if s is not None
-    )
-    lane_axes = (Axis(name="_lane", extent=lanes),) if lanes > 1 else ()
-    axes = (*lead_axes, *block_axes, *t.axes, *lane_axes)
-
-    cells = [(i, j) for i in range(offset[0].reg) for j in range(offset[1].reg)]
     state = state_decls(cells)
-    top_decls, kstmts = reduce_region(cells, offset, mn)
-    stores = [s for (i, j) in cells for s in store(i, j, offset, mn)]
+    top_decls, reduction = reduce_region(cells, offset, mn)
+    stores = [stmt for i, j in cells for stmt in store(i, j, offset, mn)]
     aux_threads = 0
     if workers is not None:
         aux_threads = 32 * workers.producer_warps
         stores = [Cond(cond=BinaryExpr("<", Builtin("thread_idx.x"), Literal(block_threads, "int")), body=tuple(stores))]
-    # A 2-D-tiled output (both mn Sides bound) marks its (m, n) block axes as
-    # rasterization-eligible — the structural fact only this seal knows; whether (and how) the
-    # CTA order actually groups them is the resolved ``RASTER`` codec threaded down off the
-    # TileOp's knobs (``None`` / ineligible ⇒ the flat N-fastest order, byte-identical codegen).
-    raster_axes = (mn[0].block, mn[1].block) if (mn[0] is not None and mn[1] is not None) else None
+    raster_axes = (mn[0].block, mn[1].block) if tiled else None
     return Tile(
         axes=axes,
-        body=Body((*state, *top_decls, *kstmts, *stores)),
+        body=Body((*state, *top_decls, *reduction, *stores)),
         block_threads=block_threads,
         aux_threads=aux_threads,
         raster_axes=raster_axes,

--- a/emmy/compiler/pipeline/passes/lowering/tile/025_block.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/025_block.py
@@ -1,0 +1,22 @@
+"""Install the symbolic axis blocks that every later schedule choice binds."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from emmy.compiler.graph import Node
+from emmy.compiler.ir.tile import TileOp, blockify
+from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
+
+PATTERN = [Pattern("root", TileOp)]
+
+
+def rewrite(match: Match, root: Node, ctx=None) -> TileOp:
+    del match, ctx
+    tile: TileOp = root.op
+    if tile.op is None or tile.place.is_mapped or tile.schedule is not None:
+        raise RuleSkipped("TileOp already scheduled / nothing to block")
+    blocks = blockify(tile)
+    if blocks == tile.blocks:
+        raise RuleSkipped("symbolic blocks already installed")
+    return replace(tile, blocks=blocks)

--- a/emmy/compiler/pipeline/passes/lowering/tile/035_block.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/035_block.py
@@ -26,7 +26,7 @@ from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.pure import Fold, Lambda
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body
-from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.ir.tile import TileOp, blockify
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
 from emmy.compiler.pipeline.passes.lowering.tile._split import sliced_edge
 
@@ -40,9 +40,14 @@ def rewrite(match: Match, root: Node, ctx=None) -> TileOp:
         raise RuleSkipped("TileOp already scheduled / nothing to block")
     blocked = block_tree(tile.op, tile.axes)
     if blocked is None:
-        raise RuleSkipped("no stream a block gives a contraction to")
+        blocks = blockify(tile)
+        if blocks == tile.blocks:
+            raise RuleSkipped("symbolic blocks already installed")
+        return replace(tile, blocks=blocks)
     op, axes = blocked
-    return replace(tile, op=op, axes=axes)
+    # Structural blocking creates new Fold sites; declare their symbolic blocks on the new tree.
+    result = replace(tile, op=op, axes=axes, blocks=())
+    return replace(result, blocks=blockify(result))
 
 
 MAX_BLOCK = 64

--- a/emmy/compiler/pipeline/passes/lowering/tile/_split.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_split.py
@@ -42,7 +42,7 @@ from emmy.compiler.ir.schedule.catalog import splitk_moves
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Body, Load, Write
 from emmy.compiler.ir.stmt.passes import projection_distributes
-from emmy.compiler.ir.tile import OutputSpec, Placement, TileOp
+from emmy.compiler.ir.tile import BlockAxis, OutputSpec, Placement, TileOp
 from emmy.compiler.ir.tile.ops import Sched, carries_partition, head, projection_regions, projection_root, projection_tail
 from emmy.compiler.pipeline import Match
 from emmy.compiler.pipeline.fork import DeferredFork
@@ -57,14 +57,15 @@ _SPLIT = "_ksplit"  # the cross-CTA split grid axis
 # ---- what a kernel / an axis can carry -------------------------------------------------------- #
 
 
-def splitk_width(k_axis: Axis, width: int) -> str | None:
+def splitk_width(block: BlockAxis, width: int) -> str | None:
     """A cross-CTA split needs a STATIC reduce axis its width divides evenly — the σ-reindex
     reconstructs an absolute k from ``ksplit·(K/w) + kslice``, which is a bijection only when the
     extent is known and ``w`` divides it. Total over a symbolic axis rather than raising out of
     ``as_static``, so the catalog drops the width and a pin reports the reason."""
-    if not k_axis.extent.is_static:
-        return f"cross-CTA split of the symbolic reduce axis {k_axis.name!r} is not built"
-    big_k = k_axis.extent.as_static()
+    axis = block.axis
+    if not axis.extent.is_static:
+        return f"cross-CTA split of the symbolic reduce axis {axis.name!r} is not built"
+    big_k = axis.extent.as_static()
     if big_k % width == 0:
         return None
     return f"split-K width {width} does not divide K={big_k}; pick a dividing split width."
@@ -216,7 +217,8 @@ def split_forks(match: Match, root: Node, *, unsplit_tile: TileOp | None = None)
         return None
     node = head(tile.op)
     assert node is not None and node.axis is not None
-    k_axis = tile.axis_of(node.axis)  # the node names its K; the kernel's axis table holds its extent
+    block = tile.blocks_of(node).reduce
+    assert block is not None
     key = Sched(tile).key("REDUCE", node) or "REDUCE"
     unsplit = DeferredFork(lambda: replace(unsplit_tile or tile, split_consumed=True), {key: ""})
     element = axis_of(key)
@@ -226,7 +228,7 @@ def split_forks(match: Match, root: Node, *, unsplit_tile: TileOp | None = None)
         plan = Reduce.parse(pin, Work.parse(WORK.raw()))
         if not plan.needs_split:
             return [unsplit]
-        _enforce(splitk_width(k_axis, plan.cta))
+        _enforce(splitk_width(block, plan.cta))
         _enforce(_projection_refusal(tile, node))
         if plan.finalize == "atomic":
             _enforce(atomic_finalize(node, tail, tile.outputs))
@@ -238,7 +240,7 @@ def split_forks(match: Match, root: Node, *, unsplit_tile: TileOp | None = None)
     options: list[DeferredFork] = [unsplit]
     atomic_why = atomic_finalize(node, tail, tile.outputs)
     for plan in splitk_moves():
-        why = splitk_width(k_axis, plan.cta) or (atomic_why if plan.finalize == "atomic" else None)
+        why = splitk_width(block, plan.cta) or (atomic_why if plan.finalize == "atomic" else None)
         if why is not None:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("split g%d%s not offered: %s", plan.cta, plan.finalize[0], why)
@@ -255,34 +257,16 @@ def _split_fork(match: Match, root: Node, key: str, cta: int, finalize: str) -> 
 # ---- slicing the head fold -------------------------------------------------------------------- #
 
 
-def _slice_fold(fold: Fold, axis: Axis, b: int, split: Axis) -> tuple[Axis, Fold]:
+def _slice_fold(fold: Fold, axis: Axis, split: Axis, sigma: Sigma) -> Fold:
     """``(the sliced axis, the same monoid Fold over one CTA's absolute contiguous slice)`` — the
     generic (non-contraction) slicer: the whole fold rides ``Fold.rewrite`` under the σ-offset."""
-    offset = BinaryExpr("+", Var(axis.name), BinaryExpr("*", Var(_SPLIT), Literal(b, "int")))
-    sigma = Sigma({axis.name: offset})
-    sliced_axis = replace(axis, extent=Dim(b), window=Window(parent=axis.source_axis or axis, partition=True))
     # RE-DERIVED over a narrower axis, not renamed and not substituted-through: the fold keeps its
     # own binder (same name, sliced extent) while its operands' coordinates take the σ-offset. A
     # blanket σ would be refused as capture — this fold BINDS the name σ maps — and rightly so;
     # what changes here is the axis itself, which only the caller can say.
-    operands = tuple(sliced_edge(edge, sigma, axis.name, sliced_axis, split) for edge in fold.operands)
+    operands = tuple(sliced_edge(edge, sigma, fold.axis, axis, split) for edge in fold.operands)
     body = Body(tuple(stmt.substitute(sigma) for stmt in fold.lift.body))
-    return sliced_axis, replace(fold, operands=operands, lift=replace(fold.lift, body=body))
-
-
-def _factor_k(k_axis: Axis, w: int) -> tuple[Axis, Axis, Sigma]:
-    """Factor a STATIC contraction axis into ``ksplit × kslice``. ``ksplit`` (extent ``w``, name
-    ``_<k>_ks``) becomes the partial's lead grid axis, parallelized across CTAs and combined in
-    the finalize; ``kslice`` (extent ``K/w``, the ORIGINAL name) is the sliced contraction's. The
-    ``sigma`` maps the original ``k`` to ``ksplit·(K/w) + kslice`` so the operand loads
-    reconstruct the absolute index; distinct names are what avoid a double-reduce. The slice
-    carries its parentage: a cross-CTA split is CONSUMED by the rewrite that realizes it, and an
-    axis that is already a partition window is one nothing may partition again."""
-    b = k_axis.extent.as_static() // w
-    ksplit = Axis(name=f"_{k_axis.name}_ks", extent=Dim(w))
-    kslice = replace(k_axis, extent=Dim(b), window=Window(parent=k_axis.source_axis or k_axis, partition=True))
-    sigma = Sigma({k_axis.name: BinaryExpr("+", BinaryExpr("*", Var(ksplit.name), Literal(b, "int")), Var(k_axis.name))})
-    return ksplit, kslice, sigma
+    return replace(fold, operands=operands, lift=replace(fold.lift, body=body))
 
 
 def sliced_edge(edge, sigma: Sigma, k_name: str, kslice=None, ksplit: Axis | None = None):
@@ -317,13 +301,13 @@ def sliced_edge(edge, sigma: Sigma, k_name: str, kslice=None, ksplit: Axis | Non
 #: eight-wide atom), and a block no fragment grid covers is a block no tensor core can take.
 
 
-def _sliced_contraction(node: Fold, k_axis: Axis, w: int) -> tuple[Axis, Axis, Fold]:
+def _sliced_contraction(node: Fold, block: BlockAxis, w: int) -> tuple[Axis, Axis, Fold]:
     """``(ksplit, kslice, sliced)`` for a contraction head: the SAME bilinear node a non-split matmul
     builds, over ``kslice`` with operands σ-reindexed to absolute k, threading the node's OWN
     semiring (the reassociation ``fold_k = fold_{ksplit} ∘ fold_{kslice}`` is licensed by that
     ⊕-monoid's associativity). ``Fold.contraction`` regenerates the componentwise ⊕ over the same
     accumulator names, so the finalize folds the workspace states through the same monoid."""
-    ksplit, kslice, sigma = _factor_k(k_axis, w)
+    ksplit, kslice, sigma = block.partition(w, outer=f"_{block.axis.name}_ks")
     # Rebuilt DIRECTLY over the σ-reindexed operands, in stored order: the slice is the same term
     # with a narrower axis, so its lift, monoid and seeds are the node's own — there is nothing for
     # a former to re-derive, and no role to re-name.
@@ -501,13 +485,14 @@ def realize_split(match: Match, root: Node, cta: int, finalize: str) -> Graph:
     assert node is not None, "the split offer fires on node-form kernels only"
     root, region, body, stores, projection_pieces = _split_projection(tile, root, node)
     free = tuple(tile.place.free)
-    k_axis = tile.axis_of(node.axis)
+    block = tile.blocks_of(node).reduce
+    assert block is not None
     if node.as_contraction() is not None:
-        split, kslice, partial_fold = _sliced_contraction(node, k_axis, cta)
+        split, kslice, partial_fold = _sliced_contraction(node, block, cta)
     else:
-        _enforce(splitk_width(k_axis, cta))
-        split = Axis(name=_SPLIT, extent=Dim(cta))
-        kslice, partial_fold = _slice_fold(node, k_axis, k_axis.extent.as_static() // cta, split)
+        _enforce(splitk_width(block, cta))
+        split, kslice, sigma = block.partition(cta, outer=_SPLIT)
+        partial_fold = _slice_fold(node, kslice, split, sigma)
     axes = _with_axes(tile.axes, split, kslice)  # the pieces' axis table: the slice under its own name
     states = partial_fold.combine.results
     n_comp = len(states)

--- a/tests/compiler/ir/schedule/test_classic.py
+++ b/tests/compiler/ir/schedule/test_classic.py
@@ -2,7 +2,7 @@
 
 import json
 import pickle
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, replace
 from itertools import permutations
 
 import pytest
@@ -46,7 +46,7 @@ from emmy.compiler.ir.schedule.classic import (
     parse_node_id,
 )
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
-from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.ir.tile import TileOp, blockify
 from emmy.compiler.pipeline.fork import DeferredFork, iter_leaves, schedule_forks
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
 from tests.compiler.helpers import classic_cartesian_assignments, enumerate_classic_reference
@@ -71,6 +71,7 @@ def _problem(root: Fold, target=None) -> tuple[TileOp, object]:
     """The ``(tile, target)`` problem the schedule model tests compose over."""
     m, n = Axis("m", 8), Axis("n", 8)
     tile = TileOp(op=root, place=Placement(free=(m, n)), axes=(m, n, _K))
+    tile = replace(tile, blocks=blockify(tile))
     return tile, Context.from_target((12, 0)) if target is None else target
 
 
@@ -176,7 +177,8 @@ def test_independent_nodes_compose_only_at_matching_physical_axis_geometry() -> 
     first = contraction(k1, Load("a1", "a1", (Var("m"), Var("k1"))), (Load("b1", "b1", (Var("k1"), Var("n"))), "left"))
     second = contraction(k2, Load("a2", "a2", (Var("n"), Var("k2"))), (Load("b2", "b2", (Var("k2"), Var("m"))), "right"))
     root = projection((first, second), (), ("left", "right"))
-    problem = (TileOp(op=root, place=Placement(free=(m, n)), axes=(m, n, k1, k2)), Context.from_target((12, 0)))
+    source = TileOp(op=root, place=Placement(free=(m, n)), axes=(m, n, k1, k2))
+    problem = (replace(source, blocks=blockify(source)), Context.from_target((12, 0)))
 
     def pick(context, node, choice):
         site = context.site(node)
@@ -333,6 +335,7 @@ def test_an_authored_tile_bypasses_enumeration_precision_policy() -> None:
         inputs={"a": Tensor("a", (8, 16), "f16"), "b": Tensor("b", (16, 8), "f16")},
         outputs={"out": Tensor("out", (8, 8), "f16")},
     )
+    source = replace(source, blocks=blockify(source))
     problem = (source, Context.from_target((12, 0)))
     base = ClassicScheduleContext(*problem)
     site = base.tile_op.node_sites[0]
@@ -613,6 +616,7 @@ def test_tile_requires_complete_materialization() -> None:
             op=root,
             place=Placement(free=(m, n)),
             axes=(m, n, _K),
+            blocks=context.tile_op.blocks,
             schedule=schedule,
             materialization=ClassicMaterialization({}, {}),
         )
@@ -622,6 +626,7 @@ def test_tile_requires_complete_materialization() -> None:
             op=root,
             place=Placement(free=(m, n)),
             axes=(m, n, _K),
+            blocks=context.tile_op.blocks,
             schedule=schedule,
             materialization=ClassicMaterialization({site: placed, site + 1: placed}, {}),
         )
@@ -645,6 +650,7 @@ def test_tile_graph_round_trip_uses_the_strict_schedule_codec() -> None:
         name="classic",
         place=Placement(free=(m, n), grid=(m, n), mapped=True),
         axes=(m, n, _K),
+        blocks=context.tile_op.blocks,
         schedule=schedule,
         materialization=ClassicMaterialization({site: plan.at(m, n)}, {}),
     )

--- a/tests/compiler/ir/test_graph.py
+++ b/tests/compiler/ir/test_graph.py
@@ -221,6 +221,7 @@ def test_tile_op_scalar_atom_schedule_roundtrip(monkeypatch):
     """A dumped tile-stage graph must rehydrate the scalar output-tile schedule."""
     import copy
     import json
+    from dataclasses import replace
 
     from emmy.compiler.ir.atom import ScalarAtom
     from emmy.compiler.ir.schedule import Raster, Schedule, Work
@@ -232,11 +233,12 @@ def test_tile_op_scalar_atom_schedule_roundtrip(monkeypatch):
         ProjectionSchedule,
     )
     from emmy.compiler.ir.stmt import Const
-    from emmy.compiler.ir.tile import TileOp
+    from emmy.compiler.ir.tile import TileOp, blockify
     from tests.compiler.terms import projection
 
     fold = projection(body=(Const(name="zero", value=0.0),))
     source = TileOp(op=fold)
+    source = replace(source, blocks=blockify(source))
     context = ClassicScheduleContext(source)
     classic = Schedule(
         KernelSchedule(Work(), Raster()),
@@ -246,7 +248,7 @@ def test_tile_op_scalar_atom_schedule_roundtrip(monkeypatch):
     g = Graph()
     x = g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (1,), "f16"), node_id="x")
     g.add_node(
-        op=TileOp(op=fold, schedule=classic, materialization=ClassicMaterialization({}, {})),
+        op=TileOp(op=fold, blocks=source.blocks, schedule=classic, materialization=ClassicMaterialization({}, {})),
         inputs=[x],
         output=Tensor("out", (1,), "f16"),
         node_id="out",

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -17,6 +17,8 @@ them — never from the term; (e) a λ that is not closed says what it captures.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure import Fold, Lambda
@@ -30,7 +32,7 @@ from emmy.compiler.ir.schedule.classic import (
     ReductionSchedule,
 )
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
-from emmy.compiler.ir.tile import OutputSpec, TileOp
+from emmy.compiler.ir.tile import OutputSpec, TileOp, blockify
 from emmy.compiler.ir.tile._dump import pretty
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
 from tests.compiler.terms import contraction, projection
@@ -99,6 +101,25 @@ def test_contraction_dump_shows_the_k_axis_and_every_channel() -> None:
     # The binding labels connect the edges above to their positional lift params, A first.
     assert "lift: λ(k, a_e, acc_g_b, acc_u_b) -> (acc_g__v, acc_u__v)" in text
     assert "└─ combine: λ(acc_g, acc_u, acc_g__o, acc_u__o) -> (acc_g, acc_u)" in text
+
+
+def test_blockified_matmul_dump_exposes_its_symbolic_domains() -> None:
+    """Blockification declares M, N and K before a schedule supplies their widths."""
+    m, n, k = Axis("m", 128), Axis("n", 96), Axis("k", 64)
+    fold = contraction(
+        k,
+        Load(name="a", input="A", index=(Var("m"), Var("k"))),
+        (Load(name="b", input="B", index=(Var("k"), Var("n"))), "acc"),
+    )
+    bare = TileOp(op=fold, name="k_matmul", place=Placement(free=(m, n)), axes=(m, n, k))
+    tile = replace(bare, blocks=blockify(bare))
+
+    assert "\n".join(tile.pretty_body().splitlines()[:6]) == """    place  free=(m, n)  unmapped
+    blocks
+    ├─ b0.m: m → grid × unit × register × atom
+    ├─ b0.n: n → grid × unit × register × atom
+    └─ b0.k: k → grid × block × register × tile × atom × serial
+    Fold[k in 0..64] contraction"""
 
 
 def test_projection_dump_shows_the_binder_and_its_operands() -> None:
@@ -248,7 +269,8 @@ def test_slices_annotate_a_node_only_when_the_owning_tileop_supplies_them() -> N
     bare = TileOp(op=fold, name="k_stat", axes=(K_STAT,))
     assert "REDUCE=" not in bare.pretty_body()
 
-    context = ClassicScheduleContext(bare)
+    source = replace(bare, blocks=blockify(bare))
+    context = ClassicScheduleContext(source)
     nodes = {
         site: ProjectionSchedule(Tile()) if view.axis is None else ReductionSchedule(Tile(), Reduce.of(reg=4))
         for site, view in enumerate(context.tile_op.views)
@@ -262,6 +284,7 @@ def test_slices_annotate_a_node_only_when_the_owning_tileop_supplies_them() -> N
         op=fold,
         name="k_stat",
         axes=(K_STAT,),
+        blocks=source.blocks,
         schedule=classic,
         materialization=ClassicMaterialization({}, {}),
     )

--- a/tests/compiler/passes/test_classic_schedule_domains.py
+++ b/tests/compiler/passes/test_classic_schedule_domains.py
@@ -17,7 +17,7 @@ from emmy.compiler.ir.schedule.classic import (
 )
 from emmy.compiler.ir.schedule.classic_projection import project_classic
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
-from emmy.compiler.ir.tile import Placement, TileOp
+from emmy.compiler.ir.tile import Placement, TileOp, blockify
 from emmy.compiler.ir.tile.ops import carries_partition
 from emmy.compiler.pipeline.fork import iter_leaves
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
@@ -25,6 +25,10 @@ from tests.compiler.helpers import enumerate_classic_reference
 from tests.compiler.terms import contraction, projection
 
 classic_forks = import_module("emmy.compiler.pipeline.passes.lowering.tile.040_schedule").classic_forks
+
+
+def _blockified(tile: TileOp) -> TileOp:
+    return dc_replace(tile, blocks=blockify(tile))
 
 
 def _signature(codec, assignment) -> tuple[tuple[str, str], ...]:
@@ -64,7 +68,7 @@ def _pointwise() -> TileOp:
     the cell, as the lift leaves it for a root nothing reduces over."""
     n = Axis("n", 8)
     root = projection((), (Load(name="x", input="x", index=(Var("n"),)), Assign("y", "add", ("x", "x"))), ("y",))
-    return TileOp(op=root, place=Placement(free=(n,)), axes=(n,))
+    return _blockified(TileOp(op=root, place=Placement(free=(n,)), axes=(n,)))
 
 
 def _row_sum(k: Axis, n: Axis) -> TileOp:
@@ -72,14 +76,14 @@ def _row_sum(k: Axis, n: Axis) -> TileOp:
     root = fold_from_loop(
         Loop(axis=k, body=Body((Load(name="xv", input="x", index=(Var("k"),)), Accum(name="acc", value="xv", op="add", axes=("k",)))))
     )
-    return TileOp(op=root, place=Placement(free=(n,)), axes=(n, k))
+    return _blockified(TileOp(op=root, place=Placement(free=(n,)), axes=(n, k)))
 
 
 def _matmul(m: Axis, n: Axis, k: Axis, a=None, **fields) -> TileOp:
     """``acc[m, n] = Σ_k a[m, k] · b[k, n]`` — one contraction site; ``a`` may be a computed edge."""
     a = a if a is not None else Load(name="a_e", input="a", index=(Var("m"), Var("k")))
     root = contraction(k, a, (Load(name="b_e", input="b", index=(Var("k"), Var("n"))), "acc"))
-    return TileOp(op=root, place=Placement(free=(m, n)), axes=(m, n, k), **fields)
+    return _blockified(TileOp(op=root, place=Placement(free=(m, n)), axes=(m, n, k), **fields))
 
 
 def test_production_enumeration_is_the_compatible_independent_product() -> None:
@@ -195,12 +199,14 @@ def test_multi_channel_contraction_domain_contains_per_cell_and_warp_compute_fil
         (Load(name="b0_e", input="b0", index=(Var("k"), Var("n"))), "acc0"),
         (Load(name="b1_e", input="b1", index=(Var("k"), Var("n"))), "acc1"),
     )
-    tile = TileOp(
-        op=root,
-        place=Placement(free=(m, n)),
-        axes=(m, n, k),
-        inputs={name: Tensor(name, (16, 16), "f16") for name in ("a", "b0", "b1")},
-        outputs={"out": Tensor("out", (16, 16), "f16")},
+    tile = _blockified(
+        TileOp(
+            op=root,
+            place=Placement(free=(m, n)),
+            axes=(m, n, k),
+            inputs={name: Tensor(name, (16, 16), "f16") for name in ("a", "b0", "b1")},
+            outputs={"out": Tensor("out", (16, 16), "f16")},
+        )
     )
     target = Context.from_target((12, 0))
     domains = project_classic(tile, target)

--- a/tests/compiler/passes/test_move_catalog.py
+++ b/tests/compiler/passes/test_move_catalog.py
@@ -15,6 +15,8 @@ file pins the catalog's **legal set** three ways:
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from emmy.compiler.context import Context
 from emmy.compiler.dim import Dim
 from emmy.compiler.graph import Graph, Tensor
@@ -26,7 +28,7 @@ from emmy.compiler.ir.schedule import Reduce, Tile, Work, derive_workers, resolv
 from emmy.compiler.ir.schedule.catalog import MAX_BLOCK_THREADS as _MAX_BLOCK_THREADS
 from emmy.compiler.ir.schedule.catalog import coop_reduce_moves, scalar_tile_moves
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
-from emmy.compiler.ir.tile import Placement, TileOp
+from emmy.compiler.ir.tile import Placement, TileOp, blockify
 from emmy.compiler.pipeline import TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import iter_leaves
 from emmy.compiler.pipeline.knob import axis_of, complete_kernel_row, family_of, family_value, is_off_value
@@ -249,6 +251,8 @@ def _rows_of(tile, ctx=None) -> list[dict]:
     from importlib import import_module
 
     classic_forks = import_module("emmy.compiler.pipeline.passes.lowering.tile.040_schedule").classic_forks
+    if not tile.blocks:
+        tile = replace(tile, blocks=blockify(tile))
     out = classic_forks(tile, "k", {}, ctx or Context.from_target((12, 0)))
     return [dict(leaf.knobs) for leaf in iter_leaves(out)]
 

--- a/tests/compiler/passes/test_reduce_tier_chain.py
+++ b/tests/compiler/passes/test_reduce_tier_chain.py
@@ -21,7 +21,7 @@ from emmy.compiler.ir.schedule.classic import (
     ReductionSchedule,
 )
 from emmy.compiler.ir.stmt import Assign, Cond, Load, Loop, StridedLoop, Write
-from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.ir.tile import TileOp, blockify
 from emmy.compiler.pipeline.passes.lowering.kernel._factor import factorize
 from tests.compiler.terms import contraction, projection, reduction, slab
 
@@ -35,6 +35,7 @@ def _stamped(root: Fold, plans: dict, axes: tuple = (_K,)) -> TileOp:
     classic assignment. The kernel ``WORK`` derives from the widest cooperative plan, because the
     assignment's own validation requires the inventory to realize the node choices."""
     tile = TileOp(op=root, place=_PLACE, axes=(_M, *axes))
+    tile = replace(tile, blocks=blockify(tile))
     by_site = {tile.node_id(node): plan for node, plan in plans.items()}
     nodes = {
         site: ProjectionSchedule(Tile()) if tile.views[site].axis is None else ReductionSchedule(Tile(), by_site.get(site, Reduce()))
@@ -204,6 +205,7 @@ def test_the_walk_offers_and_the_binder_realizes_two_partitioned_members(monkeyp
         monkeypatch.delenv(var, raising=False)
     _, _, root = _two_member_root()
     tile = TileOp(op=root, place=_PLACE, axes=(_M, _K, _J), name="k_two_member_probe", knobs={})
+    tile = replace(tile, blocks=blockify(tile))
 
     leaves = list(iter_leaves(classic_forks(tile, tile.name, {}, Context.from_target((12, 0)))))
     keys = sorted({key for leaf in leaves for key in leaf.knobs if key.split("@", 1)[0] == "REDUCE"})

--- a/tests/compiler/passes/test_scalar_cell_varying_operand.py
+++ b/tests/compiler/passes/test_scalar_cell_varying_operand.py
@@ -21,7 +21,7 @@ from emmy.compiler.ir.pure.fold import Fold
 from emmy.compiler.ir.schedule import Tile
 from emmy.compiler.ir.stmt import Assign, Body, Load, Stmt, Write
 from emmy.compiler.pipeline.passes.lowering.kernel._atom import reduce_codegen, store_sink
-from emmy.compiler.pipeline.passes.lowering.kernel._tiling import atomize, grid_tile, register_tile, unit_tile
+from emmy.compiler.pipeline.passes.lowering.kernel._tiling import grid_tile
 from tests.compiler.terms import contraction, projection
 
 _M, _N, _K = Axis("m", 8), Axis("n", 8), Axis("k", 4)
@@ -55,7 +55,6 @@ def _tile(a, b):
     state, reduce_region = reduce_codegen(c, plan, k_axis=_K, axes=(_M, _N, _K))
     epilogue = Body((Write(output="out", index=(Var("m"), Var("n")), value=c.combine.results[0]),))
     return grid_tile(
-        unit_tile(register_tile(atomize(plan.atom.shape[:2]), mn), mn),
         mn=mn,
         block_threads=plan.launch_threads,
         lanes=plan.atom.lanes,

--- a/tests/compiler/passes/test_schedule_space_separation.py
+++ b/tests/compiler/passes/test_schedule_space_separation.py
@@ -17,6 +17,7 @@ from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
 from emmy.compiler.ir.loop import LoopOp
+from emmy.compiler.ir.tile import blockify
 from emmy.compiler.pipeline import LOOP_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import iter_leaves
 
@@ -38,7 +39,19 @@ def _unmapped_tile(m: int, n: int, k: int = 64, dtype: str = "f16"):
     g.inputs, g.outputs = ["a", "b"], ["o"]
     node = Pipeline.build(LOOP_PASSES).run(g).nodes["o"]
     tile = lift_loop_op(node.op, name=node.op.name)
+    tile = replace(tile, blocks=blockify(tile))
     return replace(tile, knobs=dict(node.op.knobs), inputs=dict(node.op.inputs), outputs=dict(node.op.outputs))
+
+
+def test_matmul_blockification_does_not_add_a_schedule_family() -> None:
+    """The existing choices bind the symbolic domains; the row codec stays byte-for-byte the same."""
+    from emmy.compiler.ir.schedule.classic import ClassicScheduleCodec, ClassicScheduleContext
+    from emmy.compiler.ir.schedule.classic_projection import project_classic
+
+    tile = _unmapped_tile(128, 128)
+    ctx = Context.from_target((12, 0))
+    codec = ClassicScheduleCodec(ClassicScheduleContext(tile, ctx, project_classic(tile, ctx)))
+    assert codec.keys() == ("WORK", "RASTER", "TILE", "REDUCE", "STAGE")
 
 
 def test_a_precision_gate_pin_stamps_a_different_space() -> None:
@@ -99,6 +112,7 @@ def test_split_dim_store_does_not_share_an_identity() -> None:
         out = Pipeline.build(LOOP_PASSES).run(graph)
         node = [n for n in out.nodes.values() if isinstance(n.op, LoopOp)][-1]
         tile = lift_loop_op(node.op, name=node.op.name)
+        tile = replace(tile, blocks=blockify(tile))
         return replace(tile, knobs=dict(node.op.knobs), inputs=dict(node.op.inputs), outputs=dict(node.op.outputs))
 
     flat, split = lifted(matmul), lifted(f"{matmul}.reshape(4,32,128)")
@@ -134,6 +148,7 @@ def test_an_axis_renamed_twin_preserves_the_node_id_vocabulary() -> None:
     out = Pipeline.build(LOOP_PASSES).run(graph_from_code(code)[0])
     node = [n for n in out.nodes.values() if isinstance(n.op, LoopOp)][-1]
     tile = lift_loop_op(node.op, name=node.op.name)
+    tile = replace(tile, blocks=blockify(tile))
     tile = replace(tile, knobs=dict(node.op.knobs), inputs=dict(node.op.inputs), outputs=dict(node.op.outputs))
 
     ctx = Context.from_target((12, 0))
@@ -147,6 +162,7 @@ def test_an_axis_renamed_twin_preserves_the_node_id_vocabulary() -> None:
 
     twin_op = rewrite(tile.op, lambda n: n, Sigma({old: Var(new)}), ren)
     twin = TileOp(op=twin_op, place=tile.place, output_specs=tile.output_specs, axes=tuple(ren(axis) for axis in tile.axes))
+    twin = replace(twin, blocks=blockify(twin))
     twin = replace(twin, knobs=dict(tile.knobs), inputs=dict(tile.inputs), outputs=dict(tile.outputs))
     twin_row = dict(next(iter_leaves(classic_forks(twin, "t", twin.knobs, ctx))).knobs)
     assert spelled in twin_row

--- a/tests/compiler/passes/test_tiling_layer.py
+++ b/tests/compiler/passes/test_tiling_layer.py
@@ -1,26 +1,16 @@
-"""The axis-realization layer (`kernel/_tiling.py`) — the four levels a schedule's plan becomes
-bound `Axis` objects through, exercised without a node, a `Ctx` or any algebra.
-
-`040_schedule` decides the plan; nothing it produces is an axis a kernel loops over. This layer is
-the other half, and it is algebra-free by construction: it takes a `Side` pair, integer counts and
-three callables. These tests hold that boundary — they never build a `bilinear fold` — and pin the
-per-cell coordinate arithmetic `AxisOffset.base` accumulates across the levels, which is what the
-emitted σ substitutions index with.
-"""
+"""The algebra-free seal around already-blockified output axes."""
 
 from __future__ import annotations
-
-from dataclasses import replace
 
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import Literal, Var
 from emmy.compiler.ir.schedule import Side
 from emmy.compiler.ir.stmt import Body, Write
-from emmy.compiler.pipeline.passes.lowering.kernel._tiling import atomize, grid_tile, register_tile, shrink_axis, unit_tile
+from emmy.compiler.pipeline.passes.lowering.kernel._tiling import grid_tile
 
 
 def _side(name: str, extent: int, *, tile: int, units: int, reg: int) -> Side:
-    return Side(axis=Axis(name, extent), tile=tile, units=units, reg=reg, block=name + "_b", unit=name + "_u")
+    return Side(axis=Axis(name, extent), tile=tile, units=units, reg=reg, atom=1, block=name + "_b", unit=name + "_u")
 
 
 def _mn() -> tuple[Side, Side]:
@@ -33,24 +23,13 @@ def _empty_callables():
     return dict(state_decls=lambda _cells: [], reduce_region=lambda _c, _o, _mn: ([], []), store=lambda _i, _j, _o, _mn: [])
 
 
-def test_the_levels_accumulate_the_per_cell_coordinate() -> None:
-    """`base(r)` is `block·(units·reg·atom) + unit·(reg·atom) + r·atom` once the UNIT level is
-    present — the coordinate every emitted σ indexes the cell with. Each level contributes exactly
-    one term, so the assembled expression is the contract between them."""
+def test_the_bound_block_owns_the_per_cell_coordinate() -> None:
+    """A resolved side supplies the complete block, unit, register, and atom coordinate."""
     mn = _mn()
-    t = unit_tile(register_tile(atomize((1, 1)), mn), mn)
-    # The block var is bound by grid_tile; bind it here the same way so `base` is readable without
-    # reaching into the sealed Tile.
-    off = tuple(replace(o, block_var=s.block) for o, s in zip(t.offset, mn, strict=True))
-
-    m_cell1 = off[0].base(1)  # m: block·(4·2·1) + unit·(2·1) + 1·1
+    m_cell1 = mn[0].base(1)
     assert m_cell1 == Var("m_b") * Literal(8, "int") + Var("m_u") * Literal(2, "int") + Literal(1, "int")
-    n_cell0 = off[1].base(0)  # n: block·(8·1·1) + unit·(1·1) + 0
+    n_cell0 = mn[1].base(0)
     assert n_cell0 == Var("n_b") * Literal(8, "int") + Var("n_u") * Literal(1, "int") + Literal(0, "int")
-
-    # Without the UNIT level the offset is the bare `block·reg + r` — the degenerate arm.
-    bare = replace(register_tile(atomize((1, 1)), mn).offset[0], block_var="m_b")
-    assert bare.base(1) == Var("m_b") * Literal(2, "int") + Literal(1, "int")
 
 
 def test_the_bound_axes_are_grid_then_unit_with_no_lane_for_a_scalar_atom() -> None:
@@ -58,7 +37,7 @@ def test_the_bound_axes_are_grid_then_unit_with_no_lane_for_a_scalar_atom() -> N
     axes, then the unit axes. A scalar atom (`lanes == 1`) emits no `_lane` axis."""
     mn = _mn()
     bt = Axis("bt", 8)
-    t = grid_tile(unit_tile(register_tile(atomize((1, 1)), mn), mn), mn=mn, lead_axes=(bt,), block_threads=32, **_empty_callables())
+    t = grid_tile(mn=mn, lead_axes=(bt,), block_threads=32, **_empty_callables())
     assert [a.name for a in t.axes] == ["bt", "m_b", "n_b", "m_u", "n_u"]
     assert t.block_threads == 32
     assert t.raster_axes == ("m_b", "n_b")  # a 2-D-tiled output is rasterization-eligible
@@ -66,7 +45,7 @@ def test_the_bound_axes_are_grid_then_unit_with_no_lane_for_a_scalar_atom() -> N
 
 def test_a_warp_cooperative_atom_appends_the_lane_axis() -> None:
     mn = _mn()
-    t = grid_tile(unit_tile(register_tile(atomize((16, 8)), mn), mn), mn=mn, block_threads=128, lanes=32, **_empty_callables())
+    t = grid_tile(mn=mn, block_threads=128, lanes=32, **_empty_callables())
     assert [a.name for a in t.axes] == ["m_b", "n_b", "m_u", "n_u", "_lane"]
 
 
@@ -74,7 +53,7 @@ def test_an_untiled_output_binds_no_block_axis_and_is_not_rasterizable() -> None
     """The reduce tier / degenerate fold: `mn == (None, None)`, so the whole grid rides
     `lead_axes` and there are no (m, n) block axes to rasterize."""
     grid = (Axis("b", 4), Axis("s", 128))
-    t = grid_tile(atomize((1, 1)), mn=(None, None), lead_axes=grid, block_threads=None, **_empty_callables())
+    t = grid_tile(mn=(None, None), lead_axes=grid, block_threads=None, **_empty_callables())
     assert [a.name for a in t.axes] == ["b", "s"]
     assert t.raster_axes is None and t.block_threads is None
 
@@ -95,7 +74,6 @@ def test_the_cells_the_callables_receive_are_the_register_grid() -> None:
         return [Write(output="out", index=(Var("m"),), value="v")]
 
     t = grid_tile(
-        unit_tile(register_tile(atomize((1, 1)), mn), mn),
         mn=mn,
         block_threads=32,
         state_decls=state_decls,
@@ -107,11 +85,9 @@ def test_the_cells_the_callables_receive_are_the_register_grid() -> None:
     assert len(t.body) == 2  # one Write spliced per cell
 
 
-def test_shrink_axis_keeps_a_symbolic_extent_symbolic() -> None:
-    """The grid axis for a register-tiled free axis is `ceil(E / reg)`, so a dynamic extent sizes
-    the launch from the runtime value rather than collapsing to a static count."""
-    assert shrink_axis(Axis("m", 128), 1) == Axis("m", 128)  # reg 1 is the identity
-    shrunk = shrink_axis(Axis("m", 128), 4)
+def test_the_bound_grid_axis_keeps_a_symbolic_extent_symbolic() -> None:
+    """A block grid is a ceiling division of the logical extent by the bound tile width."""
+    shrunk = _side("m", 128, tile=4, units=1, reg=4).axes[0]
     assert shrunk.extent.as_static() == 32
     assert shrunk.window is not None and shrunk.window.parent.name == "m"
 
@@ -145,7 +121,6 @@ def test_the_tile_body_is_state_then_reduce_then_stores() -> None:
     mn = _mn()
     mk = lambda tag: Write(output=tag, index=(Var("m"),), value="v")  # noqa: E731
     t = grid_tile(
-        unit_tile(register_tile(atomize((1, 1)), mn), mn),
         mn=mn,
         block_threads=32,
         state_decls=lambda _cells: [mk("state")],


### PR DESCRIPTION
## Abstract

Tile IR now declares symbolic block domains before scheduling. Existing TILE, REDUCE, and STAGE choices bind those domains without changing the schedule codec. Matmul, reductions, MMA, staging, and split-K consume the same bound domain, while the structural attention rewrite uses the same representation.

---

## Status

Targeted Tile IR and lowering tests pass. Full finalization is still in progress.