### PR TITLE
Blame the kernel nvcc names when a bench's compile fails, quote escaped or not

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -267,9 +267,10 @@ the deploy evidence the next `compile` / `run` / `serve` picks from, which is ho
 embedded golden lowers in-process, knobs and all, so it records like a traced model; only the `--ir` JSON path, whose
 serialization drops the knobs, stays unrecorded. A greedy row that fails to bench is recorded the same way the
 tuner records a hung terminal (`bench_record.record_bench_failure`, the tuner's `persist_bench_failure`): the kernel
-the watchdog named — or a one-kernel graph's only kernel — earns a `bench_fail` perf row at the run budget's fail
-sentinel and the innocent kernels earn none, so the next compile disqualifies that arm instead of electing the same
-route and hanging again; a failure that names no kernel records nothing, and a compile-budget overrun measured
+the failure names — the one the watchdog saw hang, or the one nvcc refused to compile — or a one-kernel graph's only
+kernel earns a `bench_fail` perf row at the run budget's fail sentinel and the innocent kernels earn none, so the
+next compile disqualifies that arm instead of electing the same route and failing the same way again; a failure
+that names no kernel records nothing, and a compile-budget overrun measured
 nothing and records nothing. `--no-record-nodes` opts out of all of it.
 
 For a fair hybrid-vs-MCTS comparison, both working files start from the same inventory-only trace: do not copy verified

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1298,13 +1298,15 @@ backend). It short-circuits from the `perf` cache in three cases. A kernel whose
 slice it is in — its identity is its rendered source and launch geometry, the same bytes wherever it appears — so
 one such row decides the slice as `bench_fail`, blamed exactly as recorded, and the other kernels need no row of
 their own (an all-or-nothing lookup re-benched every hang on every fresh session, because a failure is recorded only
-against the kernel the watchdog named and the innocent kernels stay rowless — `persist_bench_failure`, the one
-writer for a failed bench, which `run --bench`'s greedy row also comes through). A failure that names no kernel in a
-multi-kernel terminal — a wall kill — blames none of them, but what IS known, that this kernel set failed at that
-budget, is filed as a `bench_fail` under the set's own key (`TerminalBench.set_key`, the digest of its kernels'
-variant keys) and replays for that exact set; the row carries no knobs and no kernel stands behind it, so the
-greedy's disqualification index (joined on `S_*` signatures) and the dataset (joined on `cuda_op`) never see it, and
-a kernel of the set enrolled on its own still benches. An `ok` replay needs every `CudaOp`'s row for the current
+against the kernel the failure names — the watchdog's hang, or nvcc's refusal of a kernel's source — and the
+innocent kernels stay rowless — `persist_bench_failure`, the one writer for a failed bench, which `run --bench`'s
+greedy row also comes through; the name is read off the message text, since the exception class does not cross
+the worker pipe, and with the quote `repr` escapes when the message also holds a `"`). A failure that names no
+kernel in a multi-kernel terminal — a wall kill — blames none of them, but what IS known, that this kernel set
+failed at that budget, is filed as a `bench_fail` under the set's own key (`TerminalBench.set_key`, the digest of
+its kernels' variant keys) and replays for that exact set; the row carries no knobs and no kernel stands behind it,
+so the greedy's disqualification index (joined on `S_*` signatures) and the dataset (joined on `cuda_op`) never see
+it, and a kernel of the set enrolled on its own still benches. An `ok` replay needs every `CudaOp`'s row for the current
 `(context_key, backend)`: the bench runs the whole graph, so a partial cache cannot stand in for the Σ. Otherwise it
 does one `await backend.benchmark_async(...)`, walks `Op.source` once to record op inventory + lowering edges + the
 `perf` row per kernel, and returns the aggregate `PerfStats` for the search to score.

