### PR TITLE
Split the operand copy across the drain, so staging depth overlaps on every card

### DIFF
--- a/emmy/compiler/ir/schedule/catalog.py
+++ b/emmy/compiler/ir/schedule/catalog.py
@@ -89,27 +89,29 @@ def warp_tile_moves(atom_names: tuple[str, ...]) -> list[Tile]:
     return moves
 
 
+#: The staging pipeline's parametrizations. ``transport`` is how gmem bytes reach the slab,
+#: ``depth`` how many chunks that hop keeps in flight, ``reg_depth`` the smem→register
+#: double-buffer beneath it. Independent knobs over one pipeline, so the domain is their PRODUCT.
+STAGE_TRANSPORTS = ("smem", "smem-async", "smem-tma")
+STAGE_DEPTHS = (1, 2, 3, 4)
+STAGE_REG_DEPTHS = (1, 2)
+
+
 def stage_moves(*, warp: bool, ctx=None) -> list[Stage]:
-    """Return the finite staging domain, filtered to transports available on ``ctx``."""
-    smem = [Stage.parse(spelling) for spelling in ("d1/smem", "d2/smem", "d3/smem", "d4/smem")]
-    depths = [
-        Stage.parse(spelling)
-        for spelling in (
-            "d1/smem-async",
-            "d2/smem-async",
-            "d3/smem-async",
-            "d4/smem-async",
-            "d1/smem-tma",
-            "d2/smem-tma",
-            "d3/smem-tma",
-            "d4/smem-tma",
-        )
+    """Return the finite staging domain — every combination the hardware allows.
+
+    Nothing here picks which pairings are worth trying: :meth:`Stage.available_on` drops the
+    transports the card cannot issue, the resolvers cap what a shape cannot size (the smem budget,
+    and a split blocking copy's one-chunk register ring), and measured evidence ranks what survives.
+    ``reg_depth >= 2`` is the fragment ping-pong under the mma drain, so it is warp-tier only."""
+    reg_depths = STAGE_REG_DEPTHS if warp else (1,)
+    moves = [
+        Stage(depth=depth, transport=transport, reg_depth=reg_depth)
+        for transport in STAGE_TRANSPORTS
+        for depth in STAGE_DEPTHS
+        for reg_depth in reg_depths
     ]
-    if warp:
-        smem.extend(Stage.parse(spelling) for spelling in ("d1/smem/p2", "d2/smem/p2"))
-        depths.extend((Stage.parse("d2/smem-async/p2"), Stage.parse("d2/smem-tma/p2")))
-    depths = [*smem, *depths]
-    return depths if ctx is None else [move for move in depths if move.available_on(ctx)]
+    return moves if ctx is None else [move for move in moves if move.available_on(ctx)]
 
 
 def raster_moves() -> tuple[str, ...]:

--- a/emmy/compiler/ir/schedule/staging.py
+++ b/emmy/compiler/ir/schedule/staging.py
@@ -56,6 +56,15 @@ def stage_target(stage: Stage, ctx) -> str | None:
     return f"STAGE {stage.spell()}: {need}"
 
 
+#: The deepest ring a SPLIT blocking copy can run. Its in-flight chunk rides REGISTERS — issued at
+#: the top of the loop body and landed at the bottom of the same body — so exactly one chunk is ever
+#: in flight, however many slots the codec asks for. A third slot would hold no extra chunk, only
+#: idle smem, so the ring caps here the way it caps at the smem budget. Both resolvers apply it; the
+#: staged K-loop skeleton asserts it (``lands_after_drain`` groups prime exactly one chunk, and two
+#: primes would redeclare the same staging registers).
+SPLIT_COPY_DEPTH = 2
+
+
 def _clamp_depth(depth: int, slot_bytes: int, budget: int) -> int:
     """The deepest ring the smem ``budget`` affords at ``slot_bytes`` per ringed slot, never deeper
     than asked. Shared by the warp copy ring and the fill's B-slab ring; the scalar resolver
@@ -477,6 +486,8 @@ def resolve_warp_stage(
     if slot_bytes > budget:
         return None
     depth = _clamp_depth(stage.depth, slot_bytes, budget)
+    if sync_ok:
+        depth = min(depth, SPLIT_COPY_DEPTH)
     choice = replace(stage, depth=depth, reg_depth=min(stage.reg_depth, tile.bk))
     return ResolvedStage(choice, bk_elems=bk_elems)
 
@@ -521,7 +532,9 @@ def resolve_scalar_stage(c: Fold, tile: Tile, stage: Stage, inputs, budget: int,
     if not n_ext.is_static or (k * elem_bytes) % _TMA_ALIGN or (n_ext.as_static() * elem_bytes) % _TMA_ALIGN:
         return None
     b_bytes = inputs[c.operands[1].as_slab().load.input].dtype.nbytes if c.operands[1].as_slab().load.input in inputs else elem_bytes
-    depth, bk_elems = max(1, stage.depth), 0
+    # A scalar tile always copies with the blocking load/store, so its ``smem`` ring splits too.
+    requested = min(stage.depth, SPLIT_COPY_DEPTH) if stage.transport == "smem" else stage.depth
+    depth, bk_elems = max(1, requested), 0
     while depth >= 1:
         cap = budget // (depth * max(1, tile.m.tile * elem_bytes + tile.n.tile * b_bytes))
         bk_elems = next((v for v in (128, 64, 32, 16, 8, 4) if v <= cap and k % v == 0), 0)

--- a/emmy/compiler/ir/schedule/staging.py
+++ b/emmy/compiler/ir/schedule/staging.py
@@ -60,8 +60,8 @@ def stage_target(stage: Stage, ctx) -> str | None:
 #: the top of the loop body and landed at the bottom of the same body — so exactly one chunk is ever
 #: in flight, however many slots the codec asks for. A third slot would hold no extra chunk, only
 #: idle smem, so the ring caps here the way it caps at the smem budget. Both resolvers apply it; the
-#: staged K-loop skeleton asserts it (``lands_after_drain`` groups prime exactly one chunk, and two
-#: primes would redeclare the same staging registers).
+#: staged K-loop skeleton asserts it (a split fill primes exactly one chunk, and two primes would
+#: redeclare the same staging registers).
 SPLIT_COPY_DEPTH = 2
 
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -222,9 +222,9 @@ operand-group is a `(transport, depth)` pair, and the fill / wait / barrier plac
 live range (`[first reader, last reader]` over the segments) — wait before the first reader, a CTA barrier past the
 last, `depth >= 2` prefetching chunk `i+ring-1` at the top of the body, whole-body `depth == 1` filling the current
 chunk (the single-buffer degenerate), and a `depth == 1` group live in a PROPER sub-interval refilling chunk `i+1` at
-its kill point so the copy overlaps every segment outside the live range. A group whose fill is SPLIT
-(`lands_after_drain`) also gets a **deposit** placed past its last reader, just ahead of that barrier — the copy's
-second half, landing the registers its fill issued. cp.async `wait_group(N)` counts are a
+its kill point so the copy overlaps every segment outside the live range. A transport whose fill is SPLIT also offers a
+**deposit**, placed past its last reader and just ahead of that barrier — the copy's second half, landing the registers
+its fill issued. Offering one IS the seam: nothing else marks such a group. cp.async `wait_group(N)` counts are a
 static pass over the placed schedule (the commits younger than a group's fill at its wait point); the prologue primes
 exactly the fills the pre-loop iterations would have issued. `staged_kloop` is the whole-body single-group entry
 (the matmul tier's classic `fill → commit → wait → drain → Sync` phases fall out of the derivation). Behind it, a

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -222,14 +222,16 @@ operand-group is a `(transport, depth)` pair, and the fill / wait / barrier plac
 live range (`[first reader, last reader]` over the segments) — wait before the first reader, a CTA barrier past the
 last, `depth >= 2` prefetching chunk `i+ring-1` at the top of the body, whole-body `depth == 1` filling the current
 chunk (the single-buffer degenerate), and a `depth == 1` group live in a PROPER sub-interval refilling chunk `i+1` at
-its kill point so the copy overlaps every segment outside the live range. cp.async `wait_group(N)` counts are a
+its kill point so the copy overlaps every segment outside the live range. A group whose fill is SPLIT
+(`lands_after_drain`) also gets a **deposit** placed past its last reader, just ahead of that barrier — the copy's
+second half, landing the registers its fill issued. cp.async `wait_group(N)` counts are a
 static pass over the placed schedule (the commits younger than a group's fill at its wait point); the prologue primes
 exactly the fills the pre-loop iterations would have issued. `staged_kloop` is the whole-body single-group entry
 (the matmul tier's classic `fill → commit → wait → drain → Sync` phases fall out of the derivation). Behind it, a
 `Transport` strategy: `SyncTransport` (the `smem` fill — a producer cone evaluated per thread into its slab, its
 materialized peers copied underneath it, closed by one CTA barrier; `copy_sync` swaps those peer copies from
 `cp.async` to the blocking vector load/store on a target without it, which is also how a fully materialized term
-stages on sm_70), `CpAsyncTransport`
+stages on sm_70, and `staged` splits that copy across the drain), `CpAsyncTransport`
 (fill → commit → wait-group), and `TmaTransport` (an `arrive.expect_tx` + box copy gated by a **per-slot mbarrier
 array**, so `depth` is a free knob for TMA too). The three producers —
 structurally different primitives — sit behind one `fill`/`commit`/`wait` seam, and
@@ -252,15 +254,27 @@ materialization. The `state` builder (which slots the operand fragments) and sha
 apply the resolved facts verbatim. The `Stage` choice names the intermediate storage and its fill mechanism — `smem`
 (the synchronous thread fill), `smem-async` (cp.async), `smem-tma` (TMA); an EMPTY `STAGE` is no intermediate at all
 (gmem→register on a materialized operand, register-to-register on a computed one) — and spells two buffering levels:
-`d<depth>` is the gmem→smem ring (blocking synchronous slot fill / cp.async commit group / TMA mbarrier-phased
-prefetch over the K-slab loop),
-`p<reg_depth>` is the smem→register double-buffer (the fragment-load ping-pong over the inner atom-K steps). Staging is a
+`d<depth>` is the gmem→smem ring — **chunks in flight**, whatever holds them: registers on the blocking copy, the
+commit group on cp.async, the mbarrier-phased box on TMA;
+`p<reg_depth>` is the smem→register double-buffer (the fragment-load ping-pong over the inner atom-K steps). The two
+are independent, and so is the transport, so `stage_moves` offers their PRODUCT rather than a hand-picked list —
+`Stage.available_on` drops what the card cannot issue, the resolvers cap what a shape cannot size, and measured
+evidence ranks the rest. Staging is a
 **pure perf transform** — an ineligible kernel (masked N, or a symbolic / non-divisible K on a BYTE-COPIED
 operand, whose chunk runs along K; a transposed B stages N-major on every transport since the serving-layout work)
 silently falls back to gmem-direct, and a staged kernel is
-**bit-identical** to its gmem-direct baseline. A synchronous `smem` ring uses the same slot rotation and barriers, but
-the fill runs on the consumer threads and therefore cannot overlap the current drain; `/p<n>` remains the independent
-smem→register fragment pipeline. The Volta m8n8k4 atom enables the synchronous fill for materialized and computed f16
+**bit-identical** to its gmem-direct baseline. A synchronous `smem` ring uses the same slot rotation, and overlaps the
+drain the only way a target without `cp.async` can: the blocking copy SPLITS across it. The fill issues the prefetch
+chunk's global loads into registers, the resident chunk drains, and the deposit stores those registers into the
+prefetch slot — one barrier per chunk, since the slot it writes was freed two chunks back. The split is
+all-or-nothing per transport and needs every per-chunk slab to stripe evenly over the CTA (its staged values live in
+unrolled registers); a slab that does not keeps the one-phase fill, and the ring caps at `SPLIT_COPY_DEPTH` slots
+because exactly one chunk is ever in flight in registers. Measured on a V100, the split turned `d2/smem` from a small
+loss against no ring at all (474 vs 468 us on a 512x4096x4096 projection) into 306 us — and into a loss on a
+512x4096x28672 one, whose 896 CTAs already hide the latency and whose doubled slab costs occupancy. Which deploys is
+evidence's call per shape, which is the point: before the split, `depth >= 2` was a pessimization everywhere on that
+card. `/p<n>` remains the independent smem→register fragment pipeline. The Volta m8n8k4 atom enables the synchronous
+fill for materialized and computed f16
 A/B edges; its cooperative gather drains either slab, while newer instruction families stay disabled. The
 **`smem-tma`** transport
 additionally requires **sm_90+**

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -1269,6 +1269,9 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
             cta=cta,
             prologue_stmts=tuple(stat_pro),
             copy_sync=not tile.is_warp or tile.atom.sync_copy_staging,
+            # A ring under a blocking copy asks for the register-staged split — that is what makes
+            # ``depth`` mean chunks-in-flight here, as it does on the cp.async / TMA transports.
+            staged=stage.depth >= 2,
         )
     else:
         assert len(ops.channels) == 1, "cp.async / TMA staging is single-fold — a multi-B node rides the smem compute fill"

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -652,13 +652,6 @@ class SyncTransport:
             and all(_sync_copy_runs(op.shape, self.cta, op.elem_bytes or self.elem_bytes) is not None for op in self.copy_operands)
         )
 
-    @property
-    def lands_after_drain(self) -> bool:
-        """Implements the :func:`pipelined_kloop` transport seam: this group's in-flight chunk lands
-        AFTER the resident chunk's drain, not before it. True only for the register-staged split —
-        cp.async and TMA land ahead of the drain they feed, in their own ``wait``."""
-        return self.register_staged
-
     def slab_decls(self, ring: int) -> list[Stmt]:
         # Sync-filled slabs are single-buffer (see :meth:`SyncOperand.slot_row`); of the copied
         # peers only the per-chunk ones allocate the ring — the loop-invariant peers never advance,
@@ -1255,11 +1248,6 @@ def pipelined_kloop(
         g.first, g.last = readers[0], readers[-1]
         if g.ring >= 2:
             g.kind, g.lag = "ring", g.ring - 1
-            # A split fill primes ONE chunk (its staging registers are named per lane, not per
-            # slot), which the resolvers guarantee by capping such a ring at ``SPLIT_COPY_DEPTH``.
-            assert not (getattr(g.transport, "lands_after_drain", False) and g.lag > 1), (
-                f"a split fill holds one chunk in registers, but its ring is {g.ring} — the resolver did not cap the depth"
-            )
         elif g.first == 0 and g.last == len(segments) - 1:
             g.kind, g.lag = "current", 0
         else:
@@ -1301,14 +1289,20 @@ def pipelined_kloop(
         decls += g.transport.slab_decls(g.ring)
     for g in groups:
         pre += g.transport.prologue(g.ring)
+    primed_slots = False
     for g in groups:  # prime exactly ``lag`` chunks per group — what iterations -lag..-1 would have filled
         for c in range(g.lag):
             pre += g.transport.fill(k0=_prime_k0(c), slot=_lit(c))
             # A split fill has no copy engine to leave the prime in flight, and no drain ahead of
-            # the loop to hide it behind — land it right here.
-            pre += _deposit(g, _lit(c))
+            # the loop to hide it behind — land it right here. Its staging registers are named per
+            # LANE, not per slot, so a second prime would redeclare them; the resolvers guarantee
+            # there is never one by capping such a ring at ``SPLIT_COPY_DEPTH`` slots.
+            landing = _deposit(g, _lit(c))
+            assert not (landing and c), f"a split fill primes one chunk, but this ring asked for {g.ring} slots"
+            pre += landing
             pre += g.transport.commit()
-    if any(getattr(g.transport, "lands_after_drain", False) for g in groups):
+            primed_slots |= bool(landing)
+    if primed_slots:
         pre.append(Sync())  # every primed slot visible to every lane before the first drain reads it
 
     # The wait-group counting pass: lay the committing fills out in body order (top fills first,

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -1255,6 +1255,11 @@ def pipelined_kloop(
         g.first, g.last = readers[0], readers[-1]
         if g.ring >= 2:
             g.kind, g.lag = "ring", g.ring - 1
+            # A split fill primes ONE chunk (its staging registers are named per lane, not per
+            # slot), which the resolvers guarantee by capping such a ring at ``SPLIT_COPY_DEPTH``.
+            assert not (getattr(g.transport, "lands_after_drain", False) and g.lag > 1), (
+                f"a split fill holds one chunk in registers, but its ring is {g.ring} — the resolver did not cap the depth"
+            )
         elif g.first == 0 and g.last == len(segments) - 1:
             g.kind, g.lag = "current", 0
         else:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -192,6 +192,77 @@ def sync_copy_fill(
     return [StridedLoop(axis=fe, start=cta.linear_tid, step=_lit(cta.n_threads), body=body, unroll=False)]
 
 
+def _sync_copy_runs(shape: tuple[int, int], cta: CtaTile, elem_bytes: int) -> tuple[int, int] | None:
+    """``(V, trips)`` for the SPLIT blocking copy — the chunk width and the number of ``V``-element
+    chunks each lane carries. ``None`` when the striped chunks do not divide evenly over the CTA:
+    the split unrolls the lane's trips so the staged values stay in registers, and a ragged tail has
+    no unrolled shape (such a slab keeps the one-phase :func:`sync_copy_fill`)."""
+    rows, cols = shape
+    v = _cp_async_width(cols, elem_bytes)
+    chunks = (rows * cols) // v
+    return (v, chunks // cta.n_threads) if chunks % cta.n_threads == 0 else None
+
+
+def _sync_copy_coords(trip: int, v: int, cols: int, cta: CtaTile) -> tuple[Expr, Expr]:
+    """The ``(row, col)`` slab coordinates of lane-local ``trip`` — the unrolled form of the
+    one-phase fill's ``for e = tid; e < chunks; e += n_threads`` stride."""
+    base = _mul(_add(cta.linear_tid, _lit(trip * cta.n_threads)), _lit(v))
+    return BinaryExpr("/", base, _lit(cols)), BinaryExpr("%", base, _lit(cols))
+
+
+def _staged_regs(name: str, trip: int, v: int) -> tuple[str, ...]:
+    """The register names one lane's ``trip`` stages between issue and deposit."""
+    return tuple(f"_{name}_stage{trip}_{i}" for i in range(v))
+
+
+def sync_copy_issue(*, shape: tuple[int, int], src: str, gmem_index, cta: CtaTile, elem_bytes: int, name: str) -> list[Stmt] | None:
+    """The gmem→REGISTER half of :func:`sync_copy_fill`: every lane vector-LOADS each of its
+    ``V``-element chunks and STOPS, leaving the values in registers for :func:`sync_copy_deposit`.
+
+    Splitting the copy is what puts a chunk IN FLIGHT on a target without ``cp.async``. The resident
+    chunk's drain runs between the two halves and covers the load latency, so ``depth`` counts
+    chunks in flight here exactly as it counts commit groups on the cp.async ring and mbarrier slots
+    on TMA's — one meaning of the knob across all three transports, differing only in WHERE the
+    in-flight bytes sit (registers / the copy engine / the descriptor's box). ``None`` when the
+    lane's chunks do not divide evenly (:func:`_sync_copy_runs`)."""
+    run = _sync_copy_runs(shape, cta, elem_bytes)
+    if run is None:
+        return None
+    v, trips = run
+    cols = shape[1]
+    out: list[Stmt] = []
+    for trip in range(trips):
+        row, col = _sync_copy_coords(trip, v, cols, cta)
+        out.append(Load(names=_staged_regs(name, trip, v), input=src, index=tuple(gmem_index(row, col))))
+    return out
+
+
+def sync_copy_deposit(
+    *,
+    slab: str,
+    shape: tuple[int, int],
+    cta: CtaTile,
+    elem_bytes: int,
+    name: str,
+    row_offset: Expr | None = None,
+    swizzle: str = "NONE",
+) -> list[Stmt] | None:
+    """The REGISTER→smem half — one vector store per staged chunk, into ring row ``row_offset``.
+    Pairs with :func:`sync_copy_issue` off the same striping, so the slab it leaves is identical to
+    the one-phase fill's."""
+    run = _sync_copy_runs(shape, cta, elem_bytes)
+    if run is None:
+        return None
+    v, trips = run
+    cols = shape[1]
+    out: list[Stmt] = []
+    for trip in range(trips):
+        row, col = _sync_copy_coords(trip, v, cols, cta)
+        smem_row = _add(row_offset, row) if row_offset is not None else row
+        out.append(Write(output=slab, index=(smem_row, col), values=_staged_regs(name, trip, v), swizzle=swizzle))
+    return out
+
+
 def cp_async_commit() -> list[Stmt]:
     """Close the current cp.async batch into a commit-group (the depth-``D`` ring commits one
     group per filled slot, so ``CpAsyncWait(group=D-1)`` can drain exactly the slot it needs)."""
@@ -523,9 +594,16 @@ class SyncTransport:
     ``CpAsyncWait`` + CTA barrier), or the BLOCKING vector load/store (:func:`sync_copy_fill`,
     closed by the CTA barrier alone) on a target without ``cp.async``. The slab layout, the
     striping and the drain are identical either way; only the copy instruction and the handshake
