### PR TITLE
Re-measure the 4090's staging rows, and name the causes behind the rest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,47 +12,44 @@ body hard to edit. The ~120-character rule applies to files in the repository, n
 
 ## Abstract
 
-Twenty-three more recorded rows come back, leaving thirteen of the original hundred and five. The 4080 and the PRO 6000 were entirely dead and cost nothing to repair: every one of their rows had simply left a knob unspelled where the enumeration spells it at its off value, and neither card needs to be reachable for that. Five rows on the 5090 pinned a staging choice their kernels no longer expose, so those were re-benched on the card rather than respelled, and the result is worth stating plainly — the tuning win they recorded is one the default pick has since absorbed. The rest of the work went into finding why five attention rows spell a tensor-core cell the enumeration never offers. That is located, and the one-line fix for it is not shippable; the memo says why.
+Two more recorded rows come back, and the four the memo could not explain now have named causes. What matters more than the count is that the remaining eleven are all one kind of thing: every one is blocked by a compiler behaviour someone can go and read, and none of them is a stale spelling or a missing measurement. That was not true when this started, when two thirds of every card's rows simply matched nothing and there was no way to tell a codec drift from a lost capability.
 
 | Card | Rows | Dead before | Dead now |
 | --- | --- | --- | --- |
-| RTX 4080 | 9 | 9 | 0 |
-| RTX PRO 6000 | 10 | 9 | 0 |
-| RTX 5090 | 63 | 8 | 3 |
-| RTX 4090 | 73 | 10 | 10 |
+| RTX 4090 | 73 | 10 | 8 |
+| RTX 5090 | 63 | 3 | 3 |
 
 ---
 
-## The two unreachable cards
+## The two measured rows
 
-All 18 of their rows differ from an offered row by the same single thing: the record omits `REDUCE` where the enumeration spells it at off. That is the class already closed on the other two cards, and it is meaning-preserving, so the measurements stand and no GPU is involved. That is exactly why these went first — neither card is reachable, and an omitted off value never needed one.
+Same repair as the five closed on the 5090: they pin `STAGE: d1/smem` where their kernels expose no staging family, so the key names a decision that does not exist and the stored microseconds do not survive dropping it. Re-benched at O3 on the card as pinned rows — a measurement, not a search.
 
-## The five re-measured rows
+    attention.hd128.dynM.pv  39.23 us against a 39.12 us greedy reference
+    attention.hd64.dynM.pv   15.22 us against 15.01 us
 
-Each recorded `STAGE: d1/smem`. Those kernels expose no staging family at all now, so the key names a decision that does not exist and the row decodes the moment it is dropped. The stored microseconds do not survive that: they were taken with a synchronous shared-memory fill, and the kernel stages however the tiling stages it today. So they were re-benched at O3 on the card as pinned rows — a measurement, not a search.
+Both land on the schedule the greedy pick takes, as all five did on the 5090.
 
-All five land on the same schedule the greedy pick takes. `attention.hd64.dynM.softmax_v` recorded 13.51 us against a 59.03 us reference and now reads 11.56 against 11.54. The row is still evidence; it is no longer a win over the default.
+## An inference that became a measurement
 
-## The f16-accumulate lockout
+`attention.hd128.pv` was the third row of that class on paper. On the card both its lanes refuse to compile, with exactly the message the memo predicted from its spelling: an atomic cross-CTA reduce folds one additive state component and attention's carrier has three. It moves out of the staging class and into that blocker, where it belongs.
 
-`classic_projection._atom_families` returns `base + reduced_acc` on its general path and only `base` on the CHUNK branch — it asks `atoms_for` at the default f32 accumulator and never for the reduced one. When attention's value channel became a chunked site, the f16-accumulate cell stopped being a candidate there. That is the whole cause: the pool offers thousands of `mma_m16n8k16_f16_f32` rows and not one `f16_f16`.
+## The rows the memo called undiagnosed
 
-The precision gate is not involved. The resolved gate is folded into the pool key, so the two lanes do not share a cache entry, and pinning it explicitly changes nothing.
+Both now answer. `attention.hd256.dynM.pv` is a chunk-tier refusal that states itself — *the chunk tier reads its score operands and its streamed value as slabs* — so at that head dimension the warp atoms are never projected. `attention.hd64.pv` is the split doing it: its node refusal is `None`, the tier is willing, but the row spells a `g4k` split and what enumerates is the pieces, which offer only scalar tiles. `attention.hd64.dynM.pv#1` spells no split and keeps its tensor-core rows, which is the controlled comparison.
 
