### PR TITLE
Orient a batched contraction by its row, so one attention lifts to one kernel whatever its inputs are called

### DIFF
--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -299,9 +299,16 @@ class Fold:
                 # Two SLABS orient by layout; a computed operand keeps the order its former chose.
                 slabs = len(pair) == 2 and all(e.as_slab() is not None for e in pair)
                 k_last = [e for e in pair if slabs and self.axis in e.as_slab().load.index[-1].free_vars()]
-                # Both k-last (a matmul): A is the one reading the earlier free coordinate — the
-                # row, under the lift's declaration order — so alpha-equal terms orient alike.
-                k_last.sort(key=lambda e: min((n for n in e.free_axes if n != self.axis), default=""))
+                # Both k-last (a matmul): A is the one reading the earlier ROW — the coordinate the
+                # other operand does NOT read. A shared outer coordinate (a batched matmul's batch
+                # and head) is no row and must not be compared: it is the minimum on BOTH sides, so
+                # comparing every free axis left every batched pair tied and oriented by whichever
+                # spelling the lift happened to declare first. Then one kernel's two contractions
+                # over the same operands could orient opposite ways, and the twisted rewrite —
+                # which matches score cones by canonical form — stopped recognizing them as one
+                # score, silently demoting flash attention to its two-pass form.
+                rows = pair[0].free_axes ^ pair[1].free_axes if slabs else frozenset()
+                k_last.sort(key=lambda e: min(e.free_axes & rows, default=""))
                 a_edge = k_last[0] if len(pair) == 2 and k_last else None
             if a_edge is not None and self.operands[0] is not a_edge:
                 reordered = (a_edge, *(edge for edge in self.operands if edge is not a_edge))

--- a/tests/compiler/ir/pure/test_fold.py
+++ b/tests/compiler/ir/pure/test_fold.py
@@ -69,6 +69,25 @@ def test_a_bilinear_term_puts_its_k_last_operand_first_at_formation() -> None:
     assert mm.as_contraction() is not None and mm.as_contraction().left == "m"
 
 
+def test_a_batched_pair_orients_by_its_row_whatever_its_operands_are_called() -> None:
+    """A shared outer coordinate is no row. ``query[a0, a1, a3]`` and ``key[a0, a2, a3]`` are both
+    k-last and both read the batch coordinate ``a0``, so only ``a1`` and ``a2`` can order them —
+    and the answer must not turn on what the two operands happen to be called.
+
+    It used to: ``a0`` was the minimum on BOTH sides, the pair tied, and the tie fell through to
+    the product's argument order, which is its operand NAMES (commutative args sort). Those names
+    are minted in emission order, so one attention kernel's two contractions over the same operands
+    could orient opposite ways — and the twisted rewrite, which matches score cones by canonical
+    form, then stopped reading them as one score."""
+    reduce_axis = Axis("a3", Dim(16))
+    for query_name, key_name in (("p", "r"), ("r", "p")):
+        query = slab(query_name, "query", "a0", "a1", "a3")
+        key = slab(key_name, "key", "a0", "a2", "a3")
+        fold = contraction(reduce_axis, query, (key, "acc"))
+        assert fold.operands == (query, key), f"the query slab named {query_name!r} lost the A slot"
+        assert fold.lift.params[:3] == ("a3", query_name, key_name)
+
+
 def test_a_multi_channel_term_puts_the_shared_operand_first_at_formation() -> None:
     """With several products A is the argument they share, whatever the slab layouts say."""
     x, g, u = slab("l", "x", "k", "m"), slab("g", "wg", "n", "k"), slab("u", "wu", "n", "k")

--- a/tests/compiler/passes/test_cut_forks.py
+++ b/tests/compiler/passes/test_cut_forks.py
@@ -437,7 +437,9 @@ def test_child_identity_receipts_decode_per_child_and_join_by_stored_identity() 
     lift_identity = _lifted_target(parent).identity_key(with_io=True)
     children = {i: rows for i, rows in _replay(parent, exhaustive=True).rows.items() if i is not None and i != lift_identity}
     assert len(children) == 2, "the pinned cut must resolve to two distinctly identified child kernels"
-    (id_a, rows_a), (id_b, rows_b) = sorted(children.items())
+    # One child's rows are a subset of the other's, and which identity digest sorts first is not a
+    # fact about the kernels — take the child that HAS a row its sibling does not offer.
+    (id_a, rows_a), (id_b, rows_b) = sorted(children.items(), key=lambda child: len(child[1]), reverse=True)
     row_a = next(iter(rows_a - rows_b), None)
     assert row_a is not None, "the children must offer at least one distinguishing schedule row"
 

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s128.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s128.yaml
@@ -43,4 +43,4 @@ configs:
       STAGE: ''
       RASTER: ''
       WORK: t32x16
-    identity: 3a4b84d27383d81e107c3ab1f76d96f9ae59dc6174abf6ce77fc44e5677b06d3
+    identity: 30a735d3a7c0043938c9d42256685a60c5d6fda938ef2b609160c8b76f5ca19f

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s32.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s32.yaml
@@ -43,4 +43,4 @@ configs:
       STAGE: ''
       RASTER: ''
       WORK: t32x16
-    identity: 435b9460c09691a6110fef7ef81269a8fb56e355cd71919163fcd790cab077b3
+    identity: b7d9f7ff453d464850643a9ef271585ba14302fefc9e9f7ceda75091c7bf3d6a

--- a/tests/compiler/realization/cases/qwen3emb/sdpa-s512.yaml
+++ b/tests/compiler/realization/cases/qwen3emb/sdpa-s512.yaml
@@ -43,4 +43,4 @@ configs:
       STAGE: ''
       RASTER: ''
       WORK: t32x8
-    identity: be8f648729dc1f74a75374b9d336455d95304b5096c636e1ef791b6b52e6c9da
+    identity: 8bf84f929395ff6b4d892aecc9e7de7d16d61540bb5b9b4e76adae35a22ce099


### PR DESCRIPTION
## Abstract

The same attention program lifted to two different kernels depending on what its input tensors were called: anonymous inputs gave the flash form, inputs named `q`, `k`, `v` gave a two-pass form with the score contraction oriented key-first. A bilinear term orients itself by the slab reading the earlier free coordinate, and for a batched matmul that coordinate is the batch axis both slabs read, so every batched pair tied and the tie fell through to the trace's emission order, which follows variable names. The term now compares the row, the coordinate the other slab does not read, so one program lifts to one kernel under every spelling and its recorded evidence, cache entries and golden identity are filed under one identity.

---

Draft. Verification so far: the fold, cut-forks and twisted-rewrite tests, the corpus staleness check with three qwen3emb cases restamped (identity digest only), and the named spelling deploying under `--strict-evidence` on the RTX 5090. Still to run: the full suite, the RTX 5090 attention receipt rows, the model golden decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AULFmCQJuZWUeEunyB8MLr
