### PR TITLE
Read a recorded row and an enumerated leaf as the same schedule when only their OFF anchors differ

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,38 +1,62 @@
-<!--
-Title: a functional description, readable with no context. "Fix X", "Optimize Y", "Do X because Y".
-Not a component name, not a branch name, not a ticket id.
-
-Write this body, then revise it at least twice before posting. Each pass: read it as a reviewer who has no context,
-check it against the rules below and against the design philosophy in AGENTS.md, and cut. A first draft is always too
-long. Stop when nothing else can come out without losing the point.
-
-Do not hard-wrap the text you write here. GitHub wraps it for the reader, and manual line breaks only make the
-body hard to edit. The ~120-character rule applies to files in the repository, not to a pull-request body.
--->
-
 ## Abstract
 
-<!--
-One short paragraph, plain technical English: what was done and why. Four or five sentences is already long. No file
-paths, no symbol names, no code.
+More than half the rows recorded in the goldens matched nothing the compiler enumerates, so the gate that says whether a card's measurements still describe today's compiler was reporting most of them dead. The cause was not stale data. A resolved kernel carries an explicit value for every scheduling decision it declined, and that is the row a recording is taken from; a fork offers its alternatives carrying only the decisions that kernel actually has, so the same schedule is written two ways depending on which side names it. The comparison demanded they match exactly. Reading them as the same schedule when only the declined decisions differ, and re-keying twenty-one rows that name a reduction site by a spelling the compiler retired, brings back 719 rows with the measurements they were recorded with.
 
-No bullets. A list here is almost always a first draft that was never revised — if the points belong together, they
-belong in the paragraph, and if they do not, they belong below the rule. In the rare case a list is genuinely the
-clearest form, five bullets is the hard cap.
+### Rows that decode
 
-"Abstract" is the one fixed heading. Everything below is named for whatever the change is about.
--->
-
-<!--
-OPTIONAL: one small artifact that carries the abstract's claim — a short table of before/after numbers, a diagram, a
-few lines of output. One only, and only if it says something the paragraph cannot. Name the heading for what it shows
-("Latency", "New pass order"). Delete this block if there is nothing worth showing.
--->
+| golden | rows | before | after |
+| --- | ---: | ---: | ---: |
+| DeepSeek-V4-Flash (V100) | 279 | 20 | 279 |
+| gemma-4-12B-it (5090) | 352 | 126 | 346 |
+| gemma-4-12B (5090) | 194 | 24 | 194 |
+| gemma-4-12B-it (4090) | 240 | 129 | 197 |
+| OLMoE (5090) | 13 | 7 | 9 |
+| the five hardware goldens | 224 | 224 | 224 |
+| Laguna, Qwen3.5 | 52 | 45 | 45 |
+| **total** | **1354** | **575** | **1294** |
 
 ---
 
