### PR TITLE
Cut the mxfp4 expert's gate-up projection out of its down-projection loop

### DIFF
--- a/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
+++ b/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
@@ -28591,6 +28591,79 @@ configs:
       NVIDIA Tesla V100 SXM3 32GB:
         emmy_us: 1377833.984375
         eager_us: 25181.184768676758
+    kernel_set:
+    - expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.7f821ab65404
+    - expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.fec324df6e4b
+  - name: expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.7f821ab65404
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      PLACE@map.1/inner.2/map.1/inner: cut
+    identity: 7f821ab654040c58390b6ea58b413c9fe50caf225e3026bc78570940bfb1e3d1
+    measurements:
+      emmy_us: 409.5938510399094
+      reference_us: 436.20643793952235
+      reference_backend: same-input-greedy
+  - name: expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.fec324df6e4b
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE: g64k
+    identity: fec324df6e4bf56ecc62a2a8603f590b8cf675dcdb33e04944cdd7e9e4654e77
+    measurements:
+      emmy_us: 282.87385470678714
+      reference_us: 306.2864321411825
+      reference_backend: same-input-greedy
+  - name: expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.e42561678f7e
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      RASTER: ''
+    identity: e42561678f7e1123d2b58938665884fd35aa78e75a8254c6da2cfd49a55fd3b2
+    measurements:
+      emmy_us: 126.71999633312225
+      reference_us: 129.92000579833984
+      reference_backend: same-input-greedy
+  - name: expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.8076a4cbff49
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m8n8k4_f16_f32/f1x1/k4
+      REDUCE: ''
+      STAGE: d1/smem
+      RASTER: ''
+    identity: 8076a4cbff490819ab9b3a94e96b2f04986db1c54493cef38d1dee4f3ae27ca8
+    measurements:
+      emmy_us: 279.55201268196106
+      reference_us: 302.7626673380534
+      reference_backend: same-input-greedy
+  - name: expert-sym@mxfp4.k_linear_reduce_0de949.7d644f512b51.m1.7f821ab65404.8c0373000cfc
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      REDUCE: ''
+      RASTER: ''
+    identity: 8c0373000cfcfd70bce8298140d9e4f99b3cdb63bb7d6f437906441c78a77e0d
+    measurements:
+      emmy_us: 3.3218420248261022
+      reference_us: 3.523764803129084
+      reference_backend: same-input-greedy
 - program: 1
   target:
     loop: 1
@@ -28670,6 +28743,79 @@ configs:
       NVIDIA Tesla V100 SXM3 32GB:
         emmy_us: 1293945.80078125
         eager_us: 25151.487350463867
+    kernel_set:
+    - expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.7f821ab65404
+    - expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.fec324df6e4b
+  - name: expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.7f821ab65404
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      PLACE@map.1/inner.2/map.1/inner: cut
+    identity: 7f821ab654040c58390b6ea58b413c9fe50caf225e3026bc78570940bfb1e3d1
+    measurements:
+      emmy_us: 408.6721099486656
+      reference_us: 435.3568626239019
+      reference_backend: same-input-greedy
+  - name: expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.fec324df6e4b
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE: g64k
+    identity: fec324df6e4bf56ecc62a2a8603f590b8cf675dcdb33e04944cdd7e9e4654e77
+    measurements:
+      emmy_us: 282.3361165395088
+      reference_us: 305.9488607241827
+      reference_backend: same-input-greedy
+  - name: expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.e42561678f7e
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      RASTER: ''
+    identity: e42561678f7e1123d2b58938665884fd35aa78e75a8254c6da2cfd49a55fd3b2
+    measurements:
+      emmy_us: 126.3359934091568
+      reference_us: 129.40800189971924
+      reference_backend: same-input-greedy
+  - name: expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.8076a4cbff49
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m8n8k4_f16_f32/f1x1/k4
+      REDUCE: ''
+      STAGE: d1/smem
+      RASTER: ''
+    identity: 8076a4cbff490819ab9b3a94e96b2f04986db1c54493cef38d1dee4f3ae27ca8
+    measurements:
+      emmy_us: 279.04000878334045
+      reference_us: 302.42133140563965
+      reference_backend: same-input-greedy
+  - name: expert1@mxfp4.k_linear_reduce_8da262.cf99757467d0.m1.7f821ab65404.8c0373000cfc
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      REDUCE: ''
+      RASTER: ''
+    identity: 8c0373000cfcfd70bce8298140d9e4f99b3cdb63bb7d6f437906441c78a77e0d
+    measurements:
+      emmy_us: 3.2961077561683525
+      reference_us: 3.5275293185430416
+      reference_backend: same-input-greedy
 - program: 3
   target:
     loop: 3