--- a/emmy/compiler/pipeline/search/policy/terminal_bench.py
+++ b/emmy/compiler/pipeline/search/policy/terminal_bench.py
@@ -352,10 +352,13 @@ def persist_kernel_perf(
     return True
 
 
-#: The kernel a watchdog message NAMES — ``kernel 'k_foo (iter 0)' did not complete …``. The
-#: exception class does not survive the bench worker's pipe (it arrives wrapped in a
-#: ``BenchWorkerJobError``), so the label is recovered from the text.
-_NAMED_KERNEL = re.compile(r"kernel '([A-Za-z_][A-Za-z0-9_]*)")
+#: The kernel a failure message NAMES — ``kernel 'k_foo (iter 0)' did not complete …`` from the
+#: watchdog, ``nvcc compile failed for kernel 'k_foo': …`` from the compiler. The exception class
+#: does not survive the bench worker's pipe (it arrives wrapped in a ``BenchWorkerJobError``
+#: carrying the child exception's ``repr``), so the label is recovered from the text — and
+#: ``repr`` escapes the name's quote as ``\'`` when the message also holds a ``"`` (nvcc quotes
+#: identifiers that way), so the quote is matched with or without its backslash.
+_NAMED_KERNEL = re.compile(r"kernel \\?'([A-Za-z_][A-Za-z0-9_]*)")
 
 
 def persist_bench_failure(db, context_key: str, backend_name: str, cuda_nodes, exc, fail_us: float) -> list:

--- a/tests/compiler/pipeline/search/policy/test_terminal_bench.py
+++ b/tests/compiler/pipeline/search/policy/test_terminal_bench.py
@@ -190,6 +190,22 @@ async def test_a_hung_kernel_is_blamed_alone() -> None:
     assert len(per_kernel) == 1, "only the culprit trains the prior on this failure"
 
 
+async def test_a_kernel_nvcc_refuses_is_blamed_alone() -> None:
+    """A worker-side nvcc failure names its kernel too, but it reaches the parent through ``repr``
+    of the child's exception, and nvcc's detail quotes identifiers with ``"``, so the name's own
+    ``'`` comes back escaped as ``\\'``. Blame must read it anyway: left unrecorded, the same source
+    is elected and refused again on every compile (a host loop re-elected one such kernel with
+    nothing filed)."""
+    db, cand = SearchDB(), _candidate_pair()
+    inner = RuntimeError("nvcc compile failed for kernel 'k_culprit': k.cu(135): error: identifier \"a26_1\" is undefined")
+    exc = BenchWorkerJobError(f"bench worker error: {inner!r}")
+
+    _stats, status, _measured, _per_kernel = await bench_terminal_async(cand, backend=_RaisingBackend(exc), db=db)
+
+    assert status == "bench_fail"
+    assert _fail_rows(db, cand) == {"k_culprit": "bench_fail"}, "the refused kernel is the one nvcc named"
+
+
 async def test_a_blamed_kernel_replays_the_hang_for_its_slice() -> None:
     """The culprit's row is the slice's evidence: a kernel that hung hangs every slice it is in, so
     on the next session the slice must be served ``bench_fail`` from the cache without the innocent


### PR DESCRIPTION
## Abstract

A bench that fails because nvcc refuses one kernel's source names that kernel, but the failure was recorded against nobody, so the next compile elected the same route and failed the same way — the evidence loop for the DeepSeek-V4-Flash post4096 twin stopped on exactly this after the parallel tune had filled its DB. The blamed kernel is read off the failure text because the exception class does not survive the bench worker's pipe; the worker wraps the child's exception through `repr`, and an nvcc message quotes identifiers with `"`, so `repr` escapes the kernel name's own quote and the blame pattern missed it. A hang's message holds only single quotes, which is why every hang was blamed and this was not. The pattern now accepts the escaped quote, so a compiler-refused kernel earns its `bench_fail` row like a hung one and the election moves on.

## What it took to see

`run --bench --record-greedy` on the 623-`ok`-row DB elected a 15-kernel route whose second kernel (`…__place_0fee4f4677`, a Volta `mma` tile over `a26_1 × a34`) does not compile — its B-operand address uses the unsplit axis `a26_1` while the kernel's decode only defines `a26_1_b` / `a26_1_u` (a codegen defect, reported separately, not touched here). The log said `pinning bench_fail … for 0 of 2 kernel(s)` shape-wise: nothing filed, `perf` unchanged, and the concurrent CPU dump proved the election deterministic. Reproduced GPU-free: `_NAMED_KERNEL.search("bench worker error: " + repr(RuntimeError("nvcc compile failed for kernel 'k_x': … \"_lane\" …")))` is `None`; with the escaped quote allowed it is `k_x`, and the hung-kernel text still matches.

## Tests

`tests/compiler/pipeline/search/policy/test_terminal_bench.py::test_a_kernel_nvcc_refuses_is_blamed_alone`: a two-kernel terminal whose worker-wrapped nvcc failure names the culprit; red before (`0 of 2 kernel(s)` blamed), green after, the innocent kernel rowless either way. The hung-kernel and unattributable-failure cases beside it are unchanged.

## Gates

- `make test`: 4194 passed, 1039 skipped, 21 xfailed.
- `make lint`: clean.
- `make test-goldens`: the change is a pattern in the failure writer, outside the schedule codec; the gate's state is reported in the PR thread once the run completes (it is red on `main` today for all files).
- Core line balance: `emmy/` +7 −4 — the pattern's comment grew by the reason the escaped quote exists; no new mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