-**Adding the reduced accumulator to that branch is not the fix.** It offers 2282 f16 rows and makes all five rows decode. It also empties the enumeration of `attention/sdpa-hd128-softmax-v-mma`, a closed corpus case: that case pins its TILE bare, so once the chunked score node accepts `f16_f16` the pin binds at both contraction sites and the pair realizes nothing. The chunk tier's lowering refuses this path for a reason the projection only exposes. Reverted rather than shipped with a corpus regression.
-
-One fact for the next attempt, since it inverts the obvious reading: this atom does not produce an f16 result. Its mma chain runs on packed f16 partials and folds them into f32 shadows every 64 K-elements, and the shadows keep the names every sink reads. The repack gathers an f32 fragment either way, so `c_to_a_repack` keying on shape alone is correct and the refusal is somewhere else.
+That makes `hd64.pv` the same open question as the `g4a` dead end already in the memo: why a cross-CTA split mints pieces the tensor-core tier does not serve.
 
 ## What is left
 
-13 rows, all attention, in `plans/golden-row-decode-gaps.md`: five behind the lockout above, two whose atomic cross-CTA reduce cannot fold a three-component carrier (and whose compiler-suggested alternative collapses the target to a scalar pair at 139.5 us against 26.1 us unsplit), four needing the 4090 for the staging re-measure, and two undiagnosed.
+Eleven rows behind three named behaviours, in `plans/golden-row-decode-gaps.md`: the chunk tier never offering the reduced accumulator, the atomic cross-CTA reduce refusing a multi-component carrier, and the tensor-core tier being absent from two targets. Four rows carry two blockers at once. The memo also records the four dead ends walked so far, and what the 4090 host needs — nvcc is installed there but not on PATH, and emmy has no NVRTC fallback, so a bench dies until `CUDA_HOME` is set.
 
 No row was re-recorded to make it green.
 
 ## Verification
 
-339 passed, 7 skipped, 13 xfailed across the search tests. The realization corpus is 424 passed, 8 skipped, 3 xfailed on its GPU-free stages — the check that caught the projection change and the reason it is not in this diff.
+144 passed, 7 skipped, 11 xfailed on the golden decode. The registry shrank by two, and each removal is a row the ratchet then demanded pass.
 
-`git diff --stat main -- emmy/` is +33 −20, all of it recorded rows. No compiler code changed.
+`git diff --stat main -- emmy/` is +6 −8 — two rows re-measured and their dead staging key dropped. No compiler code changed.
 
 **Draft.** `make test` has not been run.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,6 +50,10 @@ No row was re-recorded to make it green.
 
 144 passed, 7 skipped, 11 xfailed on the golden decode. The registry shrank by two, and each removal is a row the ratchet then demanded pass.
 
-`git diff --stat main -- emmy/` is +6 −8 — two rows re-measured and their dead staging key dropped. No compiler code changed.
+`make test` passes: 4,388 passed, 1,042 skipped, and 23 xfailed. The default lane now records every test taking at least 1 s in its output, and the CI-only 5.9 s cold-start row that failed the original run is in `tests/durations.json`.
 
-**Draft.** `make test` has not been run.
+`make lint` passes.
+
+`make test-goldens` remains red on seven pre-existing model-golden files: Laguna, OLMoE, Qwen3.5, DeepSeek V4, `gemma-4-12B`, and the two `gemma-4-12B-it` card files. This PR changes no model golden or compiler code.
+
+`git diff --stat main -- emmy/` is +6 −8 — two rows re-measured and their dead staging key dropped. No compiler code changed.

--- a/Makefile
+++ b/Makefile
@@ -72,13 +72,13 @@ format: setup
 # ~12% cold / ~6% warm on a 5090 (923s vs 1031s cold), not the "~3x" this comment used
 # to claim — that predated the WMMA->mma.sync migration which removed the cicc unroll
 # blowup it rested on. See AGENTS.md for the measurement.