@@ -28690,6 +28836,8 @@ configs:
       NVIDIA Tesla V100 SXM3 32GB:
         emmy_us: 200190.97900390625
         eager_us: 29217.792510986328
+    kernel_set:
+    - expert4096@mxfp4.k_linear_reduce_a3f064.592880680b39.m4096.7e22d4bab7d7.7e22d4bab7d7
   - name: expert4096@mxfp4.k_linear_reduce_a3f064.592880680b39.m4096.ea9536b34e57
     bindings:
       num_tokens: 4096
@@ -28721,6 +28869,50 @@ configs:
     measurements:
       emmy_us: 11442.17586517334
       reference_us: 11416.576385498047
+      reference_backend: same-input-greedy
+  - name: expert4096@mxfp4.k_linear_reduce_a3f064.592880680b39.m4096.7e22d4bab7d7.7e22d4bab7d7
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      PLACE@map.1/inner.1/map.1/inner: cut
+    identity: 7e22d4bab7d7527e70ecc772ef07c53e51aa99b237092ad317e8382a70af231e
+    measurements:
+      emmy_us: 38149.120807647705
+      reference_us: 38231.040477752686
+      reference_backend: same-input-greedy
+  - name: expert4096@mxfp4.k_linear_reduce_a3f064.592880680b39.m4096.7e22d4bab7d7.93f0a0e7072b
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m8n8k4_f16_f32/f1x2
+      REDUCE: ''
+      STAGE: d2/smem
+      RASTER: ''
+    identity: 93f0a0e7072b8d06ec161a0d8aa6780bd68fad4248c016c539f9de9178bb2c28
+    measurements:
+      emmy_us: 30797.82485961914
+      reference_us: 30780.41648864746
+      reference_backend: same-input-greedy
+  - name: expert4096@mxfp4.k_linear_reduce_a3f064.592880680b39.m4096.7e22d4bab7d7.6d6cc5eb4ffd
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m8n8k4_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      RASTER: ''
+    identity: 6d6cc5eb4ffdab6ebd903718e4c57c057bdf5145d843e46fb6b44ec16d6aaaa9
+    measurements:
+      emmy_us: 7351.295948028564
+      reference_us: 7450.623989105225
       reference_backend: same-input-greedy
 - program: 4
   target:


### PR DESCRIPTION
## Abstract

Every emmy-versus-eager pair the repository's model goldens record lives in one file, and 2.87 of the 2.87 seconds it loses sat in four rows: the DeepSeek V4 MoE expert at mxfp4. The expert lowered as a single kernel whose down-projection loop, 2048 contraction steps long, re-derived the entire gate-up projection inside itself — 2048 x 4096 dequantized multiply-adds that do not depend on the output channel, evaluated once for each of 4096 of them. The placement fork already offered that seam; the recorded route declined it. So there is no compiler change here. The same compiler cuts the kernel in three as soon as the row says to, and the two worst targets in the corpus go from 0.02x of eager to roughly 57x the other way.

| Target | File held | Now | |
| --- | ---: | ---: | ---: |
| expert1 m1 | 1294 ms | **438 us** | 2956x |
| expert-sym m1 | 1378 ms | **438 us** | 3146x |
| expert4096 m4096 | 200 ms | **38.1 ms** | 5.3x |
| expert-sym m4096 | 107.8 ms | 107.5 ms | left alone |

---

## Why a recording and not a fix

