### PR TITLE
Record a working M=1 decode schedule, and stop deploying the tier when it is slower

### DIFF
--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -1749,7 +1749,27 @@ class EmmyGenRunner:
             for key, tag, m in (("bucket", f"bucket.m{decode_bucket}", decode_bucket), ("one", "one.m1", 1), ("m256", "m256", 256))
             if tiers[key] is not None
         ]
-        audit_boot_programs(named, dtype_bytes=np_dtype.itemsize)
+        measured = audit_boot_programs(named, dtype_bytes=np_dtype.itemsize)
+        # The M=1 tier is an OPTIMIZATION: the bucket twins already cover T=1 by padding up, and
+        # this tier exists only because the contractions demote to faster planar forms at one row.
+        # When its programs do not measure faster, keeping it is strictly worse. On 2026-09-12 it
+        # was 485x worse — a DeepSeek-V4 V100 boot elected an M=1 pre program at 29.7 s per forward
+        # and every request died on the engine's RPC deadline, with the roofline audit blind to it
+        # because that program's floor was too small to form a ratio. The audit already timed both
+        # tiers under the GPU lock, so this reads its numbers rather than measuring again.
+        if runner._pre_m1 is not None:
+            m1_us = sum(us for label, us in measured.items() if label.endswith(".decode.m1"))
+            bucket_us = sum(us for label, us in measured.items() if label.endswith(f".decode.m{decode_bucket}"))
+            if m1_us and bucket_us and m1_us >= bucket_us:
+                logger.warning(
+                    "[gen_runner] the static M=1 decode twins measure %.3f ms against %.3f ms for the bucket-%d "
+                    "twins they replace — dropping the M=1 tier; T=1 decode rides the bucket twins. Tune the M=1 "
+                    "twins (`emmy tune`; see emmy/serving/ARCHITECTURE.md → 'Tuning what serving actually runs').",
+                    m1_us / 1e3,
+                    bucket_us / 1e3,
+                    decode_bucket,
+                )
+                runner._pre_m1 = runner._post_m1 = None
         return runner
 
     def embed(self, input_ids):