-# --durations: the slowest tests are printed on every run (CI included), so a new long
-# pole is visible in the log the moment it lands rather than after someone profiles.
+# --durations=0 plus --durations-min=1 prints every test taking at least 1s on each
+# run (CI included); the session gate still rejects unbaselined tests at 5s.
 # `EMMY_GOLDEN_FILE=` (set, empty) deploys no repository golden in this lane: the correctness lane never asks how
 # fast a pick is, and importing a card's goldens is work every worker process would repeat. Tests that need golden
 # evidence scope it themselves (`--golden PATH`, `records_override`), which takes precedence.
 test: setup
-	EMMY_NVCC_FLAGS="-Xcicc -O1" EMMY_GOLDEN_FILE= ./venv/bin/pytest tests/ -v -n auto --dist=loadgroup --durations=25
+	EMMY_NVCC_FLAGS="-Xcicc -O1" EMMY_GOLDEN_FILE= ./venv/bin/pytest tests/ -v -n auto --dist=loadgroup --durations=0 --durations-min=1
 
 # Restamp the realization corpus's derived half (program wire, name, identity, canonical knobs)
 # after a kernel-identity or schedule-codec change. `make test` DETECTS staleness on any machine,
@@ -100,7 +100,7 @@ test-goldens: setup
 # LPT-buckets on, so CI's first (cache-less) run is balanced. Runs through one xdist
 # worker: loadgroup stamps the canonical @cuda group suffixes the parallel suite
 # looks up, without concurrent workers inflating the measurements. Commit the result
-# when the balance has drifted (a new heavy test, a big pass-cost change).
+# when the balance has drifted (a newly reported slow test, a big pass-cost change).
 test-durations: setup
 	EMMY_NVCC_FLAGS="-Xcicc -O1" EMMY_GOLDEN_FILE= ./venv/bin/pytest tests/ -q -p no:randomly -n 1 --dist=loadgroup --write-durations
 

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
@@ -1743,12 +1743,11 @@ configs:
       WORK: w1x16
       TILE: mma_m16n8k16_f16_f32/f2x1/k4
       REDUCE: ''
-      STAGE: d1/smem
       RASTER: ''
     measurements:
-      emmy_us: 10.25
-      reference_us: 127.74
-      reference_backend: emmy-greedy
+      emmy_us: 39.23
+      reference_us: 39.12
+      reference_backend: same-input-greedy
   - name: attention.hd128.dynM.pv
     bindings: {}
     pins:
@@ -1921,12 +1920,11 @@ configs:
       WORK: w2x2
       TILE: mma_m16n8k16_f16_f32/f1x4/k8
       REDUCE: ''
-      STAGE: d1/smem
       RASTER: ''
     measurements:
-      emmy_us: 13.81
-      reference_us: 102.6
-      reference_backend: emmy-greedy
+      emmy_us: 15.22
+      reference_us: 15.01
+      reference_backend: same-input-greedy
   - name: attention.hd64.dynM.pv
     bindings: {}
     pins:

--- a/plans/golden-row-decode-gaps.md
+++ b/plans/golden-row-decode-gaps.md
@@ -1,8 +1,9 @@
 # Hardware-golden rows that still decode to nothing
 
-Status: 13 of 155 recorded rows across the four hardware goldens equal no enumerated leaf, down from 105. Three are
-on the RTX 5090, ten on the RTX 4090; the 4080 and the PRO 6000 are clean. Every one that is left is an attention
-row. This memo covers what blocks each, and the four dead ends already walked so nobody walks them twice.
+Status: 11 of 155 recorded rows across the four hardware goldens equal no enumerated leaf, down from 105. Three are
+on the RTX 5090, eight on the RTX 4090; the 4080 and the PRO 6000 are clean. Every one that is left is an attention
+row, and every one is now blocked by a NAMED compiler behaviour — nothing left here is a spelling or a measurement.
+This memo covers what blocks each, and the four dead ends already walked so nobody walks them twice.
 
 Do not re-record a row to make it green. A row that stops decoding because the schedule it names is gone is a
 regression in the enumeration, and recording today's pick in its place writes that regression in as the reference.
@@ -16,34 +17,33 @@ limits, not measurement.
 | --- | --- | --- |
 | A family omitted where the enumeration spells it at its off value | 60 | Spell the key; measurements survive |
 | A `g<n>` split compared to a leaf the pieces cannot spell | 27 | Fixed the decode to compare the piece row |
-| The kernel offers no staging family at all | 5 | Drop the key, re-measure on the card |
+| The kernel offers no staging family at all | 7 | Drop the key, re-measure on the card |
 
 The first two are meaning-preserving and needed no GPU. The third does not preserve meaning — the stored
