### PR TITLE
Serve three Qwen3.8 checkpoints on Volta, and record what the sm_70 image cannot build

### DIFF
--- a/experiments/Qwen3.8-27B-FP8/serving/RESULTS.md
+++ b/experiments/Qwen3.8-27B-FP8/serving/RESULTS.md
@@ -1,0 +1,42 @@
+# Qwen3.8-27B-FP8 serving on V100
+
+Factual artifact index for the shared serving protocol. Each platform section records what was executed and where the
+raw evidence lives; it does not interpret the measurements. The recommended-configuration report lives beside the
+recipe in `recipes/Qwen3.8-27B-FP8/RESULTS.md`.
+
+## NVIDIA Tesla V100 SXM2 16GB x4
+
+- Archive: `results_v100x4.tar.gz`, archived root `2026-09-05_02-53-27/`.
+- Run timestamp `2026-09-05T02:53:27Z`; repository revision `01588556cef50c202e5370927e6788f039550801`, staged
+  source clean.
+- Host: `riftvm`, Ubuntu 24.04.1, kernel 6.8.0-51-generic, Intel Xeon E5-2680 v4, 48 logical CPUs, 409 GiB RAM.
+- GPUs: four NVIDIA Tesla V100-SXM2-16GB, 16,384 MiB each, compute capability 7.0, driver 580.126.20. The host
+  reports PHB between every GPU pair, so the tensor-parallel all-reduce crosses PCIe.
+- Model: `Qwen/Qwen3.8-27B-FP8@017b9c7af6b5689d5dd426a76e0bc077eb5ca20a`.
+- Engine image: `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` (vLLM
+  `1.2.3.dev87+gd76126608.d20260810`).
+- Controls: seed 0, temperature 0, ignored EOS, 2 warm-ups, text-only path (`--language-model-only`), context
+  262,144, TP4, Triton GDN prefill backend, FLASH_ATTN_V100 attention backend, `VLLM_SM70_FP8_TURBOMIND=1`,
+  `VLLM_SM70_QUANT_BACKEND=turbomind`, `VLLM_SM70_GDN_DECODE_FLASHQLA=0`.
+- Measured KV pool: 292,125 tokens, 1.11x maximum concurrency at full context.
+- Rows executed: 1 of 1 succeeded, 0 failed requests.
+
+| Row | Input / output | Concurrency | Prompts |
+| --- | ---: | ---: | ---: |
+| `v100x4_mc4_np16_ril1000_rol1000` | 1,000 / 1,000 | 4 | 16 |
+
+This row uses 16 prompts rather than the 32 used on the other two platforms. The 32-prompt form of the same workload
+ran 1,631 s on the FP16 lane, over the 20-minute per-variant cap; halving the request count is the prescribed remedy
+and this row completed in 492.87 s. Request count therefore differs from the FP16 and Int4 rows and the totals are
+not directly comparable, though the per-token latencies are.
+
+Startup cost recorded for this row: deploy 445.5 s in total from container create to health.
+
+The archive contains the per-row system-only experiment record, the client benchmark log, the engine server log, and
+the executed recipe snapshot.
+
+## Reproduce
+
+```bash
+emmy bench experiments/Qwen3.8-27B-FP8/serving --ssh USER@HOST
+```

--- a/experiments/Qwen3.8-27B-FP8/serving/recipe.yaml
+++ b/experiments/Qwen3.8-27B-FP8/serving/recipe.yaml
@@ -1,0 +1,58 @@
+# Volta qualification lane for Qwen3.8-27B-FP8.
+#
+# Target is four V100 SXM2 16 GB (sm_70). Weights are 30.9 GB, so min-to-serve is about 40.2 GB
+# and four cards (4 x 16,384 MiB = 68.7 GB) are the smallest admissible platform; two cards hold
+# 34.4 GB and cannot take the weights.
+#
+# Volta has no native FP8 arithmetic. The 1Cat fork serves FP8 checkpoints on sm_70 through its
+# TurboMind dequantization path, which the DeepSeek-V4-Flash lane on this same engine selects
+# with VLLM_SM70_FP8_TURBOMIND and VLLM_SM70_QUANT_BACKEND. Neither is baked into the image, so
+# this lane sets both explicitly. This is emulation, not hardware FP8: treat any throughput
+# result as a property of that dequantization path.
+#
+# TP4 divides cleanly: 24 attention heads / 4 = 6 and 4 key/value heads / 4 = 1.
+model:
+  huggingface: "Qwen/Qwen3.8-27B-FP8"
+  revision: 017b9c7af6b5689d5dd426a76e0bc077eb5ca20a
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 4
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    context_length: 262144
+    max_concurrent_requests: 4
+    vllm:
+      image: "cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --gdn-prefill-backend triton
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser qwen3_coder
+        --reasoning-parser qwen3
+      extra_env:
+        VLLM_SM70_FP8_TURBOMIND: "1"
+        VLLM_SM70_QUANT_BACKEND: "turbomind"
+        # The GDN decode path reaches for the flash_qla JIT extension independently of the
+        # prefill backend, and building it fails in this image at a missing cusparse header.
+        VLLM_SM70_GDN_DECODE_FLASHQLA: "0"
+
+benchmark:
+  # 16 prompts, not 32: the same workload at 32 ran 1,631 s on the FP16 lane, over the 20-minute
+  # per-variant cap. Halving the request count is the prescribed remedy and keeps this row inside
+  # it without changing the shape being measured.
+  max_concurrency: 4
+  num_prompts: 16
+  random_input_len: 1000
+  random_output_len: 1000
+  num_warmups: 2
+  seed: 0
+  temperature: 0.0
+  ignore_eos: true
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 4

--- a/experiments/Qwen3.8-27B-FP8/serving/results_v100x4.tar.gz
+++ b/experiments/Qwen3.8-27B-FP8/serving/results_v100x4.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0c7b453ad0f74f4f4c815a84f9f6ed506de45163316e95134e71c9d2c0aeb7b
+size 16874