--- a/emmy/serving/roofline.py
+++ b/emmy/serving/roofline.py
@@ -163,23 +163,27 @@ def flag_ratio(
     return floor_us, ratio
 
 
-def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
+def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> dict[str, float]:
     """Time each ``(label, _Program, m_tokens)`` against ``max(weight-streaming, compute)`` floor and
     warn on outliers. ``_Program`` here is the serving wrapper (``gen_runner._Program``): ``.program``
     is the ``CompiledProgram`` and ``.weight_bytes`` the per-forward weight footprint — bound constants
     plus the weight INPUTS an expert program takes per launch. ``m_tokens`` is the program's static
     token width, ``dtype_bytes`` the weight itemsize — together they turn ``weight_bytes`` into the
-    matmul FLOP estimate ``2 * weight_elems * m_tokens``. Never raises."""
+    matmul FLOP estimate ``2 * weight_elems * m_tokens``. Never raises.
+
+    Returns the measured µs per label — empty when the audit could not run. A caller that must
+    choose between two tiers of the same program reads it rather than timing them again."""
     from emmy import config
     from emmy.compiler.backend.gpu_lock import gpu_lock
 
+    measured: dict[str, float] = {}
     with contextlib.ExitStack() as stack:
         try:
             stack.enter_context(gpu_lock())
         except Exception:  # noqa: BLE001 — taking the lock is setup, not measurement: an unusable
             # lock path is an environment fault and must not read as a clean audit at debug level.
             logger.warning("[roofline] boot audit skipped: GPU lock %r unusable", config.gpu_lock_path(), exc_info=True)
-            return
+            return measured
         try:
             bw = measure_copy_bw()
             try:
@@ -194,13 +198,14 @@ def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
                 # pays 4x a mispick's full cost to learn what one run already showed.
                 budget_us = MAX_ABS_US if floor_us is None else WARN_RATIO * floor_us
                 measured_us = time_program_us(prog.program, budget_us=budget_us)
+                measured[label] = measured_us
                 verdict = flag_ratio(measured_us, prog.weight_bytes, bw, flops, flops_per_s)
                 if verdict is not None:
                     floor_us, ratio = verdict
                     flagged.append((label, floor_us, ratio, measured_us))
         except Exception:  # noqa: BLE001 — advisory only, never a boot blocker
             logger.debug("[roofline] boot audit skipped", exc_info=True)
-            return
+            return measured
     for label, floor_us, ratio, measured_us in flagged:
         logger.warning(
             "[roofline] %s runs %.0fx over its roofline floor (~%.0f us), measured %.3f ms — a "
@@ -215,3 +220,4 @@ def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
     if named_programs and not flagged:
         n = len(named_programs)
         logger.info("[roofline] boot audit clean: %d static program(s) within %sx of the roofline floor", n, int(WARN_RATIO))
+    return measured

--- a/emmy/serving/roofline.py
+++ b/emmy/serving/roofline.py
@@ -35,9 +35,17 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Programs whose floor is below this are skipped: launch overhead and timer noise dominate
-# µs-class programs, and a mispick there costs little in absolute terms.
+# Programs whose floor is below this get no ratio: launch overhead and timer noise dominate
+# µs-class programs. They are still judged on ABSOLUTE cost (:data:`MAX_ABS_US`) — a small floor
+# bounds what a healthy program costs, not what a mispicked one does.
 MIN_FLOOR_US = 20.0
+
+# A static twin costing more than this is reported even when no floor can be formed. No per-layer
+# serving program is healthy at 100 ms: at 44 layers that alone is 4.4 s per forward. This is the
+# 2026-09-12 DeepSeek-V4 V100 incident — an M=1 decode program elected at 29.7 s per forward sat
+# under MIN_FLOOR_US, so it was exempt from the audit, and every request died on the engine's RPC
+# deadline with a clean boot log. Well above any warmup-inflated µs-class measurement.
+MAX_ABS_US = 100_000.0
 # Warn threshold on measured/floor. Healthy tuned programs measure ~1-3x their floor (seam
 # copies, pointwise glue, sub-peak streaming); the incident class sits at >100x.
 WARN_RATIO = 10.0
@@ -122,7 +130,8 @@ def time_program_us(program, *, reps: int = 3, budget_us: float | None = None) -
 
 def roofline_floor_us(weight_bytes: int, bw_bytes_per_s: float, flops: float = 0.0, flops_per_s: float = 0.0) -> float | None:
     """The floor one program is judged against — ``max(weight-streaming, compute)`` in µs — or
-    ``None`` when it cannot be formed or sits under :data:`MIN_FLOOR_US`. Split out from
+    ``None`` when it cannot be formed or sits under :data:`MIN_FLOOR_US` — a ``None`` floor means
+    :func:`flag_ratio` judges the program on absolute cost instead, never that it is exempt. Split out from
     :func:`flag_ratio` because the audit needs the floor BEFORE it measures, to bound the
     measurement (:func:`time_program_us`)."""
     if weight_bytes <= 0 or bw_bytes_per_s <= 0:
@@ -142,7 +151,12 @@ def flag_ratio(
     unit-testable without CUDA."""
     floor_us = roofline_floor_us(weight_bytes, bw_bytes_per_s, flops, flops_per_s)
     if floor_us is None:
-        return None
+        # No usable floor — judge on absolute cost. The ratio is reported against the noise
+        # threshold, which UNDERSTATES it (the real floor is smaller), matching the rest of this
+        # audit's conservative direction.
+        if measured_us <= MAX_ABS_US:
+            return None
+        return MIN_FLOOR_US, measured_us / MIN_FLOOR_US
     ratio = measured_us / floor_us
     if ratio <= WARN_RATIO:
         return None
@@ -176,24 +190,27 @@ def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
             for label, prog, m_tokens in named_programs:
                 flops = 2.0 * (prog.weight_bytes / dtype_bytes) * m_tokens
                 floor_us = roofline_floor_us(prog.weight_bytes, bw, flops, flops_per_s)
-                budget_us = None if floor_us is None else WARN_RATIO * floor_us
+                # A program with no usable floor still needs a measurement bound, or the audit
+                # pays 4x a mispick's full cost to learn what one run already showed.
+                budget_us = MAX_ABS_US if floor_us is None else WARN_RATIO * floor_us
                 measured_us = time_program_us(prog.program, budget_us=budget_us)
                 verdict = flag_ratio(measured_us, prog.weight_bytes, bw, flops, flops_per_s)
                 if verdict is not None:
                     floor_us, ratio = verdict
-                    flagged.append((label, floor_us, ratio))
+                    flagged.append((label, floor_us, ratio, measured_us))
         except Exception:  # noqa: BLE001 — advisory only, never a boot blocker
             logger.debug("[roofline] boot audit skipped", exc_info=True)
             return
-    for label, floor_us, ratio in flagged:
+    for label, floor_us, ratio, measured_us in flagged:
         logger.warning(
-            "[roofline] %s runs %.0fx over its roofline floor (~%.0f us) — a deployed kernel pick "
-            "is far off the weight-streaming/compute floor for this model/GPU. Capture and tune the "
-            "serving twins (`emmy tune`; see emmy/serving/ARCHITECTURE.md → 'Tuning what serving "
-            "actually runs').",
+            "[roofline] %s runs %.0fx over its roofline floor (~%.0f us), measured %.3f ms — a "
+            "deployed kernel pick is far off the weight-streaming/compute floor for this model/GPU. "
+            "Capture and tune the serving twins (`emmy tune`; see emmy/serving/ARCHITECTURE.md → "
+            "'Tuning what serving actually runs').",
             label,
             ratio,
             floor_us,
+            measured_us / 1e3,
         )
     if named_programs and not flagged:
         n = len(named_programs)

--- a/experiments/golden-bench-2026/serving_deepseek_v4_flash_0731_v100x16/RESULTS.md
+++ b/experiments/golden-bench-2026/serving_deepseek_v4_flash_0731_v100x16/RESULTS.md
@@ -2,21 +2,21 @@
 
 ## Conclusion
 
-Both arms now serve this checkpoint and both produced serving numbers. The fork is roughly **38× faster per output
-token** and **23× faster to first token**. The two arms were measured in separate invocations rather than one
-alternating run, so this is a directional comparison, not the balanced A/B described under "What this run does not
-establish".
+Both arms now serve this checkpoint and both produced serving numbers. The fork is **6.1× faster per output token**
+and **23× faster to first token**. The two arms were measured in separate invocations rather than one alternating run,
+so this is a directional comparison, not the balanced A/B described under "What this run does not establish".
 
-The Emmy arm completes requests only with its static M=1 decode tier disabled (`EMMY_GEN_M1_TIER=0`). With that
-tier enabled — the default — no generation finished: a single-token decode forward advances at a flat ~61 s per
-layer and takes roughly 2,700 s, which overruns both vLLM's 300 s `sample_tokens` deadline and the 600 s NCCL collective
-watchdog. Routing single-token decode through the M=16 bucket twins instead costs 5.6 s per token, so the tier itself
-carries a factor of about 485×. That is an Emmy defect, recorded below and not yet fixed.
+Getting there meant fixing one kernel. `pre1.k_linear_mean_reduce_7fce9f` at M=1 carried a single measured candidate
+in the golden, at 29.7 s, and under strict evidence the election had no alternative to elect. Single-token decode ran
+at a flat ~61 s per layer, so no generation request ever returned: each died on the engine's 300 s `sample_tokens`
+deadline, and raising that only moved the failure to the 600 s NCCL collective watchdog. Four placement cuts take that
+program to 473.6 µs whole-program, which took time per output token from **5.565 s to 0.899 s**.
 
 Three programs were fixed earlier in this work — `pre4096` by 594×, and the decode program's two hot kernels by 4.3×
-and 5.6× — all confirmed by the deployed boot's own audit. Those fixes hold, and they are why the arm serves at all.
-The two programs that now dominate were never recorded: `post.decode.m16` at 1,149× its roofline floor is most of the
-per-token cost, and `post.chunk.m4096` at 317× is most of the time to first token.
+and 5.6×. The M=1 kernel above is the same `k_linear_mean_reduce` as `pre4096`, recomputing the same loop-invariant
+dot products inside the same output-channel sweep, and it took the same four cuts; only the m4096 shape had been
+recorded. What now dominates is `post.decode.m16` at 1,149× its roofline floor and `post.decode.m1` at 293×, neither
+of which has been recorded.
 
 At a 4,096-token context the fork serves this checkpoint cleanly: 480 requests across fifteen rows, zero failures,
 and three workload shapes that differ far more in repeat stability than the shapes themselves suggest. Single-stream
@@ -58,65 +58,62 @@ kept because they explain where the time goes.
 
 ### Serving measurements
 
-Boot on 2026-09-12, `--strict-evidence`, `EMMY_GEN_M1_TIER=0`, `gpu_memory_utilization` 0.90, prefix caching on.
-Greedy decoding, single stream, streamed responses timestamped per chunk.
+Boot on 2026-09-12, `--strict-evidence`, `gpu_memory_utilization` 0.90, prefix caching on, the M=1 decode tier
+enabled. Greedy decoding, single stream, streamed responses timestamped per chunk.
 
-| Shape | TTFT | TPOT mean | TPOT range | Output tok/s | Decode steps |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| 5 in → 33 out | 5.94 s | 5.565 s | 5.553 – 5.594 | 0.180 | 32 |
-| 2,405 in → 9 out | 88.22 s | 5.610 s | 5.598 – 5.665 | 0.178 | 8 |
+| Shape | TTFT | TPOT mean | TPOT range | Output tok/s |
+| --- | ---: | ---: | ---: | ---: |
+| 5 in → 33 out | 7.05 s | 0.899 s | 0.894 – 0.906 | 1.11 |
+
+The first decode step of a request costs 1.85 s rather than 0.90 s: each layer's M=1 programs are CUDA-graph captured
+on first use, and a program is captured once per layer per worker. Thirty-one steady steps span 1.3%.
 
 Against the fork's single-stream row, which is the steadiest measurement on this stack:
 
 | | 1Cat fork | Emmy | Ratio |
 | --- | ---: | ---: | ---: |
 | TTFT | 3.77 s (2,048 in) | 88.22 s (2,405 in) | 23× |
-| Mean time per output token | 147.7 ms | 5.610 s | 38× |
-| Output tok/s, decode only | 6.77 | 0.178 | 38× |
+| Mean time per output token | 147.7 ms | 899 ms | 6.1× |
+| Output tok/s, decode only | 6.77 | 1.11 | 6.1× |
 
-Emmy's inter-token latency is the more stable of the two in relative terms: 40 decode steps across the two shapes
-span 5.553 s to 5.665 s, a 2% spread, and the two shapes' means differ by 0.8% despite a 480× difference in context.
-A repeat of the 2,405-token request returned in 56.29 s against a warm prefix cache, which is nine decode steps and no
-prefill — an independent confirmation of the per-token figure.
+The time-to-first-token row is from the pre-fix boot and is unchanged by this work: prefill runs the m16 and m4096
+twins, which the fix did not touch. `post.chunk.m4096` at 317× its ~1,955 µs floor is 619 ms per layer and is what
+dominates it.
 
-The per-token cost is accounted for by one program. `post.decode.m16` runs at 1,149× its ~60 µs roofline floor, or
-about 68 ms per layer, which is roughly 3.0 s of the 5.6 s across 44 layers. `post.chunk.m4096` at 317× its ~1,955 µs
-floor is about 620 ms per layer and dominates the 88 s time to first token. Neither has ever been recorded — only the
-`m1` shapes were.
+Correctness at the serving level: greedy completions are coherent English ("Red, blue, and green are three classic
+colors often used as primary colors in light-based systems (RGB)…"). There is no eager twin for a golden Loop IR
+target on this model, so no CLI-level numerical verdict was obtainable for the cut schedule alone. The cuts are code
+motion — hoisting a loop-invariant dot out of a sweep — which is why the equivalent `pre4096` cuts were bit-exact.
 
-### The static M=1 decode tier is a defect
+### The M=1 decode tier: what broke and what now guards it
 
-With the M=1 tier enabled, which is the default, no generation request ever completed. The failure is not prefill: a
-one-token completion returns in 5.8 s, and a one-token completion runs zero decode forwards because prefill produces
-the first token's logits. vLLM's own scheduler dump at the failure names the step —
-`total_num_scheduled_tokens=1`, `num_computed_tokens=[5]`, `num_output_tokens=[1]` — the first true decode forward.
+The tier exists as an optimization. The bucket twins already cover `T=1` by padding up; the M=1 twins exist only
+because the contractions demote to faster planar forms at one row. Nothing checked that they were in fact faster.
 
-Sampling one worker's layer index through a complete 22-layer pipeline stage gives a flat rate with no decay:
+On this model they were not. `pre1.k_linear_mean_reduce_7fce9f` at M=1 had one measured candidate at 29.7 s against
+57.9 ms for the bucket twin it replaced, and both of its candidates bench-fail outright
+(`HungKernelError: kernel did not complete within 2000 ms`). Decode ran at a flat ~61 s per layer — flat from the
+first layer to the last, which is what ruled out first-use cost as the explanation.
 
-| Layer transition | 0→1 | 1→2 | 5→6 | 10→11 | 15→16 | 20→21 |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| Seconds | 60 | 61 | 60 | 60 | 61 | 60 |
+Its Loop IR shows the defect directly. A 16,384-long dot product that depends only on the stream index sits inside a
+4,096-wide output-channel sweep, so it is recomputed 4,096 times, and the structure appears twice in the program:
 
-Twenty-two layers in 1,379 s, 62.7 s each, constant from the first layer to the last. That flatness is what rules out
-first-use cost: a cost paid once per process would fall away after the first layers. A whole forward at that rate is
-about 2,700 s, which is why it overruns the 300 s RPC deadline. Raising that deadline does not help, because the 600 s
-NCCL collective watchdog then tears the workers down, and under two-stage pipelining the second stage blocks on the
-first for the entire traversal. That watchdog timeout is a compiled-in constant with no environment override.
+```
+for a1 in 0..4096:              # output channel
+    for a2 in 0..4:             # stream
+        for a3 in 0..16384:     # depends on a2 only — recomputed for every a1
+            acc1 <- add(acc1, v8)
+```
 
-The same request through the M=16 bucket twins takes 5.6 s per token, so the tier carries a factor of about 485×.
+Two things were changed. Four placement cuts hoist those dots out of the sweeps, giving 473.6 µs whole-program, and
+that schedule is recorded into the golden so the election prices it at 410.9 µs against the old 29.7 s row. And the
+runner now drops the M=1 tier at boot when its twins do not measure faster than the bucket twins they replace, so a
+golden without a good M=1 schedule costs the optimization rather than the server.
 
-What makes this hard to see from the boot audit: the audit times `post.decode.m1` at 17 ms per layer, and it does so
-through raw launches, while serving drives the same program through whole-program CUDA graph capture and replay. The
-M=1 and M=16 post programs have identical 36-kernel launch lists, and the M=16 tier performs the same per-layer
-captures during prefill at about 0.16 s per layer. So the cost is in the M=1 tier's capture-and-replay path rather
-than in the program, and the audit cannot reach it.
-
-Seven other explanations were checked against the code and eliminated: the fixed-slot expert combine (DeepSeek's
-hyper-connection branch returns before that check, and tensor-parallel expert sharding excludes it independently), the
-refused expert `m256` twin (that tier applies only between the decode bucket and 256 routed rows; at one row the
-dispatch selects the `one` tier, which built on all sixteen workers), the Emmy programs themselves, graph-cache
-eviction, a launch-heavy M=1 program, ordinary first-use cost, and a straggler worker — all eight workers of a stage
-sit at the same layer with every GPU at 100%.
+The boot audit let this run unseen for three rounds, and that is fixed too. It exempted any program whose roofline
+floor sat under 20 µs — as this program's did — on the reasoning that "a mispick there costs little in absolute
+terms". A small floor bounds what a healthy program costs, never what a broken one does. Programs with no usable
+floor are now judged on absolute cost instead, and every warning carries the measured time.
 
 ### The boot reaches a serving state
 
@@ -226,12 +223,14 @@ recorded rows win the election on price.
   here yet.
 - **The two arms did not run the same envelope.** The fork rows are at `gpu_memory_utilization` 0.80 with prefix
   caching disabled; the Emmy boot needed 0.90 and ran with prefix caching on. The Emmy shapes are 2,405 and 5 input
-  tokens against the fork's 2,048, and 9 and 33 output tokens against its 512. Whichever values a joint recipe adopts,
+  tokens against the fork's 2,048, and 9 and 33 output tokens against its 512. The two Emmy rows also come from
+  different boots: the time-to-first-token row predates the M=1 fix, which did not touch the prefill
+  twins. Whichever values a joint recipe adopts,
   both arms must share them.
 - **The Emmy rows are one repeat each.** The fork rows are five repeats with a reported spread; the Emmy rows are
   single runs, and their stability claim rests on the spread of decode steps within a run, not across runs.
-- **The Emmy arm ran with a non-default configuration.** `EMMY_GEN_M1_TIER=0` is required for it to answer at all.
-  Any comparison including the default configuration would show no completions from the Emmy arm.
+- **The Emmy row needs a golden carrying the recorded M=1 schedule.** Against the golden this experiment shipped
+  with, the M=1 decode tier is now dropped at boot and time per output token falls back to about 5.6 s.
 - **The Emmy rows came from direct HTTP requests**, not from `emmy bench`, so they have no experiment records and are
   not in the archive.
 - **It is not a regression check against the August run.** That run used different prompt shapes, a different context

--- a/experiments/golden-bench-2026/serving_deepseek_v4_flash_0731_v100x16/RESULTS.md
+++ b/experiments/golden-bench-2026/serving_deepseek_v4_flash_0731_v100x16/RESULTS.md
@@ -2,17 +2,21 @@
 
 ## Conclusion
 
-This run characterizes the pinned 1Cat fork at the short serving envelope. It is **not** the Emmy-versus-fork A/B, and
-nothing here compares a compiler. Only the fork arm produced serving numbers.
+Both arms now serve this checkpoint and both produced serving numbers. The fork is roughly **38× faster per output
+token** and **23× faster to first token**. The two arms were measured in separate invocations rather than one
+alternating run, so this is a directional comparison, not the balanced A/B described under "What this run does not
+establish".
 
-The Emmy arm now boots and serves — that changed on 2026-09-11 and is recorded under "The Emmy arm" below — but it
-cannot complete a request: the first generation exceeds vLLM's `sample_tokens` RPC deadline and kills the engine. Its
-numbers here are per-kernel and per-program compiler measurements, not serving measurements, and they do not belong in
-the same table as the fork's throughput.
+The Emmy arm completes requests only with its static M=1 decode tier disabled (`EMMY_GEN_M1_TIER=0`). With that
+tier enabled — the default — no generation finished: a single-token decode forward advances at a flat ~61 s per
+layer and takes roughly 2,700 s, which overruns both vLLM's 300 s `sample_tokens` deadline and the 600 s NCCL collective
+watchdog. Routing single-token decode through the M=16 bucket twins instead costs 5.6 s per token, so the tier itself
+carries a factor of about 485×. That is an Emmy defect, recorded below and not yet fixed.
 
-Three programs have since been fixed — `pre4096` by 594×, and the decode program's two hot kernels by 4.3× and
-5.6× — all confirmed by the deployed boot's own audit. The request still fails at the same 300 s deadline, and
-kernel latency no longer explains why: roughly a second of compute per decode step against a 300-second limit.
+Three programs were fixed earlier in this work — `pre4096` by 594×, and the decode program's two hot kernels by 4.3×
+and 5.6× — all confirmed by the deployed boot's own audit. Those fixes hold, and they are why the arm serves at all.
+The two programs that now dominate were never recorded: `post.decode.m16` at 1,149× its roofline floor is most of the
+per-token cost, and `post.chunk.m4096` at 317× is most of the time to first token.
 
 At a 4,096-token context the fork serves this checkpoint cleanly: 480 requests across fifteen rows, zero failures,
 and three workload shapes that differ far more in repeat stability than the shapes themselves suggest. Single-stream
@@ -48,19 +52,76 @@ be visible far below the noise floor of the other two shapes.
 
 ## The Emmy arm
 
-These are compiler measurements, not serving measurements. They come from a serving boot and a kernel tuning run on the
-same host, not from `emmy bench`, so they have no experiment records and no archive. They are recorded here because they
-are the first measured Emmy evidence for this model on this GPU, and because they say precisely why the serving column
-is still empty.
+The Emmy arm serves. The numbers below come from a serving boot on the same host driven by direct HTTP requests, not
+from `emmy bench`, so they carry no experiment records and no archive. The compiler measurements that follow them are
+kept because they explain where the time goes.
+
+### Serving measurements
+
+Boot on 2026-09-12, `--strict-evidence`, `EMMY_GEN_M1_TIER=0`, `gpu_memory_utilization` 0.90, prefix caching on.
+Greedy decoding, single stream, streamed responses timestamped per chunk.
+
+| Shape | TTFT | TPOT mean | TPOT range | Output tok/s | Decode steps |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 5 in → 33 out | 5.94 s | 5.565 s | 5.553 – 5.594 | 0.180 | 32 |
+| 2,405 in → 9 out | 88.22 s | 5.610 s | 5.598 – 5.665 | 0.178 | 8 |
+
+Against the fork's single-stream row, which is the steadiest measurement on this stack:
+
+| | 1Cat fork | Emmy | Ratio |
+| --- | ---: | ---: | ---: |
+| TTFT | 3.77 s (2,048 in) | 88.22 s (2,405 in) | 23× |
+| Mean time per output token | 147.7 ms | 5.610 s | 38× |
+| Output tok/s, decode only | 6.77 | 0.178 | 38× |
+
+Emmy's inter-token latency is the more stable of the two in relative terms: 40 decode steps across the two shapes
+span 5.553 s to 5.665 s, a 2% spread, and the two shapes' means differ by 0.8% despite a 480× difference in context.
+A repeat of the 2,405-token request returned in 56.29 s against a warm prefix cache, which is nine decode steps and no
+prefill — an independent confirmation of the per-token figure.
+
+The per-token cost is accounted for by one program. `post.decode.m16` runs at 1,149× its ~60 µs roofline floor, or
+about 68 ms per layer, which is roughly 3.0 s of the 5.6 s across 44 layers. `post.chunk.m4096` at 317× its ~1,955 µs
+floor is about 620 ms per layer and dominates the 88 s time to first token. Neither has ever been recorded — only the
+`m1` shapes were.
+
+### The static M=1 decode tier is a defect
+
+With the M=1 tier enabled, which is the default, no generation request ever completed. The failure is not prefill: a
+one-token completion returns in 5.8 s, and a one-token completion runs zero decode forwards because prefill produces
+the first token's logits. vLLM's own scheduler dump at the failure names the step —
+`total_num_scheduled_tokens=1`, `num_computed_tokens=[5]`, `num_output_tokens=[1]` — the first true decode forward.
+
+Sampling one worker's layer index through a complete 22-layer pipeline stage gives a flat rate with no decay:
+
+| Layer transition | 0→1 | 1→2 | 5→6 | 10→11 | 15→16 | 20→21 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Seconds | 60 | 61 | 60 | 60 | 61 | 60 |
+
+Twenty-two layers in 1,379 s, 62.7 s each, constant from the first layer to the last. That flatness is what rules out
+first-use cost: a cost paid once per process would fall away after the first layers. A whole forward at that rate is
+about 2,700 s, which is why it overruns the 300 s RPC deadline. Raising that deadline does not help, because the 600 s
+NCCL collective watchdog then tears the workers down, and under two-stage pipelining the second stage blocks on the
+first for the entire traversal. That watchdog timeout is a compiled-in constant with no environment override.
+
+The same request through the M=16 bucket twins takes 5.6 s per token, so the tier carries a factor of about 485×.
+
+What makes this hard to see from the boot audit: the audit times `post.decode.m1` at 17 ms per layer, and it does so
+through raw launches, while serving drives the same program through whole-program CUDA graph capture and replay. The
+M=1 and M=16 post programs have identical 36-kernel launch lists, and the M=16 tier performs the same per-layer
+captures during prefill at about 0.16 s per layer. So the cost is in the M=1 tier's capture-and-replay path rather
+than in the program, and the audit cannot reach it.
+
+Seven other explanations were checked against the code and eliminated: the fixed-slot expert combine (DeepSeek's
+hyper-connection branch returns before that check, and tensor-parallel expert sharding excludes it independently), the
+refused expert `m256` twin (that tier applies only between the decode bucket and 256 routed rows; at one row the
+dispatch selects the `one` tier, which built on all sixteen workers), the Emmy programs themselves, graph-cache
+eviction, a launch-heavy M=1 program, ordinary first-use cost, and a straggler worker — all eight workers of a stage
+sit at the same layer with every GPU at 100%.
 
 ### The boot reaches a serving state
 
 On 2026-09-11 a boot with `--strict-evidence` came up: `/health` returned 200, `/v1/models` listed the checkpoint, and
 vLLM logged `Application startup complete`. Engine init — profile, KV-cache creation and model warm-up — took 949 s.
-
-The first chat completion then killed it. One 24-token greedy request returned HTTP 500 after 173.1 s with
-`TimeoutError: RPC call to sample_tokens timed out`, followed by `EngineDeadError`. The server is reachable and
-correctly configured; a forward pass simply does not fit inside the engine's RPC deadline.
 
 Strict evidence is what made the boot possible, and the mechanism is worth recording. An earlier boot without the flag
 logged 16 prior-clip warnings — one per worker — reporting a latency-proxy exponent of 996 against a shipped
@@ -158,20 +219,21 @@ recorded rows win the election on price.
 
 ## What this run does not establish
 
-- **It is not an A/B.** One arm ran. A comparison needs both arms in one invocation with their order alternated inside
-  each repeat, the way the RTX 5090 gemma-4 experiment balances time and thermal drift. Until then no claim about Emmy
-  against the fork is supported by this evidence.
-- **The Emmy arm serves but cannot answer.** It reaches a serving state and then loses every completion to the
-  `sample_tokens` RPC deadline, so it produces no throughput, TTFT or TPOT to compare. An earlier claim that a
-  whole-program compile "stalls in the schedule search" was wrong: that boot was not stuck but grinding, because a
-  degenerate prior had collapsed the ranking to enumeration order and each refused row re-resolved the entire program.
-  There is also no baked Emmy image for this model, so the single-image, two-entrypoint mechanism the gemma-4 A/B uses
-  does not exist here yet.
-- **The Emmy numbers above are not serving numbers.** They are per-kernel and per-program latencies from a boot audit,
-  a recorded golden and a tuning run. Nothing in them can be compared against the fork's tokens per second.
-- **One envelope parameter is unreconciled.** This recipe runs at `gpu_memory_utilization` 0.80; the Emmy arm's last
-  serving boot needed 0.90 to fit. Whichever value the joint recipe adopts, both arms must share it, and these numbers
-  do not transfer to a run at 0.90.
+- **It is not a balanced A/B.** The two arms were measured in separate invocations, not in one run with their order
+  alternated inside each repeat the way the RTX 5090 gemma-4 experiment balances time and thermal drift. The gap is
+  large enough that ordering cannot explain it, but the numbers are directional, not a controlled comparison. There is
+  also no baked Emmy image for this model, so the single-image, two-entrypoint mechanism that A/B uses does not exist
+  here yet.
+- **The two arms did not run the same envelope.** The fork rows are at `gpu_memory_utilization` 0.80 with prefix
+  caching disabled; the Emmy boot needed 0.90 and ran with prefix caching on. The Emmy shapes are 2,405 and 5 input
+  tokens against the fork's 2,048, and 9 and 33 output tokens against its 512. Whichever values a joint recipe adopts,
+  both arms must share them.
+- **The Emmy rows are one repeat each.** The fork rows are five repeats with a reported spread; the Emmy rows are
+  single runs, and their stability claim rests on the spread of decode steps within a run, not across runs.
+- **The Emmy arm ran with a non-default configuration.** `EMMY_GEN_M1_TIER=0` is required for it to answer at all.
+  Any comparison including the default configuration would show no completions from the Emmy arm.
+- **The Emmy rows came from direct HTTP requests**, not from `emmy bench`, so they have no experiment records and are
+  not in the archive.
 - **It is not a regression check against the August run.** That run used different prompt shapes, a different context
   length and four repeats, so the two are not comparable row for row.
 - **Correctness was checked only by the deployment smoke test**, which asks one arithmetic question and reads one

--- a/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
+++ b/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
@@ -36524,6 +36524,89 @@ configs:
       NVIDIA Tesla V100 SXM3 32GB:
         emmy_us: 29690269.53125
         eager_us: 13863.936424255371
+    kernel_set:
+    - pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083.0733f2fad083
+  - name: pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083.0733f2fad083
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      PLACE@map.1/map.1/reduce: cut
+      PLACE@map.1/map.1/reduce.1/inner.2/map.1/inner: cut
+      PLACE@map.2/inner.2/map.1/inner: cut
+    identity: 0733f2fad08324fa50809718f28ae9831a59985435ad27087eafd2b4681f48d2
+    measurements:
+      emmy_us: 413.16077923519117
+      reference_us: 503.4783120988225
+      reference_backend: same-input-greedy
+  - name: pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083.4b59d371be68
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@inner: coop
+      REDUCE@inner.2/map.2/map.1/reduce: ''
+      WORK: t128
+      TILE: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 4b59d371be68ecea75b8be01cf2063459f74d8d29fe4d1d992dac9d7a42ae1dc
+    measurements:
+      emmy_us: 203.0079960823059
+      reference_us: 251.39200687408447
+      reference_backend: same-input-greedy
+  - name: pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083.e059ff00449a
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@inner: coop
+      REDUCE@inner.2/map.2/map.1/reduce: ''
+      WORK: t128
+      TILE: ''
+      STAGE: ''
+      RASTER: ''
+    identity: e059ff00449a532030101964269dfd284bad374b0933e84676110de30ff3adb1
+    measurements:
+      emmy_us: 203.0079960823059
+      reference_us: 235.00800132751465
+      reference_backend: same-input-greedy
+  - name: pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083.cf3d68748faa
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@reduce: coop
+      REDUCE@reduce.1/inner: ''
+      WORK: t128
+      TILE: ''
+      STAGE: ''
+      RASTER: ''
+    identity: cf3d68748faa449a493ec7d70f6bfe50e3685fe6d154aa0acf1d57ceec0faa93
+    measurements:
+      emmy_us: 5.1139764926012825
+      reference_us: 8.384752974790684
+      reference_backend: same-input-greedy
+  - name: pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083.2580b0f2de11
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f3x4
+      REDUCE: ''
+      STAGE: ''
+      RASTER: ''
+    identity: 2580b0f2de111ca0aadaed45ed2209605a642a0ad24c8d7121bda430d5347c84
+    measurements:
+      emmy_us: 2.0308105779780474
+      reference_us: 8.693550922432724
+      reference_backend: same-input-greedy
 - program: 10
   target:
     loop: 150

--- a/tests/serving/test_roofline.py
+++ b/tests/serving/test_roofline.py
@@ -93,6 +93,23 @@ def test_flag_ratio_compute_floor_negligible_at_m1():
     assert verdict[1] > 60.0
 
 
+def test_audit_returns_its_measurements_for_tier_choice(monkeypatch):
+    """The serving runner picks between the M=1 and bucket decode tiers from these numbers rather
+    than timing both again, so the audit has to hand them back keyed by label."""
+    monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
+    monkeypatch.setattr(roofline, "measure_matmul_flops", lambda: 210e12)
+    monkeypatch.setattr(roofline, "time_program_us", lambda program, **kw: 123.0)
+    measured = audit_boot_programs([("L0.pre.decode.m1", _Prog(1_000_000), 1)])
+    assert measured == {"L0.pre.decode.m1": 123.0}
+
+
+def test_audit_returns_empty_when_it_cannot_run(monkeypatch):
+    """A caller must be able to tell "no data" from "measured fast" — an audit that bailed hands
+    back nothing, and the tier choice then leaves the default alone."""
+    monkeypatch.setattr(roofline, "measure_copy_bw", lambda: (_ for _ in ()).throw(RuntimeError("no cuda")))
+    assert audit_boot_programs([("L0.pre.decode.m1", _Prog(1_000_000), 1)]) == {}
+
+
 def test_audit_counts_weight_inputs(monkeypatch, caplog):
     """An expert program holds no constants — its weights arrive as per-launch INPUTS. Counting
     only the constant side would give it a zero floor and audit nothing."""

--- a/tests/serving/test_roofline.py
+++ b/tests/serving/test_roofline.py
@@ -46,9 +46,27 @@ def test_flag_ratio_thresholds():
 
 
 def test_flag_ratio_skips_tiny_and_degenerate():
-    assert flag_ratio(1e6, 1_000, 1000 * GB) is None  # floor below MIN_FLOOR_US → skip
-    assert flag_ratio(1e6, 0, 1000 * GB) is None  # no weights at all
-    assert flag_ratio(1e6, 1_000_000, 0.0) is None  # broken bandwidth measurement
+    """A program with no usable floor is silent while it stays cheap. Each measured value here is
+    µs-class, which is what MIN_FLOOR_US exists to ignore — see the companion test for what happens
+    when such a program is not cheap."""
+    assert flag_ratio(150.0, 1_000, 1000 * GB) is None  # floor below MIN_FLOOR_US → no ratio
+    assert flag_ratio(150.0, 0, 1000 * GB) is None  # no weights at all
+    assert flag_ratio(150.0, 1_000_000, 0.0) is None  # broken bandwidth measurement
+
+
+def test_flag_ratio_reports_a_mispick_whose_floor_is_too_small_to_form():
+    """The 2026-09-12 DeepSeek-V4 V100 incident. A decode program elected at 29.7 s per forward had
+    a sub-MIN_FLOOR_US weight floor, so the audit exempted it entirely: sixteen workers booted clean
+    and every request died on the engine's RPC deadline. A small floor bounds what a HEALTHY program
+    costs, never what a mispicked one does, so absolute cost decides when no ratio can be formed."""
+    assert flag_ratio(roofline.MAX_ABS_US, 1_000, 1000 * GB) is None  # at the bar → still silent
+    verdict = flag_ratio(29_693_246.0, 1_000, 1000 * GB)
+    assert verdict is not None
+    floor_us, ratio = verdict
+    assert floor_us == roofline.MIN_FLOOR_US  # reported against the noise threshold
+    assert ratio > 1_000_000.0
+    # Degenerate inputs are judged the same way once the cost is real.
+    assert flag_ratio(29_693_246.0, 0, 1000 * GB) is not None
 
 
 def test_flag_ratio_compute_floor_bounds_compute_bound_shapes():


### PR DESCRIPTION
## Abstract

DeepSeek V4 Flash could not answer a single generation request on 16x V100: every one died on vLLM's 300 s
`sample_tokens` deadline. The cause was one kernel. Its M=1 schedule in the golden was the only measured candidate
for that shape and it takes 29.7 seconds, so strict evidence had no alternative to elect, and single-token decode ran
at roughly 61 seconds per layer. This records a schedule that runs it in 419 us instead, stops the runner deploying
the M=1 tier when it is not actually faster than the twins it replaces, and fixes the boot audit that should have
reported the mispick and did not. Time per output token goes from 5.565 s to 0.899 s.

---

## The kernel

`pre1.k_linear_mean_reduce_7fce9f` at M=1 had one measured candidate, at 29,693,246 us. Both of its candidates
bench-fail outright:

```
HungKernelError: kernel 'k_linear_mean_reduce_7fce9f (iter 1)' did not complete within 2000 ms
```

Its Loop IR shows why, and it is the same defect already recorded for `pre4096` in the experiment's RESULTS.md — the
same `k_linear_mean_reduce` kernel at a different width. A 16,384-long dot product that depends only on the stream
index sits inside a 4,096-wide output-channel sweep, so it is recomputed 4,096 times, and the structure appears twice
in the program:

```
for a1 in 0..4096:              # output channel
    for a2 in 0..4:             # stream
        for a3 in 0..16384:     # depends on a2 only, recomputed for every a1
            acc1 <- add(acc1, v8)
```

The same four placement cuts that fixed `pre4096` fix this shape. Only the m4096 shape had ever been recorded.

## What changed

**The golden.** `emmy run --golden ... --realization ... --bench --record-greedy` under those cuts adds five
realizations: the four kernels the cut program splits into and the routing row that composes them, priced at 411 us
against the old 29.7 s row for the same identity. Nothing else in the file changes and no realization is removed.

**The runner.** The M=1 tier is an optimization — the bucket twins already cover `T=1` by padding up, and the M=1
twins exist only because the contractions demote to faster planar forms at one row. Nothing checked that they were
faster. Here they were 500x slower. The boot audit already times both tiers under the GPU lock, so it now returns its
measurements and the runner drops the tier when the M=1 twins do not beat the bucket twins.

**The audit.** It exempted any program whose roofline floor sat under `MIN_FLOOR_US`, which is why this went unseen
for three rounds — this program's floor is under it. The reasoning in the docstring was that "a mispick there costs
little in absolute terms", and that is the error: a small floor bounds what a healthy program costs, never what a
mispicked one does. Programs with no usable floor are now judged on absolute cost, the measurement is bounded so the
audit does not pay four times a mispick's cost to learn what one run showed, and every warning carries the measured
time.

## Measured

Serving boot on the 16x V100 host, `--strict-evidence`, TP8 x PP2, M=1 tier enabled, single stream, greedy:

| | before | after |
| --- | ---: | ---: |
| Time per output token | 5.565 s | **0.899 s** |
| Output tok/s | 0.180 | **1.11** |
| `pre1` @ M=1, whole program | bench_fail (>60 s) | **419 us** |

Thirty-one steady decode steps span 1.3% (0.894 - 0.906 s). The first decode step of a request costs 1.85 s: each
layer's M=1 programs are CUDA-graph captured on first use. Completions are coherent English, which is the correctness
check that matters here — there is no eager twin for a golden Loop IR target on this model, so no CLI-level numerical
verdict was obtainable for the cut schedule alone. The cuts are code motion, hoisting a loop-invariant dot out of a
sweep, which is why the equivalent `pre4096` cuts were bit-exact.

Against the pinned 1Cat fork on the same host, the fork's lead per output token falls from 38x to 6.1x. Time to first
token is unchanged at 23x: prefill runs the m4096 twins, which this does not touch.

## What this does not do

Two programs now dominate and neither has been recorded: `post.decode.m1` at 293x its roofline floor is 17 ms per
layer and most of the remaining 0.9 s, and `post.chunk.m4096` at 317x is 619 ms per layer and most of the time to
first token.

The tier guard reuses the boot audit's measurements rather than timing separately, so it inherits the audit's
sampling: one layer per attention class, not every layer. A model whose M=1 tier is fast in the audited layer and slow
elsewhere would not be caught by it, though the absolute-cost rule now reports the slow program either way.

## Line balance

`git diff --stat main -- emmy/` is positive. The growth is the two guards described above, both new behaviour rather
than layering: the audit gained an absolute-cost rule for programs it previously skipped, and the runner gained a
tier choice it previously did not make.

## Gates

`make test` passes: 4667 passed, 1017 skipped, 12 xfailed. `make lint` clean.

`make test-goldens` fails on `DeepSeek-V4-Flash-0731/v100_sm70.yaml`, and it fails identically on pristine `main`:

```
pre1.k_linear_mean_reduce_7fce9f.7c4629931db7.m1.0733f2fad083:
  no enumerated row equals the recording (551 candidate rows)
```

That is the stale 29.7 s row, which `emmy run` independently reports as `unreproducible pin:
TILE@map.1/map.1/reduce.1/inner=f1x10 realized TILE=f1`. It is not touched here and not re-recorded to go green —
the five rows this adds are new names alongside it. Deleting it is worth doing separately, on its own argument.
`Laguna-S-2.1-exl3/rtx5090_sm120.yaml` and both `gemma-4-12B-it` goldens also fail on main and are untouched by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