-    differ. Under a blocking copy a depth above one is correct but cannot overlap the copy with the
-    current drain on the same threads; it stays a searchable schedule rather than a promised
-    latency-hiding mechanism.
+    differ.
+
+    ``staged`` SPLITS that blocking copy into :func:`sync_copy_issue` (gmem→register) and
+    :meth:`deposit` (register→smem), which is how ``depth`` buys overlap without ``cp.async``: the
+    lane loads chunk ``i+ring-1`` into registers, the resident chunk's drain runs, and only then do
+    the registers land in the slab. The in-flight bytes sit in registers instead of the copy engine
+    — the same ``depth`` knob, one level further down the hierarchy — and the deposit's own CTA
+    barrier is the whole handshake, so the pipelined loop carries ONE barrier per chunk rather than
+    the two an unsplit fill needs. Requested by a ``depth >= 2`` schedule and confirmed per slab:
+    see :attr:`register_staged`.
 
     ``depth >= 2`` is the **asymmetric (peer-only) prefetch ring**: only the ``copy_operands``
     slabs ring (the copies for chunk ``i+ring-1`` fly under the compute fill AND the drain of chunk
@@ -556,6 +634,30 @@ class SyncTransport:
     elem_bytes: int = 2
     # ``True`` → the peers copy with the BLOCKING vector load/store (no ``cp.async`` on the target).
     copy_sync: bool = False
+    # ``True`` → the schedule asked for a ring (``depth >= 2``), so split that blocking copy across
+    # the drain. :attr:`register_staged` is the confirmed answer.
+    staged: bool = False
+
+    @property
+    def register_staged(self) -> bool:
+        """Whether the peer copies actually split (issue → drain → deposit). A ring on a blocking
+        copy asks for it; every per-chunk peer must also stripe evenly over the CTA, because the
+        staged values live in unrolled registers (:func:`_sync_copy_runs`). All-or-nothing across
+        the peers: one unsplit slab would need its own barrier before the drain, which is the very
+        cost the split exists to remove."""
+        return (
+            self.staged
+            and self.copy_sync
+            and bool(self.copy_operands)
+            and all(_sync_copy_runs(op.shape, self.cta, op.elem_bytes or self.elem_bytes) is not None for op in self.copy_operands)
+        )
+
+    @property
+    def lands_after_drain(self) -> bool:
+        """Implements the :func:`pipelined_kloop` transport seam: this group's in-flight chunk lands
+        AFTER the resident chunk's drain, not before it. True only for the register-staged split —
+        cp.async and TMA land ahead of the drain they feed, in their own ``wait``."""
+        return self.register_staged
 
     def slab_decls(self, ring: int) -> list[Stmt]:
         # Sync-filled slabs are single-buffer (see :meth:`SyncOperand.slot_row`); of the copied
@@ -681,6 +783,18 @@ class SyncTransport:
         copy = sync_copy_fill if self.copy_sync else cp_async_fill
         for op in self.copy_operands:
             assert op.swizzle == "NONE" or op.pad_cols == 0, "a padded slab must stay NONE-swizzle"
+            if self.register_staged:
+                # The issue half only — :meth:`deposit` stores these registers into ``slot`` past
+                # the drain the skeleton places between the two.
+                out += sync_copy_issue(
+                    shape=op.shape,
+                    src=op.buf,
+                    gmem_index=op.index(k0),
+                    cta=self.cta,
+                    elem_bytes=op.elem_bytes or self.elem_bytes,
+                    name=op.tag,
+                )
+                continue
             out += copy(
                 slab=op.slab,
                 shape=op.shape,
@@ -750,10 +864,31 @@ class SyncTransport:
             out.append(StridedLoop(axis=fe, start=self.cta.linear_tid, step=_lit(self.cta.n_threads), body=Body(tuple(body)), unroll=False))
         return out
 
+    def deposit(self, *, slot: Expr) -> list[Stmt]:
+        """Land the registers :meth:`fill` issued into ring ``slot`` — the second half of the split
+        blocking copy, placed by :func:`pipelined_kloop` past the resident chunk's drain. Empty on
+        every unsplit transport, whose bytes land in their own ``wait``."""
+        if not self.register_staged:
+            return []
+        out: list[Stmt] = []
+        for op in self.copy_operands:
+            out += sync_copy_deposit(
+                slab=op.slab,
+                shape=op.shape,
+                cta=self.cta,
+                elem_bytes=op.elem_bytes or self.elem_bytes,
+                name=op.tag,
+                row_offset=op.slot_row(slot),
+                swizzle=op.swizzle,
+            )
+        return out
+
     def commit(self) -> list[Stmt]:
         return cp_async_commit() if self.copy_operands and not self.copy_sync else []
 
     def wait(self, *, in_flight: int, slot: Expr, phase: Expr) -> list[Stmt]:  # noqa: ARG002
+        if self.register_staged:
+            return []  # the deposit's own barrier past the drain is this group's whole handshake
         return cp_async_wait(in_flight) if self.copy_operands and not self.copy_sync else [Sync()]
 
 
@@ -1037,6 +1172,14 @@ class _Group:
     kind: str = "current"
     lag: int = 0
     n_flight: int = 0  # cp.async wait_group count (the static counting pass below)
+    fill_slot: Expr = Literal(0, "int")  # the slot this iteration's fill targets — where a split fill lands
+
+
+def _deposit(group: _Group, slot: Expr) -> list[Stmt]:
+    """The transport's register→smem landing, or nothing for a transport whose fill is not split
+    (cp.async / TMA leave their in-flight bytes with the copy engine, not in registers)."""
+    land = getattr(group.transport, "deposit", None)
+    return land(slot=slot) if land is not None else []
 
 
 def pipelined_kloop(
@@ -1156,7 +1299,12 @@ def pipelined_kloop(
     for g in groups:  # prime exactly ``lag`` chunks per group — what iterations -lag..-1 would have filled
         for c in range(g.lag):
             pre += g.transport.fill(k0=_prime_k0(c), slot=_lit(c))
+            # A split fill has no copy engine to leave the prime in flight, and no drain ahead of
+            # the loop to hide it behind — land it right here.
+            pre += _deposit(g, _lit(c))
             pre += g.transport.commit()
+    if any(getattr(g.transport, "lands_after_drain", False) for g in groups):
+        pre.append(Sync())  # every primed slot visible to every lane before the first drain reads it
 
     # The wait-group counting pass: lay the committing fills out in body order (top fills first,
     # then the kill-point refills by segment), and for each group count the commits issued between
@@ -1181,8 +1329,8 @@ def pipelined_kloop(
     body: list[Stmt] = []
     for g in groups:  # top fills: the ring prefetch / the single-buffer current-chunk fill
         if g.kind == "ring":
-            fill_slot = BinaryExpr("%", BinaryExpr("+", i_expr, _lit(g.lag)), _lit(g.ring))
-            body += g.transport.fill(k0=_fill_k0(g.lag), slot=fill_slot, k0_cur=Var(k0))
+            g.fill_slot = BinaryExpr("%", BinaryExpr("+", i_expr, _lit(g.lag)), _lit(g.ring))
+            body += g.transport.fill(k0=_fill_k0(g.lag), slot=g.fill_slot, k0_cur=Var(k0))
             body += g.transport.commit()
         elif g.kind == "current":
             body += g.transport.fill(k0=Var(k0), slot=_lit(0), k0_cur=Var(k0))
@@ -1194,6 +1342,11 @@ def pipelined_kloop(
         body += stmts
         enders = [g for g in groups if g.last == s]
         if enders:
+            # A split fill lands HERE — past every reader of the resident slot, ahead of the barrier
+            # that publishes it. It targets the PREFETCH slot, which no lane is reading, so this one
+            # barrier serves both the landing and the slab protection: the group needs no other.
+            for g in enders:
+                body += _deposit(g, g.fill_slot)
             body.append(Sync())  # every reader past the slab(s) before a refill / later prefetch overwrites them
             for g in enders:
                 if g.kind == "kill":

--- a/tests/compiler/ir/schedule/test_choices.py
+++ b/tests/compiler/ir/schedule/test_choices.py
@@ -43,6 +43,23 @@ def test_scalar_stage_catalog_offers_sync_staging_on_volta() -> None:
     ]
 
 
+def test_warp_stage_catalog_is_the_product_of_its_parametrizations() -> None:
+    """Staging is ONE pipeline whose knobs are independent, so the catalog offers their product and
+    nothing hand-picks which pairings are worth trying — the target filter, the resolvers and
+    measured evidence do that."""
+    hopper = stage_moves(warp=True, ctx=Context.from_target((9, 0)))
+    assert {(stage.transport, stage.depth, stage.reg_depth) for stage in hopper} == {
+        (transport, depth, reg_depth)
+        for transport in ("smem", "smem-async", "smem-tma")
+        for depth in (1, 2, 3, 4)
+        for reg_depth in (1, 2)
+    }
+    # sm_70 issues neither cp.async nor TMA; the register ping-pong still pairs with what is left.
+    volta = stage_moves(warp=True, ctx=Context.from_target((7, 0)))
+    assert {stage.transport for stage in volta} == {"smem"}
+    assert {stage.reg_depth for stage in volta} == {1, 2}
+
+
 def test_tile_site_value_carries_no_worker_tokens() -> None:
     from emmy.compiler.ir.atom import ATOM_REGISTRY
 

--- a/tests/compiler/ir/schedule/test_choices.py
+++ b/tests/compiler/ir/schedule/test_choices.py
@@ -49,10 +49,7 @@ def test_warp_stage_catalog_is_the_product_of_its_parametrizations() -> None:
     measured evidence do that."""
     hopper = stage_moves(warp=True, ctx=Context.from_target((9, 0)))
     assert {(stage.transport, stage.depth, stage.reg_depth) for stage in hopper} == {
-        (transport, depth, reg_depth)
-        for transport in ("smem", "smem-async", "smem-tma")
-        for depth in (1, 2, 3, 4)
-        for reg_depth in (1, 2)
+        (transport, depth, reg_depth) for transport in ("smem", "smem-async", "smem-tma") for depth in (1, 2, 3, 4) for reg_depth in (1, 2)
     }
     # sm_70 issues neither cp.async nor TMA; the register ping-pong still pairs with what is left.
     volta = stage_moves(warp=True, ctx=Context.from_target((7, 0)))

--- a/tests/compiler/passes/test_volta_mma.py
+++ b/tests/compiler/passes/test_volta_mma.py
@@ -201,6 +201,31 @@ def test_sm70_sync_copy_composes_ring_and_register_pipelines(monkeypatch) -> Non
     assert "cp.async" not in src and "ldmatrix" not in src
 
 
+def test_sm70_ring_splits_the_blocking_copy_across_the_drain(monkeypatch) -> None:
+    """A ring on a target without ``cp.async`` puts its in-flight chunk in REGISTERS.
+
+    The fill issues the next chunk's global loads, the resident chunk's mma drain runs, and only
+    then do the registers land in the slab — so the drain covers the load latency and ONE barrier
+    per chunk publishes the deposit. Back-to-back load/store fills (what a ring emitted before)
+    leave the latency fully exposed and need two barriers, which measured slower than no ring at
+    all on every V100 shape tried."""
+    monkeypatch.setenv("EMMY_TILE", f"{VOLTA}/f2x2/k4")
+    monkeypatch.setenv("EMMY_WORK", "w2x2")  # 128 threads: the slabs stripe evenly, so the split engages
+    monkeypatch.setenv("EMMY_STAGE", "d2/smem")
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    src, knobs = _source(_graph(m=64, n=64, k=32), Context(compute_capability=(7, 0)))
+    assert family_value(knobs, "STAGE") == "d2/smem"
+    prologue, _, body = src.partition("for (int _ks")
+    issue = body.index("_v__a_stage0_0")  # the staged gmem load of the PREFETCH chunk
+    drain = body.index("emmy_mma_m8n8k4_f16_f32")
+    deposit = body.index("*reinterpret_cast<uint4*>(&_a_smem[")
+    assert issue < drain < deposit, "the drain must sit between the staged load and its slab store"
+    assert body.count("__syncthreads();") == 1, "the deposit's barrier is the whole per-chunk handshake"
+    assert prologue.count("__syncthreads();") == 1, "the primed slot is published once before the loop"
+    for forbidden in NEWER_INSTRUCTIONS:
+        assert forbidden not in src
+
+
 def test_sm70_register_tile_keeps_the_volta_fragment_layout_through_the_reroll(monkeypatch) -> None:
     """A register tile wide enough to ROLL back into a loop still drains and stores as Volta.
 

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -264,6 +264,7 @@
  "tests/compiler/passes/test_volta_mma.py::test_sm70_newer_stage_pin_refuses[d1/smem-async]": 0.77,
  "tests/compiler/passes/test_volta_mma.py::test_sm70_newer_stage_pin_refuses[d1/smem-tma]": 0.77,
  "tests/compiler/passes/test_volta_mma.py::test_sm70_register_tile_keeps_the_volta_fragment_layout_through_the_reroll": 0.78,
+ "tests/compiler/passes/test_volta_mma.py::test_sm70_ring_splits_the_blocking_copy_across_the_drain": 0.54,
  "tests/compiler/passes/test_volta_mma.py::test_sm70_source_uses_only_the_volta_mma_family[False]": 0.78,
  "tests/compiler/passes/test_volta_mma.py::test_sm70_source_uses_only_the_volta_mma_family[True]": 0.78,
  "tests/compiler/passes/test_volta_mma.py::test_sm70_sync_copy_composes_ring_and_register_pipelines": 0.78,


### PR DESCRIPTION
## Abstract

On a card that cannot issue an asynchronous copy, emmy moved operand bytes into shared memory with a load and a store back to back, so asking for a deeper pipeline there allocated buffers that overlapped nothing. Splitting that copy in half, so the waiting work runs between the load and the store, turns the depth knob into a real pipeline on those cards and gives it one meaning everywhere: how many chunks are in flight, whether they wait in registers, in the copy engine, or in a descriptor's box. The catalog that offers staging schedules was a hand-picked list, which is why the register-level double buffer reached only four of its combinations; it is now the product of the knobs, filtered by what the card can issue.

V100, 512-row projections at the knobs their golden rows record, microseconds:

| row | no ring | ring before | ring after |
| --- | --- | --- | --- |
| o_proj, 4096 x 4096 | 468.0 | 474.6 | **305.8** |
| square, 4096 x 4096 | 501.8 | 514.0 | **303.1** |
| gate_up, 4096 x 28672 | 2534.4 | 2615.3 | 3627.0 |

---

## The split

The synchronous transport now issues the next chunk's global loads into registers, lets the resident chunk's drain run, and only then stores those registers into the slab. The staged K-loop skeleton places the two halves. A transport that offers a deposit is one whose bytes land after the drain rather than before it, and offering one is the whole seam — no flag says so separately. The loop also carries one barrier per chunk instead of two, because the slot a deposit writes was freed two chunks back.

The split is all-or-nothing per transport and needs every per-chunk slab to stripe evenly over the CTA, since the staged values live in unrolled registers. A slab that does not keeps the one-phase fill and behaves exactly as before. The ring caps at two slots, because exactly one chunk is ever in flight in registers: both resolvers apply the cap and the skeleton asserts it. No recorded row anywhere spells a depth the cap touches, so no golden changes meaning.

## The catalog

`stage_moves` listed which combinations were worth offering. Nothing about the pipeline makes the transport, the shared-memory depth and the register depth dependent on each other, so the domain is now their product: the target filter drops what the card cannot issue, the resolvers cap what a shape cannot size, and measured evidence ranks the rest. The warp-tier domain grows from 16 schedules to 24, so the tests that enumerate all of them do proportionally more work.

## What got slower

The 4096 x 28672 projection loses 39% at ring depth two. It launches 896 CTAs onto 80 SMs, so concurrency already hid the latency the split exists to hide, and the doubled slab costs occupancy. That row keeps depth one, which is what it already recorded. The useful part is that the knob is now worth measuring in both directions — before this change a ring was a small loss on every V100 shape tried, so there was nothing for a search to find.

## What is not verified

The V100 numbers come from pinned knobs on one card, not from a tuning round. No golden row is re-recorded here, so no card's recorded schedules change, and whether the split earns a place in the deployed picks needs a tune this PR does not run.

One realization case, `matmul/nvfp4-w4a4-packed-slab-loopify`, failed once in a full parallel run and passed on every re-run, standalone and in a parallel subset. I could not reproduce it and cannot explain it. Separately, `reduce/rms-norm-cut-sweep-work` fails identically on `main`, so it is not from this change.

## Line balance

`emmy/` grows by 184 lines. The change adds a pipeline form that did not exist, so the growth is capability rather than layering; the audit removed the one redundant piece it had, a flag that only restated that a transport offers a deposit.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMjMmVq7dMD7SBf5Se9HN2