--- a/experiments/Qwen3.8-27B-GPTQ-Int4/serving/RESULTS.md
+++ b/experiments/Qwen3.8-27B-GPTQ-Int4/serving/RESULTS.md
@@ -1,0 +1,48 @@
+# Qwen3.8-27B GPTQ Int4 serving on V100
+
+Factual artifact index for the shared serving protocol. Each platform section records what was executed and where the
+raw evidence lives; it does not interpret the measurements. The recommended-configuration report lives beside the
+recipe in `recipes/Qwen3.8-27B-GPTQ-Int4/RESULTS.md`.
+
+## NVIDIA Tesla V100 SXM2 16GB x2
+
+- Archive: `results_v100x2.tar.gz`, archived root `2026-09-05_01-19-15/`.
+- Run timestamp `2026-09-05T01:19:15Z`, completed `2026-09-05T01:40:28Z`; repository revision
+  `01588556cef50c202e5370927e6788f039550801`, staged source clean.
+- Host: `riftvm`, Ubuntu 24.04.1, kernel 6.8.0-51-generic, Intel Xeon E5-2680 v4, 48 logical CPUs, 409 GiB RAM.
+- GPUs: two NVIDIA Tesla V100-SXM2-16GB, 16,384 MiB each, compute capability 7.0, driver 580.126.20,
+  UUIDs `GPU-e34b3197-e72f-6bad-42ec-6098b55c4d85` and `GPU-b6e63246-059f-6237-c010-1dfb569ade18`.
+  The host reports PHB between every GPU pair, so the tensor-parallel all-reduce crosses PCIe.
+- Model: `Max73333/Qwen3.8-27B-GPTQ-Int4-V100@d5a18cc1477e301e50d3fe4167fbf76db9337edc`.
+- Engine image: `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` (vLLM
+  `1.2.3.dev87+gd76126608.d20260810`).
+- Controls: seed 0, temperature 0, ignored EOS, 2 warm-ups, text-only path (`--language-model-only`), context 65,536,
+  TP2, Triton GDN prefill backend, `VLLM_SM70_GDN_DECODE_FLASHQLA=0`.
+- Rows executed: 1 of 1 succeeded, 0 failed requests.
+
+| Row | Input / output | Concurrency | Prompts |
+| --- | ---: | ---: | ---: |
+| `v100x2_mc4_np32_ril1000_rol1000` | 1,000 / 1,000 | 4 | 32 |
+
+Startup cost recorded for this row: weights load 8.6 s, `torch.compile` 105.0 s, CUDA graph capture 110.0 s,
+model load and warm-up 317.9 s in total.
+
+The archive contains the per-row system-only experiment record, the client benchmark log, the engine server log, and
+the executed recipe snapshot.
+
+### Configuration attempts that did not reach health
+
+Recorded because each one is a property of this engine image on this platform, not of the workload:
+
+| Attempt | Outcome |
+| --- | --- |
+| context 262,144 (native) | KV gate: 8.16 GiB needed against a 4.57 GiB pool; engine ceiling 145,040 |
+| context 131,072, Triton GDN | KV gate: 4.16 GiB needed against a 3.06 GiB pool; engine ceiling 95,648 |
+| `--gdn-prefill-backend flashqla_sm70` | JIT build of `flash_qla_sm70_gdn_strided` fails at `fatal error: cusparse.h` |
+| Triton prefill, flash_qla decode left enabled | same JIT build failure, reached from the GDN decode path |
+
+## Reproduce
+
+```bash
+emmy bench experiments/Qwen3.8-27B-GPTQ-Int4/serving --ssh USER@HOST
+```

--- a/experiments/Qwen3.8-27B-GPTQ-Int4/serving/recipe.yaml
+++ b/experiments/Qwen3.8-27B-GPTQ-Int4/serving/recipe.yaml
@@ -1,0 +1,71 @@
+# Volta qualification lane for Qwen3.8-27B GPTQ Int4.
+#
+# Target is two V100 SXM2 16 GB (sm_70). Weights are 19.6 GB, so one 16 GB card cannot hold them;
+# TP2 is the smallest tensor-parallel size that fits (2 x 16,384 MiB = 34.4 GB against a 25.5 GB
+# min-to-serve). The surrounding eight-card host is not used by this lane.
+#
+# Engine: the 1Cat-vLLM sm_70 fork. Stock vLLM has no Volta support, and the older
+# cloudriftai/1cat-vllm-sm70:1.0.0 image predates Qwen3.8 -- its qwen3_5 config has no
+# partial_rotary_factor, so it would silently apply full rotary to a model that declares 0.25.
+# This image is built from fork commit d76126608, whose qwen3_5 config defaults
+# partial_rotary_factor to 0.25 and whose Gated DeltaNet layer accepts output_gate_type="swish";
+# both are Qwen3.8-specific fields.
+#
+# Qwen3.8-27B is 64 layers, 48 of them linear attention (Gated DeltaNet) and 16 full attention,
+# so the GDN prefill backend matters more than the attention backend here. The fork's Volta-native
+# flashqla_sm70 path is NOT usable in this image: it is a JIT torch extension, and building it
+# fails at `fatal error: cusparse.h: No such file or directory` because the runtime layer ships
+# the flash_qla sources without the CUDA development headers they include. triton is the backend
+# the checkpoint author validated on a V100 and needs no JIT. A future purpose-built sm_70 image
+# should either prebuild that extension or ship the headers.
+#
+# Context starts at the checkpoint's native 262,144. Qualification halves it on a measured
+# capacity failure and keeps the largest context that both starts and completes a materially
+# full request.
+model:
+  huggingface: "Max73333/Qwen3.8-27B-GPTQ-Int4-V100"
+  revision: d5a18cc1477e301e50d3fe4167fbf76db9337edc
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 2
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    # Native context is 262,144 and does not fit. Measured on this platform: 262,144 needs
+    # 8.16 GiB of KV against a 4.57 GiB pool, and 131,072 needs 4.16 GiB against 3.06 GiB once
+    # the Triton GDN path takes its workspace. The engine put the ceiling at 95,648, so 65,536
+    # is the largest power-of-two halving that fits, at 2.08 GiB.
+    context_length: 65536
+    max_concurrent_requests: 4
+    vllm:
+      image: "cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608"
+      # --dtype half: Volta has no bfloat16. --language-model-only drops the vision tower for
+      # this text-only qualification. --max-num-seqs comes from max_concurrent_requests above.
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --gdn-prefill-backend triton
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser qwen3_coder
+        --reasoning-parser qwen3
+      extra_env:
+        # Selecting the Triton GDN *prefill* backend is not enough: the GDN decode path reaches
+        # for flash_qla independently and hits the same missing-header build failure. This knob
+        # is what actually keeps the JIT extension out of the run.
+        VLLM_SM70_GDN_DECODE_FLASHQLA: "0"
+
+benchmark:
+  max_concurrency: 4
+  num_prompts: 32
+  random_input_len: 1000
+  random_output_len: 1000
+  num_warmups: 2
+  seed: 0
+  temperature: 0.0
+  ignore_eos: true
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 2

--- a/experiments/Qwen3.8-27B-GPTQ-Int4/serving/results_v100x2.tar.gz
+++ b/experiments/Qwen3.8-27B-GPTQ-Int4/serving/results_v100x2.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe25415582540248eecf73490fbb0926da5a2b6c4c47054f79038d570e356099
+size 18553

