### PR TITLE
Record the first Emmy serving numbers for DeepSeek V4 on 16x V100, and the M=1 decode tier that blocked them

### DIFF
--- a/experiments/golden-bench-2026/serving_deepseek_v4_flash_0731_v100x16/RESULTS.md
+++ b/experiments/golden-bench-2026/serving_deepseek_v4_flash_0731_v100x16/RESULTS.md
@@ -2,17 +2,21 @@
 
 ## Conclusion
 
-This run characterizes the pinned 1Cat fork at the short serving envelope. It is **not** the Emmy-versus-fork A/B, and
-nothing here compares a compiler. Only the fork arm produced serving numbers.
+Both arms now serve this checkpoint and both produced serving numbers. The fork is roughly **38× faster per output
+token** and **23× faster to first token**. The two arms were measured in separate invocations rather than one
+alternating run, so this is a directional comparison, not the balanced A/B described under "What this run does not
+establish".
 
-The Emmy arm now boots and serves — that changed on 2026-09-11 and is recorded under "The Emmy arm" below — but it
-cannot complete a request: the first generation exceeds vLLM's `sample_tokens` RPC deadline and kills the engine. Its
-numbers here are per-kernel and per-program compiler measurements, not serving measurements, and they do not belong in
-the same table as the fork's throughput.
+The Emmy arm completes requests only with its static M=1 decode tier disabled (`EMMY_GEN_M1_TIER=0`). With that
+tier enabled — the default — no generation finished: a single-token decode forward advances at a flat ~61 s per
+layer and takes roughly 2,700 s, which overruns both vLLM's 300 s `sample_tokens` deadline and the 600 s NCCL collective
+watchdog. Routing single-token decode through the M=16 bucket twins instead costs 5.6 s per token, so the tier itself
+carries a factor of about 485×. That is an Emmy defect, recorded below and not yet fixed.
 
-Three programs have since been fixed — `pre4096` by 594×, and the decode program's two hot kernels by 4.3× and
-5.6× — all confirmed by the deployed boot's own audit. The request still fails at the same 300 s deadline, and
-kernel latency no longer explains why: roughly a second of compute per decode step against a 300-second limit.
+Three programs were fixed earlier in this work — `pre4096` by 594×, and the decode program's two hot kernels by 4.3×
+and 5.6× — all confirmed by the deployed boot's own audit. Those fixes hold, and they are why the arm serves at all.
+The two programs that now dominate were never recorded: `post.decode.m16` at 1,149× its roofline floor is most of the
+per-token cost, and `post.chunk.m4096` at 317× is most of the time to first token.
 
 At a 4,096-token context the fork serves this checkpoint cleanly: 480 requests across fifteen rows, zero failures,
 and three workload shapes that differ far more in repeat stability than the shapes themselves suggest. Single-stream
@@ -48,19 +52,76 @@ be visible far below the noise floor of the other two shapes.
 
 ## The Emmy arm
 
