### PR TITLE
Record a hung greedy's bench_fail evidence before the pinned re-bench, and skip re-electing it

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -271,7 +271,11 @@ the failure names — the one the watchdog saw hang, or the one nvcc refused to 
 kernel earns a `bench_fail` perf row at the run budget's fail sentinel and the innocent kernels earn none, so the
 next compile disqualifies that arm instead of electing the same route and failing the same way again; a failure
 that names no kernel records nothing, and a compile-budget overrun measured
-nothing and records nothing. `--no-record-nodes` opts out of all of it.
+nothing and records nothing. `--no-record-nodes` opts out of all of it. This recording happens before any pinned row
+compiles — including when an embedded Loop's same-input reference completed but its repeated greedy timing crossed
+the watchdog — and a pinned row that pins no knobs beyond the greedy compile's own input regime is then skipped
+rather than re-elected and re-failed identically; a pinned row carrying its own knobs (a genuinely different config,
+or an `--ab` row) still benches.
 
 For a fair hybrid-vs-MCTS comparison, both working files start from the same inventory-only trace: do not copy verified
 knob rows into either baseline as proposals. Canonical goldens remain the common implicit deploy context for both runs.

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -2430,20 +2430,36 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                     )
                 if resp.get("greedy_error"):
                     greedy_fail = f"greedy timing failed after reference execution: {resp['greedy_error']}"
+                    _record_greedy_failure(args, backend, graph, resp["greedy_error"])
             if pinned and tail:
                 if ab_ref is None:
                     reason = greedy_fail or "the greedy worker returned no run outputs"
                     missing = "pinned embedded-Loop verification requires same-input greedy outputs, but none were returned"
                     reference_error = f"{missing}: {reason}"
                 elif same_input_greedy or not strict_correctness or accuracy_error is None:
+                    to_bench = pinned
                     if greedy_fail:
-                        logger.error("%s — untimed greedy is ineligible; pinned rows still bench", greedy_fail)
+                        # An automatic golden-config row with no knobs pins nothing beyond the input
+                        # regime the greedy compile already used, so re-compiling it reaches the exact
+                        # same election and re-fails the same way (the DeepSeek-V4 double-hang cost).
+                        # An --ab row or a row with real schedule knobs is a genuinely different
+                        # config and still benches.
+                        same_election = [s for s in pinned if getattr(s, "shape", None) is not None and not s.knobs]
+                        if same_election:
+                            to_bench = [s for s in pinned if s not in same_election]
+                            logger.warning(
+                                "%s — pinned re-bench of %s skipped: it has no knobs to pin it away from the greedy pick that just failed",
+                                greedy_fail,
+                                ", ".join(s.name for s in same_election),
+                            )
+                        if to_bench:
+                            logger.error("%s — untimed greedy is ineligible; pinned rows still bench", greedy_fail)
                     else:
                         greedy_iso = await _bench_greedy_isolated(backend, graph, warmup=args.warmup, iters=args.iters)
                     ab_benches = await _bench_golden_variants(
                         backend,
                         embedded,
-                        pinned,
+                        to_bench,
                         warmup=args.warmup,
                         iters=args.iters,
                         ref=ab_ref,

--- a/tests/compiler/cli/test_golden_file_replay.py
+++ b/tests/compiler/cli/test_golden_file_replay.py
@@ -858,3 +858,92 @@ def test_run_files_a_hung_greedy_kernel_as_bench_fail_evidence(monkeypatch, tmp_
     filed = {name: row.status for name, row in rows.items() if row is not None}
     assert filed == {nodes[-1].op.kernel_name: "bench_fail"}, "only the kernel the watchdog named is evidence"
     assert rows[nodes[-1].op.kernel_name].stats.median == pytest.approx(2.0e6), "priced at the run budget's fail sentinel"
+
+
+def test_run_skips_pinned_rebench_of_the_same_election_after_a_greedy_hang(monkeypatch, tmp_path):
+    """An embedded Loop golden has no Torch twin, so its greedy job can complete the same-input
+    reference and only then have its repeated timing cross the watchdog (``resp["greedy_error"]``).
+    Before, ``run`` still re-compiled and re-benched the seed's automatic pin in that case even
+    though the pin carries no knobs of its own: with nothing pinning it away from the greedy
+    compile's own choices, it re-elects and re-hangs the identical program a second time (the
+    DeepSeek-V4-Flash post4096 double-cost defect). The fix (1) records the bench_fail evidence
+    for the failed election BEFORE any pinned compile begins, and (2) skips re-benching the
+    knob-less automatic pin, leaving any pinned row that DOES carry its own knobs to bench as
+    usual."""
+    from emmy.commands import run as run_module
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    _working_loop(path)  # default state: an untuned seed realization with no recorded knobs
+    args = _args(
+        path,
+        realization="working.relu",
+        ir=None,
+        bench=True,
+        ab=None,
+        debug=False,
+        dump_dir=None,
+        bench_backends="emmy",
+        warmup=5,
+        iters=20,
+        seed=0,
+        json=None,
+        profile=False,
+        record=False,
+        record_greedy=False,
+        strict_correctness=False,
+    )
+    resolve_golden_arg(args)
+    assert args.golden_configs and not args.golden_configs[0].knobs, "the seed must carry no knobs"
+
+    class FakeBackend:
+        name = "cuda"
+        tune_db = None
+        bench_compile_timeout_s = 1.0
+        bench_run_timeout_s = 1.0
+
+        def __init__(self, **_kwargs):
+            pass
+
+        async def benchmark_compare_async(self, _graph, **_kwargs):
+            return {
+                "results": {},
+                "result": None,
+                "captured": False,
+                "torch_available": False,
+                "accuracy_error": None,
+                "run_io": ({"x": object()}, {"y": object()}),
+                "greedy_error": "HungKernelError: repeated timing crossed the watchdog",
+                "reference_run_us": 4_000_000.0,
+            }
+
+        async def aclose_async_worker(self):
+            pass
+
+    class FakeDump:
+        @staticmethod
+        def resolve(_path):
+            return None
+
+    calls = []
+
+    def fake_record_failure(*_args, **_kwargs):
+        calls.append("record")
+
+    async def fake_bench_golden_variants(_backend, _source, pinned, **_kwargs):
+        calls.append(("bench_golden_variants", list(pinned)))
+        return []
+
+    async def fail_if_isolated(*_args, **_kwargs):
+        raise AssertionError("a failed greedy timing must not be re-benched or made eligible")
+
+    monkeypatch.setattr(run_module, "_record_greedy_failure", fake_record_failure)
+    monkeypatch.setattr(run_module, "_bench_golden_variants", fake_bench_golden_variants)
+    monkeypatch.setattr(run_module, "_bench_greedy_isolated", fail_if_isolated)
+    monkeypatch.setattr(run_module, "_print_kernel_stats", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(SystemExit):
+        run_module._handle_run_ir(args, FakeBackend, FakeDump)
+
+    assert calls[0] == "record", "the bench_fail row must be recorded before the pinned walk starts"
+    assert calls[1] == ("bench_golden_variants", []), "the knob-less seed pin must not be re-compiled and re-benched"


### PR DESCRIPTION
## Abstract

A greedy job on an embedded Loop target can complete its same-input reference run and only then have
its repeated timing cross the watchdog. That failure reached the run only as data, never through the
usual bench-failure recording, so nothing was written before the run went on to recompile and re-bench
the exact same program as a "pinned" row — paying the full placement cost and the hang a second time,
and in the worst case losing the only record of the failure when the second hang ran long enough to be
killed by hand.

## The mechanism

`run --golden FILE --realization NAME --bench` benches the greedy pick, then benches every pinned
configuration of that realization — normally a distinct, hand-pinned schedule worth measuring on its
own. But the realization's OWN automatic pin (the "seed") pins nothing beyond the input regime the
greedy compile already used: with no schedule knobs of its own, compiling it reaches the identical
election the greedy job just made. When the greedy job hangs after its reference completes, the failure
was reported back as a string on the response rather than a raised exception, so the existing
bench-failure recording — wired only to the raised-exception path — never ran, and the pinned walk went
on to recompile and re-bench that same seed as if nothing had happened.

## The fix

The reference-completed-but-timing-hung case now records its bench_fail evidence the same way a hard
failure does, before any pinned compile begins. The pinned walk then skips re-benching a row that pins
no knobs of its own — it would only reproduce the failure that was just recorded — while a row that
does carry its own knobs (a genuinely different configuration, or an explicit `--ab` row) still benches
as before. One line reports the skip.

## Tests

Added `test_run_skips_pinned_rebench_of_the_same_election_after_a_greedy_hang`, alongside the existing
hung-greedy coverage in `tests/compiler/cli/test_golden_file_replay.py`. It drives the real
`--golden --realization --bench` path through a fake backend that completes the reference but reports
a timing hang, and asserts (a) the bench-failure recording call precedes the pinned-bench call, and (b)
the pinned-bench call receives an empty row list — the seed is skipped rather than recompiled. Confirmed
red before the fix (the recording call never happened and the seed was handed to the pinned bench
unfiltered) and green after.

## Gates

`make test`: 4221 passed, 1046 skipped, 19 xfailed. `make lint`: clean. No compiler code was touched, so
`make test-goldens` does not apply.

## Line balance

`git diff --stat origin/main -- emmy/` shows +18/-2 in `emmy/commands/run.py`. This is a net addition
because it closes a real gap (a failure path with no recording at all, not merely a misordering) and
adds the skip check the harness was missing; it does not add new configurability or restructure
anything already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)