--- a/experiments/Qwen3.8-27B/serving/RESULTS.md
+++ b/experiments/Qwen3.8-27B/serving/RESULTS.md
@@ -1,0 +1,41 @@
+# Qwen3.8-27B FP16 serving on V100
+
+Factual artifact index for the shared serving protocol. Each platform section records what was executed and where the
+raw evidence lives; it does not interpret the measurements. The recommended-configuration report lives beside the
+recipe in `recipes/Qwen3.8-27B/RESULTS.md`.
+
+## NVIDIA Tesla V100 SXM2 16GB x8
+
+- Archive: `results_v100x8.tar.gz`, archived root `2026-09-05_01-41-34/`.
+- Run timestamp `2026-09-05T01:41:35Z`; repository revision `01588556cef50c202e5370927e6788f039550801`, staged
+  source clean.
+- Host: `riftvm`, Ubuntu 24.04.1, kernel 6.8.0-51-generic, Intel Xeon E5-2680 v4, 48 logical CPUs, 409 GiB RAM.
+- GPUs: eight NVIDIA Tesla V100-SXM2-16GB, 16,384 MiB each, compute capability 7.0, driver 580.126.20. The host
+  reports PHB between every GPU pair, so the eight-way tensor-parallel all-reduce crosses PCIe.
+- Model: `Qwen/Qwen3.8-27B@1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`, BF16 weights served as FP16 (`--dtype half`).
+- Engine image: `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` (vLLM
+  `1.2.3.dev87+gd76126608.d20260810`).
+- Controls: seed 0, temperature 0, ignored EOS, 2 warm-ups, text-only path (`--language-model-only`), context
+  262,144, TP8, Triton GDN prefill backend, FLASH_ATTN_V100 attention backend,
+  `VLLM_SM70_GDN_DECODE_FLASHQLA=0`.
+- Measured KV pool: 293,427 tokens, 1.12x maximum concurrency at full context.
+- Rows executed: 1 of 1 succeeded, 0 failed requests.
+
+| Row | Input / output | Concurrency | Prompts |
+| --- | ---: | ---: | ---: |
+| `v100x8_mc4_np32_ril1000_rol1000` | 1,000 / 1,000 | 4 | 32 |
+
+This row ran 1,631.13 s, over the 20-minute per-variant benchmark cap. It is retained because it completed with all
+32 requests successful and no failures; the overrun is a property of decode speed on this platform, recorded here
+rather than corrected by shrinking the workload.
+
+Startup cost recorded for this row: deploy 545.9 s in total from container create to health.
+
+The archive contains the per-row system-only experiment record, the client benchmark log, the engine server log, and
+the executed recipe snapshot.
+
+## Reproduce
+
+```bash
+emmy bench experiments/Qwen3.8-27B/serving --ssh USER@HOST
+```

--- a/experiments/Qwen3.8-27B/serving/recipe.yaml
+++ b/experiments/Qwen3.8-27B/serving/recipe.yaml
@@ -1,0 +1,58 @@
+# Volta qualification lane for the official Qwen3.8-27B checkpoint at FP16.
+#
+# Target is eight V100 SXM2 16 GB (sm_70). The checkpoint is 55.6 GB of BF16 weights, so
+# min-to-serve is about 72.3 GB and eight cards (8 x 16,384 MiB = 137.4 GB) are the smallest
+# admissible platform on this fleet; four cards hold only 68.7 GB and cannot take the weights
+# plus a usable KV cache.
+#
+# Volta has no bfloat16, so --dtype half casts the checkpoint to FP16. That makes this the only
+# lane with no quantization kernel in the path, which is why it is the cleanest test of whether
+# the engine understands Qwen3.8 at all.
+#
+# TP8 divides cleanly: 24 attention heads / 8 = 3, 48 linear-attention value heads / 8 = 6,
+# 16 linear-attention key heads / 8 = 2. The 4 key/value heads are fewer than the 8 ranks, which
+# vLLM handles by replicating them because 8 % 4 == 0.
+#
+# The host exposes no NVLink (nvidia-smi topo reports PHB between every pair), so the TP8
+# all-reduce crosses PCIe. Expect that to dominate decode latency relative to a 4-card lane on a
+# smaller checkpoint; it is a property of the platform, not of the model.
+model:
+  huggingface: "Qwen/Qwen3.8-27B"
+  revision: 1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 8
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    context_length: 262144
+    max_concurrent_requests: 4
+    vllm:
+      image: "cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --gdn-prefill-backend triton
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser qwen3_coder
+        --reasoning-parser qwen3
+      extra_env:
+        # The GDN decode path reaches for the flash_qla JIT extension independently of the
+        # prefill backend, and building it fails in this image at a missing cusparse header.
+        VLLM_SM70_GDN_DECODE_FLASHQLA: "0"
+
+benchmark:
+  max_concurrency: 4
+  num_prompts: 32
+  random_input_len: 1000
+  random_output_len: 1000
+  num_warmups: 2
+  seed: 0
+  temperature: 0.0
+  ignore_eos: true
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 8

--- a/experiments/Qwen3.8-27B/serving/results_v100x8.tar.gz
+++ b/experiments/Qwen3.8-27B/serving/results_v100x8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff9c812efa006bc4f592988b5a5688388447f8f6776cd1e1f52854e5effcbcf1
+size 19567