The fused kernel's inner loop is the whole story:

```c
for (int a1 = a1_co; a1 < 2048; a1 += 32) {       // the down-projection's K
    <dequantize w_down[a0, a1]>
    for (int a2 = 0; a2 < 4096; a2++) {           // the gate-up projection, entire
        <dequantize w_gate_up[a1, a2]>            // invariant in a0 — and a0 is the grid
        <dequantize w_gate_up[a1 + 2048, a2]>
        acc0 += x[a2] * ...;  acc1 += x[a2] * ...;
    }
    acc2 += silu(acc0) * clamp(acc1) * <w_down>;
}
```

`a0` is the output channel and runs to 4096 on the grid. Nothing in the inner loop reads it. Pinning `PLACE@map.1/inner.2/map.1/inner=cut` leaves three kernels — the gate-up once, the down-projection as an mma tile over a split K, and its finalize — at 129 / 302 / 3.5 microseconds.

A golden row is measured evidence and outranks any prior, so the slow route kept being picked until it was measured against. That is the whole reason this needed a recording.

## What was measured and discarded

The gate-up piece spends its time decoding block scales, and the loader spells an mxfp4 scale as `pow(2, e)` — a power of two written as a general power, so `powf`, a log-plus-exp polynomial, 16.8 million times per launch. That looked like the rest of the kernel, and an `exp2` op is bit-exact against it (`torch.exp2` equals `torch.pow(2, e)` on all 255 e8m0 exponents) and one SFU instruction.

It measures flat. Cut alone is 435.7 us; cut plus `exp2` is 438.7 us. The kernel was never `powf`-bound, and the 0.44 s per-iteration figure that suggested otherwise was the launch watchdog's *wait* line on early iterations, not steady-state kernel time. The change touched nine files of intrinsic tables for no measured win, so it is not here. The strength reduction is still real and still correct, if a `powf`-bound kernel ever turns up.

## The eager column

Two things about it. It is the golden's program run through PyTorch op by op, with the dequantization's broadcasts materialized, so it is an upper bound on PyTorch rather than a fair opponent. And on these targets it cannot be benched interleaved at all: materializing those weight tensors stalls the device long enough that the harness charges the wait to Emmy's kernel and reports 0.44 s for a 131 us launch. Every number above is emmy-only, replayed from the committed file on an idle card.

## The seeds this turns red

`make test-goldens` goes from 5 undecodable rows on this file to 7, both new ones the m1 expert seeds, by the mechanism #793 documented: a seed that gains a `kernel_set` naming the cut resolves to three kernels, and its own knobs spell the one fused kernel nothing routes to any more. `expert4096`'s seed stays green because its recorded route already held a cut.

Seven is enough of these that the question #793 deferred — whether such a seed keeps the knobs it was measured at, or the receipts replace it — is worth settling deliberately rather than once more per recording. It is a decision about the file, and it is the same decision for all seven.

## What is still slow

`expert-sym` at m4096 is the one target the cut does not help: 107.5 ms against the 107.8 ms the file holds, so nothing is recorded for it. It stays at 0.27x of eager, and its down-projection piece alone is 76.6 ms across 256 CTAs of 1024 threads. That one is not a placement question.

After this, the largest remaining losses in the file are sub-millisecond — a handful of `post*.k_div_*_reduce` rows at m4096 around 1.3 ms against 0.5 ms eager.

## Verification

`make test-goldens` as described. `make lint` clean. `make test` on an RTX 5090: **1 failed, 5399 passed**. That one is `matmul/nvfp4-w4a4-packed-slab-loopify` at `built`, which passes standalone four times out of four, was already in the failure list before this branch, and is an nvfp4 realization case nothing in this diff reaches — the default suite does not read checked-in model goldens at all.

Worth noting for whoever reviews the stack: rebasing onto #791's head took that list from 15 failures to 1, because #791 re-records the serving golden the thirteen `tests/serving/generation` failures were stale against.

## Line balance

No change under `emmy/`. The diff is 192 added lines in one recipe golden and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i6CpBdUZmbeWw954KcGYb
