### PR TITLE
Prune a schedule branch that already decided a site OFF, so a row lookup stays linear

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -546,7 +546,10 @@ At a **schedule fork** (one kernel's row):
    leaf, whether it came from the tune DB or from a golden file — `_direct_measured_pick` descends the lazy tree
    straight to it, asking each branch whether it admits the row (`Fork.admits`: a schedule branch spells a prefix of
    what its leaves will spell, a level branch a projection of it, and a knob the row leaves undecided is free), so a
-   partial row reaches its leaf whatever the pool size. The index is built once per compile and memoized per process on
+   partial row reaches its leaf whatever the pool size. The prefix reading excludes the empty spelling: a site the
+   branch itself DECIDED off admits only off, since every string extends the empty one and the descent would otherwise
+   fail no earlier than leaf matching. An off merely inherited down the branch is a pin rather than a decision and
+   still admits. The index is built once per compile and memoized per process on
    the DB path and mtime, the context key and the golden scope. It holds the tune DB's CUDA `perf` rows for this
    compile's context key (one lane, because a sweep measures in the regime a deploy compiles in; rows from a
    deliberately non-deployable `--nvcc-flags` run key elsewhere and are simply never consulted) and the **golden rows**

--- a/emmy/compiler/pipeline/fork.py
+++ b/emmy/compiler/pipeline/fork.py
@@ -197,13 +197,26 @@ class _ScheduleFork(Fork):
         anything), so the row's value must extend the branch's value at a segment boundary. A
         site the row names only by its bare family key reads as a bare pin does
         (``evidence_row_vouches``): the site may be OFF or carry the value, never another — pruned
-        here so a row that names no leaf costs O(path), not the pool."""
+        here so a row that names no leaf costs O(path), not the pool.
+
+        The prefix reading has one exception, and leaving it out cost the pool bound it advertises:
+        every string extends the empty one, so an OFF already in ``row`` admitted every request and
+        the descent only failed at leaf matching. One such site doubles the work and these kernels
+        carry dozens. The claim is only about the EMPTY spelling — a field in ``row`` is one the
+        codec emitted, not necessarily one whose spelling is complete (``WORK`` still grows its
+        producer band there) — and an emitted empty never fills in later: the classic codec writes a
+        site's node and edge values when that site advances, and an unclaimed inventory stays
+        ``None`` rather than spelling ``Work()``. An OFF merely INHERITED through ``branch_knobs``
+        is a pin, not a decision, and still admits, as does a bare family key — a bare pin permits
+        OFF."""
         for name, value in self.knobs.items():
             if name.startswith(("S_", "H_")):
                 continue
             family = name.split("@", 1)[0]
             if name in row:
                 want = str(row[name])
+                if name in self.row and not str(value) and want:
+                    return False
             elif name != family and family in row:
                 want = str(row[family])
             else:

--- a/tests/compiler/pipeline/test_fork.py
+++ b/tests/compiler/pipeline/test_fork.py
@@ -280,3 +280,28 @@ def test_admits_reads_a_level_projection_and_a_schedule_prefix() -> None:
     )
     assert not sited.admits({"REDUCE": "coop"}), "a bare row key prunes a site that decided another non-OFF value"
     assert _ScheduleFork(tree=SimpleNamespace(branch_knobs={}), context=None, row={"REDUCE@map.1/twist": "coop"}).admits({"REDUCE": "coop"})
+
+
+def test_admits_prunes_a_site_this_branch_already_decided_OFF() -> None:
+    """A branch that DECIDED a site OFF cannot reach a leaf carrying a value there.
+
+    ``admits`` reads a branch's value as a PREFIX of what its leaves will spell, and every string
+    extends the empty one — so an OFF the branch had already settled admitted every request and the
+    descent only failed at leaf matching. With one such site per fork that is a factor of two, and
+    the kernels this bites have dozens: a 16-rank serving boot sat in the schedule search for 45
+    minutes without compiling a single kernel. An OFF the branch merely INHERITED is still
+    undecided and still admits, and so does a site the row names only by its bare family key.
+    """
+    from types import SimpleNamespace
+
+    from emmy.compiler.pipeline.fork import _ScheduleFork
+
+    decided = _ScheduleFork(tree=SimpleNamespace(branch_knobs={}), context=None, row={"STAGE@map.1/inner": ""})
+    assert not decided.admits({"STAGE@map.1/inner": "d1/smem"})
+    assert decided.admits({"STAGE@map.1/inner": ""})
+
+    inherited = _ScheduleFork(tree=SimpleNamespace(branch_knobs={"STAGE@map.1/inner": ""}), context=None, row={})
+    assert inherited.admits({"STAGE@map.1/inner": "d1/smem"}), "an inherited OFF is undecided, not a decision"
+
+    bare = _ScheduleFork(tree=SimpleNamespace(branch_knobs={}), context=None, row={"REDUCE@map.1/inner": ""})
+    assert bare.admits({"REDUCE": "coop"}), "a bare family key still reads as a bare pin: OFF or the value"


### PR DESCRIPTION
## Abstract

A schedule branch that had already decided a site OFF was admitted for any value a row asked of it, because `admits` reads a branch's value as a prefix of what its leaves will spell and every string extends the empty one. The branch survived to leaf matching instead of being pruned at the fork, so a lookup that should cost O(path) walked the pool. One such site doubles the work and these kernels carry dozens.

Measured with the real `_ScheduleFork` over a synthetic tree whose lookup row is complete and valid, so a missing row was never needed to trigger it:

| sites | expansions before | after |
| ---: | ---: | ---: |
| 4 | 31 | 5 |
| 8 | 511 | 9 |
| 12 | 8,191 | 13 |
| 16 | 131,071 | 17 |

---

## What changed

An OFF already in the branch's own `row` is now compared exactly rather than as a prefix. Two readings are deliberately left alone: an OFF merely inherited through `branch_knobs` is a pin rather than a decision and still admits, and a site the row names only by its bare family key keeps the `evidence_row_vouches` semantics where OFF is permitted.

The claim is only about the empty spelling. A field in `row` is one the codec emitted, not necessarily one whose spelling is complete — `WORK` still grows its producer band there — but an emitted empty never fills in later, because the classic codec writes a site's node and edge values when that site advances and an unclaimed inventory stays `None` rather than spelling `Work()`.

## Effect on the golden decode

`make test-goldens` moves no row. Rebased onto `3ebd8fc6` and compared against a pristine worktree at the same commit, the failing set is identical — `Laguna-S-2.1-exl3/rtx5090_sm120`, `gemma-4-12B-it/rtx4090_sm89`, `gemma-4-12B-it/rtx5090_sm120` — and all three fail on main as well. Nothing is repaired either.

The control also says something about the cost. This branch decodes all seven files in 6:42. The control was still inside `DeepSeek-V4-Flash-0731/v100_sm70` when I stopped it at 15:00, which is the file carrying the sites this change prunes. That is consistent with the table above but it is not a clean measurement, because the control never finished.

## Why the core grows

`emmy/` gains 18 lines for no new capability, which the line-balance check flags. Three of them are the guard; the rest are a docstring paragraph and the matching sentence in the pipeline architecture document. The prefix reading is the invariant the whole lazy descent rests on, and this change carves an exception into it, so the exception has to be written down where the next reader meets the rule. Shrinking that back would buy two dozen characters and lose the reason the guard is correct.

## Where this came from

A 16-rank DeepSeek-V4 serving boot sat in the schedule search for 45 minutes without compiling a single kernel. Codex review located the defect and built the first version of the reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