--- a/recipes/Qwen3.8-27B-FP8/RESULTS.md
+++ b/recipes/Qwen3.8-27B-FP8/RESULTS.md
@@ -1,0 +1,98 @@
+# Qwen3.8-27B-FP8 on four V100 SXM2 16GB
+
+Qualified 2026-09-05 against repository revision `01588556cef50c202e5370927e6788f039550801`.
+
+The interesting property of this lane is that **Volta has no FP8 arithmetic at all**. The checkpoint is served
+through the 1Cat-vLLM fork's TurboMind dequantization path, the same route the DeepSeek-V4-Flash lane uses on this
+engine. Every number below is a property of that dequantization path, not of hardware FP8.
+
+## What was measured
+
+| Item | Value |
+| --- | --- |
+| Model | `Qwen/Qwen3.8-27B-FP8@017b9c7af6b5689d5dd426a76e0bc077eb5ca20a` |
+| GPUs | 4 x NVIDIA Tesla V100 SXM2 16GB, compute capability 7.0, driver 580.126.20 |
+| Engine image | `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` (vLLM `1.2.3.dev87+gd76126608.d20260810`) |
+| Serving shape | TP4, context 262,144, max 4 concurrent requests, `gpu_memory_utilization` 0.88, text-only |
+| Backends | FLASH_ATTN_V100 attention, Triton Gated DeltaNet prefill, TurboMind FP8 dequantization |
+| Workload | 16 prompts, 1,000 input / 1,000 output tokens, client concurrency 4, seed 0, temperature 0, ignored EOS, 2 warm-ups |
+
+| Metric | Result |
+| --- | ---: |
+| Successful / failed requests | 16 / 0 |
+| Benchmark duration | 492.87 s |
+| Output token throughput | 32.46 tok/s |
+| Total token throughput | 64.93 tok/s |
+| Peak output token throughput | 48.00 tok/s |
+| Median TTFT | 23,072.16 ms |
+| Mean / P99 TTFT | 18,972.64 / 23,124.08 ms |
+| Median TPOT | 100.98 ms |
+| Mean / P99 TPOT | 104.33 / 122.43 ms |
+| Median inter-token latency | 92.94 ms |
+
+Deploy from container create to health took 445.5 s.
+
+## Capability checks
+
+| Gate | Result |
+| --- | --- |
+| Coherent chat | Pass — returns `Tokyo` for a capital-city question |
+| Tool calling | Pass — structured `tool_calls`, `get_weather{"city": "Paris"}` |
+| Reasoning separation | Pass — the `reasoning` field is populated and `content` holds only the answer |
+| Context fill | Pass at 60,295 tokens — a planted marker was retrieved. See the caveat below. |
+
+Reasoning requires `chat_template_kwargs: {"enable_thinking": true}`; Qwen3.8 defaults thinking off and otherwise
+reasons inline in `content`.
+
+## Fit
+
+30.9 GB of FP8 weights give a min-to-serve near 40.2 GB against 4 x 16,384 MiB = 68.7 GB of platform capacity. Two
+cards hold only 34.4 GB and cannot take the weights, so four is the floor. TP4 divides cleanly: 24 attention heads
+/ 4 = 6, 4 key/value heads / 4 = 1.
+
+## How it compares on this host
+
+All three Qwen3.8 Volta lanes were measured on the same machine, same engine image, same 1,000/1,000 workload at
+client concurrency 4. The Int4 and FP16 lanes ran 32 prompts; this one ran 16 to stay inside the 20-minute
+per-variant cap, so **total throughput is not directly comparable** — the per-token latencies are.
+
+| Lane | Cards | Weights | Output tok/s | Median TPOT | Median TTFT |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| GPTQ Int4, TP2 | 2 | 19.6 GB | 40.21 | 96.76 ms | 2,884 ms |
+| FP8, TP4 (this) | 4 | 30.9 GB | 32.46 | 100.98 ms | 23,072 ms |
+| FP16, TP8 | 8 | 55.6 GB | 19.62 | 147.98 ms | 54,250 ms |
+
+The ordering tracks bytes moved per weight — 0.5, 1, and 2 — and the widening tensor-parallel degree. Since the host
+exposes no NVLink (`nvidia-smi topo` reports PHB between every pair), each doubling of the parallel degree adds
+PCIe all-reduce traffic on every layer, which is why the widest lane is also the slowest.
+
+## Limitations
+
+- **The advertised 262,144 context is memory-backed but not validated end to end.** The measured KV pool holds
+  292,125 tokens at that window, but retrieval is validated at 60,295 tokens. On the FP16 lane a near-full-window
+  prompt did not finish prefilling within 20 minutes; prefill cost grows faster than linearly, so the practical
+  ceiling on this hardware is prefill time rather than memory. Treat 262,144 as the allocated window.
+- **A 23-second median TTFT** at concurrency 4 makes this a batch or background configuration, not an interactive
+  one.
+- **FP8 here is emulation.** Volta has no FP8 units; throughput reflects TurboMind dequantization and should not be
+  read as an FP8 hardware result, nor compared against FP8 numbers from Hopper or Blackwell parts.
+- **The engine image cannot build its own Volta Gated DeltaNet kernel.** 48 of the 64 layers are Gated DeltaNet.
+  `flash_qla_sm70_gdn_strided` is a JIT torch extension whose build fails at `fatal error: cusparse.h: No such file
+  or directory`, because the runtime layer ships the sources without the CUDA development headers. Selecting the
+  Triton GDN *prefill* backend is not enough — the GDN decode path reaches for flash_qla independently — so the
+  recipe sets `VLLM_SM70_GDN_DECODE_FLASHQLA=0`. The Volta-native kernel is therefore skipped, and a purpose-built
+  sm_70 image that prebuilds it is the most likely source of a speed-up across all three lanes.
+- **Only the Volta platform was qualified.** The discovery shell this recipe replaces proposed one RTX PRO 6000
+  Blackwell Max-Q and one H200 141GB; both remain unmeasured, not unsuitable, and both have native FP8 hardware.
+
+## Emmy
+
+Not evaluated. This run was scoped to serving qualification only, so no compiler coverage was traced, no golden was
+produced, and Emmy eligibility is **unevaluated** rather than established. There is no Emmy lane in the recipe and no
+Emmy comparison in the numbers above — every figure here is the stock 1Cat-vLLM fork serving lane.
+
+## Reproduce
+
+```bash
+emmy bench experiments/Qwen3.8-27B-FP8/serving --ssh USER@HOST
+```

--- a/recipes/Qwen3.8-27B-FP8/recipe.yaml
+++ b/recipes/Qwen3.8-27B-FP8/recipe.yaml
@@ -1,13 +1,71 @@
+# Qwen3.8-27B-FP8 on four V100 SXM2 16 GB (sm_70 Volta).
+#
+#   emmy deploy ssh --recipe recipes/Qwen3.8-27B-FP8 --ssh user@host
+#
+# This is a DEPLOYMENT config, not an experiment: one variant, no workload grid, no `benchmark:`
+# block. The workload grid that justifies these values lives in
+# experiments/Qwen3.8-27B-FP8/serving/.
+#
+# SCOPE: this recipe records the platform that was actually qualified, which is Volta. The
+# discovery shell it replaces proposed one RTX PRO 6000 Blackwell Max-Q and one H200 141GB; both
+# remain UNQUALIFIED here, which means unmeasured, not unsuitable. Either card has native FP8
+# hardware that this one lacks, so their numbers would not resemble these.
+#
+# There is no Emmy lane here: this run qualified serving only, so Emmy eligibility is unevaluated
+# rather than established. See RESULTS.md.
 tags:
-  - onboarding
-  - untested
+  - best-effort
+
 model:
   huggingface: Qwen/Qwen3.8-27B-FP8
   rationale: "Strong FP8 variant of the breakout 3.8 model for wider deployment."
   heat: 95
+  revision: 017b9c7af6b5689d5dd426a76e0bc077eb5ca20a
   task: generate
+
+engine:
+  llm:
+    # 30.9 GB of FP8 weights give a min-to-serve near 40.2 GB, so four cards
+    # (4 x 16,384 MiB = 68.7 GB) are the smallest admissible platform; two hold only 34.4 GB.
+    # TP4 divides cleanly: 24 attention heads / 4 = 6, 4 key/value heads / 4 = 1.
+    tensor_parallel_size: 4
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    # The full native window fits: the measured KV pool holds 292,125 tokens, giving 1.11x
+    # concurrency at full context. Note the caveat in RESULTS.md — that is allocated capacity,
+    # and end-to-end retrieval was validated at 60,295 tokens, not at the full window.
+    context_length: 262144
+    max_concurrent_requests: 4
+    vllm:
+      # Stock vLLM has no sm_70 support. This is the 1Cat-vLLM Volta fork; the tag is named for
+      # the model it was first built for, but the wheel is the whole fork. It is the first
+      # published sm70 image new enough for Qwen3.8: its qwen3_5 config defaults
+      # partial_rotary_factor to 0.25 and its Gated DeltaNet layer accepts output_gate_type
+      # "swish", both of which Qwen3.8 declares and the older 1cat-vllm-sm70:1.0.0 does not know.
+      image: "cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608"
+      # --dtype half sets the compute dtype; Volta has no bfloat16. --language-model-only drops
+      # the vision tower; the text path is what is qualified here.
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --gdn-prefill-backend triton
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser qwen3_coder
+        --reasoning-parser qwen3
+      extra_env:
+        # Volta has no FP8 arithmetic. The fork serves FP8 checkpoints on sm_70 through its
+        # TurboMind dequantization path, which these two switches select; neither is baked into
+        # the image, and the DeepSeek-V4-Flash lane on this same engine sets them the same way.
+        VLLM_SM70_FP8_TURBOMIND: "1"
+        VLLM_SM70_QUANT_BACKEND: "turbomind"
+        # 48 of the 64 layers are Gated DeltaNet, so that path is unavoidable. This image cannot
+        # build the Volta-native flash_qla GDN extension: it ships the sources but not the CUDA
+        # development headers, so the JIT fails at `fatal error: cusparse.h`. Selecting the Triton
+        # GDN *prefill* backend above is not sufficient, because the GDN decode path reaches for
+        # flash_qla independently; this knob is what keeps the JIT out of the run.
+        VLLM_SM70_GDN_DECODE_FLASHQLA: "0"
+
 matrices:
-- deploy.gpu: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition
-  deploy.gpu_count: 1
-- deploy.gpu: NVIDIA H200 141GB
-  deploy.gpu_count: 1
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 4

--- a/recipes/Qwen3.8-27B-GPTQ-Int4/RESULTS.md
+++ b/recipes/Qwen3.8-27B-GPTQ-Int4/RESULTS.md
@@ -1,0 +1,90 @@
+# Qwen3.8-27B GPTQ Int4 on two V100 SXM2 16GB
+
+Qualified 2026-09-05 against repository revision `01588556cef50c202e5370927e6788f039550801`.
+
+This is the 4-bit Qwen3.8 lane for Volta. It exists because the Qwen3.8-27B wave is almost entirely
+`compressed-tensors` 4-bit builds, whose kernels gate at "Min capability: 75" and refuse to run on sm_70. The
+checkpoint served here is real GPTQ (`quant_method="gptq"`, 4-bit, `group_size=128`, `desc_act=false`, `sym=true`),
+prepared and tested by its author on a V100.
+
+## What was measured
+
+| Item | Value |
+| --- | --- |
+| Model | `Max73333/Qwen3.8-27B-GPTQ-Int4-V100@d5a18cc1477e301e50d3fe4167fbf76db9337edc` |
+| GPUs | 2 x NVIDIA Tesla V100 SXM2 16GB, compute capability 7.0, driver 580.126.20 |
+| Engine image | `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` (vLLM `1.2.3.dev87+gd76126608.d20260810`) |
+| Serving shape | TP2, context 65,536, max 4 concurrent requests, `gpu_memory_utilization` 0.88, text-only |
+| Workload | 32 prompts, 1,000 input / 1,000 output tokens, client concurrency 4, seed 0, temperature 0, ignored EOS, 2 warm-ups |
+
+| Metric | Result |
+| --- | ---: |
+| Successful / failed requests | 32 / 0 |
+| Benchmark duration | 795.82 s |
+| Output token throughput | 40.21 tok/s |
+| Total token throughput | 80.42 tok/s |
+| Peak output token throughput | 44.00 tok/s |
+| Median TTFT | 2,884.09 ms |
+| Mean / P99 TTFT | 2,427.91 / 2,923.30 ms |
+| Median TPOT | 96.76 ms |
+| Mean / P99 TPOT | 97.14 / 99.27 ms |
+| Median inter-token latency | 96.24 ms |
+
+Startup on this platform is not free: weights load in 8.6 s, but `torch.compile` takes 105.0 s and CUDA graph
+capture another 110.0 s, for 317.9 s from container start to health.
+
+## Capability checks
+
+All four protocol gates were exercised against the deployed server, not inferred from startup:
+
+| Gate | Result |
+| --- | --- |
+| Coherent chat | Pass — returns `Tokyo` for a capital-city question |
+| Tool calling | Pass — returns a structured `tool_calls` entry, `get_weather{"city": "Paris"}` |
+| Reasoning separation | Pass — the engine's `reasoning` field is populated and `content` holds only the answer |
+| Context fill | Pass — a planted marker was retrieved from a 60,295-token prompt, 92% of the advertised 65,536 |
+
+**Reasoning requires an explicit opt-in.** Qwen3.8 defaults thinking *off*, unlike Qwen3-0.6B. Without
+`chat_template_kwargs: {"enable_thinking": true}` the model reasons inline in `content` and the `reasoning` field
+stays empty, which is easy to misread as a broken reasoning parser. The parser is fine; the request has to ask.
+
+## Fit
+
+19.6 GB of GPTQ 4-bit weights, so min-to-serve is about 25.5 GB against 2 x 16,384 MiB = 34.4 GB of platform
+capacity. One 16 GB card cannot hold the weights at all, which is what sets TP2 as the floor rather than a
+throughput choice. TP2 divides cleanly: 24 attention heads / 2 = 12, 4 key/value heads / 2 = 2.
+
+## Limitations
+
+- **Context is 65,536, not the advertised 262,144.** Measured on this platform: 262,144 tokens need 8.16 GiB of KV
+  against a 4.57 GiB pool, and 131,072 need 4.16 GiB against 3.06 GiB once the Triton Gated DeltaNet path takes its
+  workspace. At 65,536 the pool holds 93,206 tokens, giving 1.42x concurrency at full context — four request slots
+  queue rather than run fully parallel on long prompts.
+- **Per-stream decode is slow.** A 96.76 ms median TPOT is roughly 10 tokens/s per stream; the 40.21 tok/s figure is
+  aggregate across four. The host exposes no NVLink — `nvidia-smi topo` reports PHB between every pair — so the TP2
+  all-reduce crosses PCIe on every layer.
+- **The engine image cannot build its own Volta GDN kernel.** Qwen3.8-27B is 48 Gated DeltaNet layers out of 64, so
+  that path is unavoidable. `flash_qla_sm70_gdn_strided` is a JIT torch extension and its build fails at
+  `fatal error: cusparse.h: No such file or directory`, because the runtime layer ships the sources without the CUDA
+  development headers. Selecting the Triton GDN *prefill* backend is not sufficient — the GDN decode path reaches for
+  flash_qla independently — so the recipe also sets `VLLM_SM70_GDN_DECODE_FLASHQLA=0`. A purpose-built sm_70 image
+  that prebuilds that extension would remove this workaround and is the most likely source of a speed-up, since the
+  Volta-native kernel is the one being skipped.
+- **The image tag is misleading by name.** It is tagged for DeepSeek-V4-Flash, but the wheel is the whole 1Cat-vLLM
+  fork. It was selected because it is the first published sm_70 image new enough for Qwen3.8: its `qwen3_5` config
+  defaults `partial_rotary_factor` to 0.25 and its Gated DeltaNet layer accepts `output_gate_type: "swish"`. The
+  older `cloudriftai/1cat-vllm-sm70:1.0.0` knows neither, and would silently apply full rotary to a model that
+  declares a quarter.
+- **This checkpoint is a community quantization**, not a vendor release, and carries no upstream support guarantee.
+
+## Emmy
+
+Not evaluated. This run was scoped to serving qualification only, so no compiler coverage was traced, no golden was
+produced, and Emmy eligibility is **unevaluated** rather than established. There is no Emmy lane in the recipe and no
+Emmy comparison in the numbers above — every figure here is the stock 1Cat-vLLM fork serving lane.
+
+## Reproduce
+
+```bash
+emmy bench experiments/Qwen3.8-27B-GPTQ-Int4/serving --ssh USER@HOST
+```