-microseconds were taken with a synchronous shared-memory fill — so those rows were re-benched at O3 on the 5090.
-All five now realize what the greedy pick takes anyway: the tuning win they recorded, 13.51 us against a 59.03 us
-reference in one case, is a win the default has since absorbed.
+microseconds were taken with a synchronous shared-memory fill — so those rows were re-benched at O3 on the card
+that recorded them, five on the 5090 and two on the 4090. All seven realize what the greedy pick takes anyway: the
+tuning win they recorded, 13.51 us against a 59.03 us reference in one case, is a win the default has since
+absorbed.
 
-## The 13 that are left
+## The 11 that are left
 
-Three things block them, and four rows carry two at once. `STAGE` below means the row pins `d1/smem` where its kernel offers
-no staging family; `f16` means the row spells `mma_m16n8k16_f16_f16`; `atomic` means its `REDUCE` names an atomic
-cross-CTA reduce.
+Three things block them, and four rows carry two at once. `f16` means the row spells `mma_m16n8k16_f16_f16`;
+`atomic` means its `REDUCE` names an atomic cross-CTA reduce; `no mma` means the pool offers no tensor-core tile of
+any kind.
 
 | Row | Card | Blocked by |
 | --- | --- | --- |
 | `attention.hd128.softmax_v#1` | 5090 | f16 |
 | `attention.hd64.softmax_v#1` | 5090 | f16, atomic (`g4a`) |
-| `attention.hd64.softmax_v#2` | 5090 | STAGE, atomic (`g4a`) |
-| `attention.hd128.pv#1` | 4090 | STAGE, atomic (`g2a`) |
+| `attention.hd64.softmax_v#2` | 5090 | atomic (`g4a`) |
+| `attention.hd128.pv#1` | 4090 | atomic (`g2a`) |
 | `attention.hd128.pv#2` | 4090 | f16, atomic (`g2a`) |
-| `attention.hd128.dynM.pv#1` | 4090 | STAGE |
 | `attention.hd128.dynM.pv#2` | 4090 | f16 |
-| `attention.hd64.dynM.pv#1` | 4090 | STAGE |
 | `attention.hd64.dynM.pv#2` | 4090 | f16 |
-| `attention.hd64.pv#1` | 4090 | no mma offered (split pieces) |
-| `attention.hd64.pv#2` | 4090 | f16, no mma offered (split pieces) |
-| `attention.hd256.dynM.pv#1` | 4090 | no mma offered (chunk tier refuses) |
-| `attention.hd256.dynM.pv#2` | 4090 | no mma offered (chunk tier refuses) |
+| `attention.hd64.pv#1` | 4090 | no mma (split pieces) |
+| `attention.hd64.pv#2` | 4090 | f16, no mma (split pieces) |
+| `attention.hd256.dynM.pv#1` | 4090 | no mma (chunk tier refuses) |
+| `attention.hd256.dynM.pv#2` | 4090 | no mma (chunk tier refuses) |
 
 ## Blocker 1 — the chunk tier never offers the reduced accumulator (6 rows)
 
@@ -93,8 +93,8 @@ pair is the verified one: `#2` decodes with the staging key dropped and then fai
     — use the deferred f32 workspace finalize (REDUCE=g<n>k)
 
 Attention's carrier folds a running maximum, a denominator and an expectation, so an atomic fold over one additive
-component cannot express it. The 4090 pair is inferred from the same spelling and has not been built — that card was
-not reachable during this work.
+component cannot express it. Both pairs are verified on their own card: the 4090's `attention.hd128.pv` refuses to
+compile with the same message on both lanes.
 
 ### Dead end 4 — the compiler's own suggestion
 
@@ -124,13 +124,14 @@ that is the controlled comparison.
 
 Closing hd64.pv therefore means the same question as blocker 2: why a split's pieces lose the warp tier.
 
-## The staging rows that only need the card (3 rows)
+## Working on the 4090
 
-`attention.hd128.dynM.pv#1`, `attention.hd64.dynM.pv#1` and `attention.hd128.pv#1` on the 4090 decode as soon as the
-staging key is dropped, exactly like the five already closed on the 5090. `hd128.pv#1` carries `g2a` as well, so
-expect it to decode and then fail to build until blocker 2 is closed.
+The card at `riftuser@211.21.50.85 -p 57010` has the CUDA toolkit at `/usr/local/cuda` but nvcc is NOT on the
+default PATH, and emmy dropped its NVRTC fallback — so every bench dies with `nvcc unavailable` until the run
+carries `CUDA_HOME=/usr/local/cuda PATH=/usr/local/cuda/bin:$PATH`. `make setup` there takes about twenty minutes,
+almost all of it pulling CUDA wheels.
 
