### PR TITLE
Bound each boot roofline measurement by the ratio that would warn anyway

### DIFF
--- a/emmy/serving/roofline.py
+++ b/emmy/serving/roofline.py
@@ -86,12 +86,30 @@ def measure_matmul_flops() -> float:
     return (2.0 * float(n) ** 3 * reps) / (ms / 1e3)
 
 
-def time_program_us(program, *, reps: int = 3) -> float:
-    """Median wall time of ``program.run_once()`` in µs (one warmup run outside the window)."""
+def time_program_us(program, *, reps: int = 3, budget_us: float | None = None) -> float:
+    """Median wall time of ``program.run_once()`` in µs, over ``reps`` runs after one warmup.
+
+    ``budget_us`` bounds the work. The warmup is timed, and a program already past the budget
+    returns that one measurement instead of being run ``reps`` more times: its verdict is decided,
+    and repeating the run only buys precision the warning never prints. That case is exactly the
+    one this audit exists to report AND the one where measuring costs most — on 2026-09-09 a
+    mispicked V100 decode program took over an hour per run, so the audit held 16 GPUs for six
+    hours and the boot never reached the profiling run.
+
+    A warmup carries one-time cost (module load, allocator growth) the timed runs do not, so a
+    program near the budget can bail on an inflated number. That is the deliberate direction: the
+    threshold is 10x a conservative floor, the warning is advisory and says to tune the twins, and
+    a boot that never finishes tells the operator nothing at all."""
     import cupy as cp
 
-    program.run_once()
     start, stop = cp.cuda.Event(), cp.cuda.Event()
+    start.record()
+    program.run_once()
+    stop.record()
+    stop.synchronize()
+    warmup_us = cp.cuda.get_elapsed_time(start, stop) * 1e3
+    if budget_us is not None and warmup_us > budget_us:
+        return warmup_us
     times = []
     for _ in range(reps):
         start.record()