--- a/recipes/Qwen3.8-27B-GPTQ-Int4/recipe.yaml
+++ b/recipes/Qwen3.8-27B-GPTQ-Int4/recipe.yaml
@@ -1,0 +1,71 @@
+# Qwen3.8-27B GPTQ Int4 — the recommended serving configuration on Volta: two V100 SXM2 16 GB.
+#
+#   emmy deploy ssh --recipe recipes/Qwen3.8-27B-GPTQ-Int4 --ssh user@host
+#
+# This is a DEPLOYMENT config, not an experiment: one variant, no workload grid, no `benchmark:`
+# block. The workload grid that justifies these values lives in
+# experiments/Qwen3.8-27B-GPTQ-Int4/serving/.
+#
+# There is no Emmy lane here: this run qualified serving only, so Emmy eligibility is unevaluated
+# rather than established. See RESULTS.md.
+tags:
+  - best-effort
+
+model:
+  # The 4-bit builds of Qwen3.8-27B are mostly `compressed-tensors`, whose kernels gate at
+  # "Min capability: 75" and refuse to run on Volta's sm_70. This one is real GPTQ
+  # (quant_method="gptq", 4-bit, group_size=128, desc_act=false, sym=true) and was prepared and
+  # tested by its author on a V100, which is why it is the 4-bit checkpoint this recipe serves.
+  huggingface: "Max73333/Qwen3.8-27B-GPTQ-Int4-V100"
+  rationale: "Only Volta-capable 4-bit build of the Qwen3.8 wave; community quant, not a vendor release."
+  heat: 0
+  revision: d5a18cc1477e301e50d3fe4167fbf76db9337edc
+  task: generate
+
+engine:
+  llm:
+    # 19.6 GB of weights do not fit one 16 GB card. TP2 is the smallest size that fits and
+    # divides cleanly: 24 attention heads / 2 = 12, 4 key/value heads / 2 = 2.
+    tensor_parallel_size: 2
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    # Native context is 262,144 and does not fit. Measured here: 262,144 needs 8.16 GiB of KV
+    # against a 4.57 GiB pool, and 131,072 needs 4.16 GiB against 3.06 GiB once the Triton GDN
+    # path takes its workspace. At 65,536 the pool holds 93,206 tokens. Validated by retrieving a
+    # planted marker from a 60,295-token prompt, not by startup alone.
+    context_length: 65536
+    # The KV pool allows 1.42x concurrency at full context, so 4 slots queue rather than run
+    # fully parallel at long prompts. That is the intended tradeoff: short requests still batch.
+    max_concurrent_requests: 4
+    vllm:
+      # Stock vLLM has no sm_70 support. This is the 1Cat-vLLM Volta fork; the tag is named for
+      # the model it was first built for, but the wheel is the whole fork. It is the first
+      # published sm70 image new enough for Qwen3.8: its qwen3_5 config defaults
+      # partial_rotary_factor to 0.25 and its Gated DeltaNet layer accepts output_gate_type
+      # "swish", both of which Qwen3.8 declares and the older 1cat-vllm-sm70:1.0.0 does not know.
+      # Serving that checkpoint on 1.0.0 would apply full rotary to a model asking for a quarter.
+      image: "cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608"
+      # --dtype half: Volta has no bfloat16. --language-model-only drops the vision tower, which
+      # this checkpoint leaves unquantized; the text path is what is qualified here.
+      # --max-num-seqs comes from max_concurrent_requests above (the schema forbids it here).
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --gdn-prefill-backend triton
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser qwen3_coder
+        --reasoning-parser qwen3
+      extra_env:
+        # Qwen3.8-27B is 48 Gated DeltaNet layers out of 64, so the GDN path is unavoidable. This
+        # image cannot build the Volta-native flash_qla GDN extension: it ships the sources but
+        # not the CUDA development headers, so the JIT fails at
+        # `fatal error: cusparse.h: No such file or directory`. Selecting the Triton GDN *prefill*
+        # backend above is not sufficient, because the GDN decode path reaches for flash_qla
+        # independently; this knob is what actually keeps the JIT out of the run. A purpose-built
+        # sm_70 image should prebuild that extension instead and drop this line.
+        VLLM_SM70_GDN_DECODE_FLASHQLA: "0"
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 2