-<!--
-Everything else, under headings that fit the story: design decisions, alternatives rejected, measurements, what broke,
-what got slower, what was removed. Code references are fine here. Length is fine here, but the same revision rule
-applies — a section a reviewer would skip should not exist.
--->
+## Why the two sides disagree
+
+The pipeline stamps a pass's declared OFF values onto the variant at the pass boundary, so a resolved kernel spells every schedule family whether or not it uses one. A fork's offered leaves are read as the codec built them, and the codec keys a family off the sites the kernel has — a kernel with no contraction encodes as work and rasterization alone. Recording reads the resolved kernel. Comparison reads both. So a recorded row could only ever equal the one leaf that happened to be the resolved one, and every other leaf differed from it by anchors that carry no schedule content.
+
+Recording keeps the anchors. A forkless kernel's row **is** its OFF anchors, and dropping them there writes an empty row that spells no decision at all, which strict evidence then rejects. Only the comparison changes.
+
+## Why not require the two spellings to agree instead
+
+That is the other repair, and it has now been made three times: #744 hand-inserted 43 anchor keys into two cards, #745 did the 4080 and the PRO 6000, and #748 stamped anchors onto the leaves of the kernels the hardware goldens exercise. Each worked for the file in front of it. None reached the model goldens, which is where 98% of the corpus lives and which nobody hand-edits — they were still at 575 of 1354 before this change.
+
+The cost of this direction is worth stating: a comparison blind to anchors will no longer notice if the enumeration stops stamping one. That check was never what the golden gate was for, and it belongs with the pass that stamps.
+
+## The re-key
+
+Twenty-one rows address their cross-CTA reduction as `REDUCE@a1` or `REDUCE@a0`. Neither parses today — the site codec moved to a route over the stored tree whose last segment names the arrived-at node by kind, and an axis name is not a kind. Four more spell the family bare where the kernel has several sites.
+
+The value is untouched in every case; each row was matched to the one enumerated row carrying the same families at the same values under a different site path, and a row with more than one such match would have been left alone. None had one. This is a re-key, not a re-measurement.
+
+## What still does not decode
+
+Sixty rows, none of them reachable from a file:
+
+| | rows |
+| --- | ---: |
+| gemma-4-12B-it (4090), schedule no longer offered | 43 |
+| Laguna, stored program will not lower | 6 |
+| gemma-4-12B-it (5090) | 6 |
+| OLMoE | 4 |
+| Qwen3.5 | 1 |
+
+The Laguna six are not a schedule problem. Replaying a structural decision asks the fork's root for its identity, the identity lowers the op's body, and that lowering rejects the exl3 bitcast matmul: `no extent for coordinates ['in17'] — the closed program takes them as axes`. Enumerating the target with the record's spelling removed entirely fails the same way, so retuning cannot reach them either. It is a live crash on a path that is not golden-specific.
+
+The rest record a schedule the enumeration no longer offers — a tile width that shrank from `f8` to `f4`, a warp shape that is still offered but no longer alongside that tile and TMA staging, a kernel that now requires a tiling choice where the recording declined one. Those need the card, and only after someone decides the narrowing was intended.
+
+## Verification
+
+`make test` 4505 passed, 1075 skipped, 12 xfailed. `make lint` clean. Decode counts above are the strict decode over the whole repository corpus, run on this branch and on `origin/main` in a separate worktree; both need no GPU.
+
+A test pins both halves of the new rule: a row decodes with the anchors and without them, and still fails when a decided value is changed to nonsense.
+
+## Line balance
+
+`git diff --stat origin/main -- emmy/` is +39 −13. The executable half is four lines — one projection and three call sites. The rest is the note explaining why the two spellings differ, which is the part that was rediscovered three times.

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -687,8 +687,12 @@ offers, or a schedule row no kernel of the replay enumerates, is stale and is no
 realizes is the question the nightly `onboard-model` workflow asks with the strict decode (`golden.decode_record`),
 over the same replay: the persisted program must select exactly one kernel (a receipt selects its child by stored
 identity), a routing record's every cut key must name a seam the cut pass offers, and a schedule row must equal one