-Needs the card at `riftuser@211.21.50.85 -p 57010`, prepared the way the tune-kernels skill describes, then:
+The pinned bench that re-measures a staging row:
 
     emmy run --golden <file> --realization <name> --bench --bench-backends emmy --json <out>
 

--- a/plans/golden-row-decode-gaps.md
+++ b/plans/golden-row-decode-gaps.md
@@ -2,7 +2,7 @@
 
 Status: 13 of 155 recorded rows across the four hardware goldens equal no enumerated leaf, down from 105. Three are
 on the RTX 5090, ten on the RTX 4090; the 4080 and the PRO 6000 are clean. Every one that is left is an attention
-row. This memo covers what blocks each, and the three dead ends already walked so nobody walks them twice.
+row. This memo covers what blocks each, and the four dead ends already walked so nobody walks them twice.
 
 Do not re-record a row to make it green. A row that stops decoding because the schedule it names is gone is a
 regression in the enumeration, and recording today's pick in its place writes that regression in as the reference.
@@ -25,7 +25,7 @@ reference in one case, is a win the default has since absorbed.
 
 ## The 13 that are left
 
-Two things block them, and four rows carry both. `STAGE` below means the row pins `d1/smem` where its kernel offers
+Three things block them, and four rows carry two at once. `STAGE` below means the row pins `d1/smem` where its kernel offers
 no staging family; `f16` means the row spells `mma_m16n8k16_f16_f16`; `atomic` means its `REDUCE` names an atomic
 cross-CTA reduce.
 
@@ -40,10 +40,10 @@ cross-CTA reduce.
 | `attention.hd128.dynM.pv#2` | 4090 | f16 |
 | `attention.hd64.dynM.pv#1` | 4090 | STAGE |
 | `attention.hd64.dynM.pv#2` | 4090 | f16 |
-| `attention.hd64.pv#1` | 4090 | undiagnosed (`g4k`) |
-| `attention.hd64.pv#2` | 4090 | f16, undiagnosed (`g4k`) |
-| `attention.hd256.dynM.pv#1` | 4090 | undiagnosed |
-| `attention.hd256.dynM.pv#2` | 4090 | undiagnosed |
+| `attention.hd64.pv#1` | 4090 | no mma offered (split pieces) |
+| `attention.hd64.pv#2` | 4090 | f16, no mma offered (split pieces) |
+| `attention.hd256.dynM.pv#1` | 4090 | no mma offered (chunk tier refuses) |
+| `attention.hd256.dynM.pv#2` | 4090 | no mma offered (chunk tier refuses) |
 
 ## Blocker 1 — the chunk tier never offers the reduced accumulator (6 rows)
 
@@ -103,6 +103,27 @@ Respelling `g4a` as `g4k` splits the target into pieces that take no mma tile at
 139.5 us + 4.2 us against 26.1 us unsplit. So the choice is to make the atomic reduce carry a multi-component fold,
 or to accept that these rows have no cross-CTA plan and re-measure them unsplit.
 
+## Blocker 3 — the tensor-core tier is absent from these targets (4 rows)
+
+`attention.hd256.dynM.pv#1`/`#2` and `attention.hd64.pv#1`/`#2` on the 4090. Each records an
+`mma_m16n8k16_f16_f32` row, and the pool offers no mma tile of any kind — only the scalar tier (`t32x8`, `f26x4`,
+`f1x*`). Two different causes, both now named; neither is blocker 1 or 2.
+
+**hd256 is a chunk-tier refusal.** `_node_refusal` answers outright:
+
+    the chunk tier reads its score operands and its streamed value as slabs
+
+So at that head dimension the tier declines the target and the warp atoms are never projected. Whether a 256-wide
+head SHOULD reach the chunk tier is the question to settle; the refusal is deliberate, not incidental.
+
+**hd64.pv is the split's doing.** Its node refusal is `None` — the tier is willing — but the row spells
+`REDUCE: g4k`, so the replay follows the split arm and what enumerates is the PIECES. Those offer only scalar tiles.
+This is the same effect seen when `g4a` was respelled to `g4k` on the 5090 (dead end 4): a cross-CTA split mints
+pieces the tensor-core tier does not serve. `attention.hd64.dynM.pv#1`, which spells no split, keeps its mma rows —
+that is the controlled comparison.
+
+Closing hd64.pv therefore means the same question as blocker 2: why a split's pieces lose the warp tier.
+
 ## The staging rows that only need the card (3 rows)
 
 `attention.hd128.dynM.pv#1`, `attention.hd64.dynM.pv#1` and `attention.hd128.pv#1` on the 4090 decode as soon as the