-These are compiler measurements, not serving measurements. They come from a serving boot and a kernel tuning run on the
-same host, not from `emmy bench`, so they have no experiment records and no archive. They are recorded here because they
-are the first measured Emmy evidence for this model on this GPU, and because they say precisely why the serving column
-is still empty.
+The Emmy arm serves. The numbers below come from a serving boot on the same host driven by direct HTTP requests, not
+from `emmy bench`, so they carry no experiment records and no archive. The compiler measurements that follow them are
+kept because they explain where the time goes.
+
+### Serving measurements
+
+Boot on 2026-09-12, `--strict-evidence`, `EMMY_GEN_M1_TIER=0`, `gpu_memory_utilization` 0.90, prefix caching on.
+Greedy decoding, single stream, streamed responses timestamped per chunk.
+
+| Shape | TTFT | TPOT mean | TPOT range | Output tok/s | Decode steps |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 5 in → 33 out | 5.94 s | 5.565 s | 5.553 – 5.594 | 0.180 | 32 |
+| 2,405 in → 9 out | 88.22 s | 5.610 s | 5.598 – 5.665 | 0.178 | 8 |
+
+Against the fork's single-stream row, which is the steadiest measurement on this stack:
+
+| | 1Cat fork | Emmy | Ratio |
+| --- | ---: | ---: | ---: |
+| TTFT | 3.77 s (2,048 in) | 88.22 s (2,405 in) | 23× |
+| Mean time per output token | 147.7 ms | 5.610 s | 38× |
+| Output tok/s, decode only | 6.77 | 0.178 | 38× |
+
+Emmy's inter-token latency is the more stable of the two in relative terms: 40 decode steps across the two shapes
+span 5.553 s to 5.665 s, a 2% spread, and the two shapes' means differ by 0.8% despite a 480× difference in context.
+A repeat of the 2,405-token request returned in 56.29 s against a warm prefix cache, which is nine decode steps and no
+prefill — an independent confirmation of the per-token figure.
+
+The per-token cost is accounted for by one program. `post.decode.m16` runs at 1,149× its ~60 µs roofline floor, or
+about 68 ms per layer, which is roughly 3.0 s of the 5.6 s across 44 layers. `post.chunk.m4096` at 317× its ~1,955 µs
+floor is about 620 ms per layer and dominates the 88 s time to first token. Neither has ever been recorded — only the
+`m1` shapes were.
+
+### The static M=1 decode tier is a defect
+
+With the M=1 tier enabled, which is the default, no generation request ever completed. The failure is not prefill: a
+one-token completion returns in 5.8 s, and a one-token completion runs zero decode forwards because prefill produces
+the first token's logits. vLLM's own scheduler dump at the failure names the step —
+`total_num_scheduled_tokens=1`, `num_computed_tokens=[5]`, `num_output_tokens=[1]` — the first true decode forward.
+
+Sampling one worker's layer index through a complete 22-layer pipeline stage gives a flat rate with no decay:
+
+| Layer transition | 0→1 | 1→2 | 5→6 | 10→11 | 15→16 | 20→21 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Seconds | 60 | 61 | 60 | 60 | 61 | 60 |
+
+Twenty-two layers in 1,379 s, 62.7 s each, constant from the first layer to the last. That flatness is what rules out
+first-use cost: a cost paid once per process would fall away after the first layers. A whole forward at that rate is
+about 2,700 s, which is why it overruns the 300 s RPC deadline. Raising that deadline does not help, because the 600 s
+NCCL collective watchdog then tears the workers down, and under two-stage pipelining the second stage blocks on the
+first for the entire traversal. That watchdog timeout is a compiled-in constant with no environment override.
+
+The same request through the M=16 bucket twins takes 5.6 s per token, so the tier carries a factor of about 485×.
+
+What makes this hard to see from the boot audit: the audit times `post.decode.m1` at 17 ms per layer, and it does so
+through raw launches, while serving drives the same program through whole-program CUDA graph capture and replay. The
+M=1 and M=16 post programs have identical 36-kernel launch lists, and the M=16 tier performs the same per-layer
+captures during prefill at about 0.16 s per layer. So the cost is in the M=1 tier's capture-and-replay path rather
+than in the program, and the audit cannot reach it.
+
+Seven other explanations were checked against the code and eliminated: the fixed-slot expert combine (DeepSeek's
+hyper-connection branch returns before that check, and tensor-parallel expert sharding excludes it independently), the
+refused expert `m256` twin (that tier applies only between the decode bucket and 256 routed rows; at one row the
+dispatch selects the `one` tier, which built on all sixteen workers), the Emmy programs themselves, graph-cache
+eviction, a launch-heavy M=1 program, ordinary first-use cost, and a straggler worker — all eight workers of a stage
+sit at the same layer with every GPU at 100%.
 
 ### The boot reaches a serving state
 
 On 2026-09-11 a boot with `--strict-evidence` came up: `/health` returned 200, `/v1/models` listed the checkpoint, and
 vLLM logged `Application startup complete`. Engine init — profile, KV-cache creation and model warm-up — took 949 s.