-enumerated leaf under the record's own pins. The default test suite does not load checked-in goldens because proving a
-row enumerates its whole fork costs record count times fork size.
+enumerated leaf under the record's own pins. Equality there is blind to the two sides' OFF anchors. A resolved kernel
+carries every declared OFF value, because the pipeline stamps them at the pass boundary, and that is the row a
+recording is taken from; a fork offers its leaves carrying only the families the kernel's own sites give it. Both
+spell the same schedule, so which anchors appear says where a spelling came from, not what it decided. The default
+test suite does not load checked-in goldens because proving a row enumerates its whole fork costs record count times
+fork size.
 
 **Whether goldens are training data differs between the two halves of the prior.** The **online** prior never trains
 on them: a recorded golden row enters no reservoir and no checkpoint. (Benchmarks of a golden *shape* during a tune

--- a/emmy/compiler/pipeline/knob.py
+++ b/emmy/compiler/pipeline/knob.py
@@ -609,14 +609,31 @@ def canonical_row_key(knobs: dict) -> tuple[tuple[str, str], ...]:
 
 
 def schedule_row_key(knobs: dict) -> tuple[tuple[str, str], ...]:
-    """The exact schedule identity projection a recorded row is compared to a leaf by (the strict
-    golden decode).
+    """The schedule families of a row, as a comparable tuple — what a kernel's schedule decision is
+    RECORDED as. :func:`schedule_match_key` is what two such rows are compared by.
 
     A recorded row legitimately carries later forks' knobs too (the
     kernel-stage policy BOOLs, ``LOOPIFY``); those are separate decisions at separate forks and
     never part of THIS fork's identity. Structural branch prefixes pass through this helper while
     matching a complete leaf, so validation belongs at recording and leaf-construction boundaries."""
     return canonical_row_key({k: v for k, v in knobs.items() if family_of(k) in SCHEDULE_FAMILIES})
+
+
+def schedule_match_key(knobs: dict) -> tuple[tuple[str, str], ...]:
+    """:func:`schedule_row_key` without its OFF anchors — the projection two rows are compared as
+    the SAME schedule by.
+
+    The two sides of that comparison are written in different spellings. A resolved kernel carries
+    every declared OFF value, because the pipeline stamps them at the pass boundary
+    (:func:`apply_off_defaults`), and that is the row a recording is taken from. A fork offers its
+    leaves in the codec's spelling, which keys only the families the kernel's own sites give it. So
+    the same schedule is spelled with different anchors depending on which side names it, and an
+    anchor carries no schedule content either way — it records a pass that declined. Comparing the
+    spellings exactly is what left two thirds of the recorded golden rows matching nothing.
+
+    Recording keeps the anchors: a forkless kernel's row IS its OFF anchors, and dropping them
+    there writes an empty row that spells no decision at all."""
+    return tuple((key, value) for key, value in schedule_row_key(knobs) if not is_off_value(family_of(key), value))
 
 
 def evidence_row_vouches(cand_tun: dict, row_tun: dict, *, exact_families: frozenset[str] = frozenset()) -> bool:

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -823,11 +823,13 @@ def decode_record(record: GoldenRecord, siblings: Sequence[GoldenRecord] = ()) -
     program selects exactly one kernel, except that a child-identity schedule receipt may select its
     kernel from a multi-kernel target by stored identity; a routing record's every cut key names a
     seam the cut pass offers on the replay (:func:`_replay`); a SCHEDULE record's spelled row equals
-    one enumerated leaf (``canonical_row_key`` equality under the record's own pins) — no prefix
-    matching, no any-of, no classified shape. A receipt's
+    one enumerated leaf (``schedule_match_key`` equality under the record's own pins) — no prefix
+    matching, no any-of, no classified shape. That equality is blind to the two sides' OFF anchors:
+    which of them a spelling writes down depends on whether it came from a resolved kernel or from a
+    fork's offered leaf, and neither carries schedule content. A receipt's
     identity must equal one kernel resolved under the record's pins, and the spelled row must equal
     one of THAT kernel's rows — a sibling child's row must not vouch for it."""
-    from emmy.compiler.pipeline.knob import schedule_row_key  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import schedule_match_key  # noqa: PLC0415
 
     verdict_key = digest(_record_fingerprint(record), str(sorted(record.knobs.items())), str(record.pins), record.identity or "")
     store = _identity_store()
@@ -848,7 +850,7 @@ def decode_record(record: GoldenRecord, siblings: Sequence[GoldenRecord] = ()) -
     # The piece row, not the recorded one: a ``g<n>`` cross-CTA half names the kernel-set arm the
     # replay already resolved, and the pieces it mints cannot stamp it, so comparing it to a leaf
     # asks a piece to spell its parent's decision.
-    row = schedule_row_key(piece_row(record.knobs))
+    row = schedule_match_key(piece_row(record.knobs))
     if record.is_receipt and (tile is None or record.identity != tile.identity_key(with_io=True)):
         child_rows = candidates.get(record.identity)
         if child_rows is None:
@@ -877,8 +879,9 @@ class _Replay(NamedTuple):
     """One replay of a record's target through the tile passes under the record's pins, following
     the record's knobs at every kernel-set fork (:func:`~emmy.compiler.pipeline.search.pins.spelled_arm`).
 
-    ``rows`` — the EXHAUSTIVE replay's answer: every schedule-row identity each kernel can realize,
-    bucketed by the kernel's deploy identity (``identity_key(with_io=True)``; ``None`` for forks
+    ``rows`` — the EXHAUSTIVE replay's answer: every schedule-row identity each kernel can realize
+    as a :func:`~emmy.compiler.pipeline.knob.schedule_match_key`, bucketed by the kernel's deploy
+    identity (``identity_key(with_io=True)``; ``None`` for forks
     whose root is not a recognized ``TileOp``): the fork leaves' rows, PLUS each resolved kernel's
     own realized row — a forkless kernel (the schedule space collapsed to one row, often the all-OFF
     anchor) never opens a fork, so its one row is read off the resolved op instead. Behind a cut the
@@ -974,6 +977,7 @@ def _replay(
         canonical_row_key,
         evidence_row_vouches,
         family_of,
+        schedule_match_key,
         schedule_pin_fingerprint,  # noqa: PLC0415
         schedule_row_key,
     )
@@ -1078,7 +1082,7 @@ def _replay(
         for leaf in ops:
             row = leaf_knobs(leaf)
             if row:
-                buckets.setdefault(identity, set()).add(schedule_row_key(row))
+                buckets.setdefault(identity, set()).add(schedule_match_key(row))
         return ops[0] if ops else leaves[0]
 
     # The seams an entry marks cut together are one composed decision where they resolve on one
@@ -1095,9 +1099,10 @@ def _replay(
     for node in out.nodes.values():
         if isinstance(node.op, TileOp):
             identity = _identity_of(node.op)
-            row = schedule_row_key(dict(node.op.knobs or {}))
+            knobs = dict(node.op.knobs or {})
+            row = schedule_row_key(knobs)
             if exhaustive:
-                buckets.setdefault(identity, set()).add(row)
+                buckets.setdefault(identity, set()).add(schedule_match_key(knobs))
             if identity is not None:
                 kernels.add(identity)
                 realized[identity] = dict(row)

--- a/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
+++ b/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
@@ -87375,7 +87375,7 @@ configs:
     knobs:
       LOOPIFY: '0'
       RASTER: ''
-      REDUCE: coop
+      REDUCE@inner: coop
       STAGE: ''
       TILE: ''
       WORK: t128
@@ -88837,7 +88837,7 @@ configs:
     knobs:
       LOOPIFY: '0'
       RASTER: ''
-      REDUCE: coop
+      REDUCE@inner: coop
       STAGE: ''
       TILE: ''
       WORK: t128
@@ -90109,7 +90109,7 @@ configs:
     knobs:
       LOOPIFY: '0'
       RASTER: ''
-      REDUCE: coop
+      REDUCE@inner: coop
       STAGE: ''
       TILE: ''
       WORK: t128
@@ -91210,7 +91210,7 @@ configs:
     knobs:
       LOOPIFY: '0'
       RASTER: ''
-      REDUCE: coop
+      REDUCE@inner: coop
       STAGE: ''
       TILE: ''
       WORK: t128
@@ -91872,7 +91872,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -91890,7 +91890,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t128
       TILE: ''
       STAGE: ''
@@ -91908,7 +91908,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -91926,7 +91926,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -91944,7 +91944,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t128
       TILE: ''
       STAGE: ''
@@ -91962,7 +91962,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -91980,7 +91980,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -91998,7 +91998,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t128
       TILE: ''
       STAGE: ''
@@ -92016,7 +92016,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -92034,7 +92034,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -92052,7 +92052,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t128
       TILE: ''
       STAGE: ''
@@ -92070,7 +92070,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t32
       TILE: ''
       STAGE: ''
@@ -92088,7 +92088,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a1: coop
+      REDUCE@inner: coop
       WORK: t256
       TILE: ''
       STAGE: ''

--- a/recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml
+++ b/recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml
@@ -12244,7 +12244,7 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      REDUCE@a0: coop
+      REDUCE@map.2/inner: coop
       WORK: t512
       TILE: ''
       STAGE: ''
@@ -12371,7 +12371,7 @@ configs:
     pins:
       FAST_MATH: true
     knobs:
-      REDUCE@a0: coop
+      REDUCE@map.2/inner: coop
       WORK: t512
       TILE: ''
       STAGE: ''

--- a/recipes/gemma-4-12B/golden/rtx5090_sm120.yaml
+++ b/recipes/gemma-4-12B/golden/rtx5090_sm120.yaml
@@ -8711,7 +8711,7 @@ configs:
       FAST_MATH: false
     name: post-sym.k_linear_mean_reduce_1831ce.901b51c12c65.m1
     knobs:
-      REDUCE@a0: coop
+      REDUCE@map.2/inner: coop
       WORK: t512
       TILE: ''
       STAGE: ''
@@ -8727,7 +8727,7 @@ configs:
       FAST_MATH: true
     name: post-sym.k_linear_mean_reduce_1831ce.901b51c12c65.m1.fm
     knobs:
-      REDUCE@a0: coop
+      REDUCE@map.2/inner: coop
       WORK: t512
       TILE: ''
       STAGE: ''

--- a/tests/compiler/pipeline/search/test_golden.py
+++ b/tests/compiler/pipeline/search/test_golden.py
@@ -108,10 +108,12 @@ def test_decode_ignores_off_anchors_but_not_a_decided_value() -> None:
     """
     from dataclasses import replace
 