@@ -115,10 +136,3 @@ Needs the card at `riftuser@211.21.50.85 -p 57010`, prepared the way the tune-ke
 
 Promote `emmy_us` from the pinned row's isolated timing and `reference_us` from the greedy isolated timing, with
 `reference_backend: same-input-greedy`.
-
-## Undiagnosed (3 rows)
-
-`attention.hd256.dynM.pv#1`/`#2` and `attention.hd64.pv#1` on the 4090. All f32-accumulate, all still dead after the
-staging key is dropped, none affected by blocker 1. `hd256.dynM` offers 234 candidate rows where its siblings offer
-2778, so that target enumerates far more narrowly — check first whether it lowers differently at that head
-dimension. `hd64.pv#1` spells `g4k`, a split rather than an atomic reduce, so it is not blocker 2.

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -209,12 +209,13 @@ renamed and deleted tests drop out instead of lingering as ghost slots the bucke
 one xdist loadgroup worker: execution stays serial, while CUDA node IDs keep the canonical ``@cuda`` / ``@cuda-cli``
 suffixes the parallel suite uses for lookup. Point it at the whole suite, never a subset.
 
-Two things keep it honest. `make test` passes `--durations=25`, so every run (CI included) prints its slowest tests and
-a new long pole shows up in the log immediately. And the session-end gate in `conftest.py` fails any run where a test
-took **5 s or more without being in the baseline**, naming the offenders and asking for `make test-durations`. The bar
-sits far above the 0.05 s recording threshold on purpose — CI runners are several times slower than a dev box, and the
-gap guarantees nothing near the threshold can drift across it. It is a session hook rather than a test case because
-only the controller, and only after the last report, has every test's duration; an xdist worker sees just its own slice.
+Two things keep it honest. `make test` passes `--durations=0 --durations-min=1`, so every run (CI included) prints every
+test that takes at least 1 s instead of only a fixed-size tail. And the session-end gate in `conftest.py` fails any run
+where a test took **5 s or more without being in the baseline**, naming the offenders and asking for
+`make test-durations`. Keeping the failure bar above the 0.05 s recording threshold lets the report expose differences
+between a development machine and CI without making worker-specific cold imports gate the run. It is a session hook
+rather than a test case because only the controller, and only after the last report, has every test's duration; an
+xdist worker sees just its own slice.
 
 The `perf` marker gates **suite-wide**, not just `tests/perf/`: the root `tests/conftest.py` hook skips every
 perf-marked item unless `-m perf` was passed, and since the root conftest loads for any `tests/` collection the gate

--- a/tests/compiler/pipeline/search/golden_xfails.yaml
+++ b/tests/compiler/pipeline/search/golden_xfails.yaml
@@ -6,13 +6,11 @@
 rtx4090_sm89.yaml:
   - attention.hd128.pv#1
   - attention.hd128.pv#2
-  - attention.hd128.dynM.pv#1
   - attention.hd128.dynM.pv#2
   - attention.hd256.dynM.pv#1
   - attention.hd256.dynM.pv#2
   - attention.hd64.pv#1
   - attention.hd64.pv#2
-  - attention.hd64.dynM.pv#1
   - attention.hd64.dynM.pv#2
 rtx5090_sm120.yaml:
   - attention.hd128.softmax_v#1

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -1290,6 +1290,7 @@
  "tests/serving/test_deepseek_native_loader.py::test_learned_hyper_connection_scale_is_not_mistaken_for_a_block_scale": 5.4,
  "tests/serving/test_deepseek_native_loader.py::test_multi_token_prediction_head_is_never_read": 1.9,
  "tests/serving/test_deepseek_native_loader.py::test_native_fp8_trunk_weight_loads_scaled": 5.1,