-
-The first chat completion then killed it. One 24-token greedy request returned HTTP 500 after 173.1 s with
-`TimeoutError: RPC call to sample_tokens timed out`, followed by `EngineDeadError`. The server is reachable and
-correctly configured; a forward pass simply does not fit inside the engine's RPC deadline.
 
 Strict evidence is what made the boot possible, and the mechanism is worth recording. An earlier boot without the flag
 logged 16 prior-clip warnings — one per worker — reporting a latency-proxy exponent of 996 against a shipped
@@ -158,20 +219,21 @@ recorded rows win the election on price.
 
 ## What this run does not establish
 
-- **It is not an A/B.** One arm ran. A comparison needs both arms in one invocation with their order alternated inside
-  each repeat, the way the RTX 5090 gemma-4 experiment balances time and thermal drift. Until then no claim about Emmy
-  against the fork is supported by this evidence.
-- **The Emmy arm serves but cannot answer.** It reaches a serving state and then loses every completion to the
-  `sample_tokens` RPC deadline, so it produces no throughput, TTFT or TPOT to compare. An earlier claim that a
-  whole-program compile "stalls in the schedule search" was wrong: that boot was not stuck but grinding, because a
-  degenerate prior had collapsed the ranking to enumeration order and each refused row re-resolved the entire program.
-  There is also no baked Emmy image for this model, so the single-image, two-entrypoint mechanism the gemma-4 A/B uses
-  does not exist here yet.
-- **The Emmy numbers above are not serving numbers.** They are per-kernel and per-program latencies from a boot audit,
-  a recorded golden and a tuning run. Nothing in them can be compared against the fork's tokens per second.
-- **One envelope parameter is unreconciled.** This recipe runs at `gpu_memory_utilization` 0.80; the Emmy arm's last
-  serving boot needed 0.90 to fit. Whichever value the joint recipe adopts, both arms must share it, and these numbers
-  do not transfer to a run at 0.90.
+- **It is not a balanced A/B.** The two arms were measured in separate invocations, not in one run with their order
+  alternated inside each repeat the way the RTX 5090 gemma-4 experiment balances time and thermal drift. The gap is
+  large enough that ordering cannot explain it, but the numbers are directional, not a controlled comparison. There is
+  also no baked Emmy image for this model, so the single-image, two-entrypoint mechanism that A/B uses does not exist
+  here yet.
+- **The two arms did not run the same envelope.** The fork rows are at `gpu_memory_utilization` 0.80 with prefix
+  caching disabled; the Emmy boot needed 0.90 and ran with prefix caching on. The Emmy shapes are 2,405 and 5 input
+  tokens against the fork's 2,048, and 9 and 33 output tokens against its 512. Whichever values a joint recipe adopts,
+  both arms must share them.
+- **The Emmy rows are one repeat each.** The fork rows are five repeats with a reported spread; the Emmy rows are
+  single runs, and their stability claim rests on the spread of decode steps within a run, not across runs.
+- **The Emmy arm ran with a non-default configuration.** `EMMY_GEN_M1_TIER=0` is required for it to answer at all.
+  Any comparison including the default configuration would show no completions from the Emmy arm.
+- **The Emmy rows came from direct HTTP requests**, not from `emmy bench`, so they have no experiment records and are
+  not in the archive.
 - **It is not a regression check against the August run.** That run used different prompt shapes, a different context
   length and four repeats, so the two are not comparable row for row.
 - **Correctness was checked only by the deployment smoke test**, which asks one arithmetic question and reads one


### PR DESCRIPTION
## Abstract