+    # The smallest target on the card, named rather than searched for: every assertion below decodes
+    # the record again, so the row this stands on decides what the test costs.
     records = _records_of(_HARDWARE_GOLDENS_DIR / "rtx5090_sm120.yaml")
-    carries_anchor = [r for r in records if any(v == "" for v in r.knobs.values()) and any(v for v in r.knobs.values())]
-    record = next((r for r in carries_anchor if _decode(r, records) is None), None)
-    assert record is not None, "no row of the card decodes, so this test can say nothing about how one is compared"
+    named = [r for r in records if r.name == "matmul.square.512" and any(v == "" for v in r.knobs.values())]
+    record = next((r for r in named if _decode(r, records) is None), None)
+    assert record is not None, "matmul.square.512 records no decoding row carrying an OFF anchor to compare against"
 
     stripped = replace(record, knobs={key: value for key, value in record.knobs.items() if value != ""})
     assert _decode(stripped, records) is None, "a row must decode without the anchors a fork's leaf would not spell"

--- a/tests/compiler/pipeline/search/test_golden.py
+++ b/tests/compiler/pipeline/search/test_golden.py
@@ -96,6 +96,33 @@ def test_recorded_row_decodes(path: Path, label: str) -> None:
     assert (reason := _decode(record, records)) is None, reason
 
 
+def test_decode_ignores_off_anchors_but_not_a_decided_value() -> None:
+    """A row's OFF anchors are not part of what it is compared by, and its decided values are.
+
+    Which anchors a spelling writes down says where it came from, not what it decided: a resolved
+    kernel carries every declared OFF value because the pipeline stamps them at the pass boundary,
+    while a fork offers its leaves carrying only the families the kernel's sites give it. Both spell
+    the same schedule. Requiring them to agree is what left two thirds of the recorded rows matching
+    nothing, so the decode compares them blind to the anchors — and stays strict about every value a
+    row actually decided.
+    """
+    from dataclasses import replace
+
+    records = _records_of(_HARDWARE_GOLDENS_DIR / "rtx5090_sm120.yaml")
+    carries_anchor = [r for r in records if any(v == "" for v in r.knobs.values()) and any(v for v in r.knobs.values())]
+    record = next((r for r in carries_anchor if _decode(r, records) is None), None)
+    assert record is not None, "no row of the card decodes, so this test can say nothing about how one is compared"
+
+    stripped = replace(record, knobs={key: value for key, value in record.knobs.items() if value != ""})
+    assert _decode(stripped, records) is None, "a row must decode without the anchors a fork's leaf would not spell"
+
+    anchored = replace(record, knobs={"STAGE": "", "REDUCE": "", "RASTER": "", **record.knobs})
+    assert _decode(anchored, records) is None, "and with the anchors a resolved kernel would be stamped with"
+
+    decided = next(key for key, value in record.knobs.items() if value not in ("", "0"))
+    assert _decode(replace(record, knobs={**record.knobs, decided: "not-a-real-value"}), records) is not None
+
+
 def _recipe_paths() -> list[Path]:
     """The recipe-local model goldens — the repository set minus the hardware files above."""
     with _repository_golden_paths() as paths:

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -284,6 +284,7 @@
  "tests/compiler/pipeline/search/policy/test_greedy.py::test_price_memo_keys_on_exact_identity_not_the_term_hash": 18.27,
  "tests/compiler/pipeline/search/prior/test_catboost_model.py::test_fit_recovers_the_planted_signal": 0.28,
  "tests/compiler/pipeline/search/prior/test_report.py::test_a_pool_too_small_for_a_metric_is_excluded_and_the_count_says_so": 0.28,
+ "tests/compiler/pipeline/search/test_golden.py::test_decode_ignores_off_anchors_but_not_a_decided_value": 5.2,
  "tests/compiler/pipeline/search/test_golden.py::test_recorded_row_decodes[rtx4080_sm89.yaml/matmul.square.1024.fp16#1]": 1.86,
  "tests/compiler/pipeline/search/test_golden.py::test_recorded_row_decodes[rtx4080_sm89.yaml/matmul.square.1024.fp16#2]": 1.88,
  "tests/compiler/pipeline/search/test_golden.py::test_recorded_row_decodes[rtx4080_sm89.yaml/matmul.square.1024]": 0.28,


### PR DESCRIPTION
## Abstract

