### PR TITLE
Store attention's twisted carrier in the coordinates it computes in

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,20 +12,49 @@ body hard to edit. The ~120-character rule applies to files in the repository, n
 
 ## Abstract
 
-The checked-in bucketing baseline gained four entries spelled without the marker suffix a CUDA test is collected under. A key that never matches is the same as no key at all, so the staleness gate goes on naming those four tests as missing and fails the run it just balanced around them. This spells them the way the gate reads them, and records the two poles that crossed five seconds on their own.
+A fused softmax carrier stored its per-element contribution in the coordinates the algebra is *defined* in rather than the ones it *computes* in, so every attention tree carried an exponential of an unshifted score — a value that overflows if anything evaluates it and that nothing was permitted to evaluate. Keeping it there also forced an extra node into the tree whose only job was to turn that value into an operand so a pattern match would fire. This change stores the contribution in the carrier's own coordinates, where softmax's is a score, a one, and the streamed value, and derives the other form on demand for the one reader that needs it. The tree loses the exponential and the node, and attention's numerics are unchanged against eager.
+
+```
+ ├─ operand[v1, e]: Fold  free                    ├─ operand[acc0]: Fold[a3] contraction
+ │    v1 = multiply(acc0, 0.125)                  ├─ operand[in7]: load v[...]
+ │    e  = exp(v1)              ← overflows       ├─ init: (-1e+30, 0, 0)
+ ├─ operand[in7]: load v[...]                     ├─ lift: λ(a2, acc0, in7) -> (v1, one, in7)
+ ├─ lift: λ(a2, v1, e, in7) -> (v1, e, ev)        │    v1  = multiply(acc0, 0.125)
+ │    ev = multiply(e, in7)                       │    one = 1
+ └─ base: (maximum, add, add)                     ├─ combine: λ(acc1, acc3, acc5__sum, …) -> …
+                                                  ├─ helper: psi λ(m, D, O) -> (m, d, o)
+                                                  └─ helper: base = (maximum, add, add)
+             before                                                  after
+```
 
 ---
 
 ## Why the ids differed
 
-A subset run and the full suite disagree on what a node id is. `make test` runs under `-n auto --dist=loadgroup`, where the xdist group marker lands in the id (`…::test_x@cuda`); a bare `pytest path::test_x` reports no suffix. The four entries were recorded from subset runs, which is how they went in without one — and why the gate kept asking for tests the file appeared to list.
+The paper states both representations of a twisted fold as equivalent, and its FlashAttention figure draws the stable one. The implementation had taken the base one. The fusion now splices the recipe's authored injection — the singleton in the carrier's own state space, where the pivot *is* the score and `exp(s)·v` has already simplified to `v`. The stable combine derives from the recipe, and the base monoid and ψ ride beside it as helpers.
 
-The baseline already held 152 keys carrying the suffix, so the file's own convention was never in doubt.
+`Fold.based` is the reading those helpers exist for: ψ⁻¹ over the stored lift, restoring `(s, exp s, exp(s)·v)`. Bilinearity lives in base coordinates and nowhere else, because ψ divides the product away at the singleton. Only `bilinear_channels` and `as_contraction` ask for it, nothing emits it, and it is restricted to the channels a term actually holds — a half-fused carrier is the ordinary case during the rewrite's fixpoint.
 
-## Evidence
+## The node that is no longer minted
 
-Under `-n 2 --dist=loadgroup` — the shape `make test` uses — the gate is quiet on the affected file. Under a bare subset run it still complains, as it did before this change: a subset sees subset ids, and this file is a baseline for the full suite.
+`_factor_weights` hoisted the weight into an operand of its own so the expectation channel read as `operands[0] ⊗ operands[k]`. That node added no computation; the emitter never placed it. It existed to satisfy a pattern.
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+The pattern now asks the right question. **A is what `operands[0]` supplies, not what it exposes** — the left factor may be a component of that edge, or a value the reading derives from those components and from kernel-uniform ones. A scale contributes no variation, so a factor reading it varies exactly as A does. A weight derived from the *streamed* value is still refused; offering an mma there would be a wrong answer, not a slow kernel.
 
-https://claude.ai/code/session_01NHvyWiofb3RYvVoDzqSeoQ
+## Three things the dump was hiding
+
+A scalar operand is spelled inside the reader that binds it, so a scale stops being a line of tree art around a constant. A lift prints under the operand's own name for every slot it binds, and only the slots it reads — attention's two consumers of one carrier now visibly take different states off it, where before both listed all three. And normalization drops operand components no reader reads: rewrites had left an epilogue cone exposing three constants nobody bound, carried alongside a second copy of the loads defining them. A reader is a consuming lift *or* a boundary store, which is how a sweep's per-cell projection reaches its `Write`.
+
+The cut pass also stops offering a seam at a scalar. That piece was a kernel writing three scalars to a workspace so its reader could read them back.
+
+## What broke
+
+`test_sdpa_score_contraction_reaches_the_mma_tier` is red and left red. The mma rows are still offered — the carrier and the score contraction both answer `contracts` and `tiles_whole`, and the carrier answers `chunked` — but the greedy's default pick moved because kernel identity changed and no recorded evidence matches the new term. It needs a tuning round. Not re-recorded, not weakened to pass.
+
+Kernel identity moved for every twisted term, and the seam under the carrier lost a hop (`PLACE@map.1/twist.1/map.1/inner.2/map` → `PLACE@map.1/twist.1/inner.2/map`). Recorded goldens, realization cases, and PLACE pins of that shape are stale.
+
+## Verification
+
+Accuracy against eager passes on SDPA, causal SDPA, softmax, softmax@V and RMSNorm, worst `max_diff` 9.8e-4 in fp16. That is the check that catches a wrong twist. Goldens and the realization corpus are the outstanding gates; both need re-recording on a GPU before this is a deployable reference.
+
+`git diff --stat main -- emmy/**/*.py` is +318 −146. The growth is new capability — a coordinate reading that did not exist, a derived base view, and a normalization rule — set against `_factor_weights`, `_already_held`, and the subtree walk in `Fold.roles` that all came out.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,14 +47,16 @@ A scalar operand is spelled inside the reader that binds it, so a scale stops be
 
 The cut pass also stops offering a seam at a scalar. That piece was a kernel writing three scalars to a workspace so its reader could read them back.
 
-## What broke
+## What broke — this is not ready
 
-`test_sdpa_score_contraction_reaches_the_mma_tier` is red and left red. The mma rows are still offered — the carrier and the score contraction both answer `contracts` and `tiles_whole`, and the carrier answers `chunked` — but the greedy's default pick moved because kernel identity changed and no recorded evidence matches the new term. It needs a tuning round. Not re-recorded, not weakened to pass.
+**The chunk tier no longer reaches the tensor cores.** Three e2e tests fail on a *pinned* chunk row, so it is not the greedy choosing differently — the row is unenumerable. The atom projection refuses a contraction any of whose operands reduce, and removing the minted node is exactly what made A reduce: A used to be the zero-axis weight cone with the score contraction nested under it, which is the shape the fragment-seam machinery (`ContractionFacts.producer`, `_fragment_agreements`) was written against. Exempting the chunked carrier from that one refusal is not sufficient on its own; there is at least one more gate downstream. Teaching the seam that A may BE the producer is the remaining work, and it is design work, not a test fix.
 
-Kernel identity moved for every twisted term, and the seam under the carrier lost a hop (`PLACE@map.1/twist.1/map.1/inner.2/map` → `PLACE@map.1/twist.1/inner.2/map`). Recorded goldens, realization cases, and PLACE pins of that shape are stale.
+`test_sdpa_score_contraction_reaches_the_mma_tier` is the same cause at a smaller scale.
+
+The realization corpus reports 32 stale cases and 14 changed verdicts. The stale half is what `make test-corpus-regen` exists for; the verdict changes need reading one at a time. Kernel identity moved for every twisted term, so recorded goldens are stale too.
 
 ## Verification
 
-Accuracy against eager passes on SDPA, causal SDPA, softmax, softmax@V and RMSNorm, worst `max_diff` 9.8e-4 in fp16. That is the check that catches a wrong twist. Goldens and the realization corpus are the outstanding gates; both need re-recording on a GPU before this is a deployable reference.
+Accuracy against eager passes on SDPA, causal SDPA, softmax, softmax@V and RMSNorm, worst `max_diff` 9.8e-4 in fp16 — the numerics of the coordinate change are sound. `make test` is 4846 passed / 59 failed; the failures are the corpus and the chunk tier above.
 
 `git diff --stat main -- emmy/**/*.py` is +318 −146. The growth is new capability — a coordinate reading that did not exist, a derived base view, and a normalization rule — set against `_factor_weights`, `_already_held`, and the subtree walk in `Fold.roles` that all came out.

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -396,21 +396,46 @@ class Fold:
 
     @cached_property
     def injected(self) -> Lambda:
-        """The lift SEEN THROUGH ψ — ``injected = psi ∘ lift``, the singleton the ⊕ folds, in the
-        operands' spelling. ``applied`` itself for a planar fold, where ψ is the identity.
+        """The singleton the ⊕ folds — :attr:`applied`, always.
 
-        For a twisted one the stored ``lift`` computes the BASE contribution, which is what makes a
-        channel read as a contraction and what a schedule tiles; it is NOT what a serial step may
-        emit, because ``Sum exp(score)`` overflows. So the step folds this instead: the score's own
-        cone, then the recipe's authored injections (:meth:`Twist.inject`) — the simplified form ψ
-        takes where the pivot IS the score. Nothing else may see through ψ.
+        The term STORES its contribution in the carrier's own coordinates (the twisted fusion
+        splices the recipe's authored injections, not its base lift), so there is nothing left to
+        see through: what the step folds is what the lift says. Kept as a name because every
+        consumer of a folded singleton reads it, and because the base reading is now the derived
+        one (:meth:`based`) rather than this.
+        """
+        return self.applied
+
+    @cached_method
+    def based(self) -> Lambda:
+        """The lift in BASE coordinates — ``psi_inv ∘ lift``, the contribution the base monoid
+        folds. :attr:`applied` itself for a planar fold, where the two coordinate systems coincide.
+
+        RECOGNITION ONLY. The base form denotes ``Sum exp(score)`` and overflows for a large enough
+        logit — that is exactly why the term stores the stable side — so nothing may emit these
+        statements. It exists because bilinearity lives in base coordinates and nowhere else: ψ
+        divides each channel by a factor at the singleton, so softmax's stable contribution is
+        ``(s, 1, v)`` with no product in it at all, while ``psi_inv`` brings back
+        ``(s, exp(s), exp(s)·v)`` where the expectation channel is a bare product of the weight and
+        the streamed value. :meth:`bilinear_channels` reads this; :meth:`step` reads the lift.
         """
         applied = self.applied
         if self.twist is None or not self.twist.channels:
-            return applied  # planar, or a merge whose elements are carrier states already
-        injection = self.twist.inject(self.roles, self.base.results)
-        score = injection.results[0]
-        return Lambda(params=applied.params, body=Body((*applied.cone(score).body, *injection.body)), results=injection.results)
+            return applied
+        psi_inv = self.twist.recipe.psi_inv
+        # ψ⁻¹ is written over the recipe's FULL carrier; this term holds the pivot plus whichever
+        # channels have fused so far, so it is restricted to those slots before instantiation — a
+        # half-fused carrier (the denominator in, the expectation not yet) is the ordinary case
+        # during the rewrite's own fixpoint.
+        slots = (0, *(1 + channel for channel in self.twist.channels))
+        wanted = tuple(psi_inv.results[slot] for slot in slots)
+        members = tuple(psi_inv.body.backward_cone(wanted).members)
+        restricted = Lambda(params=tuple(psi_inv.params[slot] for slot in slots), body=Body(members), results=wanted)
+        taken = {name for stmt in applied.body for name in stmt.defines()} | set(applied.params)
+        names = dict(zip(restricted.params, applied.results, strict=True))
+        names.update((stmt.name, stmt.name if stmt.name not in taken else f"_b_{stmt.name}") for stmt in members)
+        instance = restricted.rename(names)
+        return Lambda(params=applied.params, body=Body((*applied.body, *instance.body)), results=instance.results)
 
     @cached_property
     def roles(self) -> tuple[str, ...]:
@@ -508,7 +533,8 @@ class Fold:
         if not channels:
             return None
         channel, b_edge = channels[0]
-        product = _channel_product(self.lift, self.lift.results[channel])[1].op
+        based = self.based()
+        product = _channel_product(based, based.results[channel])[1].op
         plus = self.base.components()[channel]
         a_edge = self.operands[0]
         a_space, b_space = a_edge.free_axes, b_edge.free_axes
@@ -617,14 +643,17 @@ class Fold:
         a_edge = self.operands[0]
         a_names = {param for param, edge, _ in self.bindings if edge is a_edge}
         uniform = {param for param, edge, _ in self.bindings if edge is not a_edge and not edge.free_axes}
+        based = self.based()  # bilinearity lives in BASE coordinates; ψ divides the product away
         out: list[tuple[int, Fold]] = []
-        for index, result in enumerate(self.lift.results):
-            cone, product = _channel_product(self.lift, result)
+        for index, result in enumerate(based.results):
+            cone, product = _channel_product(based, result)
             if product is None or len(product.args) != 2:
                 continue  # a state the carrier passes through, or one whose cone ends in no product
             plus = pluses[index]
-            if not (plus.associative and plus.commutative and plus.has_identity) or self.init[index] != plus.identity:
+            if not (plus.associative and plus.commutative and plus.has_identity):
                 continue
+            if self.twist is None and self.init[index] != plus.identity:
+                continue  # a planar fold seeds the ⊕ itself; a recipe's base is a monoid by construction
             if not product.op.distributes_over(plus):
                 continue
             left = [arg for arg in product.args if _over_a(arg, cone, a_names, uniform)]
@@ -852,9 +881,11 @@ class Fold:
             # The carrier's states: the pivot's, then every channel in recipe order — the matched
             # one is this fold's own state, one without a pattern a state the recipe adds. Each
             # takes the recipe's BASE contribution for it (``lift``'s own result), instantiated at
-            # the score and this channel's extras: the term stores what the recipe declares, and ψ
-            # is applied at lowering (:attr:`injected`). The SEEDS stay the carrier's — the state
-            # is the stable one, only the per-element contribution is the base's.
+            # the score and this channel's extras. STABLE coordinates throughout: the contribution
+            # stored is the recipe's authored INJECTION — the singleton in the carrier's own state
+            # space, where the pivot IS the score and softmax's ``exp(s)·v`` has already simplified
+            # to ``v``. The base contribution is a derived reading (:meth:`based`) a matcher asks
+            # for and nothing emits. Seeds are the carrier's, as the states are.
             state = view.states[0]
             score = pivot.lift.results[0]
             added = [
@@ -871,7 +902,7 @@ class Fold:
             body, results, inits = list(pivot.lift.body), list(pivot.lift.results), list(pivot.init)
             for name, index, init in added:
                 taken = {n for stmt in body for n in stmt.defines()} | {p for _, slot in held for p in slot}
-                cone = recipe.lift.cone(recipe.lift.results[1 + index])
+                cone = recipe.channels[index].injection
                 names = {param: roles[param] for param in cone.params}
                 # Statement by statement, so a channel BINDS what the body already computes rather
                 # than spelling it again: softmax's denominator and its expectation share the whole

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -643,10 +643,14 @@ class Fold:
         pluses = self.base.components()
         if pluses is None:
             return ()
-        by_name = {param: edge for param, edge, _ in self.bindings}
+        # Keyed by the name the walk below READS — the operand's own result, since ``based`` is
+        # spelled over ``applied``. A term's param usually carries its operand's name and the two
+        # agree by accident; a cut renames the operand's result to its workspace and they part,
+        # which lost B and with it the whole channel.
+        by_name = {edge.exposes[index]: edge for _param, edge, index in self.bindings}
         a_edge = self.operands[0]
-        a_names = {param for param, edge, _ in self.bindings if edge is a_edge}
-        uniform = {param for param, edge, _ in self.bindings if edge is not a_edge and not edge.free_axes}
+        a_names = {edge.exposes[index] for _param, edge, index in self.bindings if edge is a_edge}
+        uniform = {edge.exposes[index] for _param, edge, index in self.bindings if edge is not a_edge and not edge.free_axes}
         based = self.based()  # bilinearity lives in BASE coordinates; ψ divides the product away
         out: list[tuple[int, Fold]] = []
         for index, result in enumerate(based.results):

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -466,7 +466,11 @@ class Fold:
         the :class:`~emmy.compiler.ir.pure.twist.Twist` closes this with no walk at all.
         """
         bound = {param: (edge, index) for param, edge, index in self.bindings}
-        carried = set(self.lift.results)
+        # A result the body DEFINES is the recipe's own derived channel. A result that is a bare
+        # param is the opposite: the channel passes an operand component through untouched, which
+        # is exactly what a role is — stable coordinates spell attention's expectation as the
+        # streamed value itself, so testing every result would hide the one role it names.
+        carried = {name for stmt in self.lift.body for name in stmt.defines()} & set(self.lift.results)
         extras: list[str] = []
         for result in self.lift.results[1:]:
             for param in self.lift.cone(result).params:
@@ -926,6 +930,11 @@ class Fold:
             # replaced the statements that read it.
             read = {name for stmt in body for name in stmt.deps()} | set(results)
             held = [entry for entry in held if not read.isdisjoint(entry[1])]
+            # B SECOND. A leads by canonical form; a bilinear channel's other factor must follow it,
+            # because staging and both atom tiers take B from ``operands[1]`` rather than asking the
+            # channel. An operand with no free coordinates — attention's scale — is no channel's
+            # factor at all, so it sorts behind the streamed value instead of between the pair.
+            held = [held[0], *sorted(held[1:], key=lambda entry: not entry[0].free_axes)]
             # The carrier is the RECIPE's own vector: the pivot, then the channels it holds in the
             # order the recipe declares them, whatever order the tree happened to fuse them in.
             # Softmax's is (m, D, O) whether the denominator or the expectation clicked first, so a

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -655,6 +655,18 @@ class Fold:
             return None
         return SlabView(load=self.lift.body[0])
 
+    @cached_method
+    def scalar(self) -> bool:
+        """Whether this term is ONE value for the whole kernel — no operands, no axis and no free
+        coordinates, so its body is straight-line arithmetic over scalar reads (an sdpa scale and
+        its two mask fills, an rms epsilon and its mean divisor).
+
+        Such a term DECIDES nothing. There is no residence, partition or tile to pick for a value
+        every worker holds, and a seam offered at it would launch a kernel to write one scalar to a
+        workspace so its reader could read it back — so the cut pass passes over it, exactly as the
+        node walk passes over a slab. The dump spells it inside its reader for the same reason."""
+        return self.axis is None and not self.operands and not self.free_axes and bool(self.lift.body)
+
     # ---- the DERIVED READINGS. ``Map`` and ``Contraction`` are no longer stored kinds (the
     # collapse); every field they carried reads back off the one stored term here, so their old
     # accessors keep their exact meanings and their consumers keep their exact spellings. ------- #

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -424,35 +424,29 @@ class Fold:
         the weight cone. A role the term never bound (Welford's ``1/N``, whose base contribution
         does not read it) is simply absent from the tail.
 
