### PR TITLE
Give a tail's own fold its own name, not the cell accumulator's

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -109,7 +109,10 @@ to the serial fold; each ILP copy suffixes only its per-copy SSA temps
 (`__r{r}`)
 — the shared iteration coordinates, **including any nested contraction's own reduce-axis var** (whose `for`
 declaration `copy_cell` does not rename), stay shared, so each copy re-declares its own nested
-loop under the one name; anything else tiles nothing and folds one thread per
+loop under the one name, while a name the replicated TAIL defines that is spelled like one of the term's carried
+states is renamed apart first (`_unshadowed`): both would take the same cell suffix and land on that cell's
+accumulator, two declarations of one name in one scope, and a tail that recomputes the carrier's own fold has
+exactly that shape; anything else tiles nothing and folds one thread per
 output cell (the degenerate `op.lower()` + `with_store`) — except a kernel whose ONLY work is a free output sweep,
 which distributes that sweep across its `WORK` threads through the same `_lane_close` a cooperating reduce uses for
 its projection: each lane owns a strided slice and writes its own cells, so there is no combine and no store guard.

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -79,7 +79,7 @@ from emmy.compiler.ir.stmt import (
     Write,
     mask_select_predicate,
 )
-from emmy.compiler.ir.stmt.body import free_names
+from emmy.compiler.ir.stmt.body import _exposed_defines, free_names
 from emmy.compiler.ir.stmt.passes import rename_free
 from emmy.compiler.ir.tile.ops import cone_stat, cone_stat_dtypes, make_cone
 from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
@@ -119,6 +119,22 @@ def unroll_ok_n(trips: int, cap: int | None = None) -> bool:
 
 
 # Shared per-cell helpers, used across this module (the atom-generic mma/scalar codegen).
+def _unshadowed(body, states: tuple[str, ...]) -> list:
+    """``body`` with its OWN definition of a carried state renamed apart, if it has one.
+
+    The tail replicates under the same ``__c{i}_{j}`` suffix the states take, so a tail that DEFINES
+    a value spelled like one of them lands on that cell's accumulator: two declarations of one name
+    in one scope, which nvcc refuses (``acc0__c0_0 has already been declared``). It happens where the
+    tail RECOMPUTES the carrier's own fold — one traced value whose two occurrences the tree could
+    not share because they were formed differently — and however alike they look those are two
+    values, so the tail's takes its own name. A tail that only READS a state is untouched, and still
+    reads the cell's accumulator through the ordinary suffix."""
+    shadowed = {name for stmt in body for name in _exposed_defines(stmt)} & set(states)
+    if not shadowed:
+        return list(body)
+    return [stmt.rewrite(lambda name: f"{name}__own" if name in shadowed else name) for stmt in body]
+
+
 def copy_cell(body, sigma, suffix: str, protected) -> list:
     """One copy of a tiled reduce ``body``: σ-substitute its indices (``sigma``) and suffix every
     per-copy SSA name (the shared grid / reduce / lane coordinates in ``protected`` pass through
@@ -2006,9 +2022,8 @@ class _ScalarOps(_AtomOps):
         the (overhanging) write, dedup shared operand loads."""
         c = self.c
         sigma = _scalar_sigma(mn, offset, i, j)
-        cell = copy_cell(
-            self.epilogue, sigma, f"__c{i}_{j}", _scalar_protected(c, self.tile, self.lead, body=self.epilogue, k_axis=self.k_axis)
-        )
+        tail = _unshadowed(self.epilogue, c.exposes)
+        cell = copy_cell(tail, sigma, f"__c{i}_{j}", _scalar_protected(c, self.tile, self.lead, body=tail, k_axis=self.k_axis))
         cell = _guard_writes(cell, _scalar_bound(mn, offset, i, j))
         return _dedup_loads(cell)
 