+ "tests/serving/test_deepseek_native_loader.py::test_native_trunk_names_reach_the_twin": 5.9,
  "tests/serving/test_deepseek_v4_split.py::test_hyper_connection_split_matches_eager_layer[1]": 5.4,
  "tests/serving/test_deepseek_v4_split.py::test_hyper_connection_split_matches_eager_layer[2]": 5.2,
  "tests/serving/test_moe_split.py::test_exl3_laguna_dense_and_sparse_blocks_preserve_float32_residuals": 0.3,


### PR DESCRIPTION
<!--
Title: a functional description, readable with no context. "Fix X", "Optimize Y", "Do X because Y".
Not a component name, not a branch name, not a ticket id.

Write this body, then revise it at least twice before posting. Each pass: read it as a reviewer who has no context,
check it against the rules below and against the design philosophy in AGENTS.md, and cut. A first draft is always too
long. Stop when nothing else can come out without losing the point.

Do not hard-wrap the text you write here. GitHub wraps it for the reader, and manual line breaks only make the
body hard to edit. The ~120-character rule applies to files in the repository, not to a pull-request body.
-->

## Abstract

Two more recorded rows come back, and the four the memo could not explain now have named causes. What matters more than the count is that the remaining eleven are all one kind of thing: every one is blocked by a compiler behaviour someone can go and read, and none of them is a stale spelling or a missing measurement. That was not true when this started, when two thirds of every card's rows simply matched nothing and there was no way to tell a codec drift from a lost capability.

| Card | Rows | Dead before | Dead now |
| --- | --- | --- | --- |
| RTX 4090 | 73 | 10 | 8 |
| RTX 5090 | 63 | 3 | 3 |

---

## The two measured rows

Same repair as the five closed on the 5090: they pin `STAGE: d1/smem` where their kernels expose no staging family, so the key names a decision that does not exist and the stored microseconds do not survive dropping it. Re-benched at O3 on the card as pinned rows — a measurement, not a search.

    attention.hd128.dynM.pv  39.23 us against a 39.12 us greedy reference
    attention.hd64.dynM.pv   15.22 us against 15.01 us

Both land on the schedule the greedy pick takes, as all five did on the 5090.

## An inference that became a measurement

`attention.hd128.pv` was the third row of that class on paper. On the card both its lanes refuse to compile, with exactly the message the memo predicted from its spelling: an atomic cross-CTA reduce folds one additive state component and attention's carrier has three. It moves out of the staging class and into that blocker, where it belongs.

## The rows the memo called undiagnosed

Both now answer. `attention.hd256.dynM.pv` is a chunk-tier refusal that states itself — *the chunk tier reads its score operands and its streamed value as slabs* — so at that head dimension the warp atoms are never projected. `attention.hd64.pv` is the split doing it: its node refusal is `None`, the tier is willing, but the row spells a `g4k` split and what enumerates is the pieces, which offer only scalar tiles. `attention.hd64.dynM.pv#1` spells no split and keeps its tensor-core rows, which is the controlled comparison.

That makes `hd64.pv` the same open question as the `g4a` dead end already in the memo: why a cross-CTA split mints pieces the tensor-core tier does not serve.

## What is left

Eleven rows behind three named behaviours, in `plans/golden-row-decode-gaps.md`: the chunk tier never offering the reduced accumulator, the atomic cross-CTA reduce refusing a multi-component carrier, and the tensor-core tier being absent from two targets. Four rows carry two blockers at once. The memo also records the four dead ends walked so far, and what the 4090 host needs — nvcc is installed there but not on PATH, and emmy has no NVRTC fallback, so a bench dies until `CUDA_HOME` is set.

No row was re-recorded to make it green.

## Verification

144 passed, 7 skipped, 11 xfailed on the golden decode. The registry shrank by two, and each removal is a row the ratchet then demanded pass.

`make test` passes: 4,388 passed, 1,042 skipped, and 23 xfailed. The default lane now records every test taking at least 1 s in its output, and the CI-only 5.9 s cold-start row that failed the original run is in `tests/durations.json`.

`make lint` passes.

`make test-goldens` remains red on seven pre-existing model-golden files: Laguna, OLMoE, Qwen3.5, DeepSeek V4, `gemma-4-12B`, and the two `gemma-4-12B-it` card files. This PR changes no model golden or compiler code.

`git diff --stat main -- emmy/` is +6 −8 — two rows re-measured and their dead staging key dropped. No compiler code changed.