-        What a recipe DERIVES is not a role, and two tests are needed to say so. A recipe's lift
-        defines the weight from the score (``e = exp(s)``), and formation is free to factor that
-        definition onto an operand edge; when the score arrives as a slab beside it, the weight's
-        edge is not the score's. Reading the edge identity alone mistook the weight for the
-        streamed value and the carrier folded ``exp(s)`` where it meant to fold ``v`` — a wrong
-        answer, not a slow kernel.
+        What a recipe DERIVES is not a role, and the test is that this term also CARRIES it: results
+        line up with the recipe's lift results, so a param a result passes through is that
+        definition, however far the factoring moved it. It is also the only test that still works
+        once a cut materializes the weight into a workspace, where it is a slab like any other.
 
-        - a candidate this term also CARRIES is the recipe's own derived channel: results line up
-          with the recipe's lift results, so a param a result passes through is that definition,
-          however far the factoring moved it. This is the only test left once a cut materializes
-          the weight into a workspace, where it is a slab like any other;
-        - a candidate whose own subtree computes the SCORE is that definition too, which is what
-          catches it on a term carrying the expectation before the denominator has joined, where
-          the weight is no result yet.
+        This reads THIS NODE: its stored bindings, its own lift, and its operands' interfaces —
+        never an operand's internals. The subtree walk that used to sit beside the carried test,
+        asking by object identity whether a candidate's own cone computes the score, is gone. It
+        made a twisted carrier's lowering a function of its whole subtree and of the tree-wide
+        sharing `normalize` restores, which is not a question a node may ask.
+
+        GAP it leaves: a carrier holding the expectation before the denominator has joined has not
+        made the weight one of its results yet, so the carried test cannot see it and it reads as a
+        streamed extra. The fusion knows every role when it builds the carrier, so storing them on
+        the :class:`~emmy.compiler.ir.pure.twist.Twist` closes this with no walk at all.
         """
         bound = {param: (edge, index) for param, edge, index in self.bindings}
-        supplies = bound.get(self.lift.results[0], (None, 0))[0]
         carried = set(self.lift.results)
-
-        def derives(edge: Fold) -> bool:
-            """Whether ``edge``'s value is computed from the score's — structurally, because the
-            same read reached through two edges is two objects."""
-            return edge is supplies or edge == supplies or any(derives(operand) for operand in edge.operands)
-
         extras: list[str] = []
         for result in self.lift.results[1:]:
             for param in self.lift.cone(result).params:
                 edge, index = bound.get(param, (None, 0))
-                if edge is None or param in carried or derives(edge) or edge.exposes[index] in extras:
+                if edge is None or param in carried or edge.exposes[index] in extras:
                     continue
                 extras.append(edge.exposes[index])
         return (self.applied.results[0], *extras)
@@ -514,7 +508,7 @@ class Fold:
         if not channels:
             return None
         channel, b_edge = channels[0]
-        product = self.lift.cone(self.lift.results[channel]).body[0].op
+        product = _channel_product(self.lift, self.lift.results[channel])[1].op
         plus = self.base.components()[channel]
         a_edge = self.operands[0]
         a_space, b_space = a_edge.free_axes, b_edge.free_axes
@@ -605,7 +599,15 @@ class Fold:
         that are no product at all. The ⊕ is the BASE monoid's, componentwise by construction — a
         twist's stable ``combine`` is not, and asking it would refuse every twisted carrier. Each
         channel's ⊕ must be a commutative monoid its seed is the identity of, and the product must
-        distribute over it. Memoized on the term."""
+        distribute over it.
+
+        A is what ``operands[0]`` SUPPLIES, not what it exposes: the left factor may be a component
+        of that edge, or a value this lift computes from its components alone (attention's
+        ``e = exp(r)``, the weight over the score). Requiring a component made a carrier bilinear
+        only after its weight had been reified into an operand of its own — a node that adds no
+        computation and exists to satisfy this pattern. The reach stays inside the node: the cone
+        walked is this lift's own body, and an operand is asked for nothing but its interface.
+        Memoized on the term."""
         if self.axis is None or self.base is None or len(self.operands) < 2:
             return ()
         pluses = self.base.components()
@@ -616,20 +618,19 @@ class Fold:
         a_names = {param for param, edge, _ in self.bindings if edge is a_edge}
         out: list[tuple[int, Fold]] = []
         for index, result in enumerate(self.lift.results):
-            cone = self.lift.cone(result)
-            if len(cone.body) != 1 or not isinstance(stmt := cone.body[0], Assign) or len(stmt.args) != 2:
-                continue  # a state the carrier passes through, or one whose cone is more than a product
+            cone, product = _channel_product(self.lift, result)
+            if product is None or len(product.args) != 2:
+                continue  # a state the carrier passes through, or one whose cone ends in no product
             plus = pluses[index]
             if not (plus.associative and plus.commutative and plus.has_identity) or self.init[index] != plus.identity:
                 continue
-            if not stmt.op.distributes_over(plus):
+            if not product.op.distributes_over(plus):
                 continue
-            other = set(stmt.args) - a_names
-            if len(set(stmt.args) & a_names) != 1 or len(other) != 1:
-                continue  # a product that does not multiply A by exactly one other edge
-            edge = by_name.get(next(iter(other)))
-            if edge is not None and edge is not a_edge:
-                out.append((index, edge))
+            left = [arg for arg in product.args if _over_a(arg, cone, a_names)]
+            right = [arg for arg in product.args if (edge := by_name.get(arg)) is not None and edge is not a_edge]
+            if len(left) != 1 or len(right) != 1 or left[0] == right[0]:
+                continue  # a square, or a product that does not multiply A by exactly one other edge
+            out.append((index, by_name[right[0]]))
         return tuple(out)
 
     @cached_method
@@ -1192,6 +1193,31 @@ def _(s: Fold, rename, sigma, axis_fn):
             results=tuple(rename(r) for r in s.observe.results),
         )
     return replace(s, operands=operands, lift=lift, base=base, observe=observe)
+
+
+def _channel_product(lift: Lambda, result: str) -> tuple[Lambda, Assign | None]:
+    """One carried state's cone and the ``Assign`` that ENDS it — the product a bilinear channel
+    contributes, or ``None`` when the state is a pass-through or its cone ends in something else.
+
+    The cone may hold more than that one statement: a channel whose left factor this lift derives
+    (attention's ``e = exp(r)``) carries the derivation with it, and the product is still the
+    statement defining the result."""
+    cone = lift.cone(result)
+    stmt = next((s for s in cone.body if result in s.defines()), None)
+    return cone, stmt if isinstance(stmt, Assign) else None
+
+
+def _over_a(name: str, cone: Lambda, a_names: set[str]) -> bool:
+    """Whether ``name`` is the A factor of ``cone``'s product — a component ``operands[0]`` binds,
+    or a value the cone computes from those components ALONE.
+
+    The second reading is what lets a carrier read bilinear before its weight is reified. It walks
+    the cone, which is this lift's own body, and never an operand's internals: a name bound to any
+    other edge closes back as itself and fails the test."""
+    if name in a_names:
+        return True
+    reads = set(cone.cone(name).params)
+    return bool(reads) and reads <= a_names
 
 
 def _writes_under(term: Fold, writing: set[int]) -> bool:

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -616,6 +616,7 @@ class Fold:
         by_name = {param: edge for param, edge, _ in self.bindings}
         a_edge = self.operands[0]
         a_names = {param for param, edge, _ in self.bindings if edge is a_edge}
+        uniform = {param for param, edge, _ in self.bindings if edge is not a_edge and not edge.free_axes}
         out: list[tuple[int, Fold]] = []
         for index, result in enumerate(self.lift.results):
             cone, product = _channel_product(self.lift, result)
@@ -626,8 +627,8 @@ class Fold:
                 continue
             if not product.op.distributes_over(plus):
                 continue
-            left = [arg for arg in product.args if _over_a(arg, cone, a_names)]
-            right = [arg for arg in product.args if (edge := by_name.get(arg)) is not None and edge is not a_edge]
+            left = [arg for arg in product.args if _over_a(arg, cone, a_names, uniform)]
+            right = [arg for arg in product.args if (edge := by_name.get(arg)) is not None and edge is not a_edge and edge.free_axes]
             if len(left) != 1 or len(right) != 1 or left[0] == right[0]:
                 continue  # a square, or a product that does not multiply A by exactly one other edge
             out.append((index, by_name[right[0]]))
@@ -872,13 +873,26 @@ class Fold:
                 taken = {n for stmt in body for n in stmt.defines()} | {p for _, slot in held for p in slot}
                 cone = recipe.lift.cone(recipe.lift.results[1 + index])
                 names = {param: roles[param] for param in cone.params}
-                names.update((stmt.name, stmt.name if stmt.name not in taken else f"{name}__{stmt.name}") for stmt in cone.body)
-                instance = cone.rename(names)
-                body.extend(instance.body)
-                results.append(instance.results[0])
+                # Statement by statement, so a channel BINDS what the body already computes rather
+                # than spelling it again: softmax's denominator and its expectation share the whole
+                # weight prefix, and instantiating each cone whole put two ``exp(s)`` in one lift.
+                have = {(stmt.op, stmt.args): stmt.name for stmt in body if isinstance(stmt, Assign)}
+                for stmt in cone.body:
+                    spelled = stmt.rewrite(lambda read, names=names: names.get(read, read))
+                    if isinstance(spelled, Assign) and (prior := have.get((spelled.op, spelled.args))) is not None:
+                        names[stmt.name] = prior
+                        continue
+                    fresh = stmt.name if stmt.name not in taken else f"{name}__{stmt.name}"
+                    names[stmt.name] = fresh
+                    spelled = replace(spelled, name=fresh)
+                    body.append(spelled)
+                    taken.add(fresh)
+                    if isinstance(spelled, Assign):
+                        have[(spelled.op, spelled.args)] = fresh
+                results.append(names[cone.results[0]])
                 inits.append(init)
-            _factor_weights(body, results, held, len(pivot.lift.results))
-            # An operand the factored lift no longer names is the cone's now, not the carrier's.
+            # An operand the lift no longer names is nobody's — the recipe's own contribution
+            # replaced the statements that read it.
             read = {name for stmt in body for name in stmt.deps()} | set(results)
             held = [entry for entry in held if not read.isdisjoint(entry[1])]
             # The carrier is the RECIPE's own vector: the pivot, then the channels it holds in the
@@ -1207,17 +1221,22 @@ def _channel_product(lift: Lambda, result: str) -> tuple[Lambda, Assign | None]:
     return cone, stmt if isinstance(stmt, Assign) else None
 
 
-def _over_a(name: str, cone: Lambda, a_names: set[str]) -> bool:
+def _over_a(name: str, cone: Lambda, a_names: set[str], uniform: set[str]) -> bool:
     """Whether ``name`` is the A factor of ``cone``'s product — a component ``operands[0]`` binds,
-    or a value the cone computes from those components ALONE.
+    or a value the cone computes from those components and kernel-UNIFORM ones alone.
 
     The second reading is what lets a carrier read bilinear before its weight is reified. It walks
     the cone, which is this lift's own body, and never an operand's internals: a name bound to any
-    other edge closes back as itself and fails the test."""
+    other edge closes back as itself and fails the test.
+
+    ``uniform`` are the components of operands with no free coordinates — attention's scale, an rms
+    epsilon. One contributes no variation, so a factor reading it varies exactly as A does and the
+    channel is bilinear all the same. Without them the weight ``exp(a·scale)`` reads as a product
+    of A with a second varying value and no mma is offered at all."""
     if name in a_names:
         return True
     reads = set(cone.cone(name).params)
-    return bool(reads) and reads <= a_names
+    return bool(reads & a_names) and reads <= a_names | uniform
 
 
 def _writes_under(term: Fold, writing: set[int]) -> bool:
@@ -1234,23 +1253,6 @@ def _writes_under(term: Fold, writing: set[int]) -> bool:
     return False
 
 
-def _already_held(stmt: Assign, held: list[tuple[Fold, tuple[str, ...]]]) -> str | None:
-    """The param of an operand component this statement recomputes, or ``None``.
-
-    A hoisted cone keeps the spellings it took with it, so the reader's params and the edge's own
-    results are the same names and the two programs compare directly.
-    """
-    for edge, slot in held:
-        if edge.axis is not None:
-            continue
-        definitions = edge.lift.body.definitions
-        for param, name in zip(slot, edge.exposes, strict=True):
-            own = definitions.get(name)
-            if isinstance(own, Assign) and own.op == stmt.op and own.args == stmt.args:
-                return param
-    return None
-
-
 def _slots(params: tuple[str, ...], edges) -> list[tuple[str, ...]]:
     """``params`` cut into one group per edge — the positional binding, one param per result component."""
     out, cursor = [], 0
@@ -1258,59 +1260,6 @@ def _slots(params: tuple[str, ...], edges) -> list[tuple[str, ...]]:
         out.append(tuple(params[cursor : cursor + len(edge.exposes)]))
         cursor += len(edge.exposes)
     return out
-
-
-def _factor_weights(body: list[Stmt], results: list[str], held: list[tuple[Fold, tuple[str, ...]]], start: int) -> None:
-    """Hoist a channel's WEIGHT into an operand of its own, so the channel reads as a contraction.
-
-    A twisted carrier's expectation channel contributes ``weight ⊗ value`` — one monomial, but the
-    weight is a cone over the score, so as it stands the product multiplies a body definition by an
-    operand and no bilinear reading applies. Hoisting that cone out is what the semiring formation
-    already does for a matmul's decoded A, and it leaves the channel a bare product of two operand
-    edges: A first, B second, exactly where every reader of a contraction looks for them.
-
-    Every OTHER contribution the cone computes travels with it — the score the pivot folds, the
-    weight the denominator folds — so one cone serves the whole carrier and there is one score node
-    under it. Those results keep their spellings, so what was a body definition becomes a param and
-    nothing renames.
-
-    Only the results from ``start`` on are the channels this fusion added; the ones before them are
-    the pivot's own, already factored when it was built. ``body`` and ``held`` are rewritten in place.
-    """
-
-    def hoist(name: str) -> None:
-        members = tuple(Body(tuple(body)).backward_cone((name,)).members)
-        defined = {n for stmt in members for n in stmt.defines()}
-        carried = [result for result in results if result in defined]
-        if name not in carried:
-            carried.append(name)
-        reads = {n for stmt in members for n in stmt.deps()} - defined
-        inner = [(edge, slot) for edge, slot in held if not reads.isdisjoint(slot)]
-        cone = Fold(
-            operands=tuple(edge for edge, _ in inner),
-            lift=Lambda.closing(tuple(param for _, slot in inner for param in slot), Body(members), tuple(carried)),
-        )
-        body[:] = [stmt for stmt in body if defined.isdisjoint(stmt.defines())]
-        held.insert(0, (cone, tuple(carried)))  # A leads: ``operands[0]`` is what the product multiplies
-
-    for position, result in enumerate(results[start:], start):
-        product = {stmt.name: stmt for stmt in body}.get(result)
-        if isinstance(product, Assign) and (already := _already_held(product, held)) is not None:
-            # The denominator's contribution IS the weight the expectation's product multiplies by,
-            # so it binds that operand instead of computing a second copy of it.
-            results[position] = already
-            body[:] = [stmt for stmt in body if stmt is not product]
-            continue
-        if not isinstance(product, Assign) or len(set(product.args)) != 2:
-            continue  # not a monomial over two distinct values — Welford's square is one edge, not a pair
-        bound = {param for _, slot in held for param in slot}
-        free = [arg for arg in product.args if arg not in bound]
-        if len(free) != 1:
-            continue  # already a bare product of operand edges, or a shape this rule cannot orient
-        hoist(free[0])
-        streamed = next((index for index, (_, slot) in enumerate(held) if index and not set(slot).isdisjoint(product.args)), None)
-        if streamed is not None:
-            held.insert(1, held.pop(streamed))  # B second, so the pair reads off the operands in order
 
 
 __all__ = [

--- a/emmy/compiler/ir/schedule/classic_projection.py
+++ b/emmy/compiler/ir/schedule/classic_projection.py
@@ -316,9 +316,12 @@ def _contraction_domain(
     wide_warp_tiles = tuple(
         plan for name in allowed_atoms if _kstep_refusal(facts.k_axis, (plan := Tile(atom=ATOM_REGISTRY[name], regs=(26, 4), bk=2))) is None
     )
-    # The scalar register tier folds the STORED lift, which for a twist is the base contribution
-    # and denotes ``Sum exp(score)``: only the atom tier folds the recipe's chunk patterns instead,
-    # so a twisted carrier's untiled arm is the plain serial fold and nothing between.
+    # The scalar register tier folds ONE additive accumulator per cell — ``acc__c{i}_{j} += b·a``,
+    # its multiply, its add and its single state all fixed. A twisted carrier folds three states
+    # under their own ops and seeds with the recipe's stable merge between them, which only the
+    # chunk tier does; a register tile on one reads cell copies of the states nothing declares.
+    # NOT a numerics gate any more: the term stores the STABLE contribution and ``Fold.step`` folds
+    # it under the recipe's own ⊕, so the untiled arm is sound. The tier's shape is what refuses.
     scalar_tiles = scalar_tile_moves() if len(node.operands) == 2 and node.twist is None else (Tile(),)
     catalog = (
         *scalar_tiles,

--- a/emmy/compiler/ir/schedule/classic_projection.py
+++ b/emmy/compiler/ir/schedule/classic_projection.py
@@ -207,9 +207,15 @@ def _chunk_refusal(tile: TileOp, node) -> str | None:
         return "the chunk tier folds a carrier whose pivot a nested contraction supplies"
     if any(edge.as_slab() is None for edge in (*score.operands, *node.operands[1:])):
         return "the chunk tier reads its score operands and its streamed value as slabs"
-    cone = node.operands[0].applied.cone(node.roles[0])
-    if any(not isinstance(stmt, (Assign, Load)) for stmt in cone.body):
-        return "the score's own cone holds more than a straight-line program"
+    # The score's own PREFIX is the CARRIER's lift cut to its score role — A is the score
+    # contraction, and what scales its raw accumulator lives in the lift above it. Its leaves past
+    # the producer are read once ahead of the chunk, so none of them may vary over the chunk.
+    prefix = node.applied.cone(node.roles[0])
+    if any(not isinstance(stmt, (Assign, Load)) for stmt in prefix.body):
+        return "the score's own prefix holds more than a straight-line program"
+    leaves = [edge for edge in node.operands[1:] if set(edge.exposes) & set(prefix.params)]
+    if any(node.axis in edge.free_axes for edge in leaves):
+        return "the score's prefix reads an operand that varies over the chunk"
     # The tier holds ONE accumulator — the expectation — and every other carried state as a per-row
     # register the store may read but not write out. A cross-CTA split's partial writes the whole
     # carrier to its workspace, which is a kernel this tier cannot produce.

--- a/emmy/compiler/ir/schedule/classic_projection.py
+++ b/emmy/compiler/ir/schedule/classic_projection.py
@@ -153,8 +153,13 @@ def _node_refusal(tile: TileOp, target, node, fragment_epilogue: bool, packed: t
         return "the projection epilogue is not a per-fragment straight-line program"
     # The operand tuple in stored order — there is no named A/B role any more, and a nested
     # scheduling site on ANY operand refuses the same way.
-    if any(edge.axis is not None for edge in node.operands):
+    if any(edge.axis is not None for edge in node.operands) and not node.chunked():
         return "a nested scheduling site inhabits an operand edge"
+    # A CHUNKED carrier is the one exception: its A IS the score contraction, so A reduces. That is
+    # the tier's own shape — the chunk's score is the producer's tile — and the fragment agreement
+    # composed in ``extend`` is what holds the two to one atom. It only reached here as a zero-axis
+    # cone with the contraction nested under it while the fusion still minted that cone, so the
+    # blanket refusal never saw the case it was not written about.
     if node.chunked() and (why := _chunk_refusal(tile, node)) is not None:
         return why
 

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -85,6 +85,15 @@ seam wherever it is closed at the axes of every occurrence, and kernel lowering 
 statements that read them. A computed operand (the RMSNorm'd, RoPE'd K vector) is materializable once per key rather
 than recomputed per query row because it is such a closed cone.
 
+An operand result component NO READER READS is dropped, and the edge's body cut to what its surviving results need.
+A reader is a consuming lift or a kernel-boundary store, so a sweep's per-cell projection keeps what its `Write` names
+even though no lift binds it. The dead components are rewrite residue: the twisted fusion re-seats a carrier's channels
+and mints `_unread<i>` for a slot its reader stopped binding, and an epilogue cone beside it keeps exposing a scale that
+was live when it was formed and went dead when the folds fused. Only a zero-axis operand is restricted — a reducing
+one's components ARE its carried states, and dropping one changes the monoid, which is why attention's running maximum
+stays spelled as the `_unread` it honestly is. The rule is tree-wide and unions over readers, because restricting per
+occurrence would sever the object sharing the next paragraph restores.
+
 An identity pass-through — a projection that only re-exposes its single operand's results — dissolves wherever a
 projection is formed or revisited. That is not cosmetic: a pass-through is what makes two occurrences of the same
 computation compare unequal, and the placement fork's value clustering (`lowering/tile/_cut.py`) relies on

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -225,15 +225,23 @@ which contraction normalization has placed those statistics inside a computed no
 Normalization factors remain in the projection epilogue, while a directly loaded expectation value becomes a Fold
 operand.
 
-What the fused fold STORES is the recipe's own vocabulary: the BASE monoid's per-element contribution as its `lift`,
-that monoid's componentwise ⊕ as its `base`, and the recipe itself — bound to this term's roles — as its `twist`. Both
-halves the term does not store follow from that pair: the stable ⊕ (`Fold.combine`) and the ψ-image of the lift
-(`Fold.injected`), which is the singleton the serial step actually folds. Storing the base is what leaves attention's
-expectation channel spelled as `weight ⊗ value` in the term rather than buried in a rescale program, and the weight's
-cone becomes an operand of its own, so the channel is a bare product of two operand edges. Nothing may see through ψ:
-the base form denotes `Sum exp(score)`, so the step reads the recipe's authored per-channel injections instead of
-evaluating ψ on it, and an operand no rendered statement reads — the weight cone, on the serial nest — is not placed
-at all.
+The fused fold stores its contribution in STABLE coordinates — the carrier's own state space. Its `lift` is the
+recipe's authored injection at the singleton, where the pivot IS the score and softmax's `exp(s)·v` has already
+simplified to `v`; its `init` is that carrier's seed; and the recipe, bound to this term's roles, is its `twist`. So
+softmax's carrier spells `(score, 1, value)` and no term anywhere holds an `exp` of an unshifted score. The stable ⊕
+(`Fold.combine`) derives from the recipe, and `Fold.injected` is the lift itself: the term stores what the step folds.
+
+The base monoid rides beside it as a HELPER — `base` is its componentwise ⊕, and ψ comes from the recipe. `Fold.based`
+is the reading they exist for: `psi_inv` applied to the stored lift, restoring `(s, exp s, exp(s)·v)` so a matcher can
+see the expectation channel as a bare product. Bilinearity lives in base coordinates and nowhere else, because ψ
+divides the product away at the singleton. That reading is RECOGNITION ONLY — the base form denotes `Sum exp(score)`
+and overflows — so `bilinear_channels` and `as_contraction` ask for it and nothing emits it. ψ⁻¹ is written over the
+recipe's full carrier and is restricted to the channels a term actually holds, since a half-fused carrier is the
+ordinary case during the rewrite's own fixpoint.
+
+Nothing is minted to make that reading work. A is what `operands[0]` SUPPLIES, not what it exposes: the left factor
+may be a component of that edge or a value the reading derives from those components and kernel-uniform ones (a scale,
+an epsilon — one contributes no variation, so the factor varies exactly as A does).
 
 ### One reading for "a tier folds this whole"
 

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -35,10 +35,12 @@ from emmy.compiler.ir.tile.ops import axis_names, sched_of
 # the slot it held leaves the signature with it. That is not derived material — the statements
 # printed are the edge's own.
 #
-# A lift prints APPLIED: every operand-bound param spelled as the operand result it binds, so the
-# signature echoes the brackets above it name for name. An α-rename between a producer and its
-# consumer is spelling, not computation, and where the consumer has no name at all the twist rewrite
-# supplies ``_unread<i>`` — which says less than the operand's own name for the same value.
+# A lift prints APPLIED, and only the slots it USES: every operand-bound param is spelled as the
+# operand result it binds, so the bracket above resolves which component it is and an unread one can
+# go. An α-rename between a producer and its consumer is spelling, not computation, and where the
+# consumer has no name at all the twist rewrite supplies ``_unread<i>`` — which says less than the
+# operand's own name for the same value. The binding ARITY leaves the signature with them; it stays
+# on the bracket directly above, which is where the component names are read from anyway.
 #
 # Schedule choices are not on the term at all. The owning ``TileOp`` supplies one complete
 # generic ``Schedule`` whose node choices annotate their canonical sites.
@@ -94,7 +96,8 @@ def _lam_sig(lam, ctx: _Ctx | None = None, drop: frozenset[str] = frozenset()) -
     A non-empty CAPTURE set is spelled between the params and the results — without it a λ that
     reads an enclosing value would print as though it were closed, which is the one property the
     reader most needs (an unclosed subtree can never become an operand edge). ``drop`` are the
-    slots of inlined scalar operands (:func:`_inlined`), which the body now defines."""
+    operand slots the branch does not spell — an inlined scalar's (:func:`_inlined`), which the body
+    now defines, and one this reader never reads, which the bracket above it already names."""
     rs = ", ".join(lam.results)
     cap = ctx.captures(lam) if ctx is not None else ()
     free = f" [captures {', '.join(cap)}]" if cap else ""
@@ -195,7 +198,15 @@ def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
     # it has no name to offer. The producer's spelling is the one the term is rendered in anyway
     # (``step``, ``exposes``, ``lower`` all read through it), so this is the tree's one name per
     # value rather than a second one per consumer.
+    #
+    # And only the slots it USES. Once a param is spelled by the operand result it binds, the
+    # bracket one line up resolves which component it is, so listing the rest buys nothing but
+    # length — and hides the one thing worth reading, that attention's two consumers of one carrier
+    # take different states off it. Only an operand slot can go: a trailing coordinate is in the
+    # signature BECAUSE the body reads it, and the iteration var is the fold's own.
     lift = node.applied
+    read = frozenset(lift.body.ssa_uses) | frozenset(lift.results)
+    dropped |= frozenset(name for edge in node.operands for name in edge.exposes if name not in read)
     items.append((f"lift: {_lam_sig(lift, ctx, dropped)}", _stmts((*scalars, *lift.body), ctx)))
     # The ⊕ is STORAGE only as ``base``; the twisted conjugate is derived from it and the recipe
     # (``combine = psi(psi_inv(x) base psi_inv(y))``), so a twisted node names the recipe in its

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -29,6 +29,12 @@ from emmy.compiler.ir.tile.ops import axis_names, sched_of
 # ``lift`` + ``combine`` and contributed no schedule site on seven of them. ``--ir loop`` is where
 # a reader goes for a body.
 #
+# The ONE structure it does not draw as a branch is a SCALAR operand (:meth:`Fold.scalar`) — an
+# sdpa scale, an rms epsilon. Nothing decides at one, so its branch would be a line of tree art
+# around a constant; it is spelled inside the reader that binds it (:func:`_inlined`) instead, and
+# the params it bound leave the signature with it. That is not derived material — the statements
+# printed are the edge's own, under the reader's names for them.
+#
 # Schedule choices are not on the term at all. The owning ``TileOp`` supplies one complete
 # generic ``Schedule`` whose node choices annotate their canonical sites.
 # --------------------------------------------------------------------------- #
@@ -76,17 +82,18 @@ class _Ctx:
         return f"   ⟨{' '.join(bits)}⟩" if bits else ""
 
 
-def _lam_sig(lam, ctx: _Ctx | None = None) -> str:
+def _lam_sig(lam, ctx: _Ctx | None = None, drop: frozenset[str] = frozenset()) -> str:
     """A lambda's one-line signature. A float result is the ι literal injected in the lift
     (softmax's singleton ``(x, 1)``), which has no def to name.
 
     A non-empty CAPTURE set is spelled between the params and the results — without it a λ that
     reads an enclosing value would print as though it were closed, which is the one property the
-    reader most needs (an unclosed subtree can never become an operand edge)."""
+    reader most needs (an unclosed subtree can never become an operand edge). ``drop`` are the
+    params bound to inlined scalar operands (:func:`_inlined`), which the body now defines."""
     rs = ", ".join(lam.results)
     cap = ctx.captures(lam) if ctx is not None else ()
     free = f" [captures {', '.join(cap)}]" if cap else ""
-    return f"λ({', '.join(lam.params)}){free} -> ({rs})"
+    return f"λ({', '.join(p for p in lam.params if p not in drop)}){free} -> ({rs})"
 
 
 def _axis_span(axis) -> str:
@@ -145,6 +152,26 @@ def _edge(edge, ctx: _Ctx, result: str | None = None) -> tuple[str, object]:
     return f"{head}: {_head(edge, ctx)}   ‹computed›", _subtree(edge, ctx)
 
 
+def _inlined(node) -> tuple[set[int], frozenset[str], tuple]:
+    """The SCALAR operand edges spelled inside their reader — ``(their ids, the params they bind,
+    their statements)``, the statements renamed onto those params.
+
+    A scalar term (:meth:`Fold.scalar`) is one value for the whole kernel. Its own branch carries
+    nothing a reader wants: no residence to print, no schedule keyed against it, no seam offered at
+    it — just an indirection between a scale and the multiply that reads it. So it is spelled where
+    it is read, at the head of the reader's body, and the params it bound leave the signature with
+    it. A scalar edge has no params of its own, so the rename touches its defs alone."""
+    hidden = {id(edge) for edge in node.operands if edge.scalar()}
+    if not hidden:
+        return hidden, frozenset(), ()
+    params, stmts = [], []
+    for edge in (e for e in node.operands if id(e) in hidden):
+        rename = {edge.exposes[index]: param for param, bound, index in node.bindings if bound is edge}
+        params.extend(rename.values())
+        stmts.extend(edge.lift.rename(rename).body)
+    return hidden, frozenset(params), tuple(stmts)
+
+
 def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
     """A node's STORED children, each a labelled branch with operand bindings explicit. Nothing
     derived: the step, the synthesized nodes inside it and the lowered nest are all consequences
@@ -154,13 +181,14 @@ def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
         return items
     # Stored operand order IS the presentation: a contraction's A is ``operands[0]`` by canonical
     # form, and each edge's bracket names the positional lift param it binds.
-    items += [_edge(e, ctx) for e in node.operands]
+    hidden, dropped, scalars = _inlined(node)
+    items += [_edge(e, ctx) for e in node.operands if id(e) not in hidden]
     if node.axis is not None:
         init = ", ".join(x if isinstance(x, str) else format(x, "g") for x in node.init)
         items.append((f"init: ({init})", lambda cont: []))
     # Always emitted, even for an empty body: the branch carries the SIGNATURE, and a node's
     # binder is storage whether or not it computes anything (an identity projection binds too).
-    items.append((f"lift: {_lam_sig(node.lift, ctx)}", _stmts(node.lift.body, ctx)))
+    items.append((f"lift: {_lam_sig(node.lift, ctx, dropped)}", _stmts((*scalars, *node.lift.body), ctx)))
     # The ⊕ is STORAGE only as ``base``; the twisted conjugate is derived from it and the recipe
     # (``combine = psi(psi_inv(x) base psi_inv(y))``), so a twisted node names the recipe in its
     # header and prints one op per state here instead of the twelve-statement program.

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -32,8 +32,13 @@ from emmy.compiler.ir.tile.ops import axis_names, sched_of
 # The ONE structure it does not draw as a branch is a SCALAR operand (:meth:`Fold.scalar`) — an
 # sdpa scale, an rms epsilon. Nothing decides at one, so its branch would be a line of tree art
 # around a constant; it is spelled inside the reader that binds it (:func:`_inlined`) instead, and
-# the params it bound leave the signature with it. That is not derived material — the statements
-# printed are the edge's own, under the reader's names for them.
+# the slot it held leaves the signature with it. That is not derived material — the statements
+# printed are the edge's own.
+#
+# A lift prints APPLIED: every operand-bound param spelled as the operand result it binds, so the
+# signature echoes the brackets above it name for name. An α-rename between a producer and its
+# consumer is spelling, not computation, and where the consumer has no name at all the twist rewrite
+# supplies ``_unread<i>`` — which says less than the operand's own name for the same value.
 #
 # Schedule choices are not on the term at all. The owning ``TileOp`` supplies one complete
 # generic ``Schedule`` whose node choices annotate their canonical sites.
@@ -89,7 +94,7 @@ def _lam_sig(lam, ctx: _Ctx | None = None, drop: frozenset[str] = frozenset()) -
     A non-empty CAPTURE set is spelled between the params and the results — without it a λ that
     reads an enclosing value would print as though it were closed, which is the one property the
     reader most needs (an unclosed subtree can never become an operand edge). ``drop`` are the
-    params bound to inlined scalar operands (:func:`_inlined`), which the body now defines."""
+    slots of inlined scalar operands (:func:`_inlined`), which the body now defines."""
     rs = ", ".join(lam.results)
     cap = ctx.captures(lam) if ctx is not None else ()
     free = f" [captures {', '.join(cap)}]" if cap else ""
@@ -153,23 +158,18 @@ def _edge(edge, ctx: _Ctx, result: str | None = None) -> tuple[str, object]:
 
 
 def _inlined(node) -> tuple[set[int], frozenset[str], tuple]:
-    """The SCALAR operand edges spelled inside their reader — ``(their ids, the params they bind,
-    their statements)``, the statements renamed onto those params.
+    """The SCALAR operand edges spelled inside their reader — ``(their ids, the results they
+    contribute to the signature, their statements)``.
 
     A scalar term (:meth:`Fold.scalar`) is one value for the whole kernel. Its own branch carries
     nothing a reader wants: no residence to print, no schedule keyed against it, no seam offered at
     it — just an indirection between a scale and the multiply that reads it. So it is spelled where
-    it is read, at the head of the reader's body, and the params it bound leave the signature with
-    it. A scalar edge has no params of its own, so the rename touches its defs alone."""
-    hidden = {id(edge) for edge in node.operands if edge.scalar()}
-    if not hidden:
-        return hidden, frozenset(), ()
-    params, stmts = [], []
-    for edge in (e for e in node.operands if id(e) in hidden):
-        rename = {edge.exposes[index]: param for param, bound, index in node.bindings if bound is edge}
-        params.extend(rename.values())
-        stmts.extend(edge.lift.rename(rename).body)
-    return hidden, frozenset(params), tuple(stmts)
+    it is read, at the head of the reader's body, and the slot it held leaves the signature with it.
+    The lift prints APPLIED, so a slot is already spelled by the edge's own result name and the
+    statements splice in unrenamed."""
+    hidden = tuple(edge for edge in node.operands if edge.scalar())
+    names = frozenset(name for edge in hidden for name in edge.exposes)
+    return {id(edge) for edge in hidden}, names, tuple(stmt for edge in hidden for stmt in edge.lift.body)
 
 
 def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
@@ -188,7 +188,15 @@ def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
         items.append((f"init: ({init})", lambda cont: []))
     # Always emitted, even for an empty body: the branch carries the SIGNATURE, and a node's
     # binder is storage whether or not it computes anything (an identity projection binds too).
-    items.append((f"lift: {_lam_sig(node.lift, ctx, dropped)}", _stmts((*scalars, *node.lift.body), ctx)))
+    # APPLIED, not stored: the lift prints with every operand-bound param spelled as the operand
+    # result it binds, so the signature echoes the brackets above it name for name. What the reader
+    # calls a slot it never reads is not a fact about the computation — it is whatever the rewrite
+    # that built the reader had to hand, and the twist mints ``_unread<i>`` there precisely because
+    # it has no name to offer. The producer's spelling is the one the term is rendered in anyway
+    # (``step``, ``exposes``, ``lower`` all read through it), so this is the tree's one name per
+    # value rather than a second one per consumer.
+    lift = node.applied
+    items.append((f"lift: {_lam_sig(lift, ctx, dropped)}", _stmts((*scalars, *lift.body), ctx)))
     # The ⊕ is STORAGE only as ``base``; the twisted conjugate is derived from it and the recipe
     # (``combine = psi(psi_inv(x) base psi_inv(y))``), so a twisted node names the recipe in its
     # header and prints one op per state here instead of the twelve-statement program.

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -208,11 +208,17 @@ def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
     read = frozenset(lift.body.ssa_uses) | frozenset(lift.results)
     dropped |= frozenset(name for edge in node.operands for name in edge.exposes if name not in read)
     items.append((f"lift: {_lam_sig(lift, ctx, dropped)}", _stmts((*scalars, *lift.body), ctx)))
-    # The ⊕ is STORAGE only as ``base``; the twisted conjugate is derived from it and the recipe
-    # (``combine = psi(psi_inv(x) base psi_inv(y))``), so a twisted node names the recipe in its
-    # header and prints one op per state here instead of the twelve-statement program.
+    # A twisted node's own ⊕ is κ_S, the stable combine — that and the lift above it are what the
+    # carrier IS. It prints as a signature: the stable program is a dozen statements and ``--ir
+    # loop`` has them. ψ and the base monoid follow as HELPERS, which is what they are once the
+    # term is stored in stable coordinates — the coordinate map a matcher reads back through
+    # (:meth:`Fold.based`) and the componentwise ⊕ it conjugates. They are spelled in the RECIPE's
+    # own names, not the term's: neither is bound to this carrier and neither renames with it.
     if node.twist is not None:
-        items.append((f"base: ({', '.join(op.name for op in node.base.components())})", lambda cont: []))
+        recipe = node.twist.recipe
+        items.append((f"combine: {_lam_sig(node.combine, ctx)}", lambda cont: []))
+        items.append((f"helper: psi {_lam_sig(recipe.psi, ctx)}", _stmts(recipe.psi.body, ctx)))
+        items.append((f"helper: base = ({', '.join(op.name for op in node.base.components())})", lambda cont: []))
     elif node.combine is not None:
         items.append((f"combine: {_lam_sig(node.combine, ctx)}", _stmts(node.combine.body, ctx)))
     if node.observe is not None:

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -209,14 +209,16 @@ def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
     dropped |= frozenset(name for edge in node.operands for name in edge.exposes if name not in read)
     items.append((f"lift: {_lam_sig(lift, ctx, dropped)}", _stmts((*scalars, *lift.body), ctx)))
     # A twisted node's own ⊕ is κ_S, the stable combine — that and the lift above it are what the
-    # carrier IS. It prints as a signature: the stable program is a dozen statements and ``--ir
-    # loop`` has them. ψ and the base monoid follow as HELPERS, which is what they are once the
+    # carrier IS, so it prints like any other combine, body and all. It is the longest branch on the
+    # node and it earns the room: the rescale is where the numerics live, and a signature alone left
+    # a twisted node the only kind whose algebra the dump would not show. ψ and the base monoid
+    # follow as HELPERS, which is what they are once the
     # term is stored in stable coordinates — the coordinate map a matcher reads back through
     # (:meth:`Fold.based`) and the componentwise ⊕ it conjugates. They are spelled in the RECIPE's
     # own names, not the term's: neither is bound to this carrier and neither renames with it.
     if node.twist is not None:
         recipe = node.twist.recipe
-        items.append((f"combine: {_lam_sig(node.combine, ctx)}", lambda cont: []))
+        items.append((f"combine: {_lam_sig(node.combine, ctx)}", _stmts(node.combine.body, ctx)))
         items.append((f"helper: psi {_lam_sig(recipe.psi, ctx)}", _stmts(recipe.psi.body, ctx)))
         items.append((f"helper: base = ({', '.join(op.name for op in node.base.components())})", lambda cont: []))
     elif node.combine is not None:

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -369,7 +369,7 @@ class TileOp(Op):
 
     def __post_init__(self) -> None:
         Op.__post_init__(self)
-        normalized = normalize_fold_tree(self.op)
+        normalized = normalize_fold_tree(self.op, self.output_specs)
         # A matrix row Loop IR elided at extent one is restored as a free axis when the stores
         # prove it and the tree holds a contraction to orient on it (:func:`_implicit_unit_row`).
         unit_row = _implicit_unit_row(self.output_specs, self.place.free)

--- a/emmy/compiler/ir/tile/normalize.py
+++ b/emmy/compiler/ir/tile/normalize.py
@@ -6,7 +6,8 @@ is what only the WHOLE tree can decide: an identity projection dissolves into th
 re-exposes (a closing rewrite can leave one behind, and it is what makes two occurrences of the
 same computation compare unequal), and same-value cones become ONE shared object.
 
-INVARIANT — normalization ends with same-value cones (alpha-equal, identical captures and
+INVARIANT — normalization ends with no operand result component that no reader reads
+(:func:`_prune_unread`), and with same-value cones (alpha-equal, identical captures and
 interface names) as ONE shared object (:func:`_share_common_cones`). Object identity is how the
 placement machinery recognizes that two consumption sites read one value, so a rewrite that
 copies a cone (the close rewrites do, by design) is only sound because this final pass restores
@@ -46,6 +47,94 @@ def _normalize_fold(fold: Fold) -> Fold:
     if node.axis is None and (collapsed := _passthrough(node)) is not None:
         return collapsed
     return node
+
+
+def _binds(node: Fold) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...], tuple[str, ...]]:
+    """One node's lift params split the way the positional binding reads them —
+    ``(the leading iteration var, one slot tuple per operand, the trailing free coordinates)``."""
+    lead = node.lift.params[: 1 if node.axis is not None else 0]
+    slots, cursor = [], len(lead)
+    for edge in node.operands:
+        slots.append(node.lift.params[cursor : cursor + len(edge.exposes)])
+        cursor += len(edge.exposes)
+    return lead, tuple(slots), node.lift.params[cursor:]
+
+
+def _reads(node: Fold) -> frozenset[str] | None:
+    """The lift params ``node`` actually reads — its body's reads and its results, a result that is
+    itself a param (a pass-through) among them. ``None`` when the question cannot be answered here:
+    a term whose body holds a nested node reads through it, and a node is no ``Stmt``, so the body's
+    own read set does not cover it."""
+    if any(isinstance(stmt, Fold) for stmt in node.lift.body):
+        return None
+    return frozenset(node.lift.body.ssa_uses) | frozenset(node.lift.results)
+
+
+def _prune_unread(root: Fold, stored: frozenset[str] = frozenset()) -> Fold:
+    """Drop every operand result component no reader reads — the tree-wide dead-weight rule.
+
+    A READER is a consuming lift or a kernel-boundary store: ``stored`` names the values the output
+    specifications write, which is how a sweep's per-cell projection reaches its ``Write`` without
+    any lift binding it.
+
+    A rewrite leaves these behind: the twisted fusion re-seats the carrier's channels and mints
+    ``_unread<i>`` for a slot the reader stopped binding, and the epilogue cone beside it keeps
+    exposing an sdpa scale that was live when it was formed and went dead when the folds fused.
+    Nothing then reads either, and nothing pruned them — so the term carried components its own
+    evaluation never touches, a second copy of the loads defining them rode the cone, and every
+    consumer that spells the interface (the dump's operand brackets, a reader's signature) spelled
+    the dead half beside the live one.
+
+    Only a ZERO-AXIS operand is restricted (:meth:`Fold.exposing` cuts its body to what the kept
+    results need). A reducing operand's components ARE its carried states, and dropping one changes
+    the monoid, so a fold keeps every channel it folds however little its reader binds — which is
+    what leaves attention's running maximum spelled as the ``_unread`` it honestly is.
+
+    Tree-wide, and a UNION over readers: normalization ends with same-value cones as one shared
+    object, so restricting per occurrence would sever exactly the sharing
+    :func:`_share_common_cones` exists to restore. Identity-preserving off the replacement spine.
+    """
+    kept: dict[int, set[int]] = {}
+    opaque: set[int] = set()
+    seen: set[int] = set()
+    done: dict[int, Fold] = {}
+
+    def collect(node: Fold) -> None:
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        read = _reads(node)
+        for slots, edge in zip(_binds(node)[1], node.operands, strict=True):
+            want = kept.setdefault(id(edge), set())
+            if read is None:
+                opaque.add(id(edge))
+            else:
+                want.update(index for index, param in enumerate(slots) if param in read)
+            want.update(index for index, name in enumerate(edge.exposes) if name in stored)
+            collect(edge)
+
+    def visit(node: Fold) -> Fold:
+        if id(node) in done:
+            return done[id(node)]
+        lead, slot_table, trailing = _binds(node)
+        operands, params, same = [], [], True
+        for slots, edge in zip(slot_table, node.operands, strict=True):
+            new, want = visit(edge), kept.get(id(edge), set())
+            same = same and new is edge
+            if edge.axis is not None or id(edge) in opaque or len(want) == len(slots):
+                operands.append(new)
+                params.extend(slots)
+                continue
+            same = False
+            if want:  # else no component survives, and the operand leaves with every param it bound
+                operands.append(new.exposing(tuple(name for index, name in enumerate(edge.exposes) if index in want)))
+                params.extend(slots[index] for index in sorted(want))
+        rebuilt = node if same else replace(node, operands=tuple(operands), lift=replace(node.lift, params=(*lead, *params, *trailing)))
+        done[id(node)] = rebuilt
+        return rebuilt
+
+    collect(root)
+    return visit(root)
 
 
 def _share_common_cones(root: Fold) -> Fold:
@@ -105,8 +194,13 @@ def _share_common_cones(root: Fold) -> Fold:
     return visit(root)
 
 
-def normalize_fold_tree(root):
+def normalize_fold_tree(root, stores: tuple = ()):
     """Normalize a complete Tile IR tree bottom-up; ``None`` placeholders pass through.
+
+    ``stores`` are the kernel's output specifications. A boundary store READS a term's exposed
+    component — that is how a sweep's per-cell projection reaches its ``Write`` — so it is a reader
+    like a consuming lift, and the prune keeps what it names. They key the fixpoint stamp with the
+    tree for the same reason: one term under two boundaries has two answers.
 
     The reached fixpoint is STAMPED on the result (an
     :func:`~emmy.compiler.structural.instance_memo`): the term is immutable and the rewrite
@@ -114,20 +208,22 @@ def normalize_fold_tree(root):
     re-verification, once per ``TileOp`` construction, is what turns the pipeline quadratic."""
     if not isinstance(root, Fold):
         return root
-    if instance_memo(root, "_memo_normal"):
+    stored = frozenset(name for spec in stores for name in spec.write.values)
+    if stored in instance_memo(root, "_memo_normal"):
         return root
     normalized = root
     while True:
-        # One pass is not always the fixpoint (a collapse can expose the next pass's move), and the
-        # stamp must mean the REACHED fixpoint, so iterate here rather than relying on the next
-        # construction to finish the job.
-        again = _normalize_fold(normalized)
+        # One pass is not always the fixpoint (a collapse can expose the next pass's move, and a
+        # restricted cone's own operands go dead one level down), and the stamp must mean the
+        # REACHED fixpoint, so iterate here rather than relying on the next construction to finish
+        # the job.
+        again = _prune_unread(_normalize_fold(normalized), stored)
         if again == normalized:
             break
         normalized = again
     result = root if normalized == root else normalized
     result = _share_common_cones(result)
-    instance_memo(result, "_memo_normal")[()] = True
+    instance_memo(result, "_memo_normal")[stored] = True
     return result
 
 

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -542,10 +542,11 @@ without a placement or value-cut analysis.
 `020_twisted` is a separate algebraic rewrite over the canonical tree. It fuses every reduce that reads a reduce
 into the twisted monoid a recipe recognizes (`Fold.fuse` — the pivot's state is the operand binding, the score the
 sub-cone alpha-equal to the pivot's own map, the rest a channel's pattern by canonical form), hoisting factors
-constant along the axis out of the fold first. The fused fold stores the recipe's BASE contribution as its lift and
-names the recipe in its `twist`, so the stable ⊕ and the ψ-image the step folds are both derived rather than baked in;
-a channel whose base contribution is a product gets the other factor's cone as an operand of its own, which is what
-leaves attention's expectation channel spelled as one monomial over two operand edges. Softmax, SDPA, and causal SDPA
+constant along the axis out of the fold first. The fused fold stores the recipe's authored INJECTION as its lift —
+the singleton in the carrier's own coordinates — and names the recipe in its `twist`, so the stable ⊕ derives from it
+and the base contribution is a derived reading (`Fold.based`) that only a matcher asks for. Nothing is hoisted to make
+attention's expectation channel read bilinear: A is what `operands[0]` supplies, so the weight may stay a value the
+reading derives. Softmax, SDPA, and causal SDPA
 differ only in carrier arity and score/value lambdas; there is no operation-family matcher. Nor is there an
 attention emitter: a carrier the recipe folds chunk by chunk (`Fold.chunked`) is a TILE site like any other, and
 the tier that folds it reads the recipe's patterns and its stable ⊕, never a named shape. `040_schedule` enumerates the complete

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -383,8 +383,9 @@ an atom tier of its own instead, `_atom._FlashOps`.
 
 ### The chunk tier
 
-The tier folds the RECIPE, never the stored lift — for a twist that lift is the base contribution and denotes
-`Sum exp(score)`. Per staged K chunk (`STAGE`'s `bk_elems`, the only block it uses) it emits the score, reduces it
+The tier folds the RECIPE's patterns per chunk, not the stored lift — that lift is the SINGLETON's contribution
+(`(score, 1, value)` for softmax), which is the right thing for a serial step and says nothing about a chunk. Per
+staged K chunk (`STAGE`'s `bk_elems`, the only block it uses) it emits the score, reduces it
 per row into the chunk's pivot, instantiates each channel's `pattern` against that pivot, folds a channel that is no
 product per row and the bilinear one on tensor cores, and merges the chunk's partial through the recipe's stable ⊕
 (`Fold.merge`) once per chunk.

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -2077,14 +2077,16 @@ class _FlashOps(_MmaOps):
     """The TWISTED carrier folded one staged CHUNK at a time — attention's tensor-core form.
 
     The ordinary mma tier folds a term's own lift into one accumulator per bilinear channel. A
-    twisted carrier cannot be folded that way at all: its stored lift is the BASE contribution, and
-    the states beside its expectation are a running pivot and a denominator that are no accumulator.
-    So this tier folds the RECIPE, and takes its only block from the schedule:
+    twisted carrier cannot be folded that way at all: its stored lift is the STABLE contribution,
+    whose expectation channel is the streamed value itself, and the states beside that expectation
+    are a running pivot and a denominator that are no accumulator. So this tier folds the RECIPE,
+    and takes its only block from the schedule:
 
     - the CHUNK is ``STAGE``'s ``bk_elems`` over the carrier's own axis;
-    - the SCORE for the chunk is the nested contraction (:attr:`inner`), whose output tile is the
-      ``(m, chunk)`` pair — which is why the fragment seam requires one warp column on it and its N
-      tile to equal this node's chunk;
+    - the SCORE for the chunk is the nested contraction (:attr:`inner`) with the carrier's own
+      prefix over it — A IS that contraction, so the operand exposes the raw accumulator and the
+      lift is what scales it. Its output tile is the ``(m, chunk)`` pair, which is why the fragment
+      seam requires one warp column on it and its N tile to equal this node's chunk;
     - the chunk's PIVOT is that score's ⊕ over the chunk, one :class:`FragmentRowReduce` per row;
     - each channel folds the recipe's own ``pattern`` against that pivot — a row reduce for a
       channel that is no product, an ``mma.sync`` against the streamed operand for the one that is;
@@ -2172,7 +2174,16 @@ class _FlashOps(_MmaOps):
         assert score_tile.is_warp and seam == (key.name, 1, bk, m.reg), (
             "the score's tile is the chunk this carrier folds, one warp column wide — the fragment seam's own equation"
         )
-        cone = self.c.operands[0].applied.cone(self.c.roles[0])
+        # The score's own PREFIX: the carrier's lift cut to its score role. A is the score
+        # contraction now, so the producer exposes the RAW accumulator and the carrier's lift is
+        # what scales it — the prefix reads that result and the carrier's uniform leaves, nothing
+        # else. Both are the gate's own reading (``_chunk_refusal``).
+        prefix = self.c.applied.cone(self.c.roles[0])
+        leaves = [edge for edge in self.c.operands[1:] if set(edge.exposes) & set(prefix.params)]
+        assert all(self.c.axis not in edge.free_axes for edge in leaves), (
+            "the chunk tier reads the score's prefix leaves once, ahead of the chunk loop"
+        )
+        pre = [stmt for edge in leaves for stmt in edge.lower(axes=self.axes)]
 
         chunk = Axis(name=f"{key.name}__ck", extent=key.extent)
         base = Var(chunk.name)
@@ -2183,8 +2194,6 @@ class _FlashOps(_MmaOps):
         # gmem-direct fragment loader already does.
         ragged = not key.extent.is_static or key.extent.as_static() % bk
         bound = key.extent_expr() if ragged else None
-        # The cone's row-invariant leaves (attention's scale) are read once, ahead of the chunk loop.
-        pre = [stmt for edge in self.c.operands[0].operands if edge is not score for stmt in edge.lower(axes=self.axes)]
 
         memo: dict = {}
         body: list[Stmt] = self._score_tile(offset, mn, base, cols, bound)
@@ -2192,7 +2201,7 @@ class _FlashOps(_MmaOps):
         for i in range(m.reg):
             for j in range(cols):
                 stmts, frags, _ = _residence(
-                    cone.body,
+                    prefix.body,
                     frags={score.exposes[0]: self.frag(f"_s{i}_{j}")},
                     rows={},
                     tag=f"_w{i}_{j}_",

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -204,8 +204,10 @@ def _workspace_dtypes(node: Fold, tile: TileOp, consumer: Fold | None, table: di
     consuming contraction) is the exception: it materializes explicitly at the dtype that
     contraction's output is stored at — the element the fused slab would have stored — never the
     carrier its cone computed in (only the ``a`` edge has a converting fill, so an f32 workspace on
-    a ``b`` edge could feed no warp atom). A seam whose dtypes stay undetermined is not offered:
-    the offer and the realization must agree, and a raise past the offer would kill the compile."""
+    a ``b`` edge could feed no warp atom). That exception is a ZERO-AXIS cone's; a REDUCING operand
+    would have been no slab fused either, so it keeps the f32 carrier (:func:`cuttable_seams` names
+    which edges the exception reaches). A seam whose dtypes stay undetermined is not offered: the
+    offer and the realization must agree, and a raise past the offer would kill the compile."""
     names = node.exposes
     if consumer is not None:
         dtype = _fed_store_dtype(tile, consumer)
@@ -271,12 +273,16 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
     apply to it."""
     all_sites = sites(tile.op)
     owners = _output_owners(tile)
+    # Only a ZERO-AXIS operand cone: the rule says the workspace holds what the fused slab would
+    # have stored, and a cone is exactly that element. A REDUCING operand — a twisted carrier's
+    # score contraction — is no slab fused either: it stays an f32 accumulator in registers, so its
+    # workspace is the carrier's own f32, and f16 scores would reach the softmax a percent off.
     store_dtype_consumers = {
         id(edge): site.node
         for site in all_sites
         if site.node.as_contraction() is not None
         for edge in site.node.operands
-        if isinstance(edge, Fold) and edge.as_slab() is None
+        if isinstance(edge, Fold) and edge.as_slab() is None and edge.axis is None
     }
     outer = tuple(axis.name for axis in (*tile.place.free, *(axis for store in tile.output_specs for axis in store.sweep)))
     occurrence_axes: dict[int, list[tuple]] = {}

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -298,6 +298,11 @@ def cuttable_seams(tile: TileOp) -> tuple[CutSite, ...]:
             # An observed fold's per-step results exist only inside its stream — a cut would
             # separate the scan from its streamed boundary store, which no piece can then spell.
             continue
+        if node.scalar():
+            # One value for the whole kernel (an sdpa scale and its mask fills). The piece would be
+            # a kernel that writes those scalars to a workspace so its reader can read them back —
+            # never the faster kernel set, and one more arm for the greedy to rank and price.
+            continue
         consumer = store_dtype_consumers.get(id(node))
         if consumer is not None and match_packed_pair_node(consumer, tile.inputs) is not None:
             # An operand cone of a BLOCK-SCALED packed pair reaches gmem already: its codes and

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -403,9 +403,9 @@ _CHUNK_ROW = {
     "PLACE": "fuse",
     "WORK": "w1x1",
     "TILE@map.1/twist": "mma_m16n8k16_f16_f32/f2x1/k2",
-    "TILE@map.1/twist.1/map.1/inner": "mma_m16n8k16_f16_f32/f2x4",
+    "TILE@map.1/twist.1/inner": "mma_m16n8k16_f16_f32/f2x4",
     "REDUCE@map.1/twist": "",
-    "REDUCE@map.1/twist.1/map.1/inner": "",
+    "REDUCE@map.1/twist.1/inner": "",
     "STAGE": "",
     "RASTER": "",
 }

--- a/tests/compiler/ir/pure/test_fold.py
+++ b/tests/compiler/ir/pure/test_fold.py
@@ -23,7 +23,7 @@ from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.pure import Fold, Lambda
 from emmy.compiler.ir.pure.twist import SOFTMAX, Twist
-from emmy.compiler.ir.stmt import Accum, Assign, Body, Loop, OutputSpec, Write
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Const, Loop, OutputSpec, Write
 from tests.compiler.terms import contraction, reduction, slab
 
 M_AXIS, N_AXIS, K_AXIS = Axis("m", Dim(8)), Axis("n", Dim(4)), Axis("k", Dim(16))
@@ -234,11 +234,11 @@ def test_an_observed_store_rides_the_reduce_loop_after_the_observer() -> None:
 
 
 def _twisted(states: tuple[str, str] = ("m", "l")) -> Fold:
-    """The exp-family ``(m, l)`` carrier in the BASE frame: the lift contributes ``(score, exp(score))``
-    to the ``(maximum, add)`` base monoid, and naming the softmax recipe is what derives both the
-    stable ⊕ and the ψ-image ``(score, 1)`` that the step actually folds."""
-    body = Body((Assign(name="s", op="copy", args=("y",)), Assign(name="e", op="exp", args=("s",))))
-    lift = Lambda.closing(("k", "y"), body, ("s", "e"))
+    """The exp-family ``(m, l)`` carrier in STABLE coordinates: the lift contributes the singleton
+    ``(score, 1)`` the carrier's own ⊕ folds, and naming the softmax recipe is what derives both
+    that ⊕ and the base reading ``(score, exp score)`` a matcher asks for."""
+    body = Body((Assign(name="s", op="copy", args=("y",)), Const(name="one", value=1.0)))
+    lift = Lambda.closing(("k", "y"), body, ("s", "one"))
     base = Lambda.componentwise(SOFTMAX.base[:2], states)
     twist = Twist(recipe=SOFTMAX, channels=(0,))
     return Fold(operands=(slab("y", "y", "m", "k"),), lift=lift, init=(-1e30, 0.0), base=base, twist=twist)
@@ -301,7 +301,7 @@ def test_the_step_is_the_merge_at_the_injected_singleton() -> None:
     ``Accum`` forms folding over the reduce axis, after the lift body."""
     fold = _twisted()
     injected = fold.injected
-    assert injected.results == ("s", "l__one"), "psi takes the base singleton (score, exp score) to (score, 1)"
+    assert injected.results == ("s", "one"), "the stored lift IS the singleton; nothing is applied to it"
     assert "e" not in {stmt.name for stmt in injected.body}, "nothing may see through psi: exp(score) overflows"
     step, merged = fold.step(), fold.merge(injected.results)
     assert tuple(step[: len(injected.body)]) == tuple(injected.body)

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -317,6 +317,46 @@ def test_key_swept_statistic_stays_when_a_sibling_reads_it() -> None:
     assert stat.axis is not None and any(stat is edge for edge in sweep.operands), "the statistic fold is shared, not copied"
 
 
+def test_normalization_prunes_an_operand_component_no_reader_reads() -> None:
+    """A rewrite can leave a cone exposing a value that went dead when the folds around it fused.
+    Normalization restricts the edge to what its reader binds and cuts the body to match, so the
+    dead half stops riding the interface and the loads defining it stop being carried twice."""
+    epilogue = projection(
+        (slab("acc", "workspace", "m"),),
+        (
+            Load(name="scale", input="sdpa_scale", index=(Literal(0, "int"),)),
+            Assign(name="v10", op="reciprocal", args=("acc",)),
+        ),
+        results=("scale", "v10"),
+    )
+    root = projection((epilogue,), (Assign(name="out", op="multiply", args=("v10", "v10")),))
+    tile = TileOp(
+        op=root,
+        name="k_epilogue",
+        place=Placement(free=(M8,)),
+        axes=(M8,),
+        output_specs=(OutputSpec(write=Write(output="o", index=(Var("m"),), values=("out",))),),
+    )
+    (edge,) = tile.op.operands
+    assert edge.exposes == ("v10",)  # ``scale`` went with the param nothing bound
+    assert tile.op.lift.params == ("v10",)
+    assert not [stmt for stmt in edge.lift.body if isinstance(stmt, Load) and stmt.input == "sdpa_scale"]
+
+
+def test_normalization_keeps_a_component_only_a_boundary_store_reads() -> None:
+    """A store is a reader too: a sweep's per-cell projection reaches its ``Write`` with no lift
+    binding it, so the prune keeps what the output specifications name."""
+    cell = projection((slab("acc", "workspace", "m"),), (Assign(name="v", op="exp", args=("acc",)),), results=("acc", "v"))
+    root = projection((cell,), (Assign(name="out", op="rsqrt", args=("acc",)),))
+    specs = (
+        OutputSpec(write=Write(output="o", index=(Var("m"),), values=("out",))),
+        OutputSpec(write=Write(output="tap", index=(Var("m"),), values=("v",))),
+    )
+    tile = TileOp(op=root, name="k_tap", place=Placement(free=(M8,)), axes=(M8,), output_specs=specs)
+    (edge,) = tile.op.operands
+    assert edge.exposes == ("acc", "v")  # ``v`` survives on the store's word alone
+
+
 def test_normalization_shares_structurally_identical_cones() -> None:
     """The tree-wide invariant: after normalization, no two DISTINCT Fold objects in the tree are
     the same value with the same interface names — copies fusion inlined into several consumption

--- a/tests/compiler/ir/tile/test_normalize.py
+++ b/tests/compiler/ir/tile/test_normalize.py
@@ -232,7 +232,7 @@ def test_promoted_attention_output_sweep_closes_the_a100_b_seam_idempotently() -
     assert all(spec.sweep == () for spec in tile.output_specs)
     assert reconstructed.op is tile.op
     # The authored seam — the score's K cone — is offered on the promoted tree.
-    assert "PLACE@map.1/twist.1/map.1/inner.2/map" in {seam.spelling for seam in cuttable_seams(tile)}
+    assert "PLACE@map.1/twist.1/inner.2/map" in {seam.spelling for seam in cuttable_seams(tile)}
 
 
 # ---- closure at formation ---------------------------------------------------------------------- #

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -147,20 +147,34 @@ def test_a_computed_edge_nests_as_a_subtree_a_materialized_one_is_a_leaf() -> No
     assert any("xhat = multiply(xhat_e, xhat_s)" in ln for ln in lines)
 
 
-def test_a_lift_prints_the_operand_name_for_every_slot_it_binds() -> None:
-    """The signature echoes the brackets above it, name for name. What a reader happens to call a
-    slot is spelling, not computation — and where it has no name at all (the twist rewrite's
-    ``_unread<i>``) its own spelling says strictly less than the operand's. The body is re-spelled
-    with it, so the two stay consistent."""
-    node = Fold(
+def _two_operand_reader() -> Fold:
+    """A reader with its own names for both slots, one of which it never reads — the shape the
+    twisted fusion leaves when it re-seats a carrier's channels."""
+    return Fold(
         operands=(_stat_fold(), _cone()),
         lift=Lambda(params=("_unread0", "w"), body=Body((Assign(name="o", op="exp", args=("w",)),)), results=("o",)),
     )
-    text = "\n".join(pretty(node))
-    assert "├─ operand[acc0]: Fold[k] reduce" in text
-    assert "└─ lift: λ(acc0, xhat) -> (o)" in text
+
+
+def test_a_lift_prints_the_operand_name_for_a_slot_it_reads() -> None:
+    """The signature spells a slot the way the operand does, so it echoes the bracket above it. What
+    a reader happens to call a slot is spelling, not computation. The body is re-spelled with it, so
+    the two stay consistent."""
+    text = "\n".join(pretty(_two_operand_reader()))
+    assert "├─ operand[xhat]: Fold  free" in text
+    assert "└─ lift: λ(xhat) -> (o)" in text
     assert "     o = exp(xhat)" in text  # the body follows the signature
-    assert "_unread0" not in text and "(w)" not in text
+    assert "(w)" not in text
+
+
+def test_a_lift_omits_a_slot_it_never_reads() -> None:
+    """Once a param is spelled by the operand result it binds, the bracket one line up resolves which
+    component it is — so a slot this reader does not use is length and nothing else. Its edge keeps
+    its branch: only the signature entry goes."""
+    text = "\n".join(pretty(_two_operand_reader()))
+    assert "├─ operand[acc0]: Fold[k] reduce" in text  # the edge is still there in full
+    assert "acc0" not in text.rsplit("lift: ", 1)[1].splitlines()[0]  # but not on the reader's line
+    assert "_unread0" not in text
 
 
 # --- a scalar operand is spelled inside its reader ------------------------------------------------ #

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -227,7 +227,9 @@ def test_a_twisted_node_prints_its_stable_combine_then_psi_and_the_base_as_helpe
         twist=Twist(recipe=SOFTMAX, channels=(0,)),
     )
     text = "\n".join(pretty(fold))
-    assert "├─ combine: λ(m, l, m__o, l__o) -> (m, l)" in text, "the stable ⊕, as a signature"
+    assert "├─ combine: λ(m, l, m__o, l__o) -> (m, l)" in text, "the stable ⊕ is the node's own algebra"
+    assert "│    m__o__alpha = exp(m__o__dg)" in text, "body and all — the rescale is where the numerics live"
+    assert "│    m__o__dg = subtract(m, m__o__gn)" in text, "and every exp argument is visibly a distance below the pivot"
     assert "├─ helper: psi λ(m, D, O) -> (m, d, o)" in text
     assert "│    d = multiply(D, f)" in text, "the coordinate map's own program, in the recipe's names"
     assert "└─ helper: base = (maximum, add)" in text

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -29,7 +29,7 @@ from emmy.compiler.ir.schedule.classic import (
     ProjectionSchedule,
     ReductionSchedule,
 )
-from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Const, Load, Loop, Write
 from emmy.compiler.ir.tile import OutputSpec, TileOp
 from emmy.compiler.ir.tile._dump import pretty
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
@@ -211,6 +211,27 @@ def test_a_scalar_operand_is_inlined_into_the_lift_that_reads_it() -> None:
     assert "     v2 = multiply(acc0, s0)" in text
     # The reduce beside it is untouched: an edge that DOES decide keeps its branch.
     assert "operand[acc0]: Fold[k] reduce   ‹computed›" in text
+
+
+def test_a_twisted_node_prints_its_stable_combine_then_psi_and_the_base_as_helpers() -> None:
+    """The carrier IS its stable lift and κ_S; ψ and the componentwise base monoid are what a
+    matcher reads back through, so they follow as helpers. κ_S prints as a signature — the stable
+    program is a dozen statements and ``--ir loop`` has them."""
+    from emmy.compiler.ir.pure.twist import SOFTMAX, Twist
+
+    fold = Fold(
+        operands=(_stat_fold(),),
+        lift=Lambda(params=("k", "acc0"), body=Body((Const(name="one", value=1.0),)), results=("acc0", "one")),
+        init=(-1e30, 0.0),
+        base=Lambda.componentwise(SOFTMAX.base[:2], ("m", "l")),
+        twist=Twist(recipe=SOFTMAX, channels=(0,)),
+    )
+    text = "\n".join(pretty(fold))
+    assert "├─ combine: λ(m, l, m__o, l__o) -> (m, l)" in text, "the stable ⊕, as a signature"
+    assert "├─ helper: psi λ(m, D, O) -> (m, d, o)" in text
+    assert "│    d = multiply(D, f)" in text, "the coordinate map's own program, in the recipe's names"
+    assert "└─ helper: base = (maximum, add)" in text
+    assert "acc0 <- " not in text  # still nothing derived from the step
 
 
 # --- nothing DERIVED reaches the dump ------------------------------------------------------------ #

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -18,7 +18,7 @@ them — never from the term; (e) a λ that is not closed says what it captures.
 from __future__ import annotations
 
 from emmy.compiler.ir.axis import Axis
-from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.expr import Literal, Var
 from emmy.compiler.ir.pure import Fold, Lambda
 from emmy.compiler.ir.schedule import Placement, Raster, Reduce, Schedule, Stage, Tile, Work
 from emmy.compiler.ir.schedule.classic import (
@@ -145,6 +145,42 @@ def test_a_computed_edge_nests_as_a_subtree_a_materialized_one_is_a_leaf() -> No
     assert any("‹materialized›" in ln and "load Wg" in ln for ln in lines)
     # The cone's own body is reached BELOW the a edge — the subtree is really rendered.
     assert any("xhat = multiply(xhat_e, xhat_s)" in ln for ln in lines)
+
+
+# --- a scalar operand is spelled inside its reader ------------------------------------------------ #
+
+
+def _scaled_scores() -> Fold:
+    """The sdpa score shape — a reduce scaled by a constant the frontend broadcast into a one-element
+    buffer. The lift closes over that buffer's read, so the scale arrives as its own operand edge."""
+    scale = projection(
+        body=(
+            Load(name="s0", input="sdpa_scale", index=(Literal(0, "int"),)),
+            Load(name="s1", input="sdpa_mask_fill", index=(Literal(0, "int"),)),
+        ),
+        results=("s0", "s1"),
+    )
+    return projection(
+        (_stat_fold(), scale),
+        (
+            Assign(name="v2", op="multiply", args=("acc0", "s0")),
+            Assign(name="v3", op="add", args=("v2", "s1")),
+        ),
+    )
+
+
+def test_a_scalar_operand_is_inlined_into_the_lift_that_reads_it() -> None:
+    """One value for the whole kernel decides nothing — no residence, no partition, no seam — so its
+    branch would be tree art around a constant. It is spelled where it is read instead, and the
+    params it bound leave the signature with it."""
+    text = "\n".join(pretty(_scaled_scores()))
+    assert "operand[s0, s1]" not in text  # no branch of its own
+    assert "lift: λ(acc0) -> (v3)" in text  # nor the params it bound
+    # Its statements open the reader's body, under the reader's own names for them.
+    assert "     s0 = load sdpa_scale[0]" in text
+    assert "     v2 = multiply(acc0, s0)" in text
+    # The reduce beside it is untouched: an edge that DOES decide keeps its branch.
+    assert "operand[acc0]: Fold[k] reduce   ‹computed›" in text
 
 
 # --- nothing DERIVED reaches the dump ------------------------------------------------------------ #

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -147,6 +147,22 @@ def test_a_computed_edge_nests_as_a_subtree_a_materialized_one_is_a_leaf() -> No
     assert any("xhat = multiply(xhat_e, xhat_s)" in ln for ln in lines)
 
 
+def test_a_lift_prints_the_operand_name_for_every_slot_it_binds() -> None:
+    """The signature echoes the brackets above it, name for name. What a reader happens to call a
+    slot is spelling, not computation — and where it has no name at all (the twist rewrite's
+    ``_unread<i>``) its own spelling says strictly less than the operand's. The body is re-spelled
+    with it, so the two stay consistent."""
+    node = Fold(
+        operands=(_stat_fold(), _cone()),
+        lift=Lambda(params=("_unread0", "w"), body=Body((Assign(name="o", op="exp", args=("w",)),)), results=("o",)),
+    )
+    text = "\n".join(pretty(node))
+    assert "├─ operand[acc0]: Fold[k] reduce" in text
+    assert "└─ lift: λ(acc0, xhat) -> (o)" in text
+    assert "     o = exp(xhat)" in text  # the body follows the signature
+    assert "_unread0" not in text and "(w)" not in text
+
+
 # --- a scalar operand is spelled inside its reader ------------------------------------------------ #
 
 

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -721,7 +721,11 @@ def test_a_scalar_operand_is_no_seam() -> None:
         ),
         results=("s0", "s1"),
     )
-    scores = contraction("k", Load(name="q", input="q", index=(Var("m"), Var("k"))), (Load(name="kk", input="k", index=(Var("n"), Var("k"))), "acc0"))
+    scores = contraction(
+        "k",
+        Load(name="q", input="q", index=(Var("m"), Var("k"))),
+        (Load(name="kk", input="k", index=(Var("n"), Var("k"))), "acc0"),
+    )
     root = projection(
         (scores, scale),
         (Assign(name="v0", op="multiply", args=("acc0", "s0")), Assign(name="v1", op="add", args=("v0", "s1"))),

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -268,8 +268,8 @@ def test_computed_operand_offers_fused_and_cut_and_pinned_cut_lowers(side: str) 
 def test_sdpa_score_cut_is_offered_and_pinned_cut_lowers(causal: bool) -> None:
     offered = _offered(_sdpa_graph(causal), frontend=True)
     assert {"PLACE": "fuse"} in offered
-    assert {"PLACE@map.1/twist.1/map.1/inner": "cut"} in offered
-    lowered = _lower_cut(_sdpa_graph(causal), "PLACE@map.1/twist.1/map.1/inner")
+    assert {"PLACE@map.1/twist.1/inner": "cut"} in offered
+    lowered = _lower_cut(_sdpa_graph(causal), "PLACE@map.1/twist.1/inner")
     cuda = [node for node in lowered.nodes.values() if type(node.op).__name__ == "CudaOp"]
     assert len(cuda) == 2 + causal  # the two pieces of the cut; the causal mask is its own pointwise kernel
     workspace = next(node.output for node in cuda if "__place_" in node.id)
@@ -291,7 +291,7 @@ def test_recorded_sdpa_cut_decodes_exactly_and_stale_path_fails_loudly() -> None
         "measurements": None,
         "ranking": None,
     }
-    assert decode_record(GoldenRecord(knobs={"PLACE@map.1/twist.1/map.1/inner": "cut"}, **fields)) is None
+    assert decode_record(GoldenRecord(knobs={"PLACE@map.1/twist.1/inner": "cut"}, **fields)) is None
     reason = decode_record(GoldenRecord(knobs={"PLACE@missing": "cut"}, **fields))
     assert reason is not None and "does not resolve" in reason
     # A route that resolves SOME of its seams is refused the same way. Evidence import is
@@ -331,7 +331,7 @@ def test_mimo_cut_preserves_both_outputs_and_lowers_both_pieces() -> None:
 
 
 def test_scoped_place_cut_is_consumed_once_by_both_pieces() -> None:
-    fragment = _nested_attention_cut({"PLACE@map.1/twist.1/map.1/inner.2/map": "cut"})
+    fragment = _nested_attention_cut({"PLACE@map.1/twist.1/inner.2/map": "cut"})
     pieces = [node for node in fragment.nodes.values() if isinstance(node.op, TileOp)]
 
     assert pieces and all(node.op.placement_decided for node in pieces)
@@ -339,7 +339,7 @@ def test_scoped_place_cut_is_consumed_once_by_both_pieces() -> None:
     match = Match(graph=fragment, root_node_id=node.id, rule=Rule(name="test", pattern=[]))
     # The pin is consumed: the rule offers nothing under PLACE again — its remaining domain (split
     # forks) or, with none pending, its skip.
-    with pinned_knobs({"PLACE@map.1/twist.1/map.1/inner.2/map": "cut"}):
+    with pinned_knobs({"PLACE@map.1/twist.1/inner.2/map": "cut"}):
         try:
             result = _CUT.rewrite(match, node)
         except RuleSkipped as skipped:
@@ -378,17 +378,17 @@ def test_composed_scoped_place_pins_cut_together_and_foreign_pins_are_skipped() 
     skipped, never an error."""
     match, graph = _case_match("attention/rmsnorm-qk-sdpa-composed-cut.yaml")
     pins = {
-        "PLACE@map.1/twist.1/map.1/inner.1/map": "cut",  # the normalized-Q cone
-        "PLACE@map.1/twist.1/map.1/inner.2/map": "cut",  # the normalized-K cone
-        "PLACE@map.1/twist.1/map.1/inner.2/map.3/map.1/reduce": "cut",  # the K statistic nested inside it
+        "PLACE@map.1/twist.1/inner.1/map": "cut",  # the normalized-Q cone
+        "PLACE@map.1/twist.1/inner.2/map": "cut",  # the normalized-K cone
+        "PLACE@map.1/twist.1/inner.2/map.3/map.1/reduce": "cut",  # the K statistic nested inside it
         "PLACE@map.9/map": "cut",  # no such site here — another kernel's pin
     }
     with pinned_knobs(pins):
         fork = _CUT.rewrite(match, graph.nodes[match.root_node_id])
     assert set(fork.knobs) == {
-        "PLACE@map.1/twist.1/map.1/inner.1/map",
-        "PLACE@map.1/twist.1/map.1/inner.2/map",
-        "PLACE@map.1/twist.1/map.1/inner.2/map.3/map.1/reduce",
+        "PLACE@map.1/twist.1/inner.1/map",
+        "PLACE@map.1/twist.1/inner.2/map",
+        "PLACE@map.1/twist.1/inner.2/map.3/map.1/reduce",
     }
     (fragment,) = fork.expand()
     pieces = [node for node in fragment.nodes.values() if isinstance(node.op, TileOp)]
@@ -401,7 +401,7 @@ def test_composed_scoped_place_pins_cut_together_and_foreign_pins_are_skipped() 
 
 def test_bare_and_scoped_place_cuts_compose_in_one_decision() -> None:
     match, graph = _case_match("attention/rmsnorm-qk-sdpa-composed-cut.yaml")
-    pins = {"PLACE": "cut", "PLACE@map.1/twist.1/map.1/inner.2/map": "cut"}
+    pins = {"PLACE": "cut", "PLACE@map.1/twist.1/inner.2/map": "cut"}
 
     with pinned_knobs(pins):
         fork = _CUT.rewrite(match, graph.nodes[match.root_node_id])
@@ -422,7 +422,7 @@ def _receipt_fields() -> dict:
         "program_wire": graph_to_wire(_sdpa_graph(False)),
         "origins": ("out",),
         "bindings": (),
-        "pins": (("PLACE@map.1/twist.1/map.1/inner", "cut"),),
+        "pins": (("PLACE@map.1/twist.1/inner", "cut"),),
         "measurements": None,
         "ranking": None,
     }
@@ -487,7 +487,7 @@ def test_evidence_rows_key_each_row_by_the_kernel_it_decides() -> None:
     from emmy.compiler.pipeline.search.golden import evidence_rows, records_override
 
     fields = {**_receipt_fields(), "measurements": {"emmy_us": 1.0, "reference_us": 2.0, "reference_backend": "torch"}}
-    route = {"PLACE@map.1/twist.1/map.1/inner": "cut"}
+    route = {"PLACE@map.1/twist.1/inner": "cut"}
     routing = GoldenRecord(knobs=route, **{**fields, "pins": ()})
     parent = GoldenRecord(knobs={}, **fields)
     lift_identity = _lifted_target(parent).identity_key(with_io=True)
@@ -553,7 +553,7 @@ def test_receipt_validation_requires_child_identity_and_place_pins_stay_live() -
                 "program": 0,
                 "target": {"origins": ["out"]},
                 "realizations": [
-                    {"name": "sdpa.child", "bindings": {}, "pins": {"PLACE@map.1/twist.1/map.1/inner": "cut"}, "knobs": {"WORK": "w4x2"}}
+                    {"name": "sdpa.child", "bindings": {}, "pins": {"PLACE@map.1/twist.1/inner": "cut"}, "knobs": {"WORK": "w4x2"}}
                 ],
             }
         ],
@@ -562,7 +562,7 @@ def test_receipt_validation_requires_child_identity_and_place_pins_stay_live() -
         validate_golden_file(document)
     document["configs"][0]["realizations"][0]["identity"] = "0" * 64
     validate_golden_file(document)
-    receipt = SimpleNamespace(pin_map={"PLACE@map.1/twist.1/map.1/inner": "cut"})
+    receipt = SimpleNamespace(pin_map={"PLACE@map.1/twist.1/inner": "cut"})
     assert regime_live(receipt), "a receipt's routing pins are its route, never a dead env regime"
 
 
@@ -693,7 +693,7 @@ def test_a_recorded_schedule_row_never_routes() -> None:
 def _cone_seam() -> CutSite:
     """A bare seam record standing in for a clustered operand cone."""
     node = projection((), (Load(name="w", input="w", index=(Var("n"), Var("k"))),), results=("w",))
-    return CutSite(node=node, spelling="PLACE@map.1/twist.1/map.1/inner.2/map", axes=(Axis("n", 8), Axis("k", 8)), dtypes=(F16,))
+    return CutSite(node=node, spelling="PLACE@map.1/twist.1/inner.2/map", axes=(Axis("n", 8), Axis("k", 8)), dtypes=(F16,))
 
 
 def test_alpha_equivalent_operand_cones_cluster_into_one_seam() -> None:

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -708,6 +708,37 @@ def test_alpha_equivalent_operand_cones_cluster_into_one_seam() -> None:
     assert len(clustered) == 1 and len(clustered[0].siblings) == 1
 
 
+def test_a_scalar_operand_is_no_seam() -> None:
+    """A value uniform over the kernel — an sdpa scale beside its mask fills — offers no cut. The
+    piece would be a kernel writing scalars to a workspace so its reader could read them back, and
+    a seam nothing realizes costs the greedy an arm per rank."""
+    from emmy.compiler.ir.expr import Literal
+
+    scale = projection(
+        body=(
+            Load(name="s0", input="sdpa_scale", index=(Literal(0, "int"),)),
+            Load(name="s1", input="sdpa_mask_fill", index=(Literal(0, "int"),)),
+        ),
+        results=("s0", "s1"),
+    )
+    scores = contraction("k", Load(name="q", input="q", index=(Var("m"), Var("k"))), (Load(name="kk", input="k", index=(Var("n"), Var("k"))), "acc0"))
+    root = projection(
+        (scores, scale),
+        (Assign(name="v0", op="multiply", args=("acc0", "s0")), Assign(name="v1", op="add", args=("v0", "s1"))),
+    )
+    tile = TileOp(
+        op=root,
+        name="k_scores",
+        place=Placement(free=(Axis("m", 8), Axis("n", 8))),
+        axes=(Axis("m", 8), Axis("n", 8), Axis("k", 8)),
+        output_specs=(OutputSpec(write=Write(output="out", index=(Var("m"), Var("n")), values=("v1",))),),
+        inputs={name: Tensor(name, (8, 8), "f16") for name in ("q", "k", "sdpa_scale", "sdpa_mask_fill")},
+        outputs={"out": Tensor("out", (8, 8), "f16")},
+    )
+    assert scale.scalar() and not scores.scalar()
+    assert [seam.node for seam in cuttable_seams(tile)] == [scores]
+
+
 def test_every_seam_is_an_unpinned_arm() -> None:
     """The unpinned fork offers every cuttable seam as its own structural arm, spelled by the same
     key the pin path resolves."""

--- a/tests/compiler/passes/test_schedule_walk.py
+++ b/tests/compiler/passes/test_schedule_walk.py
@@ -332,9 +332,9 @@ def test_every_computed_statistic_receives_a_node_id(unpinned, monkeypatch) -> N
     # the cone the carrier's product multiplies by carries it, so no second binder reaches it.
     assert reduce_keys == {
         "REDUCE@map.1/twist",
-        "REDUCE@map.1/twist.1/map.1/inner",
-        "REDUCE@map.1/twist.1/map.1/inner.1/map.2/map.1/reduce",
-        "REDUCE@map.1/twist.1/map.1/inner.2/map.2/map.1/reduce",
+        "REDUCE@map.1/twist.1/inner",
+        "REDUCE@map.1/twist.1/inner.1/map.2/map.1/reduce",
+        "REDUCE@map.1/twist.1/inner.2/map.2/map.1/reduce",
     }
 
 

--- a/tests/compiler/passes/test_twisted_rewrite.py
+++ b/tests/compiler/passes/test_twisted_rewrite.py
@@ -99,22 +99,25 @@ def _twisted(code: str) -> Fold:
 
 
 def test_softmax_rewrites_to_twisted_pair() -> None:
-    """The row maximum and the exp-weighted sum fuse into one ``(m, l)`` carrier over the BASE
-    monoid: the lift contributes ``(score, exp(score))`` off the score slab, and ψ takes that
-    singleton to ``(score, 1)`` for the step to fold."""
+    """The row maximum and the exp-weighted sum fuse into one ``(m, l)`` carrier in STABLE
+    coordinates: the lift contributes ``(score, 1)`` off the score slab — the singleton the
+    carrier's own ⊕ folds — and ψ⁻¹ brings back ``(score, exp score)`` for a matcher to read."""
     fold = _twisted("torch.softmax(torch.randn(4, 8, dtype=torch.float16), dim=-1)")
 
     assert fold.twist.recipe is SOFTMAX and fold.combine == SOFTMAX.program(fold.as_reduction().states)
     assert len(fold.init) == 2 and fold.init[1] == 0.0
     assert [edge.as_slab() is not None for edge in fold.operands] == [True], "the score slab is its one operand"
-    assert [stmt.op.name for stmt in fold.lift.body] == ["exp"], "the base contribution is (score, exp score)"
+    assert [stmt.value for stmt in fold.lift.body if isinstance(stmt, Const)] == [1.0], "the stable singleton is (score, 1)"
+    assert not [stmt for stmt in fold.lift.body if isinstance(stmt, Assign) and stmt.op.name == "exp"], "no exp in the term"
+    assert [stmt.op.name for stmt in fold.based().body if isinstance(stmt, Assign)] == ["exp", "multiply"], "psi_inv restores it"
     assert any(isinstance(stmt, Const) and stmt.value == 1.0 for stmt in fold.injected.body), "psi injects 1"
 
 
 def test_sdpa_rewrites_to_twisted_expectation() -> None:
-    """Attention's value channel joins the same carrier, and the carrier reads A × B with the
-    WEIGHT STILL IN THE LIFT: the score contraction leads, the value slab is the streamed operand,
-    and no cone is minted to hold ``exp(s)``. The ``1/l`` factor hoists into the epilogue above."""
+    """Attention's value channel joins the same carrier, stored in STABLE coordinates: the score
+    contraction leads, the value slab is the streamed operand, and the expectation channel injects
+    that value unchanged. The bilinear reading comes back through ψ⁻¹ (:meth:`Fold.based`), so no
+    cone is minted to hold ``exp(s)``. The ``1/l`` factor hoists into the epilogue above."""
     tile = _tile(
         "F.scaled_dot_product_attention("
         "torch.randn(1, 1, 4, 2, dtype=torch.float16), "
@@ -128,7 +131,7 @@ def test_sdpa_rewrites_to_twisted_expectation() -> None:
     (_, streamed) = fold.bilinear_channels()[0]
     assert streamed.as_slab() is not None and streamed.free_axes, "the value slab is B"
     assert fold.as_contraction() is not None
-    assert [stmt.name for stmt in fold.lift.body if stmt.op.name == "exp"] == ["e"], "one weight, in the lift"
+    assert not [s for s in fold.lift.body if isinstance(s, Assign) and s.op.name == "exp"], "the weight is not in the term"
     assert tile.op.axis is None and any(stmt.op.name == "multiply" for stmt in tile.op.lift.body), "the epilogue applies 1/l once"
 
 
@@ -246,8 +249,9 @@ def test_welford_variance_pair_fuses_into_one_carrier() -> None:
     score, one, mean, square = fold.lift.results
     consts = {stmt.name: stmt.value for stmt in fold.lift.body if isinstance(stmt, Const)}
     products = {stmt.name: stmt.args for stmt in fold.lift.body if isinstance(stmt, Assign) and stmt.op.name == "multiply"}
-    assert mean == score and consts[one] == 1.0, "the base contribution is (x, 1, x, x*x)"
-    assert products[square] == (score, score), "channel 3 squares one edge, so it is no contraction"
+    assert mean == score and consts[one] == 1.0, "the stable singleton is (x, 1, x, 0)"
+    assert consts[square] == 0.0, "one element deviates from its own mean by nothing"
+    assert products == {}, "no product in the term at all, so no channel reads bilinear"
     injected = {stmt.name: stmt.value for stmt in fold.injected.body if isinstance(stmt, Const)}
     assert injected[fold.injected.results[3]] == 0.0, "psi takes it to 0 — a lone element deviates from its own mean by nothing"
     lowered = fold.lower(axes=axes)

--- a/tests/compiler/passes/test_twisted_rewrite.py
+++ b/tests/compiler/passes/test_twisted_rewrite.py
@@ -112,9 +112,9 @@ def test_softmax_rewrites_to_twisted_pair() -> None:
 
 
 def test_sdpa_rewrites_to_twisted_expectation() -> None:
-    """Attention's value channel joins the same carrier, and the carrier comes out A × B: the
-    weight cone leads, the value slab is the streamed operand, and the score contraction sits under
-    the cone — one node, not one per binder. The ``1/l`` factor hoists into the epilogue above."""
+    """Attention's value channel joins the same carrier, and the carrier reads A × B with the
+    WEIGHT STILL IN THE LIFT: the score contraction leads, the value slab is the streamed operand,
+    and no cone is minted to hold ``exp(s)``. The ``1/l`` factor hoists into the epilogue above."""
     tile = _tile(
         "F.scaled_dot_product_attention("
         "torch.randn(1, 1, 4, 2, dtype=torch.float16), "
@@ -124,9 +124,11 @@ def test_sdpa_rewrites_to_twisted_expectation() -> None:
     (fold,) = _twisted_folds(tile.op)
 
     assert len(fold.init) == 3
-    cone, streamed = fold.operands
-    assert cone.axis is None and streamed.as_slab() is not None
-    assert sum(edge.as_contraction() is not None for edge in cone.operands) == 1, "the one score node"
+    assert fold.operands[0].as_contraction() is not None, "the one score node leads — A is what it supplies"
+    (_, streamed) = fold.bilinear_channels()[0]
+    assert streamed.as_slab() is not None and streamed.free_axes, "the value slab is B"
+    assert fold.as_contraction() is not None
+    assert [stmt.name for stmt in fold.lift.body if stmt.op.name == "exp"] == ["e"], "one weight, in the lift"
     assert tile.op.axis is None and any(stmt.op.name == "multiply" for stmt in tile.op.lift.body), "the epilogue applies 1/l once"
 
 

--- a/tests/compiler/passes/test_twisted_rewrite.py
+++ b/tests/compiler/passes/test_twisted_rewrite.py
@@ -21,13 +21,50 @@ from emmy.compiler.ir.cuda import CudaOp
 from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.loop import LoopOp
-from emmy.compiler.ir.pure import Fold
+from emmy.compiler.ir.pure import Fold, Lambda
 from emmy.compiler.ir.pure.twist import SOFTMAX, WELFORD
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Const, Load, Loop, Write
 from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pipeline
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import lift_loop_op
 from emmy.compiler.pipeline.passes.lowering.tile._twist import _hoist_invariant, rewrite_twisted
+from tests.compiler.terms import projection, slab
+
+
+def _carrier(weight_of: str) -> Fold:
+    """FlashAttention's carrier with the weight still IN the lift — the shape the fusion holds
+    before ``_factor_weights`` reifies ``e`` into an operand of its own. ``weight_of`` names the
+    value the weight is derived from, so the negative case differs by one argument."""
+    score = projection((slab("s", "S", "i", "j"),), (Assign(name="r", op="negative", args=("s",)),))
+    value = slab("v", "V", "j", "n")
+    return Fold(
+        operands=(score, value),
+        lift=Lambda(
+            params=("j", "r", "v"),
+            body=Body((Assign(name="e", op="exp", args=(weight_of,)), Assign(name="ev", op="multiply", args=("e", "v")))),
+            results=("r", "e", "ev"),
+        ),
+        init=(-1e30, 0.0, 0.0),
+        base=Lambda.componentwise((ElementwiseImpl("maximum"), ElementwiseImpl("add"), ElementwiseImpl("add")), ("m", "d", "o")),
+    )
+
+
+def test_a_carrier_reads_bilinear_before_its_weight_is_reified() -> None:
+    """A is what ``operands[0]`` SUPPLIES, not what it exposes: the weight the lift derives from the
+    score is the left factor, so the channel is a contraction with no operand minted for it."""
+    carrier = _carrier("r")
+    (channel, streamed) = carrier.bilinear_channels()[0]
+    assert channel == 2 and streamed is carrier.operands[1]
+    view = carrier.as_contraction()
+    assert view is not None and view.axis == "j" and view.channel == 2
+    assert set(view.left_axes) == {"i"} and set(view.right_axes) == {"n"}
+
+
+def test_a_weight_derived_from_the_streamed_value_is_no_contraction() -> None:
+    """The left factor must come from A alone. Derived from B it is a square in disguise, and
+    offering an mma for it would be a wrong answer, not a slow kernel."""
+    assert _carrier("v").bilinear_channels() == ()
+    assert _carrier("v").as_contraction() is None
 
 
 def _folds(root: Fold):

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
@@ -74,7 +74,7 @@ configs:
       REDUCE@map.1/twist.1/map.1/inner.1/map.3/map.1/reduce: ''
       STAGE: ''
       RASTER: ''
-    identity: 3e19a07198d6996afe3966f2516f487ebe6f28dace3340220fc370e15a0ff492
+    identity: 52347c5dfb3cc1ca10acb6535bb32065319adcde005b4567518dd4a4062e3535
   - name: k_sdpa_rms_norm_reduce_deba55.f77edf4b7e93.9a8d71ef07fd
     bindings: {}
     pins:

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-b-cut.yaml
@@ -1,7 +1,7 @@
 # Reduced Qwen3 decoder attention: fp16 RMSNorm feeding causal grouped-query attention.
 #
 # evidence: repeated strict O3 A100 measurements materialize the clustered normalized-K value
-# through PLACE@map.1/twist.1/map.1/inner.2/map in one cooperative producer plus one consumer,
+# through PLACE@map.1/twist.1/inner.2/map in one cooperative producer plus one consumer,
 # reaching 6.91-7.01 us against torch.compile's 10.09 us for this exact target.
 compute_cap:
 - 8
@@ -65,13 +65,13 @@ configs:
     bindings: {}
     pins:
       FAST_MATH: true
-      PLACE@map.1/twist.1/map.1/inner.2/map: cut
+      PLACE@map.1/twist.1/inner.2/map: cut
     knobs:
       TILE: ''
       WORK: t8
       REDUCE: coop
-      REDUCE@map.1/twist.1/map.1/inner: ''
-      REDUCE@map.1/twist.1/map.1/inner.1/map.3/map.1/reduce: ''
+      REDUCE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist.1/inner.1/map.3/map.1/reduce: ''
       STAGE: ''
       RASTER: ''
     identity: 52347c5dfb3cc1ca10acb6535bb32065319adcde005b4567518dd4a4062e3535

--- a/tests/compiler/realization/cases/attention/rmsnorm-gqa-sdpa-stat-fill.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-gqa-sdpa-stat-fill.yaml
@@ -57,4 +57,4 @@ configs:
       TILE: mma_m16n8k16_f16_f32/f1x1
       REDUCE: ''
       STAGE: d1/smem
-    identity: 7a74adea84974180cec2f63489a0988e6e1f54825a2f3031c2047a7b1e87773c
+    identity: cdaf778a83c4b5067b45226898668752f9f828f0631d79656a37828d3549e181

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml
@@ -56,9 +56,9 @@ configs:
     bindings: {}
     pins:
       FAST_MATH: false
-      PLACE@map.1/twist.1/map.1/inner.1/map: cut
-      PLACE@map.1/twist.1/map.1/inner.2/map: cut
-      PLACE@map.1/twist.1/map.1/inner.2/map.3/map.1/reduce: cut
+      PLACE@map.1/twist.1/inner.1/map: cut
+      PLACE@map.1/twist.1/inner.2/map: cut
+      PLACE@map.1/twist.1/inner.2/map.3/map.1/reduce: cut
     knobs:
       TILE: ''
       WORK: t16

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-composed-cut.yaml
@@ -65,4 +65,4 @@ configs:
       REDUCE: coop
       STAGE: ''
       RASTER: ''
-    identity: a1e7af8b547396835ed843e5ad10e1310e063dc736bb48b82142ed46cd0acbd6
+    identity: 3ccf06e8caeec7cd3f984fea3ac280b09d66a70c6d13b84141f4b1879eef7bd4

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-output-axis.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-output-axis.yaml
@@ -54,8 +54,8 @@ configs:
       TILE: ''
       WORK: t128
       REDUCE: coop
-      REDUCE@map.1/twist.1/map.1/inner: ''
-      REDUCE@map.1/twist.1/map.1/inner.2/map.3/map.1/reduce: ''
+      REDUCE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist.1/inner.2/map.3/map.1/reduce: ''
       STAGE: ''
       RASTER: ''
     identity: 3ccf06e8caeec7cd3f984fea3ac280b09d66a70c6d13b84141f4b1879eef7bd4

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-output-axis.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-output-axis.yaml
@@ -58,4 +58,4 @@ configs:
       REDUCE@map.1/twist.1/map.1/inner.2/map.3/map.1/reduce: ''
       STAGE: ''
       RASTER: ''
-    identity: a1e7af8b547396835ed843e5ad10e1310e063dc736bb48b82142ed46cd0acbd6
+    identity: 3ccf06e8caeec7cd3f984fea3ac280b09d66a70c6d13b84141f4b1879eef7bd4

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml
@@ -58,7 +58,7 @@ configs:
       REDUCE: coop
       STAGE: ''
       RASTER: ''
-    identity: a1e7af8b547396835ed843e5ad10e1310e063dc736bb48b82142ed46cd0acbd6
+    identity: 3ccf06e8caeec7cd3f984fea3ac280b09d66a70c6d13b84141f4b1879eef7bd4
   - name: k_sdpa_rms_norm_reduce_c7db33.084d63faa9d8.3f9a6e46dece
     bindings: {}
     pins:

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-b-cut.yaml
@@ -1,4 +1,4 @@
-# evidence: the reduced q/k RMSNorm -> causal SDPA tree offers PLACE@map.1/twist.1/map.1/inner.2/map (the score contraction's
+# evidence: the reduced q/k RMSNorm -> causal SDPA tree offers PLACE@map.1/twist.1/inner.2/map (the score contraction's
 # normalized-K operand cone, corpus case rmsnorm-gqa-b-cut) and cuts it correctly. On the fused
 # single-pass tree the score is contracted once, under the flash carrier, so the K cone that two
 # score arms once shared is that one seam.
@@ -51,7 +51,7 @@ configs:
     bindings: {}
     pins:
       FAST_MATH: false
-      PLACE@map.1/twist.1/map.1/inner.2/map: cut
+      PLACE@map.1/twist.1/inner.2/map: cut
     knobs:
       TILE: ''
       WORK: t16

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-cut.yaml
@@ -55,7 +55,7 @@ configs:
       REDUCE: ''
       STAGE: ''
       RASTER: ''
-    identity: a1e7af8b547396835ed843e5ad10e1310e063dc736bb48b82142ed46cd0acbd6
+    identity: 3ccf06e8caeec7cd3f984fea3ac280b09d66a70c6d13b84141f4b1879eef7bd4
   - name: k_sdpa_rms_norm_reduce_c7db33.084d63faa9d8.48bf0d51c143
     bindings: {}
     pins:

--- a/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-cut.yaml
+++ b/tests/compiler/realization/cases/attention/rmsnorm-qk-sdpa-stat-cut.yaml
@@ -96,3 +96,11 @@ configs:
       WORK: ''
       RASTER: ''
     identity: 38829bdbae001a66b53ca9cf0627f27daa739e82c5e1ead38039b7569e13d425
+  - name: k_sdpa_rms_norm_reduce_4ef985.6a9c8ed5d103.51b691d959f9
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      RASTER: ''
+    identity: 51b691d959f945010d3d2b11066e7af130a8b42e56a400dc6b9a132256ee7488

--- a/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma_xfail_offered.yaml
@@ -46,7 +46,7 @@ configs:
       FAST_MATH: false
       PLACE@map.1/twist.3/inner: cut
     knobs:
-      TILE@map.1/twist.1/map.1/inner: mma_m16n8k16_f16_f32/f1x2
+      TILE@map.1/twist.1/inner: mma_m16n8k16_f16_f32/f1x2
       TILE@map.1/twist: mma_m16n8k16_f16_f32/f1x1
       STAGE@map.1/twist: d1/smem
       WORK: w1x1

--- a/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma_xfail_offered.yaml
@@ -52,4 +52,4 @@ configs:
       WORK: w1x1
       REDUCE: ''
       RASTER: ''
-    identity: 433d4720a7709cdd12128c5a31ae86ff083d0d9f7f30f8b2926539a8f40b713d
+    identity: 2e5ffab0c7df870373d2a8ea19d9b05cb07b18e61b8cb411c661c74142efad00

--- a/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-computed-value-cut-mma_xfail_offered.yaml
@@ -53,3 +53,19 @@ configs:
       REDUCE: ''
       RASTER: ''
     identity: 2e5ffab0c7df870373d2a8ea19d9b05cb07b18e61b8cb411c661c74142efad00
+  - name: k_sdpa_linear_reduce_c7ce6d.a3f34e57aa4f.f0d5d7006920
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      TILE@map.1/twist: ''
+      TILE@map.1/twist.1/inner: ''
+      TILE@map.1/twist.2/inner: ''
+      REDUCE@map.1/twist: ''
+      REDUCE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist.2/inner: ''
+      STAGE@map.1/twist.1/inner: ''
+      STAGE@map.1/twist.2/inner: ''
+      WORK: ''
+      RASTER: ''
+    identity: f0d5d70069204be5ec19433716ffdb1e1f310c039df1ec8d575ba8acead9da2b

--- a/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
@@ -42,7 +42,7 @@ configs:
       STAGE: d1/smem
       LOOPIFY: '0'
       RASTER: ''
-    identity: eb74b174290bc40763cc4c842e3039516584a3fcf05f5703071e81c20e19d04e
+    identity: 3ec795cedf21b59dce873ccc52ebbacf6519878078959430f44405a131ffc106
   - name: k_sdpa_6a2bfa.0015e9065043.448a0d722d09
     bindings: {}
     pins:

--- a/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
@@ -49,7 +49,7 @@ configs:
       FAST_MATH: true
     knobs:
       REDUCE@map.1/twist: ''
-      REDUCE@map.1/twist.1/map.1/inner: ''
+      REDUCE@map.1/twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -61,7 +61,7 @@ configs:
       FAST_MATH: true
     knobs:
       REDUCE@map.1/twist: ''
-      REDUCE@map.1/twist.1/map.1/inner: ''
+      REDUCE@map.1/twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -79,7 +79,7 @@ configs:
       FAST_MATH: true
     knobs:
       REDUCE@map.1/twist: ''
-      REDUCE@map.1/twist.1/map.1/inner: ''
+      REDUCE@map.1/twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''

--- a/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/attention/sdpa-hd128-softmax-v-mma_xfail_offered.yaml
@@ -85,6 +85,19 @@ configs:
       STAGE: ''
       RASTER: ''
     identity: fb05568f956bc5f3686693caa643bd929543fbeb156ffeaf808ca4ee2c4f2748
+  - name: k_sdpa_6a2bfa.0015e9065043.032fc79559fc
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      TILE@map.1/twist: ''
+      TILE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist: ''
+      REDUCE@map.1/twist.1/inner: ''
+      WORK: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 032fc79559fcae7dc66446ff62ec07ccae09426566ea765cd1a194b171fa545e
 loops:
 - inputs: [x0, x1, x2]
   outputs: [scaled_dot_product_attention]

--- a/tests/compiler/realization/cases/matmul/f16-symbolic-computed-a-k-warp_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-symbolic-computed-a-k-warp_xfail_offered.yaml
@@ -41,7 +41,7 @@ configs:
       WORK: w2x2
       STAGE: d1/smem
       REDUCE: ''
-    identity: 955199dd3c346531150b603c7db1ccac424f575f922e1298d29ce563132d438d
+    identity: ba172514db11e954136589b7b094d38a3b24dd608b59288bc5097f0e053e5407
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 36.90192655280784

--- a/tests/compiler/realization/cases/matmul/f16-symbolic-computed-a-k-warp_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-symbolic-computed-a-k-warp_xfail_offered.yaml
@@ -91,3 +91,13 @@ configs:
       REDUCE: ''
       RASTER: ''
     identity: 4fde58f4f7e00b9b17d5b89545a77a3dc9699ad4666e0fc2af647896d6337b81
+  - name: k_matmul_softmax_reduce_2c67a1.c029b4a45303.3295ee7031df
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      RASTER: ''
+    identity: 3295ee7031dff76a7235902b25f13df94728188938ebce6837201443cda7abd2

--- a/tests/compiler/realization/cases/matmul/f16-symbolic-demoted-pv-greedy_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-symbolic-demoted-pv-greedy_xfail_offered.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       TILE: mma_m16n8k16_f16_f32/f4x8/k8
       WORK: w2x2
-    identity: 955199dd3c346531150b603c7db1ccac424f575f922e1298d29ce563132d438d
+    identity: ba172514db11e954136589b7b094d38a3b24dd608b59288bc5097f0e053e5407
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 57.96894255806418

--- a/tests/compiler/realization/cases/matmul/f16-symbolic-demoted-pv-greedy_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/matmul/f16-symbolic-demoted-pv-greedy_xfail_offered.yaml
@@ -89,3 +89,13 @@ configs:
       REDUCE: ''
       RASTER: ''
     identity: 4fde58f4f7e00b9b17d5b89545a77a3dc9699ad4666e0fc2af647896d6337b81
+  - name: k_matmul_softmax_reduce_2c67a1.c029b4a45303.3295ee7031df
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      RASTER: ''
+    identity: 3295ee7031dff76a7235902b25f13df94728188938ebce6837201443cda7abd2

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
@@ -56,3 +56,16 @@ configs:
       RASTER: ''
       WORK: t32x16
     identity: 3a4b84d27383d81e107c3ab1f76d96f9ae59dc6174abf6ce77fc44e5677b06d3
+  - name: k_sdpa_d0df3e.b595be4fca99.b77e6e905e09
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      TILE@map.1/twist: ''
+      TILE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist: ''
+      REDUCE@map.1/twist.1/inner: ''
+      WORK: ''
+      STAGE: ''
+      RASTER: ''
+    identity: b77e6e905e090f5fc51419169ed51dc7a1727c55975577eed40feb198f416653

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
@@ -55,4 +55,4 @@ configs:
       STAGE: ''
       RASTER: ''
       WORK: t32x16
-    identity: 47d6ad49f5bfdd53ab7724125c38cea027b8869f35b1db441a5b2bde09c484ac
+    identity: 3a4b84d27383d81e107c3ab1f76d96f9ae59dc6174abf6ce77fc44e5677b06d3

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
@@ -7,7 +7,7 @@
 # hidden=1024 heads=16 kv_heads=8 head_dim=128, fp32, seq 128. One of the twelve layer-0
 # kernels the perf suite curated before the corpus became its case source.
 #
-# The schedule is SITE-SCOPED (TILE@map.1/twist.1/map.1/inner is the score, TILE@map.1/twist the weighted sum) because a flash
+# The schedule is SITE-SCOPED (TILE@map.1/twist.1/inner is the score, TILE@map.1/twist the weighted sum) because a flash
 # tree decides per site. It is also the row a greedy compile REALIZES on this shape, read off
 # the resolved kernel.
 #
@@ -49,7 +49,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      TILE@map.1/twist.1/map.1/inner: ''
+      TILE@map.1/twist.1/inner: ''
       TILE@map.1/twist: f1
       REDUCE: ''
       STAGE: ''

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s128_xfail_offered.yaml
@@ -1,8 +1,12 @@
-# evidence: the schedule pins a SCALAR register tile on the twisted carrier. The scalar tier folds the stored lift into
-# one accumulator per bilinear channel, and for a twist that lift is the base contribution — it denotes
-# `Sum exp(score)` — so a twisted carrier offers no scalar tile at all and the pin reaches no row. The chunk tier that
-# does fold this carrier needs a 16-bit mma atom whose C fragment repacks into an A operand, which an fp32 target has
-# none of; closing the gap means an fp32 path for the weight, not a row on this one.
+# evidence: the schedule pins a SCALAR register tile on the twisted carrier, and no scalar tile is offered on one.
+# The obstacle is NOT the numerics any more — the term stores the stable contribution and `Fold.step` folds it under
+# the recipe's own combine, which is why the untiled arm is sound. It is the tier's shape: the scalar register tier
+# folds one additive accumulator per cell, `acc__c{i}_{j} += b·a`, with its multiply, its add and its single state all
+# fixed, while this carrier folds three states under their own ops and seeds with the stable merge between them.
+# Offering the tile anyway reaches the materializer as `reads names it never binds: acc3__c0_0, acc5__sum__c0_0` —
+# the cell copies of the pivot and the denominator, which nothing declares. Closing the gap means the ILP register
+# tier folding a recipe, the way the chunk tier does on tensor cores. The chunk tier itself is no route here: it
+# needs a 16-bit mma atom whose C fragment repacks into an A operand, and this fp32 target has none.
 # Qwen3-Embedding-0.6B decoder layer 0, kernels 6 and 7: causal GQA attention.
 # hidden=1024 heads=16 kv_heads=8 head_dim=128, fp32, seq 128. One of the twelve layer-0
 # kernels the perf suite curated before the corpus became its case source.

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
@@ -1,8 +1,12 @@
-# evidence: the schedule pins a SCALAR register tile on the twisted carrier. The scalar tier folds the stored lift into
-# one accumulator per bilinear channel, and for a twist that lift is the base contribution — it denotes
-# `Sum exp(score)` — so a twisted carrier offers no scalar tile at all and the pin reaches no row. The chunk tier that
-# does fold this carrier needs a 16-bit mma atom whose C fragment repacks into an A operand, which an fp32 target has
-# none of; closing the gap means an fp32 path for the weight, not a row on this one.
+# evidence: the schedule pins a SCALAR register tile on the twisted carrier, and no scalar tile is offered on one.
+# The obstacle is NOT the numerics any more — the term stores the stable contribution and `Fold.step` folds it under
+# the recipe's own combine, which is why the untiled arm is sound. It is the tier's shape: the scalar register tier
+# folds one additive accumulator per cell, `acc__c{i}_{j} += b·a`, with its multiply, its add and its single state all
+# fixed, while this carrier folds three states under their own ops and seeds with the stable merge between them.
+# Offering the tile anyway reaches the materializer as `reads names it never binds: acc3__c0_0, acc5__sum__c0_0` —
+# the cell copies of the pivot and the denominator, which nothing declares. Closing the gap means the ILP register
+# tier folding a recipe, the way the chunk tier does on tensor cores. The chunk tier itself is no route here: it
+# needs a 16-bit mma atom whose C fragment repacks into an A operand, and this fp32 target has none.
 # Qwen3-Embedding-0.6B decoder layer 0, kernels 6 and 7: causal GQA attention.
 # hidden=1024 heads=16 kv_heads=8 head_dim=128, fp32, seq 32. One of the twelve layer-0
 # kernels the perf suite curated before the corpus became its case source.

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
@@ -55,4 +55,4 @@ configs:
       STAGE: ''
       RASTER: ''
       WORK: t32x16
-    identity: d359794f3415a950939bd69c19ae5b77d5d57e2d029d880a8977605c0f49dfff
+    identity: 435b9460c09691a6110fef7ef81269a8fb56e355cd71919163fcd790cab077b3

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
@@ -7,7 +7,7 @@
 # hidden=1024 heads=16 kv_heads=8 head_dim=128, fp32, seq 32. One of the twelve layer-0
 # kernels the perf suite curated before the corpus became its case source.
 #
-# The schedule is SITE-SCOPED (TILE@map.1/twist.1/map.1/inner is the score, TILE@map.1/twist the weighted sum) because a flash
+# The schedule is SITE-SCOPED (TILE@map.1/twist.1/inner is the score, TILE@map.1/twist the weighted sum) because a flash
 # tree decides per site. It is also the row a greedy compile REALIZES on this shape, read off
 # the resolved kernel.
 #
@@ -49,7 +49,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      TILE@map.1/twist.1/map.1/inner: ''
+      TILE@map.1/twist.1/inner: ''
       TILE@map.1/twist: f1
       REDUCE: ''
       STAGE: ''

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s32_xfail_offered.yaml
@@ -56,3 +56,16 @@ configs:
       RASTER: ''
       WORK: t32x16
     identity: 435b9460c09691a6110fef7ef81269a8fb56e355cd71919163fcd790cab077b3
+  - name: k_sdpa_eb82e8.bf2b2836f11c.412c46eda623
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      TILE@map.1/twist: ''
+      TILE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist: ''
+      REDUCE@map.1/twist.1/inner: ''
+      WORK: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 412c46eda62335c8846ac5d813a772a674b626ebca3532c007635c42dc5323e1

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
@@ -1,8 +1,12 @@
-# evidence: the schedule pins a SCALAR register tile on the twisted carrier. The scalar tier folds the stored lift into
-# one accumulator per bilinear channel, and for a twist that lift is the base contribution — it denotes
-# `Sum exp(score)` — so a twisted carrier offers no scalar tile at all and the pin reaches no row. The chunk tier that
-# does fold this carrier needs a 16-bit mma atom whose C fragment repacks into an A operand, which an fp32 target has
-# none of; closing the gap means an fp32 path for the weight, not a row on this one.
+# evidence: the schedule pins a SCALAR register tile on the twisted carrier, and no scalar tile is offered on one.
+# The obstacle is NOT the numerics any more — the term stores the stable contribution and `Fold.step` folds it under
+# the recipe's own combine, which is why the untiled arm is sound. It is the tier's shape: the scalar register tier
+# folds one additive accumulator per cell, `acc__c{i}_{j} += b·a`, with its multiply, its add and its single state all
+# fixed, while this carrier folds three states under their own ops and seeds with the stable merge between them.
+# Offering the tile anyway reaches the materializer as `reads names it never binds: acc3__c0_0, acc5__sum__c0_0` —
+# the cell copies of the pivot and the denominator, which nothing declares. Closing the gap means the ILP register
+# tier folding a recipe, the way the chunk tier does on tensor cores. The chunk tier itself is no route here: it
+# needs a 16-bit mma atom whose C fragment repacks into an A operand, and this fp32 target has none.
 # Qwen3-Embedding-0.6B decoder layer 0, kernels 6 and 7: causal GQA attention.
 # hidden=1024 heads=16 kv_heads=8 head_dim=128, fp32, seq 512. One of the twelve layer-0
 # kernels the perf suite curated before the corpus became its case source.

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
@@ -55,4 +55,4 @@ configs:
       STAGE: ''
       RASTER: ''
       WORK: t32x8
-    identity: cfedc7a18de32df6b20100e62acbc7d44cdcf333ab58abd9bd5681c0afefe505
+    identity: be8f648729dc1f74a75374b9d336455d95304b5096c636e1ef791b6b52e6c9da

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
@@ -56,3 +56,16 @@ configs:
       RASTER: ''
       WORK: t32x8
     identity: be8f648729dc1f74a75374b9d336455d95304b5096c636e1ef791b6b52e6c9da
+  - name: k_sdpa_851635.6bd8fa3f8b38.70ff9524a78a
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      TILE@map.1/twist: ''
+      TILE@map.1/twist.1/inner: ''
+      REDUCE@map.1/twist: ''
+      REDUCE@map.1/twist.1/inner: ''
+      WORK: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 70ff9524a78aae0ba55e29c258b97a0768d4b41221d7db26c19bd97e00dee567

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s512_xfail_offered.yaml
@@ -7,7 +7,7 @@
 # hidden=1024 heads=16 kv_heads=8 head_dim=128, fp32, seq 512. One of the twelve layer-0
 # kernels the perf suite curated before the corpus became its case source.
 #
-# The schedule is SITE-SCOPED (TILE@map.1/twist.1/map.1/inner is the score, TILE@map.1/twist the weighted sum) because a flash
+# The schedule is SITE-SCOPED (TILE@map.1/twist.1/inner is the score, TILE@map.1/twist the weighted sum) because a flash
 # tree decides per site. It is also the row a greedy compile REALIZES on this shape, read off
 # the resolved kernel.
 #
@@ -49,7 +49,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      TILE@map.1/twist.1/map.1/inner: ''
+      TILE@map.1/twist.1/inner: ''
       TILE@map.1/twist: f1
       REDUCE: ''
       STAGE: ''

--- a/tests/compiler/realization/cases/reduce/attention-coop-warp.yaml
+++ b/tests/compiler/realization/cases/reduce/attention-coop-warp.yaml
@@ -32,7 +32,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t32
-    identity: 2e40dced853112eb65f9137b4b380b20bfdc6884d262441e4a35e381b6f1858a
+    identity: bb5c9d5210b455653b6fe7a3817a074626e0a30dc500ebf85602bbfe34249485
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 45.85163701664318

--- a/tests/compiler/realization/cases/reduce/attention-serial.yaml
+++ b/tests/compiler/realization/cases/reduce/attention-serial.yaml
@@ -31,7 +31,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE: ''
-    identity: 2e40dced853112eb65f9137b4b380b20bfdc6884d262441e4a35e381b6f1858a
+    identity: bb5c9d5210b455653b6fe7a3817a074626e0a30dc500ebf85602bbfe34249485
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 30.74599988758564

--- a/tests/compiler/realization/cases/reduce/combine-softmax-coop-hier-symbolic.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-coop-hier-symbolic.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t128
-    identity: 138e67242c9ed6be37101db3c82b2e9153cac7fc1c56beef723e5319d168abab
+    identity: b1ae35a391d3a9f835e6bab2deb3856c3f37db60d25cb007fc16c3f45118d888
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.3174880934893929

--- a/tests/compiler/realization/cases/reduce/combine-softmax-coop-hier.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-coop-hier.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t128
-    identity: 76e6034ddaa7e12904c0f8840ac68a4c1085a18e004e93a534426d2d950300c6
+    identity: 0cab3b5315323fd3206848d10bb28d92c97de648355ca41536794cac56359be1
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 2.472792078952978

--- a/tests/compiler/realization/cases/reduce/combine-softmax-coop-warp-symbolic.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-coop-warp-symbolic.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t32
-    identity: 138e67242c9ed6be37101db3c82b2e9153cac7fc1c56beef723e5319d168abab
+    identity: b1ae35a391d3a9f835e6bab2deb3856c3f37db60d25cb007fc16c3f45118d888
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.809797101262687

--- a/tests/compiler/realization/cases/reduce/combine-softmax-coop-warp.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-coop-warp.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t32
-    identity: 76e6034ddaa7e12904c0f8840ac68a4c1085a18e004e93a534426d2d950300c6
+    identity: 0cab3b5315323fd3206848d10bb28d92c97de648355ca41536794cac56359be1
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 2.6556595842889013

--- a/tests/compiler/realization/cases/reduce/combine-softmax-ilp-coop-symbolic.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-ilp-coop-symbolic.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop/r2
       WORK: t32
-    identity: 138e67242c9ed6be37101db3c82b2e9153cac7fc1c56beef723e5319d168abab
+    identity: b1ae35a391d3a9f835e6bab2deb3856c3f37db60d25cb007fc16c3f45118d888
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.8825660336692378

--- a/tests/compiler/realization/cases/reduce/combine-softmax-ilp-coop.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-ilp-coop.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop/r2
       WORK: t32
-    identity: 76e6034ddaa7e12904c0f8840ac68a4c1085a18e004e93a534426d2d950300c6
+    identity: 0cab3b5315323fd3206848d10bb28d92c97de648355ca41536794cac56359be1
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 4.346991362779036

--- a/tests/compiler/realization/cases/reduce/combine-softmax-ilp-symbolic.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-ilp-symbolic.yaml
@@ -38,7 +38,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE: r4
-    identity: 138e67242c9ed6be37101db3c82b2e9153cac7fc1c56beef723e5319d168abab
+    identity: b1ae35a391d3a9f835e6bab2deb3856c3f37db60d25cb007fc16c3f45118d888
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 33.531733353932694

--- a/tests/compiler/realization/cases/reduce/combine-softmax-ilp.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-ilp.yaml
@@ -38,7 +38,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE: r4
-    identity: 76e6034ddaa7e12904c0f8840ac68a4c1085a18e004e93a534426d2d950300c6
+    identity: 0cab3b5315323fd3206848d10bb28d92c97de648355ca41536794cac56359be1
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 63.8900026679039

--- a/tests/compiler/realization/cases/reduce/combine-softmax-serial-symbolic.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-serial-symbolic.yaml
@@ -38,7 +38,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE: ''
-    identity: 138e67242c9ed6be37101db3c82b2e9153cac7fc1c56beef723e5319d168abab
+    identity: b1ae35a391d3a9f835e6bab2deb3856c3f37db60d25cb007fc16c3f45118d888
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 32.579095132889286

--- a/tests/compiler/realization/cases/reduce/combine-softmax-serial.yaml
+++ b/tests/compiler/realization/cases/reduce/combine-softmax-serial.yaml
@@ -38,7 +38,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE: ''
-    identity: 76e6034ddaa7e12904c0f8840ac68a4c1085a18e004e93a534426d2d950300c6
+    identity: 0cab3b5315323fd3206848d10bb28d92c97de648355ca41536794cac56359be1
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 63.1679967045784

--- a/tests/compiler/realization/cases/reduce/cross-cta-flash-kernel.yaml
+++ b/tests/compiler/realization/cases/reduce/cross-cta-flash-kernel.yaml
@@ -32,7 +32,7 @@ configs:
       PLACE: fuse
     knobs:
       REDUCE: g2k
-    identity: 2e40dced853112eb65f9137b4b380b20bfdc6884d262441e4a35e381b6f1858a
+    identity: bb5c9d5210b455653b6fe7a3817a074626e0a30dc500ebf85602bbfe34249485
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 22.498559951782227

--- a/tests/compiler/realization/cases/reduce/cross-cta-flash-kernel.yaml
+++ b/tests/compiler/realization/cases/reduce/cross-cta-flash-kernel.yaml
@@ -154,3 +154,16 @@ configs:
       REDUCE: ''
       RASTER: ''
     identity: 9d4e8c6d3ba276f2722d32e648aa41aabc3b93bdbdd0c2b32528bcbe932ac1b7
+  - name: k_sdpa_fbd178.50222a02272c.2f9f43ff4cc3
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      TILE@twist: ''
+      TILE@twist.1/inner: ''
+      REDUCE@twist: ''
+      REDUCE@twist.1/inner: ''
+      WORK: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 2f9f43ff4cc34be9038409c21fae86903b0523bbd60baf0eb9fda49811ff68fd

--- a/tests/compiler/realization/cases/reduce/cross-cta-flash-kernel.yaml
+++ b/tests/compiler/realization/cases/reduce/cross-cta-flash-kernel.yaml
@@ -52,7 +52,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE@twist: ''
-      REDUCE@twist.1/map.1/inner: ''
+      REDUCE@twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -73,7 +73,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE@twist: ''
-      REDUCE@twist.1/map.1/inner: ''
+      REDUCE@twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -94,7 +94,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE@twist: ''
-      REDUCE@twist.1/map.1/inner: ''
+      REDUCE@twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -106,7 +106,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE@twist: ''
-      REDUCE@twist.1/map.1/inner: ''
+      REDUCE@twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -118,7 +118,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE@twist: ''
-      REDUCE@twist.1/map.1/inner: ''
+      REDUCE@twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''
@@ -139,7 +139,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE@twist: ''
-      REDUCE@twist.1/map.1/inner: ''
+      REDUCE@twist.1/inner: ''
       WORK: ''
       TILE: ''
       STAGE: ''

--- a/tests/compiler/realization/cases/reduce/online-softmax-2x4x128.yaml
+++ b/tests/compiler/realization/cases/reduce/online-softmax-2x4x128.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t128
-    identity: 8c922783ff5f536ef8f764d8588fff8ade2e8d15e8a2b1c17735e98088b65a4a
+    identity: c3773c525c5ad940ca576e600262d75cb134aa4114214e902a303c29269d06ff
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.082112585311328

--- a/tests/compiler/realization/cases/reduce/online-softmax-2x64.yaml
+++ b/tests/compiler/realization/cases/reduce/online-softmax-2x64.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t64
-    identity: 7eaa21f191103b835f95b74dadffb0fc0ca6e89517a5c2d94bab1fbd40db26da
+    identity: 39bcc3b7772b51593e0155e60c2fe071dab0efaba896b15497e613a86dab94c6
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.031394820139198

--- a/tests/compiler/realization/cases/reduce/online-softmax-4x128.yaml
+++ b/tests/compiler/realization/cases/reduce/online-softmax-4x128.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t128
-    identity: b9fc2e4d52133868c0d03c41346c050081e15542a1c653578ae409b47a1d9a05
+    identity: e6d6014a2d1a89e262653018e23790049e5ee9c37ef4291c6aea2200db3688cf
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.044631128899107

--- a/tests/compiler/realization/cases/reduce/online-softmax-8x256.yaml
+++ b/tests/compiler/realization/cases/reduce/online-softmax-8x256.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t128
-    identity: 0fa3869e684b816c92ead57fadc0dc655136eafca8507eae0adb0279218b4dca
+    identity: 9ab89a45cab35457c2c5d773bc9523d9b9e4a69a5609f514abdecb2955982da5
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.2080581367160161

--- a/tests/compiler/realization/cases/reduce/symbolic-coop-softmax-t64.yaml
+++ b/tests/compiler/realization/cases/reduce/symbolic-coop-softmax-t64.yaml
@@ -39,7 +39,7 @@ configs:
     knobs:
       REDUCE: coop
       WORK: t64
-    identity: aea63613ccb651f2b70d36721d38f57e7d587125fb5142c30a2c68d217bd4a3d
+    identity: 185a57ed2bd35d96e167056a1f0650f625cbfde402db49e8ec1065e79bacaafa
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 1.4888345751073073

--- a/tests/compiler/realization/cases/reduce/symbolic-ilp-softmax-r4.yaml
+++ b/tests/compiler/realization/cases/reduce/symbolic-ilp-softmax-r4.yaml
@@ -38,7 +38,7 @@ configs:
       FAST_MATH: false
     knobs:
       REDUCE: r4
-    identity: aea63613ccb651f2b70d36721d38f57e7d587125fb5142c30a2c68d217bd4a3d
+    identity: 185a57ed2bd35d96e167056a1f0650f625cbfde402db49e8ec1065e79bacaafa
     latency:
       NVIDIA GeForce RTX 5090:
         emmy_us: 37.27644461172598


### PR DESCRIPTION
## Abstract

A fused softmax carrier stored its per-element contribution in the coordinates the algebra is *defined* in rather than the ones it *computes* in, so every attention tree carried an exponential of an unshifted score — a value that overflows if anything evaluates it and that nothing was permitted to evaluate. Keeping it there also forced an extra node into the tree whose only job was to turn that value into an operand so a pattern match would fire. This change stores the contribution in the carrier's own coordinates, where softmax's is a score, a one, and the streamed value, and derives the other form on demand for the one reader that needs it. The tree loses the exponential and the node, and attention's numerics are unchanged against eager.

```
 ├─ operand[v1, e]: Fold  free                    ├─ operand[acc0]: Fold[a3] contraction
 │    v1 = multiply(acc0, 0.125)                  ├─ operand[in7]: load v[...]
 │    e  = exp(v1)              ← overflows       ├─ init: (-1e+30, 0, 0)
 ├─ operand[in7]: load v[...]                     ├─ lift: λ(a2, acc0, in7) -> (v1, one, in7)
 ├─ lift: λ(a2, v1, e, in7) -> (v1, e, ev)        │    v1  = multiply(acc0, 0.125)
 │    ev = multiply(e, in7)                       │    one = 1
 └─ base: (maximum, add, add)                     ├─ combine: λ(acc1, acc3, acc5__sum, …) -> …
                                                  ├─ helper: psi λ(m, D, O) -> (m, d, o)
                                                  └─ helper: base = (maximum, add, add)
             before                                                  after
```

---

## Why the ids differed

The paper states both representations of a twisted fold as equivalent, and its FlashAttention figure draws the stable one. The implementation had taken the base one. The fusion now splices the recipe's authored injection — the singleton in the carrier's own state space, where the pivot *is* the score and `exp(s)·v` has already simplified to `v`. The stable combine derives from the recipe, and the base monoid and ψ ride beside it as helpers.

`Fold.based` is the reading those helpers exist for: ψ⁻¹ over the stored lift, restoring `(s, exp s, exp(s)·v)`. Bilinearity lives in base coordinates and nowhere else, because ψ divides the product away at the singleton. Only `bilinear_channels` and `as_contraction` ask for it, nothing emits it, and it is restricted to the channels a term actually holds — a half-fused carrier is the ordinary case during the rewrite's fixpoint.

## The node that is no longer minted

`_factor_weights` hoisted the weight into an operand of its own so the expectation channel read as `operands[0] ⊗ operands[k]`. That node added no computation; the emitter never placed it. It existed to satisfy a pattern.

The pattern now asks the right question. **A is what `operands[0]` supplies, not what it exposes** — the left factor may be a component of that edge, or a value the reading derives from those components and from kernel-uniform ones. A scale contributes no variation, so a factor reading it varies exactly as A does. A weight derived from the *streamed* value is still refused; offering an mma there would be a wrong answer, not a slow kernel.

## Three things the dump was hiding

A scalar operand is spelled inside the reader that binds it, so a scale stops being a line of tree art around a constant. A lift prints under the operand's own name for every slot it binds, and only the slots it reads — attention's two consumers of one carrier now visibly take different states off it, where before both listed all three. And normalization drops operand components no reader reads: rewrites had left an epilogue cone exposing three constants nobody bound, carried alongside a second copy of the loads defining them. A reader is a consuming lift *or* a boundary store, which is how a sweep's per-cell projection reaches its `Write`.

The cut pass also stops offering a seam at a scalar. That piece was a kernel writing three scalars to a workspace so its reader could read them back.

## What broke — this is not ready

**The chunk tier no longer reaches the tensor cores.** Three e2e tests fail on a *pinned* chunk row, so it is not the greedy choosing differently — the row is unenumerable. The atom projection refuses a contraction any of whose operands reduce, and removing the minted node is exactly what made A reduce: A used to be the zero-axis weight cone with the score contraction nested under it, which is the shape the fragment-seam machinery (`ContractionFacts.producer`, `_fragment_agreements`) was written against. Exempting the chunked carrier from that one refusal is not sufficient on its own; there is at least one more gate downstream. Teaching the seam that A may BE the producer is the remaining work, and it is design work, not a test fix.

`test_sdpa_score_contraction_reaches_the_mma_tier` is the same cause at a smaller scale.

The realization corpus reports 32 stale cases and 14 changed verdicts. The stale half is what `make test-corpus-regen` exists for; the verdict changes need reading one at a time. Kernel identity moved for every twisted term, so recorded goldens are stale too.

## Verification

Accuracy against eager passes on SDPA, causal SDPA, softmax, softmax@V and RMSNorm, worst `max_diff` 9.8e-4 in fp16 — the numerics of the coordinate change are sound. `make test` is 4846 passed / 59 failed; the failures are the corpus and the chunk tier above.

`git diff --stat main -- emmy/**/*.py` is +318 −146. The growth is new capability — a coordinate reading that did not exist, a derived base view, and a normalization rule — set against `_factor_weights`, `_already_held`, and the subtree walk in `Fold.roles` that all came out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HcMmRQ7RcNrCJGd9FnQgN
