### PR TITLE
Record the Gemma 4 attention-split test in the durations file

### DIFF
--- a/tests/durations.json
+++ b/tests/durations.json
@@ -1117,6 +1117,7 @@
  "tests/serving/generation/test_generate_loop.py::test_slice_last_logits_wrapper_matches_full_logits": 5.5,
  "tests/serving/test_attention_split.py::test_split_matches_eager_block[gemma3]": 1.66,
  "tests/serving/test_attention_split.py::test_split_matches_eager_block[qwen3]": 5.3,
+ "tests/serving/test_attention_split.py::test_split_matches_eager_gemma4": 6.6,
  "tests/serving/test_deepseek_native_loader.py::test_native_fp8_trunk_weight_loads_scaled": 1.64,
  "tests/serving/test_deepseek_v4_split.py::test_classic_carve_rejects_hyper_connection_block": 5.3,
  "tests/serving/test_deepseek_v4_split.py::test_hyper_connection_split_matches_eager_layer[0]": 1.02,


### PR DESCRIPTION
## Abstract

The Tests job fails its durations gate on main: the Gemma 4 attention-split serving test took 6.6 s on the runner and has no entry in the durations file. Every test passed. This adds the entry at the runner's number, as the gate asks.

---

The test is not new. Its cost is the first Gemma 4 import in a worker: 1.65 s alone on a dev box, under 0.5 s when another test in the same worker imported it first. The runner is about four times slower, which puts a cold run past the 5 s bar. It surfaced on the H100 golden PR's last run (#787), which merged with that failure.

The full suite was not run locally; CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaoCCkT9r6Kq4LH5HoYRQP