The Emmy arm of the DeepSeek V4 Flash serving comparison now completes requests and has time-to-first-token and per-token numbers for the first time, so this replaces the section of the report that said it could not answer. The fork is about 38 times faster per output token and 23 times faster to first token. Getting the arm to answer at all required disabling Emmy's static M=1 decode tier, which is a defect this report records rather than fixes: with that tier at its default, a single-token decode forward runs at a flat 61 seconds per layer and never finishes.

| | 1Cat fork | Emmy | Ratio |
| --- | ---: | ---: | ---: |
| Time to first token | 3.77 s (2,048 in) | 88.22 s (2,405 in) | 23× |
| Mean time per output token | 147.7 ms | 5.610 s | 38× |
| Output tokens per second | 6.77 | 0.178 | 38× |

---

## What changed in the report

The conclusion, which previously stated that the Emmy arm loses every completion to the `sample_tokens` RPC deadline. Two new sections: the serving measurements, and the M=1 decode tier defect. The caveat list, which claimed the arm produces no throughput to compare.

The three placement-cut fixes recorded earlier in this report are unchanged, and they are why the arm serves at all.

## The defect

With the M=1 tier enabled — the default — no generation request ever completed across four serving boots. The failure is not in prefill. A one-token completion returns in 5.8 seconds, and a one-token completion runs zero decode forwards because prefill produces the first token's logits. vLLM's own scheduler dump at the failure names the step as the first true decode forward.

Sampling one worker's layer index through a complete 22-layer pipeline stage gives 22 layers in 1,379 seconds, 62.7 seconds each, constant from the first layer to the last. That flatness is what rules out first-use cost, which would fall away after the first layers. A whole forward at that rate is roughly 2,700 seconds. Routing single-token decode through the M=16 bucket twins instead costs 5.6 seconds per token, so the tier carries a factor of about 485.

The boot roofline audit cannot see this. It times the same program at 17 ms per layer through raw launches, while serving drives it through whole-program CUDA graph capture and replay. The M=1 and M=16 post programs have identical 36-kernel launch lists, and the M=16 tier performs the same per-layer captures during prefill at about 0.16 seconds per layer. The cost lives in the M=1 tier's capture-and-replay path, which the audit never exercises.

Seven other explanations were checked against the code and eliminated; the report lists them.

## Two deadlines bound any forward here

Raising vLLM's 300 s `sample_tokens` deadline does not rescue the default configuration, because the 600 s NCCL collective watchdog then tears the workers down, and under two-stage pipelining the second stage blocks on the first for the entire traversal. That watchdog timeout is a compiled-in constant with no environment override, and `TORCH_NCCL_ASYNC_ERROR_HANDLING=0` does not suppress it.

## What this does not establish

The two arms ran in separate invocations rather than one alternating run, so the comparison is directional. They did not share an envelope: the fork rows are at `gpu_memory_utilization` 0.80 with prefix caching off, the Emmy boot needed 0.90 with prefix caching on, and the shapes differ in both input and output length. The Emmy rows are one repeat each against the fork's five. The Emmy arm ran with a non-default configuration. The Emmy rows came from direct HTTP requests rather than `emmy bench`, so they carry no experiment records and are not in the archive. All of this is written into the report's caveat section.

## What this leaves for next

Two programs dominate what remains, both already named by the boot's own audit and never recorded because only the m1 shapes were: `post.decode.m16` at 1,149× its roofline floor is most of the per-token cost, and `post.chunk.m4096` at 317× is most of the time to first token. The placement-cut method that produced the 594×, 4.3× and 5.6× results in this report applies directly to both.

The M=1 tier defect deserves its own change; it is recorded here because this is where the evidence is.

## Verification

Documentation only — one file, +95/−33, no code touched. No test reads this file; `tests/benchmark/models/test_golden_bench_2026.py` passes (14 passed). The full suite was not run, because the diff contains no code and no test input.

Earlier content from this work merged in #778, which is why this is a separate branch off current `main` rather than more commits on the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