--- a/plans/deepseek-v4-emmy-serving-v100.md
+++ b/plans/deepseek-v4-emmy-serving-v100.md
@@ -556,21 +556,16 @@ shows expert weight streaming dominates and the fused-unpack GEMM can plausibly 
 Stage −1: DONE (~2 h). Stage 0 round one: DONE (fixed upstream by #602). Stage 1: DONE (#651). Stage 2: DONE (#656).
 Stage 3 in-repo: DONE (#662); gate (c) passed once at `ab1ad4592`, gate (d)'s token-ID half with it.
 
-**Stage 0 round three remains the critical path — now as one compiler gap, not election.** Partitioning
-(#693/#694), the compiling composed cut (#700), the serial-work stamp (#702), the composed route rows (#739) and
-the route-row pricing (#741) all landed, and the working golden's own strict election measures 0.245 s per
-`post4096` forward, 75 % of it in one contraction the compiler cannot tile (two duplicate A cones on a
-two-channel fold). What holds everything now, in order: make that contraction a tile site (merge the duplicate
-cones), fix the same-scope accumulator redeclaration nvcc refuses at `post` m1, give `run --golden` finite
-inputs and an independent reference for a correctness verdict, stop concurrent recorders losing rows, then pin
-routes for the 28 realizations still without one (the second `post` kernel family at m1 / m32 / dynamic, the
-`pre` twin at m32 / dynamic). Two of those are closed: the concurrent-recorder loss (#751 — the recorder
-reloads the file under an exclusive lock and adds its rows to what is on disk, so parallel devices stop
-dropping each other's rows) and the tile site (#752, above), which replaces item one with re-measuring the
-route under the split. Nothing on that list reproduces from the checked-in
-`recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml` — its whole-model programs cat the sibling gate/up
-linears into one weight, and its `k_div_*_reduce` family emits no redeclaration under any knob set tried — so
-every one of them needs the V100 host. Then Stage 4: 2–4 days on-host (re-run gate (c), re-record the golden,
-warm/bake/verify). Stage 5: 1–2 days.
-Adding stage 6 (MXFP4 + tuning) is a further 1–3 weeks. The compiler, not the fork ABI, remains the dominant
-uncertainty.
+**Stage 0 round three is no longer a compiler gap — what is left is measurement.** Partitioning (#693/#694), the
+compiling composed cut (#700), the serial-work stamp (#702), the composed route rows (#739), the route-row pricing
+(#741), the recorder's lock (#751), the carrier taken apart (#752) and the tail's own name (#757) have all landed.
+The `post4096` forward measures **74.9 ms** as the file's own unpinned strict-evidence election, against 238.8 ms
+before the carrier came apart. What holds everything now, in order: give `run --golden` finite inputs and an
+independent reference for a correctness verdict; re-measure the recorded routes under the split (a carrier that
+comes apart needs a cut per child, and its seam paths shift one level) and pin routes for the realizations that
+still have none — the second `post` kernel family at m1 / m32 / dynamic, the `pre` twin at m32 / dynamic, and the
+two `post1` reduces #757 unblocks; then re-run gate (c). None of that reproduces from the checked-in
+`recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml`, whose whole-model programs cat the sibling gate/up linears
+into one weight, so every step needs the V100 host. Then Stage 4: 2–4 days on-host (re-run gate (c), re-record
+the golden, warm/bake/verify). Stage 5: 1–2 days. Adding stage 6 (MXFP4 + tuning) is a further 1–3 weeks. The
+evidence the deploy reads, not the fork ABI and no longer the compiler, is now the dominant uncertainty.

--- a/tests/compiler/passes/test_tail_shadows_carried_state.py
+++ b/tests/compiler/passes/test_tail_shadows_carried_state.py
@@ -1,0 +1,87 @@
+"""A tail that recomputes the carrier's own fold must not redeclare the cell's accumulator.
+
+The DeepSeek-V4-Flash ``post1`` twin's ``k_div_11_reduce`` carries one value twice: the register tile
+folds it into ``acc0``, and the projection tail below re-derives the same sum in its own loop, which
+the trace also named ``acc0`` because in Loop IR the two live in separate scopes. The scalar tier
+replicates the tail under the same ``__c{i}_{j}`` suffix the states take, so both landed on
+``acc0__c0_0`` in ONE emitted scope and nvcc refused the kernel — eight collisions, one per cell.
+
+The tail's value is its own, so it takes its own name. A tail that merely READS the state is
+untouched: that read is how a per-cell epilogue reaches its accumulator.
+"""
+
+from __future__ import annotations
+
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.schedule import Tile
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Write
+from emmy.compiler.pipeline.passes.lowering.kernel._atom import reduce_codegen, store_sink
+from emmy.compiler.pipeline.passes.lowering.kernel._tiling import atomize, grid_tile, register_tile, unit_tile
+from tests.compiler.terms import contraction
+
+_M, _N, _K = Axis("m", 8), Axis("n", 8), Axis("k", 4)
+_PLAN = Tile(units=(2, 2), regs=(2, 2))
+
+
+def _tile(epilogue: Body):
+    """The scalar contraction ``a ⊗ b`` with ``epilogue`` as its projection tail, sealed through
+    ``grid_tile`` the way ``_factor._bind``'s output-tiled arm seals it."""
+    c = contraction(
+        _K,
+        Load(name="a", input="A", index=(Var("m"), Var("k"))),
+        (Load(name="b", input="B", index=(Var("k"), Var("n"))), "acc"),
+    )
+    plan = _PLAN.at(_M, _N)
+    state, region = reduce_codegen(c, plan, k_axis=_K, axes=(_M, _N, _K))
+    return grid_tile(
+        unit_tile(register_tile(atomize(plan.atom.shape[:2]), plan.mn), plan.mn),
+        mn=plan.mn,
+        block_threads=plan.launch_threads,
+        lanes=plan.atom.lanes,
+        state_decls=state,
+        reduce_region=region,
+        store=store_sink(c, plan, epilogue, k_axis=_K, axes=(_M, _N, _K)),
+    )
+
+
+def _definitions(tile, name: str) -> int:
+    return sum(1 for stmt in Body(tile.body).iter() for defined in stmt.defines() if defined == name)
+
+
+def _recomputing_tail() -> Body:
+    """A tail that folds the same sum again into a name the term also carries."""
+    return Body(
+        (
+            Loop(
+                axis=_K,
+                body=Body(
+                    (
+                        Load(name="again", input="A", index=(Var("m"), Var("k"))),
+                        Accum(name="acc", value="again", op="add", axes=("k",)),
+                    )
+                ),
+            ),
+            Assign(name="out", op="multiply", args=("acc", "acc")),
+            Write(output="out", index=(Var("m"), Var("n")), value="out"),
+        )
+    )
+
+
+def test_a_tail_that_recomputes_a_carried_state_does_not_redeclare_the_cell_accumulator() -> None:
+    tile = _tile(_recomputing_tail())
+    assert _definitions(tile, "acc__c0_0") == 1, "the cell's accumulator is declared once — the tail's sum is its own value"
+    assert _definitions(tile, "acc__own__c0_0") == 1, "and the tail's own sum keeps a cell copy under its own name"
+
+
+def test_a_tail_that_only_reads_the_state_still_reads_the_cell_accumulator() -> None:
+    """The ordinary epilogue: no definition of its own, so nothing is renamed and the read resolves
+    to the cell's accumulator through the plain suffix."""
+    tail = Body(
+        (
+            Assign(name="scaled", op="multiply", args=("acc", "acc")),
+            Write(output="out", index=(Var("m"), Var("n")), value="scaled"),
+        )
+    )
+    reads = {dep for stmt in Body(_tile(tail).body).iter() for dep in stmt.deps()}
+    assert "acc__c0_0" in reads and not any(name.startswith("acc__own") for name in reads)


### PR DESCRIPTION
## Abstract

Two realizations of the DeepSeek-V4-Flash `post1` twin have no measured row because nvcc refuses the kernel they compile to: `acc0__c0_0 has already been declared in the current scope`, eight times, once per cell. The kernel carries one value twice — the register tile folds it into `acc0`, and the projection tail below re-derives the same sum in its own loop, which the trace also named `acc0` because in Loop IR the two live in separate scopes. The scalar tier then replicates that tail under the same per-cell suffix the carried states take, so both land on one name in one emitted scope. The tail's value is its own, so it now takes its own name.

---

## What changed

One helper, called where the scalar tier replicates its tail: a name the tail DEFINES that is spelled like one of the term's carried states is renamed apart before the per-cell copy. A tail that only READS a state is untouched — that read is exactly how a per-cell epilogue reaches its accumulator, and it still resolves through the ordinary suffix.

## Verified on the refusing kernel itself

Same target, same recorded route, same tuning database, on the V100 host:

| | lines | same-scope redeclarations | nvcc `-arch=sm_70` |
| --- | ---: | ---: | --- |
| before | 2607 | 8 | 9 errors, the first being `acc0__c0_0` |
| after | 2607 | 0 | accepts it |

The kernel is otherwise identical, which is the point: this is a naming defect in the emission, not a schedule change.

## What it does not fix

The recompute behind it. That kernel folds one value on the tile and then re-derives it per cell, so the tiled copy is dead work — two occurrences of one traced value that the tree could not share because they were formed differently. Fixing that belongs to the sharing or the seam offer, where normalization can see both occurrences; this change only stops the emission spelling two values with one name. Kernels like this one now compile and can be measured, which is what the two missing rows need.

## Size

The core grows by eighteen lines for a fix, which the contribution rules ask me to justify rather than shave. Four of
them are the rule; the rest are the reason it exists and the note in the kernel architecture doc, because the next
person to read `copy_cell` needs to know that one name in that body is not free to take the cell suffix.

## Tests

`tests/compiler/passes/test_tail_shadows_carried_state.py` builds the shape through the same `reduce_codegen` + `store_sink` + `grid_tile` seal the other scalar-tier tests use, and pins both halves: the tail's own fold gets its own name, and a read-only tail still reads the cell's accumulator. It is red on `main`'s sources with the same duplicate definition the host kernel had.

The full suite passes (4520 passed, 1077 skipped, 12 xfailed) — on a machine without CUDA, so its GPU stages skip. Lint clean. The model-golden decode gate fails five files, exactly the five that fail on pristine `main` at this base.