More than half the rows recorded in the goldens matched nothing the compiler enumerates, so the gate that says whether a card's measurements still describe today's compiler was reporting most of them dead. The cause was not stale data. A resolved kernel carries an explicit value for every scheduling decision it declined, and that is the row a recording is taken from; a fork offers its alternatives carrying only the decisions that kernel actually has, so the same schedule is written two ways depending on which side names it. The comparison demanded they match exactly. Reading them as the same schedule when only the declined decisions differ, and re-keying twenty-one rows that name a reduction site by a spelling the compiler retired, brings back 719 rows with the measurements they were recorded with.

### Rows that decode

| golden | rows | before | after |
| --- | ---: | ---: | ---: |
| DeepSeek-V4-Flash (V100) | 279 | 20 | 279 |
| gemma-4-12B-it (5090) | 352 | 126 | 346 |
| gemma-4-12B (5090) | 194 | 24 | 194 |
| gemma-4-12B-it (4090) | 240 | 129 | 197 |
| OLMoE (5090) | 13 | 7 | 9 |
| the five hardware goldens | 224 | 224 | 224 |
| Laguna, Qwen3.5 | 52 | 45 | 45 |
| **total** | **1354** | **575** | **1294** |

---

## Why the two sides disagree

The pipeline stamps a pass's declared OFF values onto the variant at the pass boundary, so a resolved kernel spells every schedule family whether or not it uses one. A fork's offered leaves are read as the codec built them, and the codec keys a family off the sites the kernel has — a kernel with no contraction encodes as work and rasterization alone. Recording reads the resolved kernel. Comparison reads both. So a recorded row could only ever equal the one leaf that happened to be the resolved one, and every other leaf differed from it by anchors that carry no schedule content.

Recording keeps the anchors. A forkless kernel's row **is** its OFF anchors, and dropping them there writes an empty row that spells no decision at all, which strict evidence then rejects. Only the comparison changes.

## Why not require the two spellings to agree instead

That is the other repair, and it has now been made three times: #744 hand-inserted 43 anchor keys into two cards, #745 did the 4080 and the PRO 6000, and #748 stamped anchors onto the leaves of the kernels the hardware goldens exercise. Each worked for the file in front of it. None reached the model goldens, which is where 98% of the corpus lives and which nobody hand-edits — they were still at 575 of 1354 before this change.

The cost of this direction is worth stating: a comparison blind to anchors will no longer notice if the enumeration stops stamping one. That check was never what the golden gate was for, and it belongs with the pass that stamps.

## The re-key

Twenty-one rows address their cross-CTA reduction as `REDUCE@a1` or `REDUCE@a0`. Neither parses today — the site codec moved to a route over the stored tree whose last segment names the arrived-at node by kind, and an axis name is not a kind. Four more spell the family bare where the kernel has several sites.

The value is untouched in every case; each row was matched to the one enumerated row carrying the same families at the same values under a different site path, and a row with more than one such match would have been left alone. None had one. This is a re-key, not a re-measurement.

## What still does not decode

Sixty rows, none of them reachable from a file:

| | rows |
| --- | ---: |
| gemma-4-12B-it (4090), schedule no longer offered | 43 |
| Laguna, stored program will not lower | 6 |
| gemma-4-12B-it (5090) | 6 |
| OLMoE | 4 |
| Qwen3.5 | 1 |

The Laguna six are not a schedule problem. Replaying a structural decision asks the fork's root for its identity, the identity lowers the op's body, and that lowering rejects the exl3 bitcast matmul: `no extent for coordinates ['in17'] — the closed program takes them as axes`. Enumerating the target with the record's spelling removed entirely fails the same way, so retuning cannot reach them either. It is a live crash on a path that is not golden-specific.

The rest record a schedule the enumeration no longer offers — a tile width that shrank from `f8` to `f4`, a warp shape that is still offered but no longer alongside that tile and TMA staging, a kernel that now requires a tiling choice where the recording declined one. Those need the card, and only after someone decides the narrowing was intended.

## Verification

`make test` 4505 passed, 1075 skipped, 12 xfailed. `make lint` clean. Decode counts above are the strict decode over the whole repository corpus, run on this branch and on `origin/main` in a separate worktree; both need no GPU.

A test pins both halves of the new rule: a row decodes with the anchors and without them, and still fails when a decided value is changed to nonsense.

## Line balance

`git diff --stat origin/main -- emmy/` is +39 −13. The executable half is four lines — one projection and three call sites. The rest is the note explaining why the two spellings differ, which is the part that was rediscovered three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrQFki2ECdpo7S2YLHC9yg