--- a/recipes/Qwen3.8-27B/RESULTS.md
+++ b/recipes/Qwen3.8-27B/RESULTS.md
@@ -1,0 +1,94 @@
+# Qwen3.8-27B at FP16 on eight V100 SXM2 16GB
+
+Qualified 2026-09-05 against repository revision `01588556cef50c202e5370927e6788f039550801`.
+
+This is the official Qwen3.8-27B checkpoint served on Volta. It is the only one of the three Qwen3.8 Volta lanes with
+no quantization kernel anywhere in the path — Volta has no bfloat16, so the BF16 checkpoint is served as FP16 — which
+makes it the cleanest evidence that the architecture itself runs on sm_70.
+
+## What was measured
+
+| Item | Value |
+| --- | --- |
+| Model | `Qwen/Qwen3.8-27B@1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0` |
+| GPUs | 8 x NVIDIA Tesla V100 SXM2 16GB, compute capability 7.0, driver 580.126.20 |
+| Engine image | `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` (vLLM `1.2.3.dev87+gd76126608.d20260810`) |
+| Serving shape | TP8, context 262,144, max 4 concurrent requests, `gpu_memory_utilization` 0.88, text-only |
+| Backends | FLASH_ATTN_V100 attention, Triton Gated DeltaNet prefill |
+| Workload | 32 prompts, 1,000 input / 1,000 output tokens, client concurrency 4, seed 0, temperature 0, ignored EOS, 2 warm-ups |
+
+| Metric | Result |
+| --- | ---: |
+| Successful / failed requests | 32 / 0 |
+| Benchmark duration | 1,631.13 s |
+| Output token throughput | 19.62 tok/s |
+| Total token throughput | 39.24 tok/s |
+| Peak output token throughput | 29.00 tok/s |
+| Median TTFT | 54,249.55 ms |
+| Mean / P99 TTFT | 49,388.50 / 61,649.02 ms |
+| Median TPOT | 147.98 ms |
+| Mean / P99 TPOT | 154.65 / 178.23 ms |
+| Median inter-token latency | 145.17 ms |
+
+Deploy from container create to health took 545.9 s. The benchmark row ran 1,631 s, over the 20-minute per-variant
+cap; it is reported rather than discarded because all 32 requests succeeded, and the overrun is the measurement, not
+an error.
+
+## Capability checks
+
+| Gate | Result |
+| --- | --- |
+| Coherent chat | Pass — returns `Tokyo` for a capital-city question |
+| Tool calling | Pass — structured `tool_calls`, `get_weather{"city": "Paris"}` |
+| Reasoning separation | Pass — the `reasoning` field is populated and `content` holds only the answer |
+| Context fill | Pass at 60,295 tokens — a planted marker was retrieved. See the caveat below. |
+
+As on the other Volta lanes, reasoning requires `chat_template_kwargs: {"enable_thinking": true}`; Qwen3.8 defaults
+thinking off and otherwise reasons inline in `content`.
+
+## Fit
+
+55.6 GB of BF16 weights give a min-to-serve near 72.3 GB against 8 x 16,384 MiB = 137.4 GB of platform capacity. Four
+cards hold only 68.7 GB and cannot take the weights, so eight is the smallest admissible platform on this fleet, not
+a throughput preference. TP8 divides cleanly: 24 attention heads / 8 = 3, 48 linear-attention value heads / 8 = 6,
+16 linear-attention key heads / 8 = 2; the 4 key/value heads are replicated because 8 % 4 == 0.
+
+## Limitations
+
+- **The advertised 262,144 context is memory-backed but not validated end to end.** The engine genuinely allocates
+  for it — the measured KV pool holds 293,427 tokens, 1.12x concurrency at full context — and this is the only one of
+  the three Volta lanes that needed no context reduction to start. But a prompt near the full window did not finish
+  prefilling within 20 minutes and was abandoned; retrieval is validated at 60,295 tokens, which completed quickly.
+  Prefill cost grows faster than linearly here, so on this hardware the practical ceiling is **prefill time, not
+  memory**. Treat 262,144 as the allocated window and roughly 60k as the size with end-to-end evidence behind it.
+- **This is the slowest of the three Volta lanes.** 19.62 tok/s output and a 148 ms median TPOT (about 6.8 tokens/s
+  per stream) are roughly half the 4-bit lane's throughput, which is expected: FP16 moves four times the weight bytes
+  per token that Int4 does, and the host exposes no NVLink — `nvidia-smi topo` reports PHB between every pair — so an
+  eight-way all-reduce crosses PCIe on every layer. A median TTFT of 54 s at concurrency 4 makes this a batch or
+  background configuration, not an interactive one.
+- **The engine image cannot build its own Volta Gated DeltaNet kernel.** 48 of the 64 layers are Gated DeltaNet, so
+  that path is unavoidable. `flash_qla_sm70_gdn_strided` is a JIT torch extension whose build fails at
+  `fatal error: cusparse.h: No such file or directory`, because the runtime layer ships the sources without the CUDA
+  development headers. Selecting the Triton GDN *prefill* backend is not enough — the GDN decode path reaches for
+  flash_qla independently — so the recipe sets `VLLM_SM70_GDN_DECODE_FLASHQLA=0`. The Volta-native kernel is
+  therefore being skipped, and a purpose-built sm_70 image that prebuilds it is the most likely source of a speed-up.
+- **Only the Volta platform was qualified.** The discovery shell this recipe replaces proposed one RTX PRO 6000
+  Blackwell Max-Q and one H200 141GB. Both remain unmeasured, not unsuitable — the model fits either far more
+  comfortably than it fits eight 16 GB cards, and the numbers here must not be read across to them.
+- **The image tag is misleading by name.** It is tagged for DeepSeek-V4-Flash, but the wheel is the whole 1Cat-vLLM
+  fork, selected because it is the first published sm_70 image new enough for Qwen3.8: its `qwen3_5` config defaults
+  `partial_rotary_factor` to 0.25 and its Gated DeltaNet layer accepts `output_gate_type: "swish"`. The older
+  `cloudriftai/1cat-vllm-sm70:1.0.0` knows neither and would silently apply full rotary to a model declaring a
+  quarter.
+
+## Emmy
+
+Not evaluated. This run was scoped to serving qualification only, so no compiler coverage was traced, no golden was
+produced, and Emmy eligibility is **unevaluated** rather than established. There is no Emmy lane in the recipe and no
+Emmy comparison in the numbers above — every figure here is the stock 1Cat-vLLM fork serving lane.
+
+## Reproduce
+
+```bash
+emmy bench experiments/Qwen3.8-27B/serving --ssh USER@HOST
+```

--- a/recipes/Qwen3.8-27B/recipe.yaml
+++ b/recipes/Qwen3.8-27B/recipe.yaml
@@ -1,13 +1,69 @@
+# Qwen3.8-27B at FP16 on eight V100 SXM2 16 GB (sm_70 Volta).
+#
+#   emmy deploy ssh --recipe recipes/Qwen3.8-27B --ssh user@host
+#
+# This is a DEPLOYMENT config, not an experiment: one variant, no workload grid, no `benchmark:`
+# block. The workload grid that justifies these values lives in experiments/Qwen3.8-27B/serving/.
+#
+# SCOPE: this recipe records the platform that was actually qualified, which is Volta. The
+# discovery shell it replaces proposed one RTX PRO 6000 Blackwell Max-Q and one H200 141GB; both
+# remain UNQUALIFIED here, which means unmeasured, not unsuitable. The model fits either card far
+# more comfortably than it fits this one, and a later run should qualify them on their own
+# evidence rather than inheriting these numbers.
+#
+# There is no Emmy lane here: this run qualified serving only, so Emmy eligibility is unevaluated
+# rather than established. See RESULTS.md.
 tags:
-  - onboarding
-  - untested
+  - best-effort
+
 model:
   huggingface: Qwen/Qwen3.8-27B
   rationale: "Undisputed breakout model of the era with maximum community attention."
   heat: 98
+  revision: 1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0
   task: generate
+
+engine:
+  llm:
+    # 55.6 GB of BF16 weights give a min-to-serve near 72.3 GB, so eight cards
+    # (8 x 16,384 MiB = 137.4 GB) are the smallest admissible platform on this fleet; four hold
+    # only 68.7 GB. TP8 divides cleanly: 24 attention heads / 8 = 3, 48 linear-attention value
+    # heads / 8 = 6, 16 linear-attention key heads / 8 = 2. The 4 key/value heads are fewer than
+    # the 8 ranks, which vLLM handles by replicating them because 8 % 4 == 0.
+    tensor_parallel_size: 8
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    # The full native window fits: the measured KV pool holds 293,427 tokens, giving 1.12x
+    # concurrency at full context. This is the one lane of the three where the advertised context
+    # needed no reduction.
+    context_length: 262144
+    max_concurrent_requests: 4
+    vllm:
+      # Stock vLLM has no sm_70 support. This is the 1Cat-vLLM Volta fork; the tag is named for
+      # the model it was first built for, but the wheel is the whole fork. It is the first
+      # published sm70 image new enough for Qwen3.8: its qwen3_5 config defaults
+      # partial_rotary_factor to 0.25 and its Gated DeltaNet layer accepts output_gate_type
+      # "swish", both of which Qwen3.8 declares and the older 1cat-vllm-sm70:1.0.0 does not know.
+      image: "cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608"
+      # --dtype half: Volta has no bfloat16, so the BF16 checkpoint is served as FP16. This is
+      # the only one of the three Qwen3.8 Volta lanes with no quantization kernel in the path.
+      # --language-model-only drops the vision tower; the text path is what is qualified here.
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --gdn-prefill-backend triton
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser qwen3_coder
+        --reasoning-parser qwen3
+      extra_env:
+        # 48 of the 64 layers are Gated DeltaNet, so that path is unavoidable. This image cannot
+        # build the Volta-native flash_qla GDN extension: it ships the sources but not the CUDA
+        # development headers, so the JIT fails at `fatal error: cusparse.h`. Selecting the Triton
+        # GDN *prefill* backend above is not sufficient, because the GDN decode path reaches for
+        # flash_qla independently; this knob is what keeps the JIT out of the run.
+        VLLM_SM70_GDN_DECODE_FLASHQLA: "0"
+
 matrices:
-- deploy.gpu: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition
-  deploy.gpu_count: 1
-- deploy.gpu: NVIDIA H200 141GB
-  deploy.gpu_count: 1
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 8


### PR DESCRIPTION
Onboards three Qwen3.8 checkpoints on V100 SXM2 16GB (sm_70 Volta), measured on one 8-GPU
CloudRift host.

## What runs

Qwen3.8-27B is `Qwen3_5ForConditionalGeneration` — the same class already qualified on V100 for
Qwen3.5-27B-AWQ and Qwen3.6-35B-A3B-AWQ — so the architecture was expected to work. The engine
image and the memory ceiling are what actually decided each lane.

All three measured on the same host, same image, 1,000 in / 1,000 out at client concurrency 4,
seed 0, temperature 0, ignored EOS:

| Lane | Cards | Weights | Output tok/s | Median TPOT | Median TTFT | Context |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `Qwen3.8-27B-GPTQ-Int4` (new) | 2 | 19.6 GB | 40.21 | 96.76 ms | 2,884 ms | 65,536 |
| `Qwen3.8-27B-FP8` | 4 | 30.9 GB | 32.46 | 100.98 ms | 23,072 ms | 262,144 allocated |
| `Qwen3.8-27B` (FP16) | 8 | 55.6 GB | 19.62 | 147.98 ms | 54,250 ms | 262,144 allocated |

Zero failed requests in every lane. The FP8 row ran 16 prompts rather than 32 to stay inside the
20-minute per-variant cap that the FP16 row overran, so its totals are not directly comparable —
the per-token latencies are. The ordering tracks bytes moved per weight (0.5 / 1 / 2) and the
widening tensor-parallel degree: the host exposes no NVLink (`nvidia-smi topo` reports PHB
between every pair), so each doubling adds PCIe all-reduce traffic on every layer.

All four capability gates pass on all three lanes: coherent chat, structured `tool_calls`,
reasoning separated into the engine's `reasoning` field, and planted-marker retrieval.

## Three findings the recipes now carry

**The published sm_70 image cannot JIT its own Volta Gated DeltaNet kernel.** Building
`flash_qla_sm70_gdn_strided` fails at `fatal error: cusparse.h: No such file or directory` — the
runtime layer ships the `flash_qla` sources without the CUDA development headers. Selecting the
Triton GDN *prefill* backend is **not** sufficient, because the GDN decode path reaches for
flash_qla independently; `VLLM_SM70_GDN_DECODE_FLASHQLA=0` is what actually unblocks it. Qwen3.8-27B
is 48 Gated DeltaNet layers out of 64, so the Volta-native kernel being skipped is the most likely
source of a future speed-up — a purpose-built sm_70 image that prebuilds that extension should be
faster across all three lanes.

**The image had to be new enough for Qwen3.8.** `cloudriftai/1cat-vllm-sm70:1.0.0` predates the
checkpoint and knows neither `partial_rotary_factor` nor `output_gate_type: "swish"`, so it would
silently apply full rotary to a model declaring a quarter — a wrong-numerics failure, not a crash.
The image pinned here is built from 1Cat-vLLM commit `d76126608`, whose `qwen3_5` config defaults
`partial_rotary_factor` to 0.25 and whose Gated DeltaNet layer accepts `"swish"`. Its tag is named
for DeepSeek-V4-Flash, but the wheel is the whole fork; each recipe says so.

**Context is bounded by prefill time, not memory.** The Int4 lane is genuinely memory-capped at
65,536 (262,144 needs 8.16 GiB of KV against a 4.57 GiB pool; 131,072 needs 4.16 against 3.06 once
Triton GDN takes its workspace). The FP16 and FP8 lanes allocate the full 262,144 window and start
cleanly, but a near-full-window prompt did not finish prefilling within 20 minutes and was
abandoned. Retrieval is validated at 60,295 tokens on all three, and the reports say exactly that
rather than claiming a window they did not exercise.

## Recipe changes

`Qwen3.8-27B` and `Qwen3.8-27B-FP8` replace their `onboarding`/`untested` discovery shells,
preserving `model.heat` and rationale. Both shells proposed an RTX PRO 6000 Blackwell Max-Q and an
H200 141GB; those platforms remain **unmeasured, not unsuitable**, and both reports say so
explicitly so the Volta numbers are not read across to them.

`Qwen3.8-27B-GPTQ-Int4` is a new recipe. The Qwen3.8 4-bit wave is almost entirely
`compressed-tensors`, whose kernels gate at "Min capability: 75" and refuse to run on sm_70;
`Max73333/Qwen3.8-27B-GPTQ-Int4-V100` is the one real-GPTQ build (`group_size=128`,
`desc_act=false`, `sym=true`) its author prepared and tested on a V100. It is a community
quantization with no upstream support guarantee, which its report states.

## Scope

Serving qualification only, as requested. No compiler coverage was traced and no golden produced,
so **Emmy eligibility is unevaluated rather than established** — no recipe carries an Emmy lane and
no number here is an Emmy comparison.

## Verification

- `pytest tests/` — 4,192 passed, 1,040 skipped, 21 xfailed, 0 failed
- `ruff check` and `ruff format --check` clean
- `emmy deploy ssh --dry-run` passes for all three recipes; `emmy bench --dry-run` passes for all
  three experiments
- No change under `emmy/`; the diff is recipes, experiments, and reports only
- Evidence archives tracked via the existing LFS rule for `experiments/**/results_*.tar.gz`

One pre-existing item worth a maintainer's eye, not introduced here: the committed evidence
archives embed the run host's SSH target (this PR's do, and so does the existing
`results_rtx4090x1.tar.gz`), which the onboarding skill's "no VM identifiers in tracked artifacts"
rule would exclude. Left consistent with the existing corpus rather than diverged unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGxXwKVLyG7ZK6RjGFnEkz