@@ -102,6 +120,19 @@ def time_program_us(program, *, reps: int = 3) -> float:
     return sorted(times)[len(times) // 2]
 
 
+def roofline_floor_us(weight_bytes: int, bw_bytes_per_s: float, flops: float = 0.0, flops_per_s: float = 0.0) -> float | None:
+    """The floor one program is judged against — ``max(weight-streaming, compute)`` in µs — or
+    ``None`` when it cannot be formed or sits under :data:`MIN_FLOOR_US`. Split out from
+    :func:`flag_ratio` because the audit needs the floor BEFORE it measures, to bound the
+    measurement (:func:`time_program_us`)."""
+    if weight_bytes <= 0 or bw_bytes_per_s <= 0:
+        return None
+    floor_us = weight_bytes / bw_bytes_per_s * 1e6
+    if flops > 0 and flops_per_s > 0:
+        floor_us = max(floor_us, flops / flops_per_s * 1e6)
+    return None if floor_us < MIN_FLOOR_US else floor_us
+
+
 def flag_ratio(
     measured_us: float, weight_bytes: int, bw_bytes_per_s: float, flops: float = 0.0, flops_per_s: float = 0.0
 ) -> tuple[float, float] | None:
@@ -109,12 +140,8 @@ def flag_ratio(
     The floor is ``max(weight-streaming, compute)``; ``flops`` / ``flops_per_s`` at 0 (compute
     throughput uncalibrated) degrade to the weight floor alone. Pure decision logic —
     unit-testable without CUDA."""
-    if weight_bytes <= 0 or bw_bytes_per_s <= 0:
-        return None
-    floor_us = weight_bytes / bw_bytes_per_s * 1e6
-    if flops > 0 and flops_per_s > 0:
-        floor_us = max(floor_us, flops / flops_per_s * 1e6)
-    if floor_us < MIN_FLOOR_US:
+    floor_us = roofline_floor_us(weight_bytes, bw_bytes_per_s, flops, flops_per_s)
+    if floor_us is None:
         return None
     ratio = measured_us / floor_us
     if ratio <= WARN_RATIO:
@@ -148,7 +175,10 @@ def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
             flagged = []
             for label, prog, m_tokens in named_programs:
                 flops = 2.0 * (prog.weight_bytes / dtype_bytes) * m_tokens
-                verdict = flag_ratio(time_program_us(prog.program), prog.weight_bytes, bw, flops, flops_per_s)
+                floor_us = roofline_floor_us(prog.weight_bytes, bw, flops, flops_per_s)
+                budget_us = None if floor_us is None else WARN_RATIO * floor_us
+                measured_us = time_program_us(prog.program, budget_us=budget_us)
+                verdict = flag_ratio(measured_us, prog.weight_bytes, bw, flops, flops_per_s)
                 if verdict is not None:
                     floor_us, ratio = verdict
                     flagged.append((label, floor_us, ratio))

--- a/tests/serving/test_roofline.py
+++ b/tests/serving/test_roofline.py
@@ -2,6 +2,8 @@
 Pure CPU: the CUDA-touching measurement helpers are stubbed."""
 
 import logging
+import sys
+import types
 
 import pytest
 
@@ -78,7 +80,7 @@ def test_audit_counts_weight_inputs(monkeypatch, caplog):
     only the constant side would give it a zero floor and audit nothing."""
     monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
     monkeypatch.setattr(roofline, "measure_matmul_flops", lambda: 210e12)
-    monkeypatch.setattr(roofline, "time_program_us", lambda program: 50_000.0)  # 500x its 100 µs floor
+    monkeypatch.setattr(roofline, "time_program_us", lambda program, **kw: 50_000.0)  # 500x its 100 µs floor
     with caplog.at_level(logging.WARNING, logger="emmy.serving.roofline"):
         audit_boot_programs([("moe.expert.one", _Prog(0, input_weight_bytes=100_000_000), 1)])
     assert len(caplog.records) == 1
@@ -89,7 +91,7 @@ def test_audit_warns_on_outlier_and_stays_quiet_on_healthy(monkeypatch, caplog):
     monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
     monkeypatch.setattr(roofline, "measure_matmul_flops", lambda: 210e12)
     times = iter([50_000.0, 150.0])  # slow program then healthy program, both floor 100 µs
-    monkeypatch.setattr(roofline, "time_program_us", lambda program: next(times))
+    monkeypatch.setattr(roofline, "time_program_us", lambda program, **kw: next(times))
     with caplog.at_level(logging.WARNING, logger="emmy.serving.roofline"):
         audit_boot_programs([("L0.post.decode.m8", _Prog(100_000_000), 8), ("L0.pre.decode.m8", _Prog(100_000_000), 8)])
     assert len(caplog.records) == 1
@@ -103,7 +105,7 @@ def test_audit_compute_bound_chunk_twin_is_silent(monkeypatch, caplog):
     monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
     monkeypatch.setattr(roofline, "measure_matmul_flops", lambda: 210e12)
     times = iter([1_620.0, 4_500.0])  # chunk.m4096 then the mispicked decode.m1
-    monkeypatch.setattr(roofline, "time_program_us", lambda program: next(times))
+    monkeypatch.setattr(roofline, "time_program_us", lambda program, **kw: next(times))
     with caplog.at_level(logging.WARNING, logger="emmy.serving.roofline"):
         audit_boot_programs([("L0.post.chunk.m4096", _Prog(68_000_000), 4096), ("L0.post.decode.m1", _Prog(46_000_000), 1)])
     assert len(caplog.records) == 1
@@ -114,7 +116,7 @@ def test_audit_degrades_to_weight_floor_without_matmul_calibration(monkeypatch, 
     """A failed compute-throughput calibration must not kill the audit — the weight floor still warns."""
     monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
     monkeypatch.setattr(roofline, "measure_matmul_flops", lambda: (_ for _ in ()).throw(RuntimeError("no cublas")))
-    monkeypatch.setattr(roofline, "time_program_us", lambda program: 50_000.0)
+    monkeypatch.setattr(roofline, "time_program_us", lambda program, **kw: 50_000.0)
     with caplog.at_level(logging.WARNING, logger="emmy.serving.roofline"):
         audit_boot_programs([("L0.post.decode.m8", _Prog(100_000_000), 8)])
     assert len(caplog.records) == 1
@@ -139,3 +141,53 @@ def test_audit_never_raises(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="emmy.serving.roofline"):
         audit_boot_programs([("L0.pre.decode.m8", _Prog(100_000_000), 8)])
     assert not caplog.records  # swallowed to debug level — a boot warning is never a boot blocker
+
+
+class _FakeEvent:
+    def record(self):
+        pass
+
+    def synchronize(self):
+        pass
+
+
+def _fake_cupy(elapsed_ms):
+    """A cupy stand-in whose event timer yields these millisecond readings, one per call."""
+    readings = iter(elapsed_ms)
+    cuda = types.SimpleNamespace(Event=_FakeEvent, get_elapsed_time=lambda a, b: next(readings))
+    return types.SimpleNamespace(cuda=cuda)
+
+
+def test_time_program_us_stops_after_a_warmup_that_blows_the_budget(monkeypatch):
+    """The mispick this audit exists to report is also the most expensive thing to measure. Once
+    the warmup alone is past the budget the verdict is settled, so the timed runs are skipped —
+    the V100 incident ran one such program four times and held the boot for six hours."""
+    monkeypatch.setitem(sys.modules, "cupy", _fake_cupy([2.0]))
+    runs = []
+    program = types.SimpleNamespace(run_once=lambda: runs.append(1))
+    assert roofline.time_program_us(program, budget_us=1000.0) == pytest.approx(2000.0)
+    assert len(runs) == 1, "a program past its budget is run once, not four times"
+
+
+def test_time_program_us_medians_the_timed_runs_inside_the_budget(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cupy", _fake_cupy([0.1, 0.3, 0.2, 0.4]))
+    runs = []
+    program = types.SimpleNamespace(run_once=lambda: runs.append(1))
+    assert roofline.time_program_us(program, budget_us=1000.0) == pytest.approx(300.0)
+    assert len(runs) == 4, "warmup plus three timed runs"
+
+
+def test_audit_bounds_each_measurement_by_the_warn_threshold(monkeypatch):
+    """The audit derives the floor BEFORE measuring and hands it down: nothing is worth timing
+    past the ratio that would warn anyway."""
+    monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
+    monkeypatch.setattr(roofline, "measure_matmul_flops", lambda: 210e12)
+    seen = {}
+
+    def _timer(program, *, budget_us=None):
+        seen["budget_us"] = budget_us
+        return 150.0
+
+    monkeypatch.setattr(roofline, "time_program_us", _timer)
+    audit_boot_programs([("L0.post.decode.m8", _Prog(100_000_000), 8)])
+    assert seen["budget_us"] == pytest.approx(roofline.WARN_RATIO * 100.0)


### PR DESCRIPTION
## Abstract

The boot roofline audit times every static serving program four times with no cap on how long a run may take. Its own docstring promises that a boot warning must not become a boot blocker, but that only covered exceptions. On 2026-09-09 a mispicked DeepSeek-V4 decode program took over an hour per run, so the audit held 16 V100s for six hours and the boot never reached the profiling run — the audit exists to report exactly that program, and could not, because reporting it meant finishing it. The floor is now derived before the measurement instead of after, and handed down as a budget: a program whose warmup alone is already past the warning threshold returns that measurement rather than being run three more times.

---

## What it looked like

Nothing in the log. The last line printed was the compile finishing; then sixteen workers at 100% GPU, silent, for six hours. `py-spy dump --locals` on a worker was the only way to learn which program it was — the frame carries `label`, and `time_program_us` showed `times: []`, meaning it had not finished the first timed run.

## The change

`roofline_floor_us` splits out of `flag_ratio`, which now calls it. `audit_boot_programs` computes the floor first and passes `WARN_RATIO * floor_us` to `time_program_us`, which times its warmup and returns early when that alone exceeds the budget.

A warmup carries one-time cost the timed runs do not — module load, allocator growth — so a program near the budget can bail on an inflated number. That direction is deliberate and written into the docstring: the threshold is ten times a conservative floor, the warning is advisory and says to tune the twins, and a boot that never finishes tells the operator nothing at all.

## Tests

Three added: a warmup past the budget runs the program once rather than four times; a program inside the budget still takes the median of three timed runs; and the audit hands down a budget equal to the warn threshold times the floor it derived. The existing stubs took `lambda program:` and now take the keyword.

## Not fixed here

There is still no ceiling on the audit as a whole — a hundred programs each just under budget can still add up. This bounds the single pathological program, which is the failure that happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
