### PR TITLE
Give a bare output sweep its own threads, not one per row

### DIFF
--- a/emmy/compiler/ir/schedule/classic.py
+++ b/emmy/compiler/ir/schedule/classic.py
@@ -470,6 +470,20 @@ class ClassicMaterialization:
             raise ValueError(f"classic producer band {schedule.kernel.work.producer} disagrees with WarpSpec producer band {producer}")
 
 
+def no_site_claims_inventory(tile_op) -> bool:
+    """Whether this kernel has no node site that could fold out a worker inventory.
+
+    Only a tiled site or a cooperative reduction claims one, so a kernel with neither — a bare
+    elementwise map, the half a placement cut leaves behind a reduction — has a kernel work that no
+    node constrains. :func:`~...classic_projection.project_classic` offers such a kernel the sweep
+    widths, and the two compatibility gates here let them through instead of filtering them back to
+    the direct per-cell form. Read off the tile rather than the projected domains, so validation
+    (which carries none) answers the same.
+    """
+    sites = tile_op.family_sites
+    return not sites["TILE"] and not sites["REDUCE"]
+
+
 @dataclass(frozen=True)
 class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeSchedule]):
     """Immutable classic ``c + p + t`` compatibility-composition state.
@@ -1113,7 +1127,11 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
         ):
             self._refuse("pick is incompatible with the classic kernel position")
         work = self._work or Work()
-        if pick.kernel.work.kind != work.kind or pick.kernel.work.units != work.units:
+        # Same rule as :meth:`_kernel_composes`: a kernel no node constrains takes any inventory
+        # its own domain offers, so a bare elementwise map's output sweep is not left serial.
+        if (pick.kernel.work.kind != work.kind or pick.kernel.work.units != work.units) and not (
+            self._work is None and self._no_site_claims_inventory()
+        ):
             self._refuse("kernel WORK does not realize the node choices")
         if not pick.kernel.raster.is_direct and not self._raster_eligible:
             self._refuse("RASTER requires a tiled contraction site")
@@ -1181,14 +1199,18 @@ class ClassicScheduleContext(ScheduleContext[KernelSchedule, NodeSchedule, EdgeS
             if isinstance(assignment.tile, PlacedTile):
                 self._refuse("node choices cannot contain placed tile geometry", site)
 
+    def _no_site_claims_inventory(self) -> bool:
+        return no_site_claims_inventory(self.tile_op)
+
     def _kernel_composes(self, kernel: KernelSchedule) -> bool:
         work = self._work or Work()
-        return (
-            kernel.work.kind == work.kind
-            and kernel.work.units == work.units
-            and (not kernel.work.producer or self._producer_eligible)
-            and (kernel.raster.is_direct or self._raster_eligible)
+        # A kernel no node constrains takes any inventory its own domain offers: with nothing to
+        # disagree with, holding it to ``Work()`` is not a compatibility rule but the collapse that
+        # leaves an output sweep serial in one worker per cell.
+        agrees = (kernel.work.kind == work.kind and kernel.work.units == work.units) or (
+            self._work is None and self._no_site_claims_inventory()
         )
+        return agrees and (not kernel.work.producer or self._producer_eligible) and (kernel.raster.is_direct or self._raster_eligible)
 
     def _supports_global(self, family: str, value: str) -> bool:
         return any(key.partition("@")[0] == family and value in self.values(key) for key in self.keys())

--- a/emmy/compiler/ir/schedule/classic_projection.py
+++ b/emmy/compiler/ir/schedule/classic_projection.py
@@ -51,6 +51,7 @@ from emmy.compiler.ir.schedule.classic import (
     _plan_node_refusal,
     _resolve_stage,
     edge_site_spelling,
+    no_site_claims_inventory,
     node_id_spelling,
 )
 from emmy.compiler.ir.schedule.views import ContractionFacts
@@ -432,6 +433,18 @@ def project_classic(tile: TileOp, target) -> ClassicDomains:
             )
             is not None
         )
+    # A kernel whose work IS its shared output sweep — a bare elementwise map, the half a placement
+    # cut leaves behind a reduction — has no site that folds out an inventory, so the loop above
+    # leaves the domain at the direct per-cell form alone: one worker per output cell with the
+    # sweep serial inside it. Offer the widths a cooperative reduction would, so the sweep can be
+    # split across workers (``_factor`` distributes it through ``_lane_close``). This widens the
+    # worker inventory only; the grid stays the cell count, unlike promoting the axis into
+    # ``place.free``, which multiplies the grid by its extent.
+    if no_site_claims_inventory(tile) and tile.output_specs:
+        shared = set.intersection(*({axis.name for axis in store.sweep} for store in tile.output_specs))
+        if shared:
+            widths = sorted({move.coop for move in coop_reduce_moves() if move.coop > 1})
+            work_domain.update(Work(kind="thread", units=(width, 1)) for width in widths)
     raster_values = (
         raster_moves()
         if any(view.as_contraction() is not None for view in tile.views) and all(axis.extent.is_static for axis in tile.place.free)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -100,9 +100,14 @@ to the serial fold; each ILP copy suffixes only its per-copy SSA temps
 (`__r{r}`)
 — the shared iteration coordinates, **including any nested contraction's own reduce-axis var** (whose `for`
 declaration `copy_cell` does not rename), stay shared, so each copy re-declares its own nested
-loop under the one name; anything else tiles nothing and folds serially one thread per
-output cell (the degenerate `op.lower()` + `with_store`) — there is **no** separate "scalar tier" branch, and no
-per-kind emitter: which axis is tiled is schedule data, not a kernel identity. The projection sink and the store value
+loop under the one name; anything else tiles nothing and folds one thread per
+output cell (the degenerate `op.lower()` + `with_store`) — except a kernel whose ONLY work is a free output sweep,
+which distributes that sweep across its `WORK` threads through the same `_lane_close` a cooperating reduce uses for
+its projection: each lane owns a strided slice and writes its own cells, so there is no combine and no store guard.
+That third path is what a placement cut needs — it leaves the reduction in one piece and a bare elementwise map in
+the other, and without it that map runs one thread per row with the sweep serial inside (an RTX 5090 measured 885.9
+us against 4.2 us for the same kernel once the sweep is distributed). There is **no** separate "scalar tier"
+branch, and no per-kind emitter: which axis is tiled is schedule data, not a kernel identity. The projection sink and the store value
 (`out_val`, the root node's produced `Handle`) are threaded down the recursion, so `with_store` is node-agnostic. The
 kernel-boundary `TileOp.output_specs` are reconstituted at the zero-axis Fold peel — an output-tiled root's region
 being its epilogue term over it —

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -106,6 +106,11 @@ class Ctx:
     # The placement's FREE axes — the un-shrunk originals. A split partial may prefix ``_ksplit``;
     # contraction views derive their output axes from the trailing pair.
     free: tuple = ()
+    # Threads per output cell for a kernel whose ONLY work is a free output sweep — the ``WORK``
+    # thread width, 1 when the inventory is absent or a warp spec. A contraction reads its worker
+    # split off ``workers`` and a cooperating reduce off its own ``coop``; this is the third case,
+    # where nothing else claims the inventory (see the degenerate arm of :func:`_factorize`).
+    sweep_workers: int = 1
 
 
 def _wire(op: Fold) -> Handle:
@@ -115,6 +120,18 @@ def _wire(op: Fold) -> Handle:
     if op.exposes:
         return Handle(op.exposes[0])
     return _wire(op.operands[0]) if op.operands else Handle("")
+
+
+def _sweep_workers(tile) -> int:
+    """The ``WORK`` thread width available to a free output sweep, or 1.
+
+    Only a kernel with no tiled site and no reduction reaches the sweep arm, so reading the width
+    here costs nothing on every other path: a warp inventory (a contraction's) and a bare direct
+    inventory both answer 1."""
+    from emmy.compiler.ir.schedule import Work  # noqa: PLC0415
+
+    work = Work.parse((tile.knobs or {}).get("WORK", "") or "")
+    return work.units[0] if work.kind == "thread" and work.units[1] == 1 else 1
 
 
 def factorize(tile, root, store=None) -> Tile:
@@ -143,6 +160,7 @@ def factorize(tile, root, store=None) -> Tile:
         # per-node structure) — parse it once here; ``grid_tile`` applies it where the 2-D
         # (m, n) block grid makes it meaningful.
         raster=Raster.parse((tile.knobs or {}).get("RASTER", "")),
+        sweep_workers=_sweep_workers(tile),
     )
     out_val = _wire(op).name if op is not None else ""
     return _factorize(op, ctx, tail=(), out_val=out_val, store=store, output_specs=tuple(tile.output_specs))
@@ -458,7 +476,18 @@ def _bind(op, ctx: Ctx, tail: tuple, out_val: str, store=None, *, output_specs: 
             axes = ctx.sched.tile.axes
             placed = op.lower(frozenset(axis.name for axis in ctx.grid), output_specs, axes) if output_specs else op.lower(axes=axes)
             body = list(dict.fromkeys([*placed, *tail]))
-            state, fold, close, bt = [], with_store(body, ctx.output, grid, out_val), [], None
+            # A kernel whose only work is a FREE output sweep — the elementwise half a placement
+            # cut leaves behind a reduction — distributes that sweep across threads exactly as a
+            # cooperating reduce distributes its projection (:func:`_lane_close`). Each lane owns a
+            # strided slice of the sweep and writes its own cells, so there is nothing to combine
+            # and no store to guard. Without a width the arm stays the one-thread-per-cell fold.
+            width = ctx.sweep_workers
+            if width > 1 and any(isinstance(s, Loop) and not s.is_reduce for s in body):
+                lane = Axis(name="sweep_co", extent=width)
+                state, fold, close, bt = [], _lane_close(body, lane, width, ctx, out_val), [], width
+                t = replace(t, axes=(lane,))
+            else:
+                state, fold, close, bt = [], with_store(body, ctx.output, grid, out_val), [], None
         elif plan.coop_transposed:
             # The ``coop-t`` k-major matvec partition: the innermost output axis splits into a
             # shrunk ``<out>_blk`` grid axis (×32) + the 32-wide ``n_lane`` thread axis (with

--- a/tests/compiler/realization/cases/reduce/rms-norm-cut-sweep-work.yaml
+++ b/tests/compiler/realization/cases/reduce/rms-norm-cut-sweep-work.yaml
@@ -1,0 +1,74 @@
+# RMSNorm k=4096 cut at its stored-Fold seam: the reduce half computes the per-row rsqrt, the
+# elementwise half multiplies it back over the 4096-wide output sweep. This pins a real worker
+# inventory on the elementwise half -- the case that made the sweep partition necessary.
+#
+# That half used to be offered ONE schedule, and to run 512 threads each walking 4096 elements.
+# Two mechanisms give a kernel more than one thread per output cell -- a contraction's warp split
+# and a cooperating reduce's ``coop`` lanes -- and both attach to something reduction-shaped, so a
+# bare elementwise map fell to the one-thread-per-cell tier with its sweep serial inside. Measured
+# on an RTX 5090 (CUDA 13.0, -O3): 885.9 us for this half against 5.4 us for the whole fused
+# kernel, which is why every placement cut with an elementwise downstream half looked hopeless.
+#
+# It now takes the third path: a kernel whose only work is a free output sweep distributes that
+# sweep across ``WORK`` threads through the same ``_lane_close`` a cooperating reduce uses for its
+# projection. Each lane owns a strided slice and writes its own cells, so there is no combine and
+# no store guard. The emitted body is the fused kernel's shape -- ``for a2 in sweep_co..4096:128``.
+# Widening the enumeration alone does NOT do this: without the emitter half all nine rows compile
+# to byte-identical CUDA. Both halves are required, which is what this case pins.
+#
+# Measured after the change: 4.2 us for this half, and the cut arm 6.3 us against 5.4 us fused --
+# a 211x kernel speedup that turns the placement fork from a foregone conclusion into a real
+# comparison. Correctness checked against eager (max abs error 3e-08).
+compute_cap: [12, 0]
+programs:
+- inputs: [x]
+  outputs: [rms_norm]
+  nodes:
+  - id: p_weight
+    op: constant
+    attrs:
+      name: p_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__: [4096]
+      source_dtype: float32
+      source_graph: null
+    outputs:
+    - - p_weight
+      - f32
+      - [4096]
+  - id: x
+    op: input
+    outputs:
+    - - x
+      - f32
+      - [512, 4096]
+  - id: rms_norm
+    op: torch.rms_norm
+    attrs: {eps: 1.0e-06}
+    inputs: [x, p_weight]
+    outputs:
+    - - rms_norm
+      - f32
+      - [512, 4096]
+configs:
+- program: 0
+  target:
+    origins: [rms_norm]
+  realizations:
+  - name: k_rms_norm_86ddb3.c342c72939b8
+    bindings: {}
+    pins: {FAST_MATH: false, PLACE@map.1/map: cut}
+    knobs: {WORK: t128, REDUCE: coop, RASTER: ''}
+    identity: 97b9a41c07253c3dfa09c8f01e5f949c07f7ee4e37f1f67ea036239c0069cdf9
+  - name: k_rms_norm_86ddb3.c342c72939b8.cac64900859e
+    bindings: {}
+    pins: {FAST_MATH: false}
+    knobs: {WORK: t512, RASTER: ''}
+    identity: cac64900859e5707820fc1f6b73473c8696a161414cc219fdff81472315525e2


### PR DESCRIPTION
## The gap

A kernel gets more than one thread per output cell in exactly two ways: a contraction's warp split, or a cooperating reduce's `coop` lanes. Both attach to something reduction-shaped, so a kernel whose only work is a **free output sweep** falls to the one-thread-per-cell fold with the sweep serial inside it.

That kernel is precisely what a placement cut manufactures. Cutting RMSNorm hands the reduction to one piece and leaves the other a bare elementwise map over a 4096-wide sweep — 512 threads each walking 4096 elements. On an RTX 5090 (CUDA 13.0, `-O3`) that half measured **885.9 µs against 5.4 µs for the whole fused kernel**, so every placement fork whose downstream half is elementwise lost by two orders of magnitude for a reason that was never about the fork.

## The change

Such a kernel now distributes its sweep across `WORK` threads through the same **`_lane_close`** a cooperating reduce already uses for its projection. Each lane owns a strided slice and writes its own cells, so there is no combine and no store guard. The emitted body becomes the fused kernel's own shape:

```
Tile[a0, sweep_co] (N=65536)
    for a2 in sweep_co..4096:128
        rms_norm[a0, a2] = v6
```

**Both halves are required, and I verified neither works alone.** The projection offers the widths a cooperative reduction would, and the two compatibility gates let them through — a kernel no node constrains takes any inventory its own domain offers (`no_site_claims_inventory`). Widening *only* the enumeration makes all nine rows pin and emit **byte-identical CUDA**, because nothing reads the inventory. The corpus case pins both halves together.

## Measured

All 18 cuttable RTX 5090 goldens, cut arms tuned per width, against the **deployed (greedy)** fused pick:

| realization | cut before | cut after | fused | ratio |
| --- | ---: | ---: | ---: | ---: |
| `rms_norm.k2048` | 448.2 | **4.19** | 3.91 | 1.07× |
| `rms_norm.k4096` | 887.5 | **6.33** | 5.39 | 1.18× |
| `rms_norm.k8192` | 1764.5 | **10.96** | 10.05 | 1.09× |
| `softmax.k2048` | 409.2 | **4.27** | 3.70 | 1.15× |
| `softmax.k8192` | 1619.2 | **11.37** | 10.19 | 1.12× |

Same for the five `.dynM` variants (1.28–1.39×). Cut arms go from **100–185× worse to 7–39% worse** — the placement fork becomes a real comparison instead of a foregone conclusion.

**Fusion still wins every one, correctly** (it saves a launch and a DRAM round-trip), so **no deployed kernel set changes**. Correctness checked under `--strict` against eager: max abs error 3e-08.

## Scope

Inert elsewhere: the sweep arm is reached only when a kernel has neither a tiled site nor a reduction, and `_sweep_workers` answers 1 for a warp inventory or a bare direct one.

Net `+79/−10` across `emmy/`. The growth is the new capability plus its docstrings; the executable part is about fifteen lines, and the audit removed a duplicated predicate by single-sourcing `no_site_claims_inventory`.

## Not addressed

Greedy still picks the degenerate width for a cut child when nothing is measured — the unpinned cut arms measure 400–1850 µs even with this change. That is the **search shortfall** the realization corpus deliberately excludes: the realization gap is closed, and the prior now needs rows to learn from. A tuning round over the affected goldens is the follow-up.

## Checks

- `make test` — 4189 passed, 21 xfailed (one fewer: this closes `rms-norm-cut-sweep-work`)
- `make lint` — clean
- `make test-goldens` — 11 failed, **unchanged from `main`** (the pre-existing post-#691 staleness); no new file
- Corpus case added and closed; `built` / `correct` verified on an RTX 5090 at the declared capability

One pre-existing failure surfaced but not touched: `attention.hd64.softmax_v`'s cut arm fails to compile (*"atomic REDUCE folds ONE additive state component; this carrier has 3"*). Reproduced with these three files reverted to `main`, so it is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrQFki2ECdpo7S2YLHC9